### PR TITLE
Filter-out suspended user from user lists

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,13 +5,13 @@ gem 'rails', '3.2.18'
 if ENV['BUNDLE_DEV']
   gem 'gds-sso', path: '../gds-sso'
 else
-  gem 'gds-sso', '9.3.0'
+  gem 'gds-sso', '10.0.0'
 end
 
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", "24.0.1"
+  gem "govuk_content_models", "24.1.0"
 end
 
 gem 'erubis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
       plek
       rack-cache
       rest-client (~> 1.6.3)
-    gds-sso (9.3.0)
+    gds-sso (10.0.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
@@ -115,10 +115,10 @@ GEM
       bootstrap-sass (~> 3.2.0.2)
       jquery-rails (~> 3.1.1)
       rails (>= 3.2.0)
-    govuk_content_models (24.0.1)
+    govuk_content_models (24.1.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
-      gds-sso (>= 7.0.0, < 10.0.0)
+      gds-sso (>= 10.0.0)
       govspeak (~> 3.1.0)
       mongoid (~> 2.5)
       plek
@@ -340,10 +340,10 @@ DEPENDENCIES
   formtastic (= 2.3.0)
   formtastic-bootstrap (= 3.0.0)
   gds-api-adapters (= 15.1.0)
-  gds-sso (= 9.3.0)
+  gds-sso (= 10.0.0)
   govspeak (~> 3.1.0)
   govuk_admin_template (= 1.1.7)
-  govuk_content_models (= 24.0.1)
+  govuk_content_models (= 24.1.0)
   has_scope
   inherited_resources
   jasmine (= 2.0.3)

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -28,7 +28,7 @@
             <%=
               select_tag("user_filter", options_for_select(
                 [["All", "all"], ["Nobody", "nobody"]] +
-                User.alphabetized.map{ |u| [u.name, u.uid] }, @user_filter
+                User.enabled.alphabetized.map{ |u| [u.name, u.uid] }, @user_filter
               ), class: 'form-control js-user-filter', "data-module" => 'assignee-select')
             %>
             <label for="string_filter" class="add-top-margin nav-header">Keyword</label>

--- a/app/views/shared/_common_edition_attributes.html.erb
+++ b/app/views/shared/_common_edition_attributes.html.erb
@@ -1,7 +1,7 @@
 <%= hidden_field_tag "return_to", params[:return_to] if params[:return_to] %>
 <div class="form-group">
   <label for="edition_assigned_to_id">Assigned to</label>
-  <%= f.collection_select :assigned_to_id, User.order_by([[:name, :asc]]).all, :id, :name, {:prompt => "Select someone"}, {:class => 'form-control input-md-3', :disabled => @resource.locked_for_edits?, "data-module" => 'assignee-select'} %>
+  <%= f.collection_select :assigned_to_id, User.enabled.order_by([[:name, :asc]]), :id, :name, {:prompt => "Select someone"}, {:class => 'form-control input-md-3', :disabled => @resource.locked_for_edits?, "data-module" => 'assignee-select'} %>
 </div>
 <%= render partial: 'major_change_fields', locals: { f: f } if @resource.published_edition %>
 

--- a/app/views/user_search/index.html.erb
+++ b/app/views/user_search/index.html.erb
@@ -9,7 +9,7 @@
           <label for="user_filter" class="nav-header">Filter by user</label>
           <%=
             select_tag("user_filter", options_for_select(
-              User.alphabetized.map{ |u| [u.name, u.uid] }, @user_filter
+              User.enabled.alphabetized.map{ |u| [u.name, u.uid] }, @user_filter
             ), :class => "form-control")
           %>
           <label for="string_filter" class="add-top-margin nav-header">Filter by keyword</label>

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -128,6 +128,15 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     assert_equal guide.assigned_to, get_user("Bob")
   end
 
+  test "doesn't show disabled users in 'Assigned to' select box" do
+    disabled_user = FactoryGirl.create(:disabled_user)
+    guide = FactoryGirl.create(:guide_edition)
+
+    visit_edition guide
+
+    refute page.has_xpath?("//select[@id='edition_assigned_to_id']/option[text() = '#{disabled_user.name}']")
+  end
+
   test "a guide is in draft after creation" do
     guide = FactoryGirl.create(:guide_edition)
 

--- a/test/integration/root_overview_test.rb
+++ b/test/integration/root_overview_test.rb
@@ -95,4 +95,12 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
 
     assert page.has_content?("XXX")
   end
+
+  test "doesn't show disabled users in 'Assignee' select box" do
+    disabled_user = FactoryGirl.create(:disabled_user)
+
+    visit "/"
+    select_box = find_field('Assignee')
+    refute page.has_xpath?(select_box.path + "/option[text() = '#{disabled_user.name}']")
+  end
 end

--- a/test/integration/user_search_test.rb
+++ b/test/integration/user_search_test.rb
@@ -78,4 +78,13 @@ class UserSearchTest < ActionDispatch::IntegrationTest
     assert page.has_content?(guides[0].title)
     refute page.has_content?(guides[1].title)
   end
+
+  test "doesn't show disabled users in 'Filter by user' select box" do
+    disabled_user = FactoryGirl.create(:disabled_user)
+
+    visit "/user_search"
+
+    select_box = find_field('Filter by user')
+    refute page.has_xpath?(select_box.path + "/option[text() = '#{disabled_user.name}']")
+  end
 end


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/5886

Uses `disabled` on `User` introduced by the `govuk_content_models` bump-up, to skip suspended users from:
- the 'Assigned to' drop-down on the editions edit
- the 'Filter by users' search in admin
- the 'Assignee' drop-down in on the editions filter view
