### PR TITLE
Clarify separation of bearer tokens in initializer.

### DIFF
--- a/config/initializers/gds_api.rb
+++ b/config/initializers/gds_api.rb
@@ -9,9 +9,10 @@ GdsApi::Base.logger = Logger.new(Rails.root.join("log/#{Rails.env}.api_client.lo
 # This can be loaded from an environment variable, or this file can
 # be overwritten with the correct details on deploy.
 # See README.md for details of how to generate a bearer token.
-options = {
-  bearer_token: ENV['PUBLISHER_API_CLIENT_BEARER_TOKEN'] || 'set_at_deploy_time'
+PANOPTICON_API_CREDENTIALS = {
+  bearer_token: ENV['PUBLISHER_PANOPTICON_CLIENT_BEARER_TOKEN'] || 'set_at_deploy_time'
 }
 
-Attachable.asset_api_client = GdsApi::AssetManager.new(Plek.current.find('asset-manager'), options)
-PANOPTICON_API_CREDENTIALS = options
+Attachable.asset_api_client = GdsApi::AssetManager.new(Plek.current.find('asset-manager'), {
+  bearer_token: ENV['PUBLISHER_ASSET_MANAGER_CLIENT_BEARER_TOKEN'] || 'also_set_at_deploy_time',
+})


### PR DESCRIPTION
This file is overwritten on deploy, so this change won't affect
production etc, but it's good to make it clear that the panopticon and
asset-manager clients use different tokens.
