### PR TITLE
Remove hack to skip validations for fact checks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", "2.5.0"
+  gem "govuk_content_models", git: "https://github.com/alphagov/govuk_content_models.git", branch: "remove_validation_hack_for_safe_html_false_positives", ref: "fcf61f835ff8b48f177dc3de65ddd46e58712884" #"2.5.0"
 end
 
 gem 'erubis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,22 @@
 GIT
+  remote: https://github.com/alphagov/govuk_content_models.git
+  revision: fcf61f835ff8b48f177dc3de65ddd46e58712884
+  ref: fcf61f835ff8b48f177dc3de65ddd46e58712884
+  branch: remove_validation_hack_for_safe_html_false_positives
+  specs:
+    govuk_content_models (2.6.0)
+      bson_ext
+      differ
+      gds-api-adapters
+      gds-sso (>= 0.7, < 3.0)
+      govspeak (>= 1.0.1, < 2.0.0)
+      mongoid (~> 2.4.10)
+      multi_json (= 1.3.7)
+      omniauth-oauth2 (~> 1.0)
+      plek
+      state_machine
+
+GIT
   remote: https://github.com/cgunther/formtastic-bootstrap.git
   revision: 3428fef4f7870b01241d65893b882ad32cfc18d8
   branch: bootstrap-2
@@ -109,16 +127,6 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (2.5.0)
-      bson_ext
-      differ
-      gds-api-adapters
-      gds-sso (>= 0.7, < 3.0)
-      govspeak (>= 1.0.1, < 2.0.0)
-      mongoid (~> 2.4.10)
-      omniauth-oauth2 (~> 1.0)
-      plek (>= 0.1.22, < 0.4)
-      state_machine
     graylog2_exceptions (1.3.0)
       gelf (= 1.1.3)
     has_scope (0.5.1)
@@ -175,7 +183,7 @@ GEM
       activemodel (~> 3.1)
       mongo (<= 1.6.2)
       tzinfo (~> 0.3.22)
-    multi_json (1.3.6)
+    multi_json (1.3.7)
     multipart-post (1.1.5)
     newrelic_rpm (3.3.4.1)
     nokogiri (1.5.5)
@@ -308,7 +316,7 @@ DEPENDENCIES
   gds-warmup-controller
   gelf
   govspeak (= 1.2.0)
-  govuk_content_models (= 2.5.0)
+  govuk_content_models!
   graylog2_exceptions
   has_scope
   inherited_resources

--- a/app/models/enhancements/user.rb
+++ b/app/models/enhancements/user.rb
@@ -2,16 +2,9 @@ require "user"
 
 class User
   alias_method :record_action_without_noise, :record_action
-  alias_method :record_action_without_validation_without_noise, :record_action_without_validation
 
   def record_action(edition, type, options = {})
     action = record_action_without_noise(edition, type, options)
-    NoisyWorkflow.make_noise(action).deliver
-    NoisyWorkflow.request_fact_check(action).deliver if type.to_s == "send_fact_check"
-  end
-
-  def record_action_without_validation(edition, type, options={})
-    action = record_action_without_validation_without_noise(edition, type, options)
     NoisyWorkflow.make_noise(action).deliver
     NoisyWorkflow.request_fact_check(action).deliver if type.to_s == "send_fact_check"
   end

--- a/test/unit/fact_check_message_processor_test.rb
+++ b/test/unit/fact_check_message_processor_test.rb
@@ -91,16 +91,4 @@ class FactCheckMessageProcessorTest < ActiveSupport::TestCase
     f = FactCheckMessageProcessor.new(message)
     assert_match /Hello/, f.body_as_utf8
   end
-
-  # until we improve the validation to produce few or no false positives
-  test "it should temporarily allow comments that would fail Govspeak/HTML validation" do
-    edition = sample_publication
-    message = Mail.read(File.expand_path("../../fixtures/fact_check_emails/hidden_nasty.txt", __FILE__))
-    f = FactCheckMessageProcessor.new(message)
-    assert f.process_for_publication(edition.id)
-
-    edition.reload
-    assert_includes(edition.actions.last.comment, 'This is some text')
-    assert_includes(edition.actions.last.comment, '<script>')
-  end
 end


### PR DESCRIPTION
A corresponding removal of hack to https://github.com/alphagov/govuk_content_models/pull/35

Ideally, the Gemfile should be changed to a to-be-released version of govuk_content_models before this pull request is merged.
