### PR TITLE
Correcting Bundler.require in application.rb

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -7,9 +7,12 @@ require "action_mailer/railtie"
 require "rails/test_unit/railtie"
 require "sprockets/railtie"
 
-# If you have a Gemfile, require the gems listed there, including any gems
-# you've limited to :test, :development, or :production.
-Bundler.require(:default, Rails.env) if defined?(Bundler)
+if defined?(Bundler)
+  # If you precompile assets before deploying to production, use this line
+  Bundler.require(*Rails.groups(:assets => %w(development test)))
+  # If you want your assets lazily compiled in production, use this line
+  # Bundler.require(:default, :assets, Rails.env)
+end
 
 module Publisher
   class Application < Rails::Application


### PR DESCRIPTION
We had deviated from the standard Rails 3.2.x `Bundler.require` directive. When we upgraded to the latest version of bootstrap-sass, Publisher deploys started failing during assets precompilation:

``` sh
govuk_setenv publisher bundle exec rake \
RAILS_ENV=production RAILS_GROUPS=assets \
assets:precompile
```

@alext pointed this out, and suggested this change to keep configs consistent with other Rails 3.2.x apps.
