### PR TITLE
Treat first editions as 'major' changes

### DIFF
--- a/app/presenters/published_edition_presenter.rb
+++ b/app/presenters/published_edition_presenter.rb
@@ -39,10 +39,14 @@ private
   def update_type(options)
     if options[:republish]
       "republish"
-    elsif @edition.major_change
+    elsif major_change?
       "major"
     else
       "minor"
     end
+  end
+
+  def major_change?
+    @edition.major_change || @edition.version_number == 1
   end
 end

--- a/test/unit/published_edition_presenter_test.rb
+++ b/test/unit/published_edition_presenter_test.rb
@@ -10,6 +10,7 @@ class PublishedEditionPresenterTest < ActiveSupport::TestCase
         major_change: true,
         updated_at: 1.minute.ago,
         change_note: 'Test',
+        version_number: 2,
       )
 
       @presenter = PublishedEditionPresenter.new(@edition)
@@ -54,6 +55,14 @@ class PublishedEditionPresenterTest < ActiveSupport::TestCase
 
       output = @presenter.render_for_publishing_api(republish: false)
       assert_equal 'minor', output[:update_type]
+    end
+
+    should 'always return a "major" update_type for a first edition' do
+      first_edition = FactoryGirl.create(:edition, major_change: false, version_number: 1)
+      presenter = PublishedEditionPresenter.new(first_edition)
+
+      output = presenter.render_for_publishing_api(republish: false)
+      assert_equal 'major', output[:update_type]
     end
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/83478146

This changes the `PublishedEditionPresenter` so that, when presenting the first edition in a series, it always sets the `update_type` field to `major` change. 

Previously, first editions would never be sent as `major` updates, as the UI is not shown to users. However, we always want to send email alerts for first editions of content, and display it in the latest changes feed for a sub-topic.
