### PR TITLE
Update content models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", "6.0.4"
+  gem "govuk_content_models", "6.0.5"
 end
 
 gem 'erubis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (6.0.4)
+    govuk_content_models (6.0.5)
       bson_ext
       differ
       gds-api-adapters
@@ -317,7 +317,7 @@ DEPENDENCIES
   gds-api-adapters (= 5.3.0)
   gds-sso (= 3.0.0)
   govspeak (= 1.2.0)
-  govuk_content_models (= 6.0.4)
+  govuk_content_models (= 6.0.5)
   has_scope
   inherited_resources
   jquery-rails


### PR DESCRIPTION
Version 6.0.5 provides [a fix for inaccurate dirty tracking on mongoid array fields](https://github.com/alphagov/govuk_content_models/pull/109).
