### PR TITLE
bump gds-api-adapters and govuk_content_models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,14 +12,14 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", "2.4.0"
+  gem "govuk_content_models", "2.5.0"
 end
 
 gem 'erubis'
 gem 'exception_notification', '~> 2.4.1', require: 'exception_notifier'
 gem 'formtastic', git: 'https://github.com/justinfrench/formtastic.git', branch: '2.1-stable'
 gem 'formtastic-bootstrap', git: 'https://github.com/cgunther/formtastic-bootstrap.git', branch: 'bootstrap-2'
-gem 'gds-api-adapters', '4.1.1'
+gem 'gds-api-adapters', '4.1.3'
 gem 'gds-warmup-controller'
 gem 'gelf'
 if ENV['GOVSPEAK_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
     faraday (0.8.4)
       multipart-post (~> 1.1)
     ffi (1.1.5)
-    gds-api-adapters (4.1.1)
+    gds-api-adapters (4.1.3)
       lrucache (~> 0.1.1)
       null_logger
       plek
@@ -109,7 +109,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (2.4.0)
+    govuk_content_models (2.5.0)
       bson_ext
       differ
       gds-api-adapters
@@ -303,12 +303,12 @@ DEPENDENCIES
   faker
   formtastic!
   formtastic-bootstrap!
-  gds-api-adapters (= 4.1.1)
+  gds-api-adapters (= 4.1.3)
   gds-sso (~> 1.2.0)
   gds-warmup-controller
   gelf
   govspeak (= 1.2.0)
-  govuk_content_models (= 2.4.0)
+  govuk_content_models (= 2.5.0)
   graylog2_exceptions
   has_scope
   inherited_resources


### PR DESCRIPTION
Upgrading the versions of these gems in order to make the transition to Plek 1.0.0 smoother
