### PR TITLE
Improve test output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ end
 gem 'has_scope'
 gem 'inherited_resources'
 gem 'kaminari', '0.13.0'
-gem 'lograge', '~> 0.1.0'
+gem 'lograge', '0.2.0'
 gem 'mongo', '1.6.2'  # Locking this down to avoid a replica set bug
 gem "mongoid_rails_migrations", "1.0.0"
 gem 'newrelic_rpm'
@@ -56,7 +56,8 @@ group :assets do
 end
 
 group :test do
-  gem 'test-unit'
+  gem 'turn', '0.9.6'
+  gem 'minitest', '3.3.0'
   gem 'shoulda'
   gem 'database_cleaner'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
       i18n (= 0.6.1)
       multi_json (~> 1.0)
     addressable (2.3.2)
+    ansi (1.4.3)
     arel (3.0.2)
     aws-ses (0.4.4)
       builder
@@ -115,10 +116,10 @@ GEM
       state_machine
     has_scope (0.5.1)
     hashie (1.2.0)
-    hike (1.2.1)
+    hike (1.2.2)
     htmlentities (4.3.1)
     httpauth (0.2.0)
-    i18n (0.6.4)
+    i18n (0.6.1)
     inherited_resources (1.3.1)
       has_scope (~> 0.5.0)
       responders (~> 0.6)
@@ -148,7 +149,7 @@ GEM
     libwebsocket (0.1.5)
       addressable
     lockfile (2.1.0)
-    lograge (0.1.2)
+    lograge (0.2.0)
       actionpack
       activesupport
     lrucache (0.1.4)
@@ -159,6 +160,7 @@ GEM
       treetop (~> 1.4.8)
     metaclass (0.0.1)
     mime-types (1.21)
+    minitest (3.3.0)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
     mongo (1.6.2)
@@ -172,7 +174,7 @@ GEM
       bundler (>= 1.0.0)
       rails (>= 3.2.0)
       railties (>= 3.2.0)
-    multi_json (1.6.1)
+    multi_json (1.7.2)
     multipart-post (1.2.0)
     newrelic_rpm (3.5.5.38)
     nokogiri (1.5.6)
@@ -255,7 +257,6 @@ GEM
       tilt (~> 1.1, != 1.3.0)
     state_machine (1.1.2)
     statsd-ruby (1.0.0)
-    test-unit (2.5.1)
     therubyracer (0.9.10)
       libv8 (~> 3.3.10)
     thor (0.17.0)
@@ -264,6 +265,8 @@ GEM
     treetop (1.4.12)
       polyglot
       polyglot (>= 0.3.1)
+    turn (0.9.6)
+      ansi
     tzinfo (0.3.37)
     uglifier (1.2.7)
       execjs (>= 0.3.0)
@@ -310,7 +313,8 @@ DEPENDENCIES
   launchy
   less-rails-bootstrap
   lockfile
-  lograge (~> 0.1.0)
+  lograge (= 0.2.0)
+  minitest (= 3.3.0)
   mocha (= 0.13.3)
   mongo (= 1.6.2)
   mongoid_rails_migrations (= 1.0.0)
@@ -325,9 +329,9 @@ DEPENDENCIES
   simplecov (~> 0.6.4)
   simplecov-rcov (~> 0.2.3)
   statsd-ruby (= 1.0.0)
-  test-unit
   therubyracer (~> 0.9.4)
   timecop
+  turn (= 0.9.6)
   uglifier
   unicorn (= 4.3.1)
   webmock


### PR DESCRIPTION
`turn` + `minitest` gives feedback on what failed/errored immediately, instead of
after running all the tests. It also reports time per named test which might
help us understand why the tests are so slow. The current setup also prints a rather nasty stack trace on test failure.

Had to upgrade lograge because otherwise it couldn't get compatible `i18n` versions.
