### PR TITLE
Remove sidekiq monitoring web interface

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,9 +57,6 @@ gem 'airbrake', '3.1.15'
 gem 'sidekiq', '2.17.2'
 gem 'sidekiq-statsd', '0.1.2'
 
-# for sidekiq monitoring
-gem 'sinatra', '>= 1.3.0', :require => nil
-
 group :assets do
   gem "therubyracer", "0.11.4"
   gem 'sass-rails', '3.2.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,8 +207,6 @@ GEM
       rack (>= 0.4)
     rack-cache (1.2)
       rack (>= 0.4)
-    rack-protection (1.3.2)
-      rack
     rack-ssl (1.3.4)
       rack
     rack-test (0.6.2)
@@ -272,10 +270,6 @@ GEM
     simplecov-html (0.5.3)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    sinatra (1.3.4)
-      rack (~> 1.4)
-      rack-protection (~> 1.3)
-      tilt (~> 1.3, >= 1.3.3)
     sprockets (2.2.2)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -362,7 +356,6 @@ DEPENDENCIES
   sidekiq-statsd (= 0.1.2)
   simplecov (~> 0.6.4)
   simplecov-rcov (~> 0.2.3)
-  sinatra (>= 1.3.0)
   statsd-ruby (~> 1.1.0)
   therubyracer (= 0.11.4)
   timecop (= 0.4.4)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,8 +36,4 @@ Publisher::Application.routes.draw do
   get "/admin(/*path)", to: redirect { |params, req| "/#{params[:path]}" }
 
   mount GovukAdminTemplate::Engine, at: "/style-guide"
-
-  require 'sidekiq/web'
-  mount Sidekiq::Web => '/sidekiq'
-
 end


### PR DESCRIPTION
We've changed the approach for doing this to use a standalone
application - https://github.com/alphagov/sidekiq-monitoring. This is
therefore uneeded.

This reverts commit 25d27f19a7db3dd927e1fbb17c7fc6d97804069b.
