### PR TITLE
Relax uniqueness constraint on local directgov id

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", "5.0.0"
+  gem "govuk_content_models", "5.1.0"
 end
 
 gem 'erubis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (5.0.0)
+    govuk_content_models (5.1.0)
       bson_ext
       differ
       gds-api-adapters
@@ -310,7 +310,7 @@ DEPENDENCIES
   gds-api-adapters (= 5.3.0)
   gds-sso (= 3.0.0)
   govspeak (= 1.2.0)
-  govuk_content_models (= 5.0.0)
+  govuk_content_models (= 5.1.0)
   has_scope
   inherited_resources
   jquery-rails


### PR DESCRIPTION
These sometimes swap around upstream, and then cause the importer to fail.  There's no need to enforce this here, as it's already done upstream.
