### PR TITLE
Addition of LGSL 1748/8 for local transaction

### DIFF
--- a/data/local_services.csv
+++ b/data/local_services.csv
@@ -263,3 +263,4 @@ LGSL,Description,Providing Tier
 1579,Find out about family information services,county/unitary
 1580,Find out how to hold a street party,all
 1584,Find out when you can check the accounts at your council,all
+1748,Find out about free early education,county/unitary


### PR DESCRIPTION
This is an addition of LGSL 1748/8 for supporting the local transaction of Find out about free early education.
