### PR TITLE
Add link to preview and fact check email address at top of History tab

### DIFF
--- a/app/views/admin/shared/_history.html.erb
+++ b/app/views/admin/shared/_history.html.erb
@@ -1,5 +1,14 @@
 <div class="row-fluid">
 
+  <% if resource.safe_to_preview? %>
+  <p>This edition can be previewed at <%= link_to preview_edition_path(resource), preview_edition_path(resource) %>.</p>
+  <% else %>
+  <p>This edition is not yet ready to be previewed.</p>
+  <% end %>
+
+  <p>Fact check responses should (when appropriate) be sent to <%= mail_to resource.fact_check_email_address %></p>
+  <hr />
+
   <div class="span6">
     <%= semantic_form_for(:note, :url=> admin_notes_path) do |f| %>
       <%= f.inputs do %>


### PR DESCRIPTION
Feedback from the Subhi has suggested this will help significantly with the fact check process. These links could be better presented, but probably work as they are?
