### PR TITLE
Update govuk_content_models version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", "26.2.0"
+  gem "govuk_content_models", "26.3.0"
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
       bootstrap-sass (~> 3.3.1)
       jquery-rails (~> 3.1.1)
       rails (>= 3.2.0)
-    govuk_content_models (26.2.0)
+    govuk_content_models (26.3.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 10.0.0)
@@ -343,7 +343,7 @@ DEPENDENCIES
   gds-sso (= 10.0.0)
   govspeak (~> 3.1.0)
   govuk_admin_template (= 1.4.0)
-  govuk_content_models (= 26.2.0)
+  govuk_content_models (= 26.3.0)
   has_scope
   inherited_resources
   jasmine (= 2.0.3)


### PR DESCRIPTION
govuk_content_models version 26.3.0 now returns the first edition
public_updated_at when no major changes have occured.
