### PR TITLE
Load Auth details from ENV

### DIFF
--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -1,8 +1,8 @@
 GDS::SSO.config do |config|
   config.user_model   = "User"
-  config.oauth_id     = ENV['PUBLISHER_OAUTH_ID']
-  config.oauth_secret = ENV['PUBLISHER_OAUTH_SECRET']
+  config.oauth_id     = ENV['PUBLISHER_OAUTH_ID'] || "abcdefghjasndjkasndpublisher"
+  config.oauth_secret = ENV['PUBLISHER_OAUTH_SECRET'] || "secret"
   config.oauth_root_url = Plek.current.find("signon")
-  config.basic_auth_user = ENV['PANOPTICON_USER']
-  config.basic_auth_password = ENV['PANOPTICON_PASSWORD']
+  config.basic_auth_user = ENV['PANOPTICON_USER'] || "api"
+  config.basic_auth_password = ENV['PANOPTICON_PASSWORD'] || "defined_on_rollout_not"
 end

--- a/config/initializers/panopticon_api_credentials.rb
+++ b/config/initializers/panopticon_api_credentials.rb
@@ -1,7 +1,7 @@
 # This file gets overwritten on deploy
 PANOPTICON_API_CREDENTIALS = {
   :basic_auth => {
-    :user     => ENV['PANOPTICON_USER'],
-    :password => ENV['PANOPTICON_PASSWORD']
+    :user     => ENV['PANOPTICON_USER'] || "api",
+    :password => ENV['PANOPTICON_PASSWORD'] || "defined_on_rollout_not"
   }
 }


### PR DESCRIPTION
Rather than having junk data for the Auth information, we're loading this data from the ENV. Also having a blank hash for the Panopticon basic auth stuff confused us somewhat, so we're populating this from the ENV too. Got a similar PR for Panopticon coming too. Hang tight! :+1: 
