### PR TITLE
Bump therubyracer to 0.11.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'less-rails-bootstrap'
 gem 'unicorn', '4.3.1'
 
 group :assets do
-  gem "therubyracer", "~> 0.9.4"
+  gem "therubyracer", "0.11.4"
   gem 'uglifier'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
       less (~> 2.2.0)
     less-rails-bootstrap (2.0.13)
       less-rails (~> 2.2.0)
-    libv8 (3.3.10.4)
+    libv8 (3.11.8.17)
     link_header (0.0.7)
     lograge (0.2.0)
       actionpack
@@ -232,6 +232,7 @@ GEM
     rdoc (3.12.2)
       json (~> 1.4)
     redis (3.0.3)
+    ref (1.0.5)
     responders (0.9.2)
       railties (~> 3.1)
     rest-client (1.6.7)
@@ -266,8 +267,9 @@ GEM
       tilt (~> 1.1, != 1.3.0)
     state_machine (1.2.0)
     statsd-ruby (1.0.0)
-    therubyracer (0.9.10)
-      libv8 (~> 3.3.10)
+    therubyracer (0.11.4)
+      libv8 (~> 3.11.8.12)
+      ref
     thor (0.18.1)
     tilt (1.4.1)
     timecop (0.4.4)
@@ -340,7 +342,7 @@ DEPENDENCIES
   simplecov (~> 0.6.4)
   simplecov-rcov (~> 0.2.3)
   statsd-ruby (= 1.0.0)
-  therubyracer (~> 0.9.4)
+  therubyracer (= 0.11.4)
   timecop
   turn (= 0.9.6)
   uglifier


### PR DESCRIPTION
This is to get the app working on Precise. The older version of libv8
that 0.9.4 depends on isn't compatible.
