### PR TITLE
Defensively add HTTP for local authority contact URLs

### DIFF
--- a/lib/local_contact_importer.rb
+++ b/lib/local_contact_importer.rb
@@ -17,7 +17,11 @@ class LocalContactImporter < LocalAuthorityDataImporter
     authority.name = decode_broken_entities( row['Name'] )
     authority.contact_address = parse_address(row)
     authority.contact_phone = decode_broken_entities( row['Telephone Number 1'] )
-    authority.contact_url = row['Contact page URL']
+    url = row['Contact page URL']
+    unless url.start_with?("http://") || url.start_with?("https://")
+      url = "http://" + url
+    end
+    authority.contact_url = url
     authority.contact_email = row['Main Contact Email']
     authority.save!
   end

--- a/test/unit/local_contact_importer_test.rb
+++ b/test/unit/local_contact_importer_test.rb
@@ -117,5 +117,21 @@ Stockport Metropolitan Borough Council,http://www.stockport.gov.uk/,http://www.s
       auth.reload
       assert_equal nil, auth.contact_phone
     end
+
+    should "add http:// to URLs without it" do
+      source=StringIO.new(<<-END)
+Name,Home page URL,Contact page URL,SNAC Code,Address Line 1,Address Line 2,Town,City,County,Postcode,Telephone Number 1 Description,Telephone Number 1,Telephone Number 2 Description,Telephone Number 2,Telephone Number 3 Description,Telephone Number 3,Fax,Main Contact Email,Opening Hours
+South Somerset District Council,www.southsomerset.gov.uk,www.southsomerset.gov.uk,40UD,Council Offices,Brympton Way,Yeovil,,Somerset,BA20 2HT,,01935 462 462,,,,,,,
+      END
+
+      auth = FactoryGirl.create(:local_authority, :snac => "40UD")
+      # Call process_row directly to bypass the top-level error rescue
+      importer = LocalContactImporter.new(nil)
+      csv = CSV.new(source, :headers => true)
+      importer.send(:process_row, csv.shift)
+
+      auth.reload
+      assert_equal "http://www.southsomerset.gov.uk", auth.contact_url
+    end
   end
 end


### PR DESCRIPTION
Councils have submitted contact URLs without a protocol, which breaks the contact link on gov.uk
https://www.pivotaltracker.com/story/show/73065224
https://govuk.zendesk.com/agent/#/tickets/718999

One of the examples is South Somerset: its current live data has been used for the test for this change. 
