### PR TITLE
Remove dependency on passenger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,10 +54,6 @@ group :assets do
   gem 'uglifier'
 end
 
-group :development do
-  gem 'passenger'
-end
-
 group :test do
   gem 'test-unit'
   gem 'shoulda'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,6 @@ GEM
     colorize (0.5.8)
     commonjs (0.2.6)
     crack (0.3.1)
-    daemon_controller (1.0.0)
     database_cleaner (0.8.0)
     differ (0.1.2)
     erubis (2.7.0)
@@ -92,7 +91,6 @@ GEM
       i18n (~> 0.4)
     faraday (0.8.4)
       multipart-post (~> 1.1)
-    fastthread (1.0.7)
     ffi (1.1.5)
     gds-api-adapters (1.8.0)
       lrucache (~> 0.1.1)
@@ -196,11 +194,6 @@ GEM
     omniauth-oauth2 (1.1.0)
       oauth2 (~> 0.8.0)
       omniauth (~> 1.0)
-    passenger (3.0.15)
-      daemon_controller (>= 1.0.0)
-      fastthread (>= 1.0.1)
-      rack
-      rake (>= 0.8.1)
     plek (0.1.24)
       builder
     polyglot (0.3.3)
@@ -329,7 +322,6 @@ DEPENDENCIES
   mongo (= 1.6.2)
   newrelic_rpm
   null_logger
-  passenger
   plek (= 0.1.24)
   rails (= 3.2.8)
   rest-client


### PR DESCRIPTION
We're not using passenger in production. I've no idea why it's a dependency in development - it's a big dependency to just have hanging around.
