### PR TITLE
Restrict allowed image hosts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", "17.1.0"
+  gem 'govuk_content_models', '19.0.0'
 end
 
 gem 'erubis'
@@ -25,7 +25,7 @@ gem "nested_form", git: 'https://github.com/alphagov/nested_form.git', branch: '
 if ENV['GOVSPEAK_DEV']
   gem 'govspeak', path: '../govspeak'
 else
-  gem 'govspeak', '~> 2.0'
+  gem 'govspeak', '3.1.0'
 end
 
 gem 'has_scope'
@@ -46,7 +46,7 @@ gem 'redis', '3.0.7', require: false # Only used in some importers
 gem 'mlanett-redis-lock', '0.2.2' # Only used in some importers
 gem 'rest-client', require: false # Only used in some importers
 gem 'retriable', require: false # Only used in some importers
-gem 'reverse_markdown', require: false # Only used in some importers
+gem 'reverse_markdown', '0.3.0', require: false # Only used in some importers
 
 gem 'statsd-ruby', '~> 1.1.0', require: false
 gem 'whenever', require: false
@@ -63,29 +63,29 @@ gem 'sinatra', '>= 1.3.0', :require => nil
 group :assets do
   gem "therubyracer", "0.11.4"
   gem 'sass-rails', '3.2.6'
-  gem 'uglifier'
+  gem 'uglifier', '1.2.7'
 end
 
 group :test do
   gem 'turn', '0.9.6'
   gem 'minitest', '3.3.0'
-  gem 'shoulda'
-  gem 'database_cleaner'
+  gem 'shoulda', '3.1.1'
+  gem 'database_cleaner', '0.8.0'
 
   gem 'capybara', '2.2.1'
   gem 'poltergeist', '1.5.0'
-  gem 'launchy'
+  gem 'launchy', '2.1.1'
 
-  gem 'webmock'
+  gem 'webmock', '1.8.7'
   gem 'mocha', '0.13.3', :require => false
   gem 'factory_girl_rails'
   gem 'faker', '1.1.2'
 
-  gem "timecop"
+  gem "timecop", '0.4.4'
 
   gem 'simplecov', '~> 0.6.4', :require => false
   gem 'simplecov-rcov', '~> 0.2.3', :require => false
-  gem 'ci_reporter'
+  gem 'ci_reporter', '1.7.0'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
       rails (>= 3.0.0)
       warden (~> 1.2)
       warden-oauth2 (~> 0.0.1)
-    govspeak (2.0.2)
+    govspeak (3.1.0)
       htmlentities (~> 4)
       kramdown (~> 1.4.1)
       nokogiri (~> 1.5.10)
@@ -107,12 +107,12 @@ GEM
       bootstrap-sass (= 3.1.0)
       jquery-rails (= 3.0.4)
       rails (>= 3.2.0)
-    govuk_content_models (17.1.0)
+    govuk_content_models (19.0.0)
       bson_ext
       differ
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 7.0.0, < 10.0.0)
-      govspeak (~> 2.0.0)
+      govspeak (~> 3.1.0)
       mongoid (~> 2.5)
       plek
       state_machine
@@ -324,8 +324,8 @@ DEPENDENCIES
   airbrake (= 3.1.15)
   bootstrap-kaminari-views (= 0.0.3)
   capybara (= 2.2.1)
-  ci_reporter
-  database_cleaner
+  ci_reporter (= 1.7.0)
+  database_cleaner (= 0.8.0)
   erubis
   factory_girl_rails
   faker (= 1.1.2)
@@ -333,14 +333,14 @@ DEPENDENCIES
   formtastic-bootstrap (= 3.0.0)
   gds-api-adapters (= 11.1.0)
   gds-sso (= 9.3.0)
-  govspeak (~> 2.0)
+  govspeak (= 3.1.0)
   govuk_admin_template (= 1.0.1)
-  govuk_content_models (= 17.1.0)
+  govuk_content_models (= 19.0.0)
   has_scope
   inherited_resources
   jasmine (= 2.0.2)
   kaminari (= 0.13.0)
-  launchy
+  launchy (= 2.1.1)
   logstasher (= 0.4.8)
   minitest (= 3.3.0)
   mlanett-redis-lock (= 0.2.2)
@@ -355,9 +355,9 @@ DEPENDENCIES
   redis (= 3.0.7)
   rest-client
   retriable
-  reverse_markdown
+  reverse_markdown (= 0.3.0)
   sass-rails (= 3.2.6)
-  shoulda
+  shoulda (= 3.1.1)
   sidekiq (= 2.17.2)
   sidekiq-statsd (= 0.1.2)
   simplecov (~> 0.6.4)
@@ -365,9 +365,9 @@ DEPENDENCIES
   sinatra (>= 1.3.0)
   statsd-ruby (~> 1.1.0)
   therubyracer (= 0.11.4)
-  timecop
+  timecop (= 0.4.4)
   turn (= 0.9.6)
-  uglifier
+  uglifier (= 1.2.7)
   unicorn (= 4.3.1)
-  webmock
+  webmock (= 1.8.7)
   whenever


### PR DESCRIPTION
This prevents images not hosted by us from being included in content on GOV.UK
by content editors or an attacker who has gained control of an editor's
account. Such images could be altered to something malicious (or a trollface)
at the whim of the website owner or an attacker who gains control of that
domain.

This is provided by version 19.0.0 of govuk_content_models.
