### PR TITLE
Remove duplicate verify_snac route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,9 +22,7 @@ Publisher::Application.routes.draw do
     root :to => 'root#index'
   end
 
-  resources :publications, :only => :show do
-    post :verify_snac, :on => :member
-  end
+  resources :publications, :only => :show
   resources :licences, :only => :index, :defaults => { :format => 'json' }
 
   post "/local_transactions/verify_snac", :to => "publications#verify_snac"


### PR DESCRIPTION
gds-api-adapters provides verify_snac at /local_transactions/#{slug}/verify_snac.json but we were also providing an option to POST to /publications/#{slug}/verify_snac that's unused. We should remove this duplication so that it's clear what API methods need to live on as we move API responsibilities around.
