### PR TITLE
Remove bodies from internal_search

### DIFF
--- a/app/models/enhancements/edition.rb
+++ b/app/models/enhancements/edition.rb
@@ -10,9 +10,7 @@ class Edition
   scope :internal_search, lambda { |term|
     regex = Regexp.new(Regexp.escape(term), true)  # case-insensitive
     any_of({title: regex}, {slug: regex}, {overview: regex},
-           {alternative_title: regex}, {licence_identifier: regex},
-           {body: regex},
-           {"parts.title" => regex}, {"parts.body" => regex})
+           {alternative_title: regex}, {licence_identifier: regex})
   }
 
   alias_method :was_published_without_indexing, :was_published

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -44,12 +44,4 @@ class EditionTest < ActiveSupport::TestCase
       end
     end
   end
-
-  context "internal_search" do
-    should "search on part titles" do
-      FactoryGirl.create(:guide_edition, title: "Big title", parts: [Part.new(title: "Little title", slug: "x", )])
-      results = Edition.internal_search("Little title")
-      assert_equal ["Big title"], results.map(&:title)
-    end
-  end
 end


### PR DESCRIPTION
These were often swamping the results, because you'd search for eg an edition
title fragment, and it would return the expected editions, but also all the editions
where the title fragment is used.
