### PR TITLE
Migration for updating become-a-driving-instructor owning app and slug

### DIFF
--- a/db/migrate/20140730074552_change_owning_app_and_slug_for_driving_instructor.rb
+++ b/db/migrate/20140730074552_change_owning_app_and_slug_for_driving_instructor.rb
@@ -21,11 +21,11 @@ class ChangeOwningAppAndSlugForDrivingInstructor < Mongoid::Migration
       end
 
       # re-register with panopticon to recreate in search
-      puts "Re-registering with panopticon to recreate in search"
+      puts "Re-registering #{SA_SLUG} with panopticon to recreate in search"
       ed = Edition.published.where(:slug => SA_SLUG).first
       ed.register_with_panopticon
     else
-      puts "Can't find artefact"
+      puts "Can't find artefact for slug '#{SA_SLUG}"
     end
   end
 
@@ -48,11 +48,11 @@ class ChangeOwningAppAndSlugForDrivingInstructor < Mongoid::Migration
       end
 
       # re-register with panopticon to recreate in search
-      puts "Re-registering with panopticon to recreate in search"
+      puts "Re-registering #{SSA_SLUG} with panopticon to recreate in search"
       ed = Edition.published.where(:slug => SSA_SLUG).first
       ed.register_with_panopticon
     else
-      puts "Can't find artefact"
+      puts "Can't find artefact with slug #{SA_SLUG}"
     end
   end
 end


### PR DESCRIPTION
become-a-driving-instructor is currently a smart-answer. It is being replaced with a simple smart-answer. This migration changes the owning app, kind and rendering app before changing the slug.

There are some other things that need to happen before this is deployed.

The new simple-smart-answer needs to be published.
The existing slug needs to be deleted in search.
The smart-answer needs to be deleted (https://github.com/alphagov/smart-answers/pull/1042)
