### PR TITLE
Remove duplication of NoisyWorkflow invocations

### DIFF
--- a/app/models/enhancements/user.rb
+++ b/app/models/enhancements/user.rb
@@ -6,13 +6,17 @@ class User
 
   def record_action(edition, type, options = {})
     action = record_action_without_noise(edition, type, options)
-    NoisyWorkflow.make_noise(action).deliver
-    NoisyWorkflow.request_fact_check(action).deliver if type.to_s == "send_fact_check"
+    make_record_action_noises(action, type)
   end
 
   def record_action_without_validation(edition, type, options={})
     action = record_action_without_validation_without_noise(edition, type, options)
-    NoisyWorkflow.make_noise(action).deliver
-    NoisyWorkflow.request_fact_check(action).deliver if type.to_s == "send_fact_check"
+    make_record_action_noises(action, type)
   end
+
+  private
+    def make_record_action_noises(action, type)
+      NoisyWorkflow.make_noise(action).deliver
+      NoisyWorkflow.request_fact_check(action).deliver if type.to_s == "send_fact_check"
+    end
 end


### PR DESCRIPTION
We want these two methods to be as similar as possible, so sharing more code without duplication is a good thing.
