### PR TITLE
Use latest govuk_content_models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", "12.3.0"
+  gem "govuk_content_models", "12.4.0"
 end
 
 gem 'erubis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
       bootstrap-sass (= 3.1.0)
       jquery-rails (= 3.0.4)
       rails (>= 3.2.0)
-    govuk_content_models (12.3.0)
+    govuk_content_models (12.4.0)
       bson_ext
       differ
       gds-api-adapters (>= 10.9.0)
@@ -315,7 +315,7 @@ DEPENDENCIES
   gds-sso (= 9.2.0)
   govspeak (= 1.6.0)
   govuk_admin_template (= 1.0.0)
-  govuk_content_models (= 12.3.0)
+  govuk_content_models (= 12.4.0)
   has_scope
   inherited_resources
   kaminari (= 0.13.0)


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/4288

release 12.4.0, which performs link validations
only on edition updates, so that drafts can be
created from published editions with link
validation errors.
