### PR TITLE
Fix deprecation warning in routes.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,5 +25,5 @@ Publisher::Application.routes.draw do
   # We used to nest all URLs under /admin so we now redirect that
   # in case people had bookmarks set up. Using a proc as otherwise the
   # path parameter gets escaped
-  get "/admin(/*path)", to: redirect { |params| "/#{params[:path]}" }
+  get "/admin(/*path)", to: redirect { |params, req| "/#{params[:path]}" }
 end


### PR DESCRIPTION
We were getting the following message:

```
DEPRECATION WARNING: redirect blocks with arity of 1 are deprecated.
Your block must take 2 parameters: the environment, and a request
object. (called from block in <top (required)> at
/var/govuk/publisher/config/routes.rb:28)
```
