### PR TITLE
Check to avoid re-registering archived content

### DIFF
--- a/app/models/enhancements/edition.rb
+++ b/app/models/enhancements/edition.rb
@@ -5,6 +5,9 @@ class Edition
   include Admin::BaseHelper
   include Searchable
 
+  class ResurrectionError < RuntimeError
+  end
+
   alias_method :was_published_without_indexing, :was_published
   def was_published
     was_published_without_indexing
@@ -17,6 +20,9 @@ class Edition
 
   def register_with_panopticon
     artefact = Artefact.find(self.panopticon_id)
+    if artefact.state == "archived"
+      raise ResurrectionError, "Cannot register archived artefact '#{artefact.slug}'"
+    end
     registerer = GdsApi::Panopticon::Registerer.new(owning_app: artefact.owning_app, rendering_app: "frontend", kind: artefact.kind)
     details = RegisterableEdition.new(self)
     registerer.register(details)

--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -17,6 +17,8 @@ namespace :panopticon do
       rescue Mongoid::Errors::DocumentNotFound
         # This happens if an Edition doesn't have a corresponding Artefact
         logger.warn "Missing Artefact for #{edition.class.name} #{edition.slug}"
+      rescue Edition::ResurrectionError
+        logger.error "Attempted to register archived edition '#{edition.slug}'"
       end
     end
   end

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -6,12 +6,30 @@ class EditionTest < ActiveSupport::TestCase
     should "register with panopticon when published" do
       user = FactoryGirl.create(:user)
       artefact = FactoryGirl.create(:artefact)
-      edition = FactoryGirl.create(:guide_edition, :state => 'ready', panopticon_id: artefact.id)
+      edition = FactoryGirl.create(:guide_edition, :state => "ready", panopticon_id: artefact.id)
 
       registerable = mock("registerable_edition")
       RegisterableEdition.expects(:new).with(edition).returns(registerable)
       GdsApi::Panopticon::Registerer.any_instance.expects(:register).with(registerable)
       user.publish(edition, comment: "I am bananas")
+    end
+
+    should "not register with Panopticon if the artefact is archived" do
+      user = FactoryGirl.create(:user)
+      artefact = FactoryGirl.create(:artefact)
+      edition = FactoryGirl.create(:guide_edition, :state => "ready", panopticon_id: artefact.id)
+
+      # Doing this after creating the edition, so the edition doesn't try to
+      # update the artefact
+      artefact.update_attributes! state: "archived"
+
+      registerable = mock("registerable_edition")
+      RegisterableEdition.stubs(:new).with(edition).returns(registerable)
+      GdsApi::Panopticon::Registerer.any_instance.expects(:register).never
+
+      assert_raises Edition::ResurrectionError do
+        edition.register_with_panopticon
+      end
     end
   end
 end


### PR DESCRIPTION
This avoids the "resurrection bug" where archived content would get
re-registered in Panopticon and restored to "live" status, making it
viewable on the site and indexed in search. We'll have code in
Panopticon to mark all editions as archived when their corresponding
artefact is archived, but this provides an extra guard against
resurrection.
