### PR TITLE
Pin the mongo gem version to 1.6.2.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,8 @@ else
   gem "govuk_content_models", "~> 0.2.6"
 end
 
+gem 'mongo', '1.6.2'  # Locking this down to avoid a replica set bug
+
 if ENV['CDN_DEV']
   gem 'cdn_helpers', path: '../cdn_helpers'
 else

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,6 +325,7 @@ DEPENDENCIES
   lockfile
   lograge
   mocha
+  mongo (= 1.6.2)
   newrelic_rpm
   null_logger
   passenger


### PR DESCRIPTION
This is partly for consistency with Panopticon and partly to make sure
we avoid a bug in versions prior to 1.6.0 which was causing a slew of
exception emails.
