### PR TITLE
Make transactions use an exact route.

### DIFF
--- a/lib/registerable_edition.rb
+++ b/lib/registerable_edition.rb
@@ -21,7 +21,7 @@ class RegisterableEdition
 
   def paths
     case @edition.class
-    when CampaignEdition, HelpPageEdition
+    when TransactionEdition, CampaignEdition, HelpPageEdition
       ["/#{@edition.slug}", "/#{@edition.slug}.json"]
     else
       ["/#{@edition.slug}.json"]
@@ -30,7 +30,7 @@ class RegisterableEdition
 
   def prefixes
     case @edition.class
-    when CampaignEdition, HelpPageEdition
+    when TransactionEdition, CampaignEdition, HelpPageEdition
       []
     else
       ["/#{@edition.slug}"]

--- a/test/unit/registerable_edition_test.rb
+++ b/test/unit/registerable_edition_test.rb
@@ -70,12 +70,22 @@ class RegisterableEditionTest < ActiveSupport::TestCase
     end
 
     context "for a HelpPageEdition" do
-      should "generate /slug prefix and /slug.json path" do
+      should "generate /slug and /slug.json path" do
         edition = FactoryGirl.build(:help_page_edition, :slug => "help/a-slug")
         registerable = RegisterableEdition.new(edition)
 
         assert_equal [], registerable.prefixes
         assert_equal ["/help/a-slug", "/help/a-slug.json"], registerable.paths
+      end
+    end
+
+    context "for a TransactionEdition" do
+      should "generate /slug and /slug.json path" do
+        edition = FactoryGirl.build(:transaction_edition, :slug => "a-slug")
+        registerable = RegisterableEdition.new(edition)
+
+        assert_equal [], registerable.prefixes
+        assert_equal ["/a-slug", "/a-slug.json"], registerable.paths
       end
     end
 


### PR DESCRIPTION
Currently some transactions (the FCO payment ones) have all subpaths under the slug routed to a separate app.  This requires the prefix route be available for this, so they have to use an exact route for frontend.

Once these transactions have been moved to the fco_services app, this can be reverted.
