### PR TITLE
Find councils by name or by snac code

### DIFF
--- a/app/controllers/local_transactions_controller.rb
+++ b/app/controllers/local_transactions_controller.rb
@@ -25,8 +25,8 @@ class LocalTransactionsController < ApplicationController
     }
   end
 
-  def find_by_council
-    council = params[:council]
+  def find_by_council_name
+    council = params[:name]
     local_authority = LocalAuthority.where(name: /^#{council}/i).first
     head 404 and return if local_authority.nil?
     render :json => {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Publisher::Application.routes.draw do
   post "/local_transactions/verify_snac", :to => "publications#verify_snac"
 
   get "/local_transactions/find_by_snac", :to => "local_transactions#find_by_snac"
-  get "/local_transactions/find_by_council", :to => "local_transactions#find_by_council"
+  get "/local_transactions/find_by_council_name", :to => "local_transactions#find_by_council_name"
 
   root to: redirect("/admin")
 end

--- a/test/integration/local_transaction_api_test.rb
+++ b/test/integration/local_transaction_api_test.rb
@@ -59,13 +59,13 @@ class LocalTransactionApiTest < ActionDispatch::IntegrationTest
   end
 
   test "404 if council not found" do
-    visit "/local_transactions/find_by_council?council=bloop"
+    visit "/local_transactions/find_by_council_name?name=bloop"
     assert_equal 404, page.status_code
     assert_equal " ", page.source
   end
 
   test "returns a council hash if provided with a lower case council name" do
-    visit "/local_transactions/find_by_council?council=some%20council"
+    visit "/local_transactions/find_by_council_name?name=some%20council"
     assert_equal 200, page.status_code
     response = JSON.parse(page.source)
     expected = {"name" => "Some Council", "snac" => "AA00"}
@@ -73,7 +73,7 @@ class LocalTransactionApiTest < ActionDispatch::IntegrationTest
   end
 
   test "returns a council hash if provided with a mixed case council name" do
-    visit "/local_transactions/find_by_council?council=Some%20Council"
+    visit "/local_transactions/find_by_council_name?name=Some%20Council"
     assert_equal 200, page.status_code
     response = JSON.parse(page.source)
     expected = {"name" => "Some Council", "snac" => "AA00"}


### PR DESCRIPTION
Publisher contains the data for a LocalAuthority which needs to be
exposed for both the LicenceApplication and the LicenceFinder. These are
two helper URLs that can be exposed through the gds-api-adapters to
simplify the steps involved with switching between name/snac code.
