### PR TITLE
Adding the slug to the views in Publisher to distinguish between pages with similar titles

### DIFF
--- a/app/views/admin/root/_amends_needed.html.erb
+++ b/app/views/admin/root/_amends_needed.html.erb
@@ -4,6 +4,7 @@
       <th scope="col"><%= sortable "_type", "Format" %></th>
       <th scope="col"><%= sortable "business_proposition", "Biz?" %></th>
       <th scope="col"><%= sortable "title" %></th>
+      <th scope="col"><%= sortable "slug" %></th>
       <th scope="col"><%= sortable "updated_at", "Updated" %></th>
       <th scope="col"><%= sortable "assignee", "Assigned to" %></th>
       <th scope="col"><%= sortable "creator", "Created by" %></th>

--- a/app/views/admin/root/_archived.html.erb
+++ b/app/views/admin/root/_archived.html.erb
@@ -4,6 +4,7 @@
       <th scope="col"><%= sortable "_type", "Format" %></th>
       <th scope="col"><%= sortable "business_proposition", "Biz?" %></th>
       <th scope="col"><%= sortable "title" %></th>
+      <th scope="col"><%= sortable "slug" %></th>
       <th scope="col"><%= sortable "updated_at", "Updated" %></th>
       <th scope="col"><%= sortable "assignee", "Assigned to" %></th>
       <th scope="col"><%= sortable "creator", "Created by" %></th>

--- a/app/views/admin/root/_drafts.html.erb
+++ b/app/views/admin/root/_drafts.html.erb
@@ -4,6 +4,7 @@
       <th scope="col"><%= sortable "_type", "Format" %></th>
       <th scope="col"><%= sortable "business_proposition", "Biz?" %></th>
       <th scope="col"><%= sortable "title" %></th>
+      <th scope="col"><%= sortable "slug" %></th>
       <th scope="col"><%= sortable "updated_at", "Updated" %></th>
       <th scope="col"><%= sortable "assignee", "Assigned to" %></th>
       <th scope="col"><%= sortable "creator", "Created by" %></th>

--- a/app/views/admin/root/_fact_check_received.html.erb
+++ b/app/views/admin/root/_fact_check_received.html.erb
@@ -4,6 +4,7 @@
       <th scope="col"><%= sortable "_type", "Format" %></th>
       <th scope="col"><%= sortable "business_proposition", "Biz?" %></th>
       <th scope="col"><%= sortable "title" %></th>
+      <th scope="col"><%= sortable "slug" %></th>
       <th scope="col"><%= sortable "updated_at", "Updated" %></th>
       <th scope="col"><%= sortable "assignee", "Assigned to" %></th>
       <th scope="col"><%= sortable "creator", "Created by" %></th>

--- a/app/views/admin/root/_in_review.html.erb
+++ b/app/views/admin/root/_in_review.html.erb
@@ -4,6 +4,7 @@
       <th scope="col"><%= sortable "_type", "Format" %></th>
       <th scope="col"><%= sortable "business_proposition", "Biz?" %></th>
       <th scope="col"><%= sortable "title" %></th>
+      <th scope="col"><%= sortable "slug" %></th>
       <th scope="col"><%= sortable "updated_at", "Updated" %></th>
       <th scope="col"><%= sortable "assignee", "Assigned to" %></th>
       <th scope="col"><%= sortable "creator", "Created by" %></th>

--- a/app/views/admin/root/_lined_up.html.erb
+++ b/app/views/admin/root/_lined_up.html.erb
@@ -4,6 +4,7 @@
       <th scope="col"><%= sortable "_type", "Format" %></th>
       <th scope="col"><%= sortable "business_proposition", "Biz?" %></th>
       <th scope="col"><%= sortable "title" %></th>
+      <th scope="col"><%= sortable "slug" %></th>
       <th scope="col"><%= sortable "updated_at", "Updated" %></th>
       <th scope="col"><%= sortable "assignee", "Assigned to" %></th>
       <th scope="col"><%= sortable "section" %></th>

--- a/app/views/admin/root/_out_for_fact_check.html.erb
+++ b/app/views/admin/root/_out_for_fact_check.html.erb
@@ -4,6 +4,7 @@
       <th scope="col"><%= sortable "format" %></th>
       <th scope="col"><%= sortable "business_proposition", "Biz?" %></th>
       <th scope="col"><%= sortable "title" %></th>
+      <th scope="col"><%= sortable "slug" %></th>
       <th scope="col"><%= sortable "updated_at", "Updated" %></th>
       <th scope="col"><%= sortable "last_fact_checked_at", "Sent Out" %></th>
       <th scope="col"><%= sortable "assignee", "Assigned to" %></th>

--- a/app/views/admin/root/_publication.html.erb
+++ b/app/views/admin/root/_publication.html.erb
@@ -26,6 +26,9 @@
     <% end %>
   </td>
   <td>
+    <%= publication.slug %>
+  </td>
+  <td>
     <%= timestamp(publication.updated_at) %>
   </td>
   <% if tab && tab == :fact_check %>

--- a/app/views/admin/root/_published.html.erb
+++ b/app/views/admin/root/_published.html.erb
@@ -4,6 +4,7 @@
       <th scope="col"><%= sortable "_type", "Format" %></th>
       <th scope="col"><%= sortable "business_proposition", "Biz?" %></th>
       <th scope="col"><%= sortable "title" %></th>
+      <th scope="col"><%= sortable "slug" %></th>
       <th scope="col"><%= sortable "updated_at", "Updated" %></th>
       <th scope="col"><%= sortable "assignee", "Assigned to" %></th>
       <th scope="col"><%= sortable "creator", "Created by" %></th>

--- a/app/views/admin/root/_published_edition.html.erb
+++ b/app/views/admin/root/_published_edition.html.erb
@@ -24,6 +24,9 @@
     </p>
   </td>
   <td>
+    <%= publication.slug %>
+  </td>
+  <td>
     <%= timestamp(publication.updated_at) %>
   </td>
   <td>

--- a/app/views/admin/root/_ready.html.erb
+++ b/app/views/admin/root/_ready.html.erb
@@ -4,6 +4,7 @@
       <th scope="col"><%= sortable "_type", "Format" %></th>
       <th scope="col"><%= sortable "business_proposition", "Biz?" %></th>
       <th scope="col"><%= sortable "title" %></th>
+      <th scope="col"><%= sortable "slug" %></th>
       <th scope="col"><%= sortable "updated_at", "Updated" %></th>
       <th scope="col"><%= sortable "assignee", "Assigned to" %></th>
       <th scope="col"><%= sortable "creator", "Created by" %></th>


### PR DESCRIPTION
There are now multiple pages in Publisher with the same (or similar) titles. This commit adds the slug to the various view pages which should help editors identify the content they want to work with. 
