### PR TITLE
Beta badge on published editions view

### DIFF
--- a/app/views/root/_published_edition.html.erb
+++ b/app/views/root/_published_edition.html.erb
@@ -18,6 +18,10 @@
       <% if publication.has_video? %>
         <i class="glyphicon glyphicon-film" alt="Has video"></i>
       <% end %>
+
+      <% if publication.in_beta? %>
+        <span class="badge badge-beta">beta</span>
+      <% end %>
     </p>
   </td>
   <td>

--- a/app/views/shared/_title_etc.html.erb
+++ b/app/views/shared/_title_etc.html.erb
@@ -15,6 +15,7 @@
         label: 'Content is in beta',
         hint: raw("A beta label will show beneath the title with a link to " +
           link_to('beta services on GOV.UK', 'https://www.gov.uk/help/beta', class: 'link-inherit')),
+        input_html: { disabled: @resource.locked_for_edits? },
         wrapper_html: { class: "form-group add-bottom-margin" } %>
 
   <%= f.input :alternative_title,


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5418

also, beta label checkbox should be disabled when edition is in scheduled or published state.

this feedback came up during product review.
