### PR TITLE
Reintroduce previous important note workflow

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -6,10 +6,13 @@ class NotesController < InheritedResources::Base
 
   def create
     comment = params[:note][:comment]
-    if comment.blank?
+    type = params[:note][:type] || Action::NOTE
+
+    if comment.blank? && type == Action::IMPORTANT_NOTE
+      resolve_important_note
+    elsif comment.blank?
       flash[:warning] = "Didn’t save empty note"
     else
-      type = params[:note][:type] || Action::NOTE
       if current_user.record_note(resource, comment, type)
         flash[:success] = "Note recorded"
       else
@@ -20,14 +23,21 @@ class NotesController < InheritedResources::Base
   end
 
   def resolve
-    if parent.important_note.present?
-      current_user.resolve_important_note(parent)
-      flash[:success] = "Note resolved"
-    end
+    resolve_important_note
     redirect_to edit_edition_path(parent) + '#history'
   end
 
   def resource
     parent
   end
+
+  private
+
+  def resolve_important_note
+    if parent.important_note.present?
+      current_user.resolve_important_note(parent)
+      flash[:success] = "Note resolved"
+    end
+  end
+
 end

--- a/app/views/shared/_history.html.erb
+++ b/app/views/shared/_history.html.erb
@@ -34,7 +34,7 @@
           <%= hidden_field_tag :edition_id, resource.id %>
           <%= hidden_field_tag "note[type]", Action::IMPORTANT_NOTE %>
           <div class="modal-body">
-            <%= f.input :comment, :label => 'Important note', :as => :text, :input_html => { :class => 'form-control', :rows => 6, :cols => 120 } %>
+            <%= f.input :comment, :label => 'Important note', :as => :text, :input_html => { class: 'form-control', rows: 6, cols: 120, value: @resource.important_note ? @resource.important_note.comment : '' } %>
             <p class="help-block">Add important notes that anyone who works on this edition needs to see, eg “(Doesn’t) need fact check, don’t publish.” Each edition can have only one important note at a time.</p>
           </div>
           <footer class="modal-footer remove-top-margin">
@@ -52,7 +52,7 @@
 
   <div class="add-bottom-margin">
     <a href="#save-edition-note" class="btn btn-primary" data-toggle="modal"><i class="glyphicon glyphicon-comment add-right-margin"></i>Add edition note</a>
-    <a href="#update-important-note" class="btn btn-default" data-toggle="modal"><i class="glyphicon glyphicon-exclamation-sign add-right-margin"></i>Add important note</a>
+    <a href="#update-important-note" class="btn btn-default" data-toggle="modal"><i class="glyphicon glyphicon-exclamation-sign add-right-margin"></i>Update important note</a>
     <% if @resource.important_note %>
       <%= semantic_form_for(@resource.important_note, :url=> resolve_note_path, :html => { :class => "add-left-margin inline" }) do |f| %>
         <%= hidden_field_tag :edition_id, resource.id %>

--- a/test/integration/edition_history_test.rb
+++ b/test/integration/edition_history_test.rb
@@ -49,14 +49,7 @@ class EditionHistoryTest < JavascriptIntegrationTest
 
     context "Important note" do
       should "be able to add and resolve a note" do
-        visit "/editions/#{@guide.id}"
-        click_on "History and notes"
-        click_on "Add important note"
-
-        within "#update-important-note" do
-          fill_in "Important note", with: "This is an important note. Take note."
-          click_on "Save important note"
-        end
+        add_important_note("This is an important note. Take note.")
 
         visit "/editions/#{@guide.id}"
         assert page.has_content? "This is an important note. Take note."
@@ -64,6 +57,25 @@ class EditionHistoryTest < JavascriptIntegrationTest
         click_on "History and notes"
         click_on "Delete important note"
         visit "/editions/#{@guide.id}"
+        assert page.has_no_css?('.important-note')
+      end
+
+      should "prepopulate with an existing note" do
+        add_important_note("This is an important note. Take note.")
+
+        visit "/editions/#{@guide.id}"
+        click_on "History and notes"
+        click_on "Update important note"
+
+        within "#update-important-note" do
+          assert_field_contains("This is an important note. Take note.", "Important note")
+        end
+      end
+
+      should "resolve an important note if an empty one is saved" do
+        add_important_note("Note")
+        add_important_note("")
+
         assert page.has_no_css?('.important-note')
       end
 
@@ -80,11 +92,22 @@ class EditionHistoryTest < JavascriptIntegrationTest
         assert page.has_no_content? "This is an important note. Take note."
 
         click_on "History and notes"
-        click_on "Add important note"
+        click_on "Update important note"
         within "#update-important-note" do
           assert_field_contains("", "Important note")
         end
       end
+    end
+  end
+
+  def add_important_note(note)
+    visit "/editions/#{@guide.id}"
+    click_on "History and notes"
+    click_on "Update important note"
+
+    within "#update-important-note" do
+      fill_in "Important note", with: note
+      click_on "Save important note"
     end
   end
 end


### PR DESCRIPTION
Previously users could easily append to existing important notes. When updating the important note model it wasn’t clear whether this was a user need or an artefact of the implementation. It is a need — users
are often appending information to the end of an existing note (eg 2i user and schedule info)
- Prepopulate important note field with existing note
- If the user blanks the field resolve the note (be consistent with old behaviour)
