### PR TITLE
Show all errors on link validation.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", "12.1.0"
+  gem "govuk_content_models", "12.3.0"
 end
 
 gem 'erubis'
@@ -25,7 +25,7 @@ gem "nested_form", git: 'https://github.com/alphagov/nested_form.git', branch: '
 if ENV['GOVSPEAK_DEV']
   gem 'govspeak', path: '../govspeak'
 else
-  gem 'govspeak', '1.2.0'
+  gem 'govspeak', '1.6.0'
 end
 
 gem 'has_scope'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,11 +104,12 @@ GEM
       rack-accept (~> 0.4.4)
       rails (>= 3.0.0)
       warden (~> 1.2)
-    govspeak (1.2.0)
+    govspeak (1.6.0)
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
-      sanitize (= 2.0.3)
-    govuk_content_models (12.1.0)
+      nokogiri (~> 1.5.10)
+      sanitize (~> 2.0.3)
+    govuk_content_models (12.3.0)
       bson_ext
       differ
       gds-api-adapters (>= 10.9.0)
@@ -120,7 +121,7 @@ GEM
     has_scope (0.5.1)
     hashie (2.0.5)
     hike (1.2.3)
-    htmlentities (4.3.1)
+    htmlentities (4.3.2)
     httpauth (0.2.0)
     i18n (0.6.9)
     inherited_resources (1.3.1)
@@ -178,7 +179,7 @@ GEM
       railties (>= 3.2.0)
     multi_json (1.10.0)
     multipart-post (1.2.0)
-    nokogiri (1.5.10)
+    nokogiri (1.5.11)
     null_logger (0.0.1)
     oauth2 (0.8.1)
       faraday (~> 0.8)
@@ -240,8 +241,8 @@ GEM
     retriable (1.3.2)
     reverse_markdown (0.3.0)
       nokogiri
-    sanitize (2.0.3)
-      nokogiri (>= 1.4.4, < 1.6)
+    sanitize (2.0.6)
+      nokogiri (>= 1.4.4)
     shoulda (3.1.1)
       shoulda-context (~> 1.0)
       shoulda-matchers (~> 1.2)
@@ -318,8 +319,8 @@ DEPENDENCIES
   formtastic-bootstrap!
   gds-api-adapters (= 10.11.0)
   gds-sso (= 9.2.0)
-  govspeak (= 1.2.0)
-  govuk_content_models (= 12.1.0)
+  govspeak (= 1.6.0)
+  govuk_content_models (= 12.3.0)
   has_scope
   inherited_resources
   jquery-rails (= 3.0.4)

--- a/config/initializers/formtastic.rb
+++ b/config/initializers/formtastic.rb
@@ -39,13 +39,13 @@
 
 # Set the way inline errors will be displayed.
 # Defaults to :sentence, valid options are :sentence, :list, :first and :none
-# Formtastic::SemanticFormBuilder.inline_errors = :sentence
+Formtastic::FormBuilder.inline_errors = :list
 # Formtastic uses the following classes as default for hints, inline_errors and error list
 
 # If you override the class here, please ensure to override it in your formtastic_changes.css stylesheet as well
 # Formtastic::SemanticFormBuilder.default_hint_class = "inline-hints"
 # Formtastic::SemanticFormBuilder.default_inline_error_class = "inline-errors"
-# Formtastic::SemanticFormBuilder.default_error_list_class = "errors"
+Formtastic::FormBuilder.default_error_list_class = "help-block"
 
 # Set the method to call on label text to transform or format it for human-friendly
 # reading when formtastic is used without object. Defaults to :humanize.


### PR DESCRIPTION
Switch to latest version of govuk_content_models which includes this fix, and set Formtastic to use list format for inline errors to make the error text readable.
