### PR TITLE
Update govuk_content_models to 7.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", "6.1.0"
+  gem "govuk_content_models", "7.1.0"
 end
 
 gem 'erubis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (6.1.0)
+    govuk_content_models (7.1.0)
       bson_ext
       differ
       gds-api-adapters
@@ -317,7 +317,7 @@ DEPENDENCIES
   gds-api-adapters (= 5.3.0)
   gds-sso (= 9.2.0)
   govspeak (= 1.2.0)
-  govuk_content_models (= 6.1.0)
+  govuk_content_models (= 7.1.0)
   has_scope
   inherited_resources
   jquery-rails


### PR DESCRIPTION
This gem in this app needs to be kept in lockstep with [govuk_content_api](https://github.com/alphagov/govuk_content_api/blob/2b32d12f2402b82209018633202273f1fa4934a9/Gemfile#L12) and [panopticon](https://github.com/alphagov/panopticon/blob/81a432b8af86612d183808bc7d3e65cb6fe5cc0d/Gemfile#L41) or else the hydration process will break.
