### PR TITLE
Disable autosave as it's causing issues.

### DIFF
--- a/app/assets/javascripts/publications.js
+++ b/app/assets/javascripts/publications.js
@@ -153,4 +153,5 @@ GOVUK.autoSave = (function() {
     }
   }
 })();
-GOVUK.autoSave.init($('form.edition'));
+// Disable autosave as it's causing issues (https://www.pivotaltracker.com/story/show/54184682)
+//GOVUK.autoSave.init($('form.edition'));

--- a/test/integration/auto_save_edition_test.rb
+++ b/test/integration/auto_save_edition_test.rb
@@ -2,6 +2,9 @@ require 'integration_test_helper'
 
 class AutoSaveEditionTest < JavascriptIntegrationTest
   test "Auto save a guide edition" do
+    skip("Autosave is currently disabled because it was causing issues")
+    # See https://www.pivotaltracker.com/story/show/54184682
+
     setup_users
 
     guide = FactoryGirl.create(:guide_edition, :title => 'How not to lose your work', 

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -259,6 +259,7 @@ class SimpleSmartAnswersTest < JavascriptIntegrationTest
     end
 
     should "not auto save" do
+      skip("Autosave is currently disabled because it was causing issues")
       assert_equal false, page.evaluate_script("GOVUK.autoSave.shouldAutoSaveForm();")
     end
   end


### PR DESCRIPTION
For example it causes duplicate parts to be created if autosave triggers between adding a part, and doing a full save.

Note: this is only being disabled, and not removed because we have another story in the backlog to look at a better approach to this.
