### PR TITLE
Remove spurious action_mailer ses config.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,8 +59,6 @@ Publisher::Application.configure do
   # Generate digests for assets URLs.
   config.assets.digest = true
 
-  config.action_mailer.delivery_method = :ses
-
   # Enable JSON-style logging
   config.logstasher.enabled = true
   config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")


### PR DESCRIPTION
This is overwritten by mailer.rb on deploy, but it's presence here will
only cause confusion.
