### PR TITLE
Update bsf area east-of-england to eastern

### DIFF
--- a/db/migrate/20141208152336_update_eastern_area.rb
+++ b/db/migrate/20141208152336_update_eastern_area.rb
@@ -1,0 +1,22 @@
+class UpdateEasternArea < Mongoid::Migration
+  def self.up
+    updated = []
+    BusinessSupportEdition.where(:state.ne => "archived", :areas.in => ["east-of-england"]).each do |edition|
+      unless edition.artefact.state == "archived"
+        edition.areas[edition.areas.index("east-of-england")] = "eastern"
+        updated << edition.slug if edition.save!(validate: false)
+      end
+    end
+    puts "Updated #{updated.size} editions:"
+    puts updated.join(", ")
+  end
+
+  def self.down
+    BusinessSupportEdition.where(:state.ne => "archived", :areas.in => ["eastern"]).each do |edition|
+      unless edition.artefact.state == "archived"
+        edition.areas[edition.areas.index("eastern")] = "east-of-england"
+        edition.save!(validate: false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
There's a mismatch of areas data between the taggable area values in publisher and the areas returned from a postcode search in Imminence. This migration addresses the editions already tagged with the wrong area slug.
https://www.agileplannerapp.com/boards/173808/cards/8907
