### PR TITLE
Avoid submitting business support form with JS

### DIFF
--- a/app/assets/javascripts/views/business_support/areas_relator.js
+++ b/app/assets/javascripts/views/business_support/areas_relator.js
@@ -17,13 +17,14 @@ $(document).ready(function() {
         });
       },
       submitWithAreaArrayInputs = function (e) {
-        e.preventDefault();
         var areaIds = $relatedAreasHiddenInput.attr("value").split(',');
         $relatedAreasHiddenInput.remove();
         for (var idx = 0; idx < areaIds.length; idx++) {
           $(this).append('<input name="edition[areas][]" type="hidden" value="'+areaIds[idx]+'"/>');
         }
-        this.submit();
+
+        // let event continue and perform its default action (form submit)
+        // submitting with javascript would lose some context (eg which workflow button was pressed)
       };
 
   $relatedAreasWrapper


### PR DESCRIPTION
Fixes https://www.agileplannerapp.com/boards/173808/cards/7908

The update action for an edition relies on the value of the commit button submitted with the form. By intercepting the form submit and resubmitting after a DOM modification (which only happens on business support) we lose that context.
- Don’t prevent default and avoid submitting form with JS
- Instead let the event bubble up and perform its default action, submitting the form as the user originally intended
- Include comment to note that this is intentional

(This only seemed to be a problem within Firefox)
