### PR TITLE
Include fact check request recipients in note

### DIFF
--- a/app/helpers/action_helper.rb
+++ b/app/helpers/action_helper.rb
@@ -8,13 +8,18 @@ module ActionHelper
   end
 
   def action_note(action)
-    if action.comment.present?
-      format_and_auto_link_plain_text(action.comment)
-    elsif action.is_fact_check_request? && action.email_addresses.present?
-      "Request sent to #{mail_to action.email_addresses}".html_safe
-    elsif action.recipient_id.present?
-      "Assigned to #{mail_to action.recipient.email, action.recipient.name}".html_safe
+    notes = []
+    notes << format_and_auto_link_plain_text(action.comment) if action.comment.present?
+
+    if action.is_fact_check_request? && action.email_addresses.present?
+      notes << content_tag(:p, "Request sent to #{mail_to action.email_addresses.gsub(/\s/,''), action.email_addresses}".html_safe)
     end
+
+    if action.recipient_id.present?
+      notes << content_tag(:p, "Assigned to #{mail_to action.recipient.email, action.recipient.name}".html_safe)
+    end
+
+    notes.join.html_safe
   end
 
   def format_and_auto_link_plain_text(text)

--- a/test/integration/edition_history_test.rb
+++ b/test/integration/edition_history_test.rb
@@ -10,7 +10,7 @@ class EditionHistoryTest < JavascriptIntegrationTest
     setup do
       @answer = FactoryGirl.create(:answer_edition, :state => "published")
 
-      @answer.new_action(@author, Action::SEND_FACT_CHECK, {:comment => "first"})
+      @answer.new_action(@author, Action::SEND_FACT_CHECK, {:comment => "first", :email_addresses => 'a@a.com, b@b.com'})
       @answer.new_action(@author, Action::RECEIVE_FACT_CHECK, {:comment => "second"})
       @answer.new_action(@author, Action::PUBLISH, {:comment => "third"})
 
@@ -33,11 +33,20 @@ class EditionHistoryTest < JavascriptIntegrationTest
       assert page.has_css?('#edition-history div.panel:first-of-type div.panel-collapse.in')
     end
 
-    should "has clickable links in notes" do
+    should "have clickable links in notes" do
       visit "/editions/#{@guide.id}"
       click_on "History and notes"
 
       assert page.has_css?('.panel a[href="http://www.some-link.com"]', text: 'http://www.some-link.com')
+    end
+
+    should "include the email addresses of fact check request recipients" do
+      visit "/editions/#{@guide.id}"
+      click_on "History and notes"
+      click_on "Edition 1"
+      assert page.has_css?('p', text: "first")
+      assert page.has_css?('p', text: "Request sent to a@a.com, b@b.com")
+      assert page.has_css?('.panel a[href="mailto:a@a.com,b@b.com"]', text: 'a@a.com, b@b.com')
     end
 
     should "hide actions when the edition title is clicked" do


### PR DESCRIPTION
Fixes https://www.agileplannerapp.com/boards/173808/cards/8677

Previous refactor led to a regression where if a user provided a comment along with a fact check request the email addresses of that request wouldn't be displayed.
- Show both comment and email addresses
- Include test to document behaviour
- Format mailto address to remove spaces, a mailto which contains spaces is an invalid link

Thanks @vinayvinay 
