### PR TITLE
Rake task for updating a mainstream slug

### DIFF
--- a/lib/mainstream_slug_updater.rb
+++ b/lib/mainstream_slug_updater.rb
@@ -1,0 +1,56 @@
+class MainstreamSlugUpdater
+
+  def initialize(old_slug, new_slug, logger = nil)
+    @old_slug = old_slug.sub(/^\//, '')
+    @new_slug = new_slug.sub(/^\//, '')
+    @logger = logger || Logger.new(nil)
+  end
+
+  def update
+    update_slug_on_all_editions
+    update_artefact_slug
+    reregister_slug_with_panopticon
+  end
+
+  def published_edition
+    @published_edition ||= editions.find { |e| e.published? }
+  end
+
+private
+  attr_reader(
+    :old_slug,
+    :new_slug,
+    :logger
+  )
+
+  def user
+    @user ||= User.find_or_create_by(name: "2nd Line Support")
+  end
+
+  def editions
+    @editions ||= Edition.where(slug: old_slug).to_a
+  end
+
+  def artefact
+    @artefact ||= Artefact.find_by_slug(old_slug)
+  end
+
+  def update_slug_on_all_editions
+    logger.info "Updating the slug on all Editions"
+    editions.each do |e|
+      e.slug = new_slug
+      e.save(validate: false)
+    end
+  end
+
+  def update_artefact_slug
+    logger.info "Updating the slug on the Artefact"
+    artefact.slug = new_slug
+    artefact.save_as(user, validate: false)
+  end
+
+  def reregister_slug_with_panopticon
+    logger.info "Re-registering with panopticon to re-create in search"
+    published_edition.register_with_panopticon
+  end
+end

--- a/lib/tasks/update_mainstream_slug.rake
+++ b/lib/tasks/update_mainstream_slug.rake
@@ -1,0 +1,6 @@
+desc "Update a mainstream slug.\n
+See original documentation @ https://github.com/alphagov/wiki/wiki/Changing-GOV.UK-URLs#making-the-change"
+
+task :update_mainstream_slug, [:old_slug, :new_slug] => :environment do |_task, args|
+  MainstreamSlugUpdater.new(args[:old_slug], args[:new_slug]).update
+end

--- a/test/unit/lib/mainstream_slug_updater_test.rb
+++ b/test/unit/lib/mainstream_slug_updater_test.rb
@@ -1,0 +1,42 @@
+require_relative '../../test_helper'
+
+class MainstreamSlugUpdaterTest < ActiveSupport::TestCase
+
+  def setup
+    @old_slug = 'old-slug'
+    @new_slug = 'new-slug'
+
+    @user = FactoryGirl.create(:user, name: "2nd Line Support")
+    @artefact = FactoryGirl.create(:artefact, slug: @old_slug)
+    @other_edition = FactoryGirl.create(:edition, slug: @old_slug, panopticon_id: @artefact.id, state: 'archived', version_number: 1)
+    @published_edition = FactoryGirl.create(:edition, slug: @old_slug, panopticon_id: @artefact.id, state: 'published', version_number: 2)
+
+    AnswerEdition.any_instance.stubs(:register_with_panopticon)
+  end
+
+  def test_slug_is_updated_on_relevent_editions
+    MainstreamSlugUpdater.new(@old_slug, @new_slug).update
+    @other_edition.reload
+    @published_edition.reload
+    assert_equal(@other_edition.slug, @new_slug)
+    assert_equal(@published_edition.slug, @new_slug)
+  end
+
+  def test_artefact_slug_updated
+    MainstreamSlugUpdater.new(@old_slug, @new_slug).update
+    @artefact.reload
+    assert_equal(@artefact.slug, @new_slug)
+  end
+
+  def test_published_edition_is_the_published_one
+    updater = MainstreamSlugUpdater.new(@old_slug, @new_slug)
+    assert_equal @published_edition, updater.published_edition
+  end
+
+  def test_slug_is_registered_with_panopticon
+    updater = MainstreamSlugUpdater.new(@old_slug, @new_slug)
+    updater.published_edition.expects(:register_with_panopticon)
+
+    updater.update
+  end
+end


### PR DESCRIPTION
Provides a rake task for updating a mainstream slug
by updating all editions, updating the artefact and
reregistering with panopticon.

This should help to speed up the process of updating mainstream slugs for Second Line

See:
https://github.com/alphagov/wiki/wiki/Changing-GOV.UK-URLs#making-the-change
