### PR TITLE
topic_changes:prepare takes output file parameter

### DIFF
--- a/lib/tasks/topic_changes.rake
+++ b/lib/tasks/topic_changes.rake
@@ -3,22 +3,23 @@ require 'csv'
 namespace :topic_changes do
 
   desc "Given a source and destination tag, writes a CSV of slugs requiring retagging"
-  task :prepare, [:source_topic_id, :destination_topic_id] => :environment do |t, args|
+  task :prepare, [:source_topic_id, :destination_topic_id, :output_path] => :environment do |t, args|
     source_topic_id = args[:source_topic_id]
     destination_topic_id = args[:destination_topic_id]
+    output_path = args[:output_path]
 
-    unless source_topic_id.present? && destination_topic_id.present?
-      raise "Missing arguments. Both 'source_topic_id' and 'destination_topic_id' are required for this task."
+    unless source_topic_id.present? && destination_topic_id.present? && output_path.present?
+      raise "Missing arguments.  This task requires 'source_topic_id', 'destination_topic_id' and 'output_path'."
+    end
+
+    if File.exists?(output_path)
+      raise "A file already exists at '#{output_path}'.  Please remove it, or use a different name."
     end
 
     puts "Initializing preparer for source topic '#{source_topic_id}' and destination topic '#{destination_topic_id}'."
     preparer = TopicChanges::Preparer.new(source_topic_id, destination_topic_id)
 
-    friendly_topic_ids = [source_topic_id, destination_topic_id].map(&:parameterize).join('-')
-    path_to_output_file = Rails.root.join("tmp", "topic-change-#{friendly_topic_ids}-#{Time.now.to_i}.csv")
-
-    puts "Attempting to create CSV: #{path_to_output_file}"
-    output_file = File.open(path_to_output_file, 'w') do |file|
+    output_file = File.open(output_path, 'w') do |file|
       file.write(preparer.build_csv)
     end
 


### PR DESCRIPTION
We want to be able to run the topic_changes:prepare task from rake.
To do this effectively, we need to be able to determine where the output
file is going to be generated.

This PR adds that as a required argument.  For safety, it also checks
that the output file doesn't exist already, to avoid overwriting files
by mistake.
