### PR TITLE
Use Redis lock to ensure single local directogv run

### DIFF
--- a/test/unit/local_authority_data_importer_test.rb
+++ b/test/unit/local_authority_data_importer_test.rb
@@ -1,0 +1,64 @@
+require_relative '../test_helper'
+require 'local_authority_data_importer'
+
+class LocalAuthorityDataImporterTest < ActiveSupport::TestCase
+  def mock_redis(lock_succeeds = true)
+    redis = stub()
+    if lock_succeeds
+      redis.stubs(:lock).yields()
+    else
+      redis.stubs(:lock).raises(Redis::Lock::LockNotAcquired)
+    end
+    redis
+  end
+
+  context "update_all" do
+    setup do
+      LocalServiceImporter.stubs(:update)
+      LocalInteractionImporter.stubs(:update)
+      LocalContactImporter.stubs(:update)
+    end
+
+    should "call LocalServiceImporter.update" do
+      LocalServiceImporter.expects(:update)
+      LocalAuthorityDataImporter.update_all
+    end
+
+    should "call LocalInteractionImporter.update" do
+      LocalInteractionImporter.expects(:update)
+      LocalAuthorityDataImporter.update_all
+    end
+
+    should "call LocalContactImporter.update" do
+      LocalContactImporter.expects(:update)
+      LocalAuthorityDataImporter.update_all
+    end
+
+    context "locking" do
+      should "obtain a lock before proceeding" do
+        redis = mock_redis
+        redis.expects(:lock).with("publisher:#{Rails.env}:local_authority_data_importer_lock", :life => (2 * 60 * 60)).yields()
+        LocalAuthorityDataImporter.stubs(:redis).returns(redis)
+
+        LocalServiceImporter.expects(:update)
+
+        LocalAuthorityDataImporter.update_all
+      end
+
+      should "not update anything if it can't obtain the lock" do
+        # Necessary, otherwise the later expects.never calls will never fail
+        LocalServiceImporter.unstub(:update)
+        LocalInteractionImporter.unstub(:update)
+        LocalContactImporter.unstub(:update)
+
+        LocalAuthorityDataImporter.stubs(:redis).returns(mock_redis(false))
+
+        LocalServiceImporter.expects(:update).never
+        LocalInteractionImporter.expects(:update).never
+        LocalContactImporter.expects(:update).never
+
+        LocalAuthorityDataImporter.update_all
+      end
+    end
+  end
+end

--- a/test/unit/tasks/local_transactions_rake_test.rb
+++ b/test/unit/tasks/local_transactions_rake_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../../test_helper'
 require 'rake'
 
 class LocalTransactionsRakeTest < ActiveSupport::TestCase
@@ -11,27 +11,9 @@ class LocalTransactionsRakeTest < ActiveSupport::TestCase
   end
 
   context "local_transactions:fetch" do
-    setup do
-      @task_name = "local_transactions:fetch"
-
-      LocalServiceImporter.stubs(:update)
-      LocalInteractionImporter.stubs(:update)
-      LocalContactImporter.stubs(:update)
-    end
-
-    should "call LocalServiceImporter.update" do
-      LocalServiceImporter.expects(:update)
-      @rake[@task_name].invoke
-    end
-
-    should "call LocalInteractionImporter.update" do
-      LocalInteractionImporter.expects(:update)
-      @rake[@task_name].invoke
-    end
-
-    should "call LocalContactImporter.update" do
-      LocalContactImporter.expects(:update)
-      @rake[@task_name].invoke
+    should "call LocalAuthorityDataImporter.update_all" do
+      LocalAuthorityDataImporter.expects(:update_all)
+      @rake["local_transactions:fetch"].invoke
     end
   end
 


### PR DESCRIPTION
This will mean that the cronjob can be safely enabled on multiple servers.
