### PR TITLE
Remove cdn_helpers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,8 @@ source 'https://rubygems.org'
 source 'https://gems.gemfury.com/vo6ZrmjBQu5szyywDszE/'
 
 gem 'aws-ses', require: 'aws/ses'
-if ENV['CDN_DEV']
-  gem 'cdn_helpers', path: '../cdn_helpers'
-else
-  gem 'cdn_helpers', '0.9'
-end
 gem 'colorize', "~> 0.5.8"
+
 if ENV['BUNDLE_DEV']
   gem 'gds-sso', path: '../gds-sso'
 else

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,9 +68,6 @@ GEM
     capybara-webkit (0.12.1)
       capybara (>= 1.0.0, < 1.2)
       json
-    cdn_helpers (0.9)
-      actionpack
-      nokogiri
     childprocess (0.3.5)
       ffi (~> 1.0, >= 1.0.6)
     chronic (0.6.7)
@@ -295,7 +292,6 @@ DEPENDENCIES
   aws-ses
   capybara (~> 1.1.0)
   capybara-webkit
-  cdn_helpers (= 0.9)
   ci_reporter
   colorize (~> 0.5.8)
   database_cleaner


### PR DESCRIPTION
This was used in the alpha (and maybe early days of the beta) but has never really been needed for publisher.

And it's one less dependency to worry about...
