### PR TITLE
Migration to remove `alternative_title` field from `Edition` class

### DIFF
--- a/db/migrate/20141121141757_remove_alternative_title_field.rb
+++ b/db/migrate/20141121141757_remove_alternative_title_field.rb
@@ -1,0 +1,9 @@
+class RemoveAlternativeTitleField < Mongoid::Migration
+  def self.up
+    Edition.all.each { |edition| edition.unset(:alternative_title) }
+  end
+
+  def self.down
+    # No down as this is a destructive action.
+  end
+end


### PR DESCRIPTION
This migration is destructive and removes the `alternative_title`
field from the database. An export has already been made and this is
the final clean up step.
