### PR TITLE
Fix sidekiq config.

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,6 +1,6 @@
 require "sidekiq"
 
-redis_config = YAML.load_file(Rails.root.join("config", "redis.yml"))
+redis_config = YAML.load_file(Rails.root.join("config", "redis.yml")).symbolize_keys
 
 Sidekiq.configure_server do |config|
   config.redis = redis_config


### PR DESCRIPTION
Sidekiq expects symbol keys, whereas the Redis client itself will handle
either.  This was causing sidekiq to run without a namespace.
