### PR TITLE
Defaulting to tomorrow to guard against accidents

### DIFF
--- a/app/views/shared/_activity_form.html.erb
+++ b/app/views/shared/_activity_form.html.erb
@@ -25,7 +25,7 @@
         <%= f.label :publish_at do %>
           Publish at <abbr title="required">*</abbr>
         <% end %>
-        <%= f.datetime_select :publish_at, { start_year: Date.today.year, end_year: Date.today.year.next }, { class: 'date' } %>
+        <%= f.datetime_select :publish_at, { default: Date.tomorrow, start_year: Date.today.year, end_year: Date.today.year.next }, { class: 'date' } %>
       <% end %>
     <% end %>
   </div>


### PR DESCRIPTION
an editor might publish too early if they select
a time very close in the future. defaulting to
tomorrow ensures that they get sufficient time
to correct that error.
