### PR TITLE
Migration to add 'the' to will_continue_on text

### DIFF
--- a/app/views/business_supports/_additional_fields.html.erb
+++ b/app/views/business_supports/_additional_fields.html.erb
@@ -50,7 +50,7 @@
 
     <%= f.input :will_continue_on,
                 :label => 'Will continue on',
-                :hint => 'Text to accompany external website link',
+                :hint => 'Text to accompany external website link, eg. "the HMRC website"',
                 :input_html => {:disabled => locked_for_edits, class: 'input-md-7' } %>
 
     <%= f.input :continuation_link,

--- a/db/migrate/20141126090229_add_the_on_will_continue_on_field.rb
+++ b/db/migrate/20141126090229_add_the_on_will_continue_on_field.rb
@@ -1,0 +1,13 @@
+class AddTheOnWillContinueOnField < Mongoid::Migration
+  def self.up
+    puts "Adding 'the' to the beginning of `will_continue_on` text on business support editions"
+    # BS editions which do not begin with 'The' or 'the'
+    BusinessSupportEdition.where(will_continue_on: /\A(?!the\s).*/i).each do |bs_edition|
+      bs_edition.set(:will_continue_on, "the #{bs_edition.will_continue_on}") if bs_edition.will_continue_on.strip.present?
+    end
+    puts "Done."
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8718

Frontend [will stop adding 'the'](https://github.com/alphagov/frontend/pull/695) to `will_continue_on` text on business support editions. This change allows editors to add 'the' when needed in the best way possible, and keeps it consistent with other formats.

This migration fixes existing data to contain that word. Also, updated the hint text to suggest that editors need to add 'the' to `will_continue_on` in business support.
