### PR TITLE
Remove expectation data from mongodb

### DIFF
--- a/db/migrate/20141205103230_remove_expectations.rb
+++ b/db/migrate/20141205103230_remove_expectations.rb
@@ -1,0 +1,9 @@
+class RemoveExpectations < Mongoid::Migration
+  def self.up
+    Edition.where(:expectation_ids.exists => true).each { |e| e.unset(:expectation_ids) }
+    Mongoid.master.collection(:expectations).drop
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8852

an [earlier story](www.agileplannerapp.com/boards/173808/cards/8707) migrated expectations to a govspeak field `need_to_know`, and this got deployed to production. so we no longer need this data in mongodb.