### PR TITLE
Scheduled publishing failure raises exceptions

### DIFF
--- a/app/workers/scheduled_publisher.rb
+++ b/app/workers/scheduled_publisher.rb
@@ -31,7 +31,7 @@ class ScheduledPublisher
 
   def perform(edition_id)
     edition = Edition.find(edition_id)
-    edition.publish_anonymously
+    edition.publish_anonymously!
     report_state_counts
   end
 

--- a/lib/enhancements/edition.rb
+++ b/lib/enhancements/edition.rb
@@ -48,12 +48,11 @@ class Edition
     all_of(for_user(user).selector, internal_search(term).selector)
   }
 
-  def publish_anonymously
-    if can_publish? && publish
+  def publish_anonymously!
+    if can_publish?
+      publish!
       actions.create!(request_type: Action::PUBLISH)
       save! # trigger denormalisation callbacks
-    else
-      false
     end
   end
 

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -67,4 +67,13 @@ class EditionTest < ActiveSupport::TestCase
     user = FactoryGirl.create(:user)
     user.publish(edition, comment: "This is a test")
   end
+
+  should "raise an exception when publish_anonymously! fails to publish" do
+    edition = FactoryGirl.create(:guide_edition_with_two_parts, state: "ready")
+    # simulate validation error causing failure to publish anonymously
+    edition.parts.first.update_attribute(:body, "[register your vehicle](registering-an-imported-vehicle)")
+
+    exception = assert_raises(StateMachine::InvalidTransition) { edition.publish_anonymously! }
+    assert_equal "Cannot transition state via :publish from :ready (Reason(s): Parts is invalid)", exception.message
+  end
 end


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8078

failure to publish a scheduled edition is difficult
to diagnose. notifying errbit of the reason for
failure should give us a hint.
