### PR TITLE
Handle non-specific HTTP errors in Panopticon

### DIFF
--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -28,6 +28,8 @@ namespace :panopticon do
         else
           logger.error "Encountered 4 timeouts for '#{edition.slug}', skipping"
         end
+      rescue GdsApi::HTTPErrorResponse => e
+        logger.error "Failed to register '#{edition.slug}' with error #{e.code}: #{e.error_details}"
       end
     end
   end


### PR DESCRIPTION
Make sure we handle `422` and other such errors when registering with Panopticon. See alphagov/whitehall#1255 for extra context.

cc @mattbostock 
