### PR TITLE
Update notices to success or danger flash messages

### DIFF
--- a/app/controllers/expectations_controller.rb
+++ b/app/controllers/expectations_controller.rb
@@ -9,7 +9,8 @@ class ExpectationsController < InheritedResources::Base
   def create
     @expectation = Expectation.new(params[:expectation])
     if @expectation.save
-      redirect_to expectations_path, :notice => 'Expectation set'
+      flash[:success] = 'Expectation set'
+      redirect_to expectations_path
     else
       @expectations = Expectation.all
       render :action => 'index'

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,17 @@
 
 <% content_for :content do %>
   <% [:success, :info, :warning, :danger, :notice, :alert].select { |k| flash[k].present? }.each do |k| %>
-    <div class="alert alert-<%= k == :notice || k == :alert ? 'warning' : k %>">
+    <%
+      case k
+      when :notice
+        alert_class = "success"
+      when :alert
+        alert_class = "danger"
+      else
+        alert_class = k
+      end
+    %>
+    <div class="alert alert-<%= alert_class %>">
       <%= flash[k] %>
     </div>
   <% end %>

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -48,7 +48,7 @@ class EditionsControllerTest < ActionController::TestCase
 
     post :duplicate, :id => @guide.id
     assert_response 302
-    assert_equal "New edition created", flash[:notice]
+    assert_equal "New edition created", flash[:success]
   end
 
   test "should update status via progress and redirect to parent" do
@@ -67,7 +67,7 @@ class EditionsControllerTest < ActionController::TestCase
       }
 
     assert_redirected_to :controller => "editions", :action => "show", :id => @guide.id
-    assert_equal "Guide updated", flash[:notice]
+    assert_equal "Guide updated", flash[:success]
   end
 
   test "should update assignment" do
@@ -128,7 +128,7 @@ class EditionsControllerTest < ActionController::TestCase
 
     post :update, :id => @guide.id, :edition => {}
 
-    assert_equal "Editions scheduled for publishing can't be edited", flash[:alert]
+    assert_equal "Editions scheduled for publishing can't be edited", flash[:danger]
   end
 
   test "should save the edition changes while performing an activity" do
@@ -162,7 +162,7 @@ class EditionsControllerTest < ActionController::TestCase
         }
       }
     }
-    assert_equal "I failed", flash[:alert]
+    assert_equal "I failed", flash[:danger]
   end
 
   test "should report publication counts on creation" do

--- a/test/functional/expectations_controller_test.rb
+++ b/test/functional/expectations_controller_test.rb
@@ -13,6 +13,6 @@ class ExpectationsControllerTest < ActionController::TestCase
   test "creating an expectation works" do
     post :create, :expectation => {:text => 'It will cost money'}
     assert_response 302
-    assert_equal "Expectation set", flash[:notice]
+    assert_equal "Expectation set", flash[:success]
   end
 end


### PR DESCRIPTION
Be clearer about a success or failure using Bootstrap alert styles.

`:notice` and `:alert` are still used by inherited_resources and responders gems, customising the flash keys doesn’t work because of the old versions being used.
- Explicitly set :success or :danger flash messages in app
- Coerce :notice to a success message
- Coerce :alert to a danger one

![screen shot 2014-11-19 at 10 38 53](https://cloud.githubusercontent.com/assets/319055/5104275/4f8128ba-6fd8-11e4-9fcb-dae3996cfe02.png)
