### PR TITLE
Fix healthcheck endpoint with no 'Accept:' header.

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -2,13 +2,11 @@ class HealthcheckController < ActionController::Base
   # Not inheriting from ApplicationController here so we don't need OAuth
   # authentication to access the health check
 
-  respond_to :json
-
   def check
     health_status = {"checks" => {}}
     health_status["checks"]["schedule_queue"] = schedule_queue_result
     health_status["status"] = health_status["checks"]["schedule_queue"]["status"]
-    respond_with health_status
+    render :json => health_status
   end
 
 private

--- a/test/functional/healthcheck_controller_test.rb
+++ b/test/functional/healthcheck_controller_test.rb
@@ -13,17 +13,17 @@ class HealthcheckControllerTest < ActionController::TestCase
     end
 
     should "return a 200 response" do
-      get :check, format: :json
+      get :check
       assert_response :success
     end
 
     should "return an overall status field" do
-      get :check, format: :json
+      get :check
       assert_includes json, "status"
     end
 
     should "have a field for the checks" do
-      get :check, format: :json
+      get :check
       assert_includes json, "checks"
       assert json["checks"].is_a? Hash
     end
@@ -36,13 +36,13 @@ class HealthcheckControllerTest < ActionController::TestCase
     end
 
     should "report the check is ok" do
-      get :check, format: :json
+      get :check
       assert_includes json["checks"], "schedule_queue"
       assert_equal "ok", json["checks"]["schedule_queue"]["status"]
     end
 
     should "report the overall status as ok" do
-      get :check, format: :json
+      get :check
       assert_equal "ok", json["status"]
     end
   end
@@ -54,13 +54,13 @@ class HealthcheckControllerTest < ActionController::TestCase
     end
 
     should "report the check as a warning" do
-      get :check, format: :json
+      get :check
       assert_includes json["checks"], "schedule_queue"
       assert_equal "warning", json["checks"]["schedule_queue"]["status"]
     end
 
     should "include a status message" do
-      get :check, format: :json
+      get :check
       assert_includes json["checks"], "schedule_queue"
       assert_equal(
         "5 scheduled edition(s); 3 item(s) queued",
@@ -69,7 +69,7 @@ class HealthcheckControllerTest < ActionController::TestCase
     end
 
     should "report the overall status as a warning" do
-      get :check, format: :json
+      get :check
       assert_equal "warning", json["status"]
     end
   end
@@ -81,7 +81,7 @@ class HealthcheckControllerTest < ActionController::TestCase
     end
 
     should "report a critical error" do
-      get :check, format: :json
+      get :check
 
       assert_equal "critical", json["checks"]["schedule_queue"]["status"]
     end
@@ -98,7 +98,7 @@ class HealthcheckControllerTest < ActionController::TestCase
     end
 
     should "report a critical error" do
-      get :check, format: :json
+      get :check
 
       assert_equal "critical", json["checks"]["schedule_queue"]["status"]
     end
@@ -111,7 +111,7 @@ class HealthcheckControllerTest < ActionController::TestCase
     end
 
     should "report a critical error" do
-      get :check, format: :json
+      get :check
 
       assert_equal "critical", json["checks"]["schedule_queue"]["status"]
     end

--- a/test/integration/healthcheck_test.rb
+++ b/test/integration/healthcheck_test.rb
@@ -2,7 +2,7 @@ require 'integration_test_helper'
 
 class HealthcheckTest < ActionDispatch::IntegrationTest
   test "returns health check status" do
-    get "/healthcheck", format: :json
+    get "/healthcheck"
     assert_response :success
     assert JSON.parse(response.body)
   end


### PR DESCRIPTION
The Nagios check hits this endpoint, and expects a 200 response to
consider the application up.  This was previously returning a 406
because the nagios request didn't include an 'Accept:' header.

Change this to always return json regardless, which makes it more robust
to this sort of issue.
