### PR TITLE
Remove autofocus to prevent page scrolling

### DIFF
--- a/app/assets/javascripts/publications.js
+++ b/app/assets/javascripts/publications.js
@@ -1,9 +1,6 @@
 // Javascript that may be used on every publication show/edit page
 
 $(function () {
-  if (! 'autofocus' in document.createElement('input')) {
-    $('*[autofocus]').focus();
-  }
 
   /*
     Mark the edition form as dirty to prevent accidental navigation away from

--- a/app/views/shared/_common_edition_attributes.html.erb
+++ b/app/views/shared/_common_edition_attributes.html.erb
@@ -5,7 +5,7 @@
 </div>
 
 <%= f.input :title,
-      :input_html => { :autofocus => true, :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>
+      :input_html => { :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>
 
 <%= f.input :in_beta,
       as: :boolean,
@@ -16,7 +16,7 @@
 <%= f.input :alternative_title,
       :label => 'Alternative title',
       :hint => 'Use this where longer title is needed for SEO purposes',
-      :input_html => { :autofocus => true, :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>
+      :input_html => { :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>
 
 <%= f.input :overview,
       :as => :text,


### PR DESCRIPTION
Remove autofocus from title and alt title fields. Autofocus was causing the page to scroll down when opened, leading to users missing vital important notes at the top of the page.
