### PR TITLE
Fix validation of licence identifiers and add Artefact#slug index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", "4.20.0"
+  gem "govuk_content_models", "4.20.1"
 end
 
 gem 'erubis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (4.20.0)
+    govuk_content_models (4.20.1)
       bson_ext
       differ
       gds-api-adapters
@@ -305,7 +305,7 @@ DEPENDENCIES
   gds-api-adapters (= 4.1.3)
   gds-sso (= 3.0.0)
   govspeak (= 1.2.0)
-  govuk_content_models (= 4.20.0)
+  govuk_content_models (= 4.20.1)
   has_scope
   inherited_resources
   jquery-rails


### PR DESCRIPTION
Currently it's not possible for a licence to use an identifier that's ever been used by another edition.  This relaxes that so that these id's are only validated against non-archived editions.

This also makes the same change for business-support editions

The second bump adds an index to Artefact#slug (see alphagov/govuk_content_models#70)
