### PR TITLE
Use section on artefact, edition section's deleted

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem 'govuk_content_models', '19.0.0'
+  gem "govuk_content_models", "20.0.0"
 end
 
 gem 'erubis'
@@ -25,7 +25,7 @@ gem "nested_form", git: 'https://github.com/alphagov/nested_form.git', branch: '
 if ENV['GOVSPEAK_DEV']
   gem 'govspeak', path: '../govspeak'
 else
-  gem 'govspeak', '3.1.0'
+  gem 'govspeak', '~> 3.1.0'
 end
 
 gem 'has_scope'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
       rails (>= 3.0.0)
       warden (~> 1.2)
       warden-oauth2 (~> 0.0.1)
-    govspeak (3.1.0)
+    govspeak (3.1.1)
       htmlentities (~> 4)
       kramdown (~> 1.4.1)
       nokogiri (~> 1.5.10)
@@ -107,7 +107,7 @@ GEM
       bootstrap-sass (= 3.1.0)
       jquery-rails (= 3.0.4)
       rails (>= 3.2.0)
-    govuk_content_models (19.0.0)
+    govuk_content_models (20.0.0)
       bson_ext
       differ
       gds-api-adapters (>= 10.9.0)
@@ -333,9 +333,9 @@ DEPENDENCIES
   formtastic-bootstrap (= 3.0.0)
   gds-api-adapters (= 11.1.0)
   gds-sso (= 9.3.0)
-  govspeak (= 3.1.0)
+  govspeak (~> 3.1.0)
   govuk_admin_template (= 1.0.1)
-  govuk_content_models (= 19.0.0)
+  govuk_content_models (= 20.0.0)
   has_scope
   inherited_resources
   jasmine (= 2.0.2)

--- a/app/views/licences/new.html.erb
+++ b/app/views/licences/new.html.erb
@@ -19,7 +19,6 @@
     <%= f.input :panopticon_id, :as => :hidden %>
     <%= f.input :title, :as => :hidden %>
     <%= f.input :slug, :as => :hidden %>
-    <%= f.input :section, :as => :hidden %>
     <%= f.input :department, :as => :hidden %>
   <% end %>
   <%= f.actions do %>

--- a/app/views/local_transactions/new.html.erb
+++ b/app/views/local_transactions/new.html.erb
@@ -18,7 +18,6 @@
     <%= f.input :panopticon_id, :as => :hidden %>
     <%= f.input :title, :as => :hidden %>
     <%= f.input :slug, :as => :hidden %>
-    <%= f.input :section, :as => :hidden %>
     <%= f.input :department, :as => :hidden %>
   <% end %>
   <%= f.actions do %>

--- a/app/views/root/_publication.html.erb
+++ b/app/views/root/_publication.html.erb
@@ -49,7 +49,7 @@
       <%= publication.creator %>
     </td>
     <td>
-      <%= publication.section %>
+      <%= publication.artefact.section %>
     </td>
     <% if tab && tab == :archived %>
     <td>

--- a/app/views/root/_published_edition.html.erb
+++ b/app/views/root/_published_edition.html.erb
@@ -37,7 +37,7 @@
     <%= publication.creator %>
   </td>
   <td>
-    <%= publication.section %>
+    <%= publication.artefact.section %>
   </td>
   <td>
     <%= publication.publisher %>

--- a/db/migrate/20140819063208_unset_section_field_in_editions.rb
+++ b/db/migrate/20140819063208_unset_section_field_in_editions.rb
@@ -1,0 +1,9 @@
+class UnsetSectionFieldInEditions < Mongoid::Migration
+  def self.up
+    Edition.all.each {|e| e.unset(:section) }
+  end
+
+  def self.down
+    Edition.all.each {|e| e.set(:section, e.artefact.section) }
+  end
+end


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5444

in order to reduce coupling between Publisher and Panopticon, we're removing the editions section field (govuk_content_models [v20.0.0](https://github.com/alphagov/govuk_content_models/pull/221)).

instead, we should infer an edition's section from its artefact. this causes a bunch of `n+1`s, which increases the response time. on the other hand, we're saving on the effort to keep section synced across edition and artefacts. with the versions of mongoid and mongo we're at there's no way to avoid `n+1`s. mongoid v3.0 introduces `.includes` with the use of identity map.

also, includes a migration to unset section field on existing editions.
