### PR TITLE
Always include detail message in health check

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -17,14 +17,12 @@ private
     scheduled_editions = Edition.scheduled_for_publishing.count
     queue_size = Sidekiq::Stats.new.scheduled_size
 
-    if scheduled_editions == queue_size
-      {"status" => "ok"}
-    else
-      {
-        "status" => "warning",
-        "message" => "#{scheduled_editions} scheduled edition(s); #{queue_size} item(s) queued"
-      }
-    end
+    status = (scheduled_editions == queue_size) ? "ok" : "warning"
+
+    {
+      "status" => status,
+      "message" => "#{scheduled_editions} scheduled edition(s); #{queue_size} item(s) queued"
+    }
   rescue Mongo::MongoRubyError, Mongo::MongoDBError, Redis::CannotConnectError
     {
       "status" => "critical",

--- a/test/functional/healthcheck_controller_test.rb
+++ b/test/functional/healthcheck_controller_test.rb
@@ -45,6 +45,15 @@ class HealthcheckControllerTest < ActionController::TestCase
       get :check, format: :json
       assert_equal "ok", json["status"]
     end
+
+    should "include a status message" do
+      get :check, format: :json
+      assert_includes json["checks"], "schedule_queue"
+      assert_equal(
+        "0 scheduled edition(s); 0 item(s) queued",
+        json["checks"]["schedule_queue"]["message"]
+      )
+    end
   end
 
   context "scheduled count does not match queue length" do


### PR DESCRIPTION
There's no harm including this, it's handy to be able to see how many publications are queued, and it simplifies the code.
