### PR TITLE
Skip validations while duplicating editions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", "13.1.0"
+  gem "govuk_content_models", "13.2.1"
 end
 
 gem 'erubis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
       bootstrap-sass (= 3.1.0)
       jquery-rails (= 3.0.4)
       rails (>= 3.2.0)
-    govuk_content_models (13.1.0)
+    govuk_content_models (13.2.1)
       bson_ext
       differ
       gds-api-adapters (>= 10.9.0)
@@ -321,7 +321,7 @@ DEPENDENCIES
   gds-sso (= 9.2.0)
   govspeak (= 1.6.0)
   govuk_admin_template (= 1.0.1)
-  govuk_content_models (= 13.1.0)
+  govuk_content_models (= 13.2.1)
   has_scope
   inherited_resources
   jasmine (= 2.0.2)

--- a/lib/edition_duplicator.rb
+++ b/lib/edition_duplicator.rb
@@ -14,7 +14,7 @@ class EditionDuplicator
   def duplicate(new_format = nil, assign_to = nil)
     self.new_edition = actor.new_version(existing_edition, new_format)
 
-    if new_edition && new_edition.save
+    if new_edition && new_edition.save(validate: false)
       update_assignment(assign_to)
       true
     else

--- a/test/unit/edition_duplicator_test.rb
+++ b/test/unit/edition_duplicator_test.rb
@@ -27,6 +27,18 @@ class EditionDuplicatorTest < ActiveSupport::TestCase
     assert_equal @fred, command.new_edition.assigned_to
   end
 
+  test "should be possible to create a new draft of an invalid edition" do
+    guide = FactoryGirl.create(:guide_edition_with_two_parts, panopticon_id: FactoryGirl.create(:artefact).id)
+    publish_item(guide, @laura)
+
+    # invalid link in body having a {:rel="external"}
+    guide.parts.first.update_attribute(:body, %q<[Home page](http://example.com "Home"){:rel="external"}>)
+    guide.reload
+
+    command = EditionDuplicator.new(guide, @laura)
+    assert command.duplicate(nil, @fred)
+  end
+
   test "should not assign after creating a new edition if assignment is blank" do
     publish_item(@guide, @laura)
 


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/4296

we have added a new validation for checking invalid links in editions. currently, editors are unable to create drafts from published editions having invalid links because this validation fails.

this proposed change will skip validations while duplicating editions. if there are existing published editions which are deemed invalid because of new validation rules, then editors should be able to create a new edition and rectify those validation errors.

govuk_content_models was updated to remove unnecessary edition save calls which caused validations to happen multiple times when an edition was duplicated, which was needed to support this change:

https://github.com/alphagov/govuk_content_models/pull/187
https://github.com/alphagov/govuk_content_models/pull/186
