### PR TITLE
Add missing require.

### DIFF
--- a/lib/enhancements/edition.rb
+++ b/lib/enhancements/edition.rb
@@ -1,4 +1,5 @@
 require "edition"
+require "registerable_edition"
 require 'gds_api/panopticon'
 
 class Edition


### PR DESCRIPTION
We're getting occasional 'uninitialized constant' errors for `RegisterableEdition` in this file.
