### PR TITLE
Allow Editor notes to have tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", "21.0.0"
+  gem "govuk_content_models", "22.2.0"
 end
 
 gem 'erubis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
       bootstrap-sass (~> 3.2.0.2)
       jquery-rails (~> 3.1.1)
       rails (>= 3.2.0)
-    govuk_content_models (21.0.0)
+    govuk_content_models (22.2.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 7.0.0, < 10.0.0)
@@ -331,7 +331,7 @@ DEPENDENCIES
   gds-sso (= 9.3.0)
   govspeak (~> 3.1.0)
   govuk_admin_template (= 1.1.6)
-  govuk_content_models (= 21.0.0)
+  govuk_content_models (= 22.2.0)
   has_scope
   inherited_resources
   jasmine (= 2.0.2)


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5154

Editor's notes were being validated as govspeak
causing safe html checks to fail. We've made an
exception in the SafeHTMLValidator to validate
only govspeak fields:

https://github.com/alphagov/govuk_content_models/pull/236
