### PR TITLE
Benefits pages should have editable part titles

### DIFF
--- a/app/views/admin/programmes/_edit.html.erb
+++ b/app/views/admin/programmes/_edit.html.erb
@@ -16,7 +16,7 @@
         <% f.object.parts.replace f.object.parts.sort_by(&:order) %>
 
         <%= f.semantic_fields_for :parts do |part| %>
-          <%= render :partial => '/admin/shared/part', :locals => {:f => part, :editable => true } %>
+          <%= render :partial => '/admin/shared/part', :locals => {:f => part, :editable => false } %>
         <% end %>
 
       </section>

--- a/app/views/admin/shared/_part.html.erb
+++ b/app/views/admin/shared/_part.html.erb
@@ -12,7 +12,7 @@
 
         <%= f.inputs do %>
           <%= f.input :title,
-                      :input_html => { :class => 'span12 title', :disabled => ! editable },
+                      :input_html => { :class => 'span12 title', :disabled => @resource.published? },
                       :hint => true,
                       :required => true %>
 

--- a/test/integration/programme_editions_test.rb
+++ b/test/integration/programme_editions_test.rb
@@ -16,16 +16,16 @@ class ProgrammeEditionsTest < JavascriptIntegrationTest
 
     click_on "Overview"
     within :css, "#overview" do
-      fill_in "Title", :with => "Part One"
+      fill_in "Title", :with => "Imagine this is Welsh"
       fill_in "Body",  :with => "Body text"
-      fill_in "Slug",  :with => "part-one"
+      fill_in "Slug",  :with => "imagine-this-is-welsh"
     end
 
     within(:css, ".workflow_buttons") { click_on "Save" }
 
     assert_include page.body, "Programme edition was successfully updated."
 
-    assert_include page.body, "Part One"
-    assert_include page.body, "part-one"
+    assert_include page.body, "Imagine this is Welsh"
+    assert_not_include page.body, "imagine-this-is-welsh"
   end
 end


### PR DESCRIPTION
As part of the work to get Welsh content added to gov.uk, content designers want the ability to edit the part titles for benefits pages so they can provide a Welsh title rather than the rigid (currently provided) set of titles.

This change (by proxy) allows editing of part slugs as well. However, there's code currently existing which redirects non-existing part slugs to the root page of an Edition.
