### PR TITLE
Delete erroneously synced users

### DIFF
--- a/db/migrate/20141128075604_fix_erroneously_synced_users_with_empty_permissions.rb
+++ b/db/migrate/20141128075604_fix_erroneously_synced_users_with_empty_permissions.rb
@@ -1,0 +1,8 @@
+class FixErroneouslySyncedUsersWithEmptyPermissions < Mongoid::Migration
+  def self.up
+    User.delete_all(:permissions => [], :created_at.gte => Time.zone.parse("27-Nov-2014 10:50"))
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
Signon push update rake task pushed information of users who had never used Publisher, so cleaning that up. see related: https://github.com/alphagov/signonotron2/pull/290/files
