### PR TITLE
Revert "Add Errbit notification to scheduled publishing worker"

### DIFF
--- a/app/workers/scheduled_publisher.rb
+++ b/app/workers/scheduled_publisher.rb
@@ -20,9 +20,6 @@ class ScheduledPublisher
     edition = Edition.find(edition_id)
     edition.publish_anonymously
     update_stats if edition.published?
-  rescue Exception => e
-    Airbrake.notify_or_ignore(e, :parameters => {:edition_id => edition_id})
-    raise
   end
 
   private

--- a/test/unit/scheduled_publisher_test.rb
+++ b/test/unit/scheduled_publisher_test.rb
@@ -38,17 +38,5 @@ class ScheduledPublisherTest < ActiveSupport::TestCase
 
       ScheduledPublisher.new.perform(@edition.id.to_s)
     end
-
-    should "notify errbit and re-raise any exceptions" do
-      err = StandardError.new("Boom!")
-      AnswerEdition.any_instance.stubs(:publish_anonymously).raises(err)
-
-      Airbrake.expects(:notify_or_ignore).with(err, :parameters => {:edition_id => @edition.id.to_s})
-
-      assert_raise err.class, err.to_s do
-        ScheduledPublisher.new.perform(@edition.id.to_s)
-      end
-
-    end
   end
 end


### PR DESCRIPTION
The automatic exception handling in errbit is working.  This explicit
notification causes duplicates in Errbit.

This reverts commit ed241050caa36ebd5176a5cdbb5a3fa5c3bd4db4.
