### PR TITLE
Add endpoint for registering topic editions.

### DIFF
--- a/app/controllers/api/search_controller.rb
+++ b/app/controllers/api/search_controller.rb
@@ -1,0 +1,18 @@
+# This endpoint is a temporary requirement until
+# the content store pipeline is in full effect.
+class Api::SearchController < ApplicationController
+  skip_before_filter :verify_authenticity_token, only: [:reindex_topic_editions]
+
+  def reindex_topic_editions
+    published_and_tagged_editions = Edition.published.or(
+      {primary_topic: params[:slug]},
+      {:additional_topics.in => [params[:slug]]}
+    )
+
+    published_and_tagged_editions.each do |edition|
+      PanopticonReregisterer.perform_async(edition.id.to_s)
+    end
+
+    render json: {result: 'ok', count: published_and_tagged_editions.count}, status: 202
+  end
+end

--- a/app/workers/panopticon_reregisterer.rb
+++ b/app/workers/panopticon_reregisterer.rb
@@ -1,0 +1,8 @@
+class PanopticonReregisterer
+  include Sidekiq::Worker
+
+  def perform(edition_id)
+    edition = Edition.find(edition_id)
+    edition.register_with_panopticon
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Publisher::Application.routes.draw do
   get '/healthcheck' => 'healthcheck#check'
 
+  namespace :api do
+    post 'reindex-topic-editions/*slug', to: 'search#reindex_topic_editions', as: 'reindex_topic_editions'
+  end
+
   resources :notes do
     put 'resolve', on: :member
   end

--- a/test/functional/api/search_controller_test.rb
+++ b/test/functional/api/search_controller_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class Api::SearchControllerTest < ActionController::TestCase
+  def setup
+    login_as_stub_user
+
+    @relevant_editions = [
+      # Published with correct primary tag
+      FactoryGirl.create(:edition, state: 'published', primary_topic: 'oil-and-gas/licensing'),
+      # Published with correct secondary tag
+      FactoryGirl.create(:edition, state: 'published', additional_topics: ['oil-and-gas/licensing'])
+    ]
+
+    @irrelevant_editions = [
+      # Correct tag, but draft
+      FactoryGirl.create(:edition, state: 'draft', primary_topic: 'oil-and-gas/licensing'),
+      # Correct tag, but archived
+      FactoryGirl.create(:edition, state: 'archived', primary_topic: 'oil-and-gas/licensing'),
+      # Published, but incorrect tag
+      FactoryGirl.create(:edition, state: 'published', additional_topics: ['environmental-management/boating']),
+      # Published, but no tag
+      FactoryGirl.create(:edition, state: 'published')
+    ]
+
+    PublishingAPINotifier.stubs(:perform_async)
+  end
+
+  test "#reindex_topic_editions resubmits to panopticon all published editions tagged to the topic" do
+    @relevant_editions.each do |edition|
+      registerable = mock("registerable_edition")
+      RegisterableEdition.stubs(:new).with(edition).returns(registerable)
+      GdsApi::Panopticon::Registerer.any_instance.expects(:register).with(registerable).once
+    end
+
+    @irrelevant_editions.each do |edition|
+      registerable = mock("registerable_edition")
+      RegisterableEdition.stubs(:new).with(edition).returns(registerable)
+      GdsApi::Panopticon::Registerer.any_instance.expects(:register).with(registerable).never
+    end
+
+    post :reindex_topic_editions, {slug: 'oil-and-gas/licensing'},
+      {'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json'}
+
+    assert_response 202
+  end
+end


### PR DESCRIPTION
A companion to https://github.com/alphagov/whitehall/pull/1865, 
in order to get tag information for published
editions into Rummager (and thence to the services
and information page, among others) when a draft
topic is published, Panopticon needs to notify
Publisher so it can resubmit all published editions
tagged with that topic.

All this code can go away when drafts are handled
through the content store pipeline.

https://www.pivotaltracker.com/story/show/83216078
