### PR TITLE
Bump plek to 1.3.1 to get sensible dev defaults.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'mongo', '1.6.2'  # Locking this down to avoid a replica set bug
 gem "mongoid_rails_migrations", "1.0.0"
 gem 'newrelic_rpm'
 gem 'null_logger'
-gem 'plek', '1.0.0'
+gem 'plek', '1.3.1'
 gem 'rails', '3.2.11'
 
 gem 'lockfile', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,8 +193,7 @@ GEM
     omniauth-oauth2 (1.1.1)
       oauth2 (~> 0.8.0)
       omniauth (~> 1.0)
-    plek (1.0.0)
-      builder
+    plek (1.3.1)
     polyglot (0.3.3)
     rack (1.4.4)
     rack-accept (0.4.5)
@@ -319,7 +318,7 @@ DEPENDENCIES
   mongoid_rails_migrations (= 1.0.0)
   newrelic_rpm
   null_logger
-  plek (= 1.0.0)
+  plek (= 1.3.1)
   rails (= 3.2.11)
   rest-client
   retriable

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-ENV["GOVUK_APP_DOMAIN"] = ENV.fetch("GOVUK_APP_DOMAIN", "dev.gov.uk")
-ENV["GOVUK_WEBSITE_ROOT"] = ENV.fetch("GOVUK_WEBSITE_ROOT", "http://www.dev.gov.uk")
-
 require File.expand_path('../config/application', __FILE__)
 require 'rake'
 require 'ci/reporter/rake/test_unit' if Rails.env.test?

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -3,8 +3,6 @@
 export FACTER_govuk_platform=test
 export RAILS_ENV=test
 export DISPLAY=":99"
-export GOVUK_APP_DOMAIN=dev.gov.uk
-export GOVUK_ASSET_HOST=http://static.dev.gov.uk
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 bundle exec rake stats


### PR DESCRIPTION
This removes the need to set the GOVUK_\* ENV variables in Rakefile and jenkins.sh
