### PR TITLE
Log errors in fact check processing

### DIFF
--- a/script/mail_fetcher
+++ b/script/mail_fetcher
@@ -22,6 +22,7 @@ begin
     handler.process
     
     if handler.errors.any?
+      Rails.logger.error(handler.errors.join("\n"))
       NoisyWorkflow.report_errors(handler.errors).deliver
     end
 


### PR DESCRIPTION
We already email them to govuk-dev, so this will just record them locally.

Looking at the production logs, it appears to be frequently sending those emails, but they
are not visible in the Google Group.

I suspect that the Google Group might have marked them as spam so they are not
showing upon browsing/searching the govuk-dev group, and I want to find out if
something is going wrong.
