### PR TITLE
Strip whitespace from URLs imported from the LGSL

### DIFF
--- a/lib/local_interaction_importer.rb
+++ b/lib/local_interaction_importer.rb
@@ -21,11 +21,11 @@ class LocalInteractionImporter < LocalAuthorityDataImporter
       authority.local_interactions.create!(
         lgsl_code: row['LGSL'],
         lgil_code: row['LGIL'],
-        url: row['Service URL']
+        url: row['Service URL'].strip
       )
     elsif existing_interactions.count == 1
       i = existing_interactions.first
-      i.update_attributes!(url: row['Service URL'])
+      i.update_attributes!(url: row['Service URL'].strip)
     else
       raise "Error: duplicate definitions already exist for interaction [lgsl=#{row['LGSL']}, lgil=#{row['LGIL']}] for authority '#{row['SNAC']}'"
     end

--- a/test/unit/fixtures/local_interaction_with_whitespace.csv
+++ b/test/unit/fixtures/local_interaction_with_whitespace.csv
@@ -1,0 +1,2 @@
+Authority Name,SNAC,LAid,Service Name,LGSL,LGIL,Service URL
+Adur District Council,45UB,1,Find out about school holiday schemes,18,8, http://www.adur.gov.uk/education/index.htm ,

--- a/test/unit/local_interaction_importer_test.rb
+++ b/test/unit/local_interaction_importer_test.rb
@@ -91,6 +91,14 @@ class LocalInteractionImporterTest < ActiveSupport::TestCase
         assert_equal 8, interaction.lgil_code
       end
 
+      should "strip trailing or preceding whitespace from the url" do
+        @source = File.open(fixture_file('local_interaction_with_whitespace.csv'))
+        LocalInteractionImporter.new(@source).run
+
+        interaction = @authority.reload.local_interactions.first
+        assert_equal "http://www.adur.gov.uk/education/index.htm", interaction.url
+      end
+
       context "interaction already defined" do
         setup do
           @authority.local_interactions.create!(
@@ -103,6 +111,14 @@ class LocalInteractionImporterTest < ActiveSupport::TestCase
           assert_no_difference "@authority.reload.local_interactions.count" do
             LocalInteractionImporter.new(@source).run
           end
+          interaction = @authority.reload.local_interactions.first
+          assert_equal "http://www.adur.gov.uk/education/index.htm", interaction.url
+        end
+
+        should "strip trailing or preceding whitespace from the url" do
+          @source = File.open(fixture_file('local_interaction_with_whitespace.csv'))
+          LocalInteractionImporter.new(@source).run
+
           interaction = @authority.reload.local_interactions.first
           assert_equal "http://www.adur.gov.uk/education/index.htm", interaction.url
         end


### PR DESCRIPTION
Interactions where the URLs have erroneous use of trailing or preceding
whitespace break Get Started links for users, unless we strip this away.
