### PR TITLE
Fix bug in index view of archived publications.

### DIFF
--- a/app/views/admin/root/_publication.html.erb
+++ b/app/views/admin/root/_publication.html.erb
@@ -14,7 +14,7 @@
 
     <% if tab && (tab == :published || tab == :archived) %>
       (Ed.<%= publication.version_number %>)
-      <% if publication.has_sibling_in_progress? %>
+      <% if publication.subsequent_siblings.first.present? %>
         (Ed.<%= publication.subsequent_siblings.first.version_number %> in <%= publication.subsequent_siblings.first.state.humanize.downcase %>)
       <% end%>
     <% else %>

--- a/test/integration/root_overview_test.rb
+++ b/test/integration/root_overview_test.rb
@@ -96,4 +96,18 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
 
     assert page.has_css?('h1', text: "Amends needed")
   end
+
+  test "invalid sibling_in_progress should not break archived view" do
+    stub_request(:get, %r{^http://panopticon\.test\.gov\.uk/artefacts/.*\.js$}).
+      to_return(status: 200, body: "{}", headers: {})
+
+    FactoryGirl.create(:user)
+    FactoryGirl.create(:guide_edition, :title => "XXX", :state => 'archived', :sibling_in_progress => 2)
+
+    visit "/admin"
+    filter_by_user("All")
+    click_on "Archived"
+
+    assert page.has_content?("XXX")
+  end
 end


### PR DESCRIPTION
If an edition has sibling_in_progress set, but didn't actually have a
sibling in progress, this view would blow up.  This fixes that.
