### PR TITLE
Publishing as bot requires no user or details

### DIFF
--- a/app/workers/scheduled_publisher.rb
+++ b/app/workers/scheduled_publisher.rb
@@ -12,13 +12,13 @@ class ScheduledPublisher
   # as String or else marshalling converts it to a hash
   def self.cancel_scheduled_publishing(cancel_edition_id)
     Sidekiq::ScheduledSet.new.select do |scheduled_job|
-      scheduled_job.args[1] == cancel_edition_id
+      scheduled_job.args.first == cancel_edition_id
     end.map(&:delete)
   end
 
-  def perform(user_id, edition_id, activity_details)
-    actor, edition = User.find(user_id), Edition.find(edition_id)
-    actor.publish(edition, activity_details)
+  def perform(edition_id)
+    edition = Edition.find(edition_id)
+    edition.publish_anonymously
     update_stats if edition.published?
   end
 

--- a/lib/edition_progressor.rb
+++ b/lib/edition_progressor.rb
@@ -21,7 +21,7 @@ class EditionProgressor
       return false
     elsif actor.progress(edition, activity.dup)
       if activity[:request_type] == 'schedule_for_publishing'
-        ScheduledPublisher.perform_at(edition.publish_at, actor.id.to_s, edition.id.to_s, activity)
+        ScheduledPublisher.perform_at(edition.publish_at, edition.id.to_s)
       end
       collect_edition_status_stats(action)
       self.status_message = success_message(action)

--- a/lib/enhancements/edition.rb
+++ b/lib/enhancements/edition.rb
@@ -28,6 +28,16 @@ class Edition
     all_of(for_user(user).selector, internal_search(term).selector)
   }
 
+  def publish_anonymously
+    if can_publish? && publish
+      action_details = published_edition ? { diff: edition_changes } : {}
+      actions.create!(action_details.merge(request_type: Action::PUBLISH))
+      save! # trigger denormalisation callbacks
+    else
+      false
+    end
+  end
+
   alias_method :was_published_without_indexing, :was_published
   def was_published
     was_published_without_indexing

--- a/test/unit/edition_progressor_test.rb
+++ b/test/unit/edition_progressor_test.rb
@@ -90,7 +90,7 @@ class EditionProgressorTest < ActiveSupport::TestCase
       Sidekiq::Testing.disable! do
         publish_at = 1.day.from_now
         @guide.update_attributes(state: :scheduled_for_publishing, publish_at: publish_at)
-        ScheduledPublisher.perform_at(publish_at, @laura.id.to_s, @guide.id.to_s, {})
+        ScheduledPublisher.perform_at(publish_at, @guide.id.to_s)
 
         activity = { request_type: "cancel_scheduled_publishing", comment: "stop!" }
         command = EditionProgressor.new(@guide, @laura, @statsd)

--- a/test/unit/scheduled_publisher_test.rb
+++ b/test/unit/scheduled_publisher_test.rb
@@ -14,7 +14,7 @@ class ScheduledPublisherTest < ActiveSupport::TestCase
       user = FactoryGirl.create(:user)
       edition = FactoryGirl.create(:edition, :scheduled_for_publishing)
 
-      ScheduledPublisher.perform_at(edition.publish_at, user.id, edition.id, comment: "schedule!")
+      ScheduledPublisher.perform_at(edition.publish_at, edition.id)
 
       assert_equal 1, ScheduledPublisher.jobs.size
       assert_equal edition.publish_at.to_i, ScheduledPublisher.jobs.first['at']
@@ -24,25 +24,19 @@ class ScheduledPublisherTest < ActiveSupport::TestCase
   context ".perform" do
     setup do
       stub_register_published_content
-      @user = FactoryGirl.create(:user)
-      @edition = FactoryGirl.create(:edition, :scheduled_for_publishing)
+      @edition = FactoryGirl.create(:edition, :scheduled_for_publishing, body: "some text")
     end
 
     should "publish the edition" do
-      ScheduledPublisher.new.perform(@user.id, @edition.id, comment: "schedule!")
+      ScheduledPublisher.new.perform(@edition.id)
       assert @edition.reload.published?
-    end
-
-    should "pass on the activity details" do
-      ScheduledPublisher.new.perform(@user.id, @edition.id, comment: "schedule!")
-      assert_equal "schedule!", @edition.reload.actions.last[:comment]
     end
 
     should "update statsd counters" do
       Statsd.any_instance.expects(:decrement).with("publisher.edition.scheduled_for_publishing")
       Statsd.any_instance.expects(:increment).with("publisher.edition.published")
 
-      ScheduledPublisher.new.perform(@user.id, @edition.id, comment: "schedule!")
+      ScheduledPublisher.new.perform(@edition.id)
     end
   end
 end


### PR DESCRIPTION
The final publish action for a scheduled publishing
happens in the background, so it is better to record
that action as done by GDSBot instead of the user.
Which also removes the need to carry forward the
activity details from scheduled publishing to publishing.

/cc @alext
