### PR TITLE
Migrate locations to Mapit areas.

### DIFF
--- a/db/migrate/20140703161500_migrate_bsf_locations_to_areas.rb
+++ b/db/migrate/20140703161500_migrate_bsf_locations_to_areas.rb
@@ -1,0 +1,11 @@
+class MigrateBsfLocationsToAreas < Mongoid::Migration
+  def self.up
+    BusinessSupportLocationMigrator.run
+  end
+
+  def self.down
+    BusinessSupportEdition.excludes(state: 'archived').each do |bs|
+      bs.update_attribute(:areas, [])
+    end
+  end
+end


### PR DESCRIPTION
Makes [this work](https://github.com/alphagov/publisher/pull/204) a simple migration rake task. 
Finds the regional Mapit area identifiers for business support locations
and populates the areas array with them.
