### PR TITLE
Register licences as prefix routes

### DIFF
--- a/lib/registerable_edition.rb
+++ b/lib/registerable_edition.rb
@@ -20,7 +20,12 @@ class RegisterableEdition
   end
 
   def paths
-    array = [slug, "#{slug}.json"]
+    if @edition.is_a?(LicenceEdition)
+      array = ["#{slug}.json"]
+    else
+      array = [slug,"#{slug}.json"]
+    end
+
     if @edition.is_a?(GuideEdition)
       array << "#{slug}/print"
       array << "#{slug}/video" if @edition.has_video?
@@ -41,6 +46,10 @@ class RegisterableEdition
   end
 
   def prefixes
-    []
+    if @edition.is_a?(LicenceEdition)
+      [slug]
+    else
+      []
+    end
   end
 end

--- a/test/unit/registerable_edition_test.rb
+++ b/test/unit/registerable_edition_test.rb
@@ -106,11 +106,11 @@ class RegisterableEditionTest < ActiveSupport::TestCase
   context "paths" do
     should "generate paths, including .json" do
       edition = FactoryGirl.create(:edition,
-        slug: "slug", 
-        title: "A publication", 
+        slug: "slug",
+        title: "A publication",
         state: "published")
       registerable = RegisterableEdition.new(edition)
-      
+
       assert_equal ["slug", "slug.json"], registerable.paths
     end
 
@@ -157,6 +157,26 @@ class RegisterableEditionTest < ActiveSupport::TestCase
         registerable = RegisterableEdition.new(edition)
 
         assert_equal ["slug", "slug.json", "slug.kml"], registerable.paths
+      end
+    end
+
+    context "LicenceEdition" do
+      should "generate only a json path" do
+        edition = LicenceEdition.create(slug: "slug", title: "A title", state: "published")
+        registerable = RegisterableEdition.new(edition)
+
+        assert_equal ["slug.json"], registerable.paths
+      end
+    end
+  end
+
+  context "prefix" do
+    context "LicenceEdition" do
+      should "generate prefix routes for licences" do
+        edition = LicenceEdition.create(slug: "slug", title: "A title", state: "published")
+        registerable = RegisterableEdition.new(edition)
+
+        assert_equal ["slug"], registerable.prefixes
       end
     end
   end


### PR DESCRIPTION
Register licence editions as prefix routes, not full routes, as
an authority and an action can also be passed as parameters to
the edition for the Licence Application integration.
