### PR TITLE
Make whenever rake tasks run under govuk_setenv

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,7 +1,7 @@
 # This file is overwritten on deploy
 set :output, {:error => 'log/cron.error.log', :standard => 'log/cron.log'}
-job_type :rake, 'cd :path && /usr/local/bin/govuk_setenv publisher bundle exec rake :task'
-job_type :run_script,  'cd :path && RAILS_ENV=:environment /usr/local/bin/govuk_setenv publisher script/:task'
+job_type :rake, 'cd :path && /usr/local/bin/govuk_setenv publisher bundle exec rake :task :output'
+job_type :run_script,  'cd :path && RAILS_ENV=:environment /usr/local/bin/govuk_setenv publisher script/:task :output'
 
 every 1.day, :at => '5am' do
   rake "local_transactions:fetch"


### PR DESCRIPTION
This will fix the local_transactions import

Also see pull-request on alphagov-deployment#186
