### PR TITLE
Use a custom address for fact check help

### DIFF
--- a/app/views/noisy_workflow/request_fact_check.text.erb
+++ b/app/views/noisy_workflow/request_fact_check.text.erb
@@ -5,7 +5,7 @@ The following piece of mainstream GOV.UK content needs to be fact checked becaus
 Title: <%= @edition.title %>
 <%= "#{Plek.current.find("private-frontend")}/#{@edition.slug}?edition=#{@edition.version_number}" %>
 
-You'll need your GOV.UK user name and password to view the content. Email govuk-feedback@digital.cabinet-office.gov.uk if you've forgotten your username and password.
+You'll need your GOV.UK user name and password to view the content. Email factcheck-help@digital.cabinet-office.gov.uk if you've forgotten your username and password.
 
 Please reply to this email and either:
 
@@ -22,7 +22,7 @@ You must make sure:
 
 Please reply within 5 working days. Let us know as soon as possible if you're not able to meet this deadline.
 
-Please don't reply to this email to ask questions or include the address in any email conversations. Email liz.lutgendorff@digital.cabinet-office.gov.uk, gwen.cheeseman@digital.cabinet-office.gov.uk, jon.sanger@digital.cabinet-office.gov.uk or your transition manager if you have any questions.
+Please don't reply to this email to ask questions or include the address in any email conversations. Email factcheck-help@digital.cabinet-office.gov.uk if you have any questions.
 
 Many thanks,
 


### PR DESCRIPTION
This supersedes #237.

We have an address for people to request help with fact check, so their requests don’t get mixed in with general feedback.
