### PR TITLE
Fix migration written to fix synced users

### DIFF
--- a/db/migrate/20141128075604_fix_erroneously_synced_users_with_empty_permissions.rb
+++ b/db/migrate/20141128075604_fix_erroneously_synced_users_with_empty_permissions.rb
@@ -1,6 +1,6 @@
 class FixErroneouslySyncedUsersWithEmptyPermissions < Mongoid::Migration
   def self.up
-    User.delete_all(:permissions => [], :created_at.gte => Time.zone.parse("27-Nov-2014 10:50"))
+    User.where(:permissions => [], :created_at.gte => Time.zone.parse("27-Nov-2014 10:50")).delete_all
   end
 
   def self.down


### PR DESCRIPTION
The earlier version was incompatible with mongoid, because it expects keys in a `delete_all` condition to be symbols or strings.
