### PR TITLE
Return a 404 when asked for a list that isn't available

### DIFF
--- a/app/controllers/admin/root_controller.rb
+++ b/app/controllers/admin/root_controller.rb
@@ -10,6 +10,7 @@ class Admin::RootController < Admin::BaseController
   def index
     @user_filter = params[:user_filter] || session[:user_filter]
     @list = params[:list].blank? ? 'lined_up' : params[:list]
+
     session[:user_filter] = @user_filter
 
     if params[:with] && params[:title_filter]
@@ -52,6 +53,12 @@ class Admin::RootController < Admin::BaseController
 
     editions = editions.page(current_page).per(ITEMS_PER_PAGE)
     @presenter = AdminRootPresenter.new(editions, user)
+
+    # Looking at another class, but the whole approach taken by this method and its
+    # associated presenter needs revisiting.
+    unless @presenter.acceptable_list?(@list)
+      head(:not_found) and return
+    end
 
     if ! params[:title_filter].blank?
       @presenter.filter_by_title_substring(params[:title_filter])

--- a/app/presenters/admin_root_presenter.rb
+++ b/app/presenters/admin_root_presenter.rb
@@ -1,4 +1,7 @@
 class AdminRootPresenter
+  AVAILABLE_LISTS = [:lined_up, :draft, :amends_needed, :in_review,
+    :fact_check, :fact_check_received, :ready, :published, :archived]
+
   def initialize(editions, user)
     @scope = case user
     when :all
@@ -13,11 +16,15 @@ class AdminRootPresenter
   attr_accessor :scope
   private :scope
 
+  def acceptable_list?(list)
+    AVAILABLE_LISTS.include?(list.to_sym)
+  end
+
   def all
     @scope
   end
 
-  [:lined_up, :draft, :amends_needed, :in_review, :fact_check, :fact_check_received, :ready, :published, :archived].each do |state|
+  AVAILABLE_LISTS.each do |state|
     define_method state do
       scope.send(state.to_s)
     end

--- a/test/functional/admin/root_controller_test.rb
+++ b/test/functional/admin/root_controller_test.rb
@@ -9,6 +9,11 @@ class Admin::RootControllerTest < ActionController::TestCase
     @guide = FactoryGirl.create(:guide_edition, state: 'draft')
   end
 
+  test "it returns a 404 for an unknown list" do
+    get :index, list: 'draFts'
+    assert response.not_found?
+  end
+
   test "it goes to the right state when a with parameter is given" do
     get :index, with: @guide.id
     assert_equal "drafts", assigns[:list]


### PR DESCRIPTION
Today's testing revealed that requests for a list that we don't offer (eg. /admin?list=NOTDRAFT)
raised exceptions that weren't handled anywhere. We now return a 404 for such requests.
