### PR TITLE
Temporarily fix Chrome 38 multiple-select bug

### DIFF
--- a/app/assets/javascripts/modules/chrome_fix.js
+++ b/app/assets/javascripts/modules/chrome_fix.js
@@ -1,0 +1,15 @@
+(function(Modules) {
+  "use strict";
+  Modules.ChromeFix = function() {
+    this.start = function(element) {
+      try {
+        var chromeVersion = window.navigator.appVersion.match(/Chrome\/(\d+)\./);
+        if (chromeVersion && parseInt(chromeVersion[1],10) < 39) {
+          window.scrollTo(0,0);
+        }
+      } catch (ex) {
+        // Ignore browser exceptions when window.navigator check fails
+      }
+    }
+  };
+})(window.GOVUKAdmin.Modules);

--- a/app/views/shared/_edition_header.html.erb
+++ b/app/views/shared/_edition_header.html.erb
@@ -1,4 +1,4 @@
-<div class="page-title">
+<div class="page-title" data-module="chrome-fix">
   <h1>
     <%= @resource.title %>
   </h1>


### PR DESCRIPTION
A temporary fix for: https://code.google.com/p/chromium/issues/detail?id=423256 (see also: http://jsfiddle.net/1z1tskwh/4/)

When an item is preselected for a `<select>` which can have multiple values, Chrome 38 scrolls down the page. This makes editing and reviewing editions difficult. This is a temporary fix that scrolls the page back to the top on Chrome versions lower than 39.

This fix should be removed when Chrome 39 has been released.
