### PR TITLE
Add publication format to edition view

### DIFF
--- a/app/views/shared/_edition_header.html.erb
+++ b/app/views/shared/_edition_header.html.erb
@@ -3,8 +3,9 @@
     <%= @resource.title %>
   </h1>
   <span class="lead">
-    <span class="label label-default">Edition <%= @resource.version_number %></span>
-    <span class="label label-info">Status: <%= @resource.status_text %></span>
+    <span class="label label-default" title="Edition">#<%= @resource.version_number %></span>
+    <span class="label label-default" title="Format"><%= @resource.format.underscore.humanize %></span>
+    <span class="label label-info" title="Status"><%= @resource.status_text %></span>
   </span>
 </div>
 <% important_note = @resource.important_note %>

--- a/test/integration/business_support_create_edit_test.rb
+++ b/test/integration/business_support_create_edit_test.rb
@@ -56,7 +56,7 @@ class BusinessSupportCreateEditTest < JavascriptIntegrationTest
     visit "/publications/#{@artefact.id}"
 
     assert_match /^\/editions\/[0-9a-z]+?$/, current_path
-    assert page.has_content? "Foo bar Edition 1"
+    assert page.has_content? 'Foo bar #1'
 
     bs = BusinessSupportEdition.first
     assert_equal @artefact.id.to_s, bs.panopticon_id
@@ -94,7 +94,7 @@ class BusinessSupportCreateEditTest < JavascriptIntegrationTest
 
     visit "/editions/#{bs.to_param}"
 
-    assert page.has_content? "Foo bar Edition 1"
+    assert page.has_content? 'Foo bar #1'
 
     assert page.has_field?("Organiser", :with => "Business support corp.")
     assert page.has_field?("Short description", :with => "Short description content")
@@ -197,7 +197,7 @@ class BusinessSupportCreateEditTest < JavascriptIntegrationTest
 
     click_on "Create new edition"
 
-    assert page.has_content? "Foo bar Edition 2"
+    assert page.has_content? 'Foo bar #2'
 
   end
 

--- a/test/integration/campaign_edit_test.rb
+++ b/test/integration/campaign_edit_test.rb
@@ -17,7 +17,7 @@ class CampaignEditTest < JavascriptIntegrationTest
   should "create a new CampaignEdition" do
     visit "/publications/#{@artefact.id}"
 
-    assert page.has_content? "No campaign, no gain Edition 1"
+    assert page.has_content? 'No campaign, no gain #1'
 
     c = CampaignEdition.first
     assert_equal @artefact.id.to_s, c.panopticon_id
@@ -34,7 +34,7 @@ class CampaignEditTest < JavascriptIntegrationTest
                                  :organisation_brand_colour => "department-for-transport")
     visit "/editions/#{campaign.to_param}"
 
-    assert page.has_content? "Singin' in the campaign Edition 1"
+    assert page.has_content? 'Singin\' in the campaign #1'
 
     assert page.has_field?("Title", :with => "Singin' in the campaign")
     assert page.has_field?("Body", :with => "I'm singin' in the campaign")
@@ -78,7 +78,7 @@ class CampaignEditTest < JavascriptIntegrationTest
 
     click_on "Create new edition"
 
-    assert page.has_content? "Campaign on your parade Edition 2"
+    assert page.has_content? 'Campaign on your parade #2'
 
     assert page.has_field?("Body", :with => "Foo")
     assert page.has_field?("Organisation formatted name", :with => "Driver & Vehicle\nLicensing\nAgency")

--- a/test/integration/completed_transactions_create_edit_test.rb
+++ b/test/integration/completed_transactions_create_edit_test.rb
@@ -17,7 +17,7 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
   should "create a new CompletedTransactionEdition" do
     visit "/publications/#{@artefact.id}"
 
-    assert page.has_content? "All bar done Edition 1"
+    assert page.has_content? 'All bar done #1'
 
     t = CompletedTransactionEdition.first
     assert_equal @artefact.id.to_s, t.panopticon_id
@@ -30,7 +30,7 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
 
     visit "/editions/#{completed_transaction.to_param}"
 
-    assert page.has_content? "All bar done Edition 1"
+    assert page.has_content? 'All bar done #1'
 
     assert page.has_field?("Title", :with => "All bar done")
 
@@ -38,7 +38,7 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
 
     assert page.has_content? "Completed transaction edition was successfully updated."
 
-    assert page.has_content? "Status: Draft"
+    assert page.has_css?('.label', text: 'Draft')
   end
 
   should "allow creating a new version of a CompletedTransactionEdition" do
@@ -51,7 +51,7 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
 
     click_on "Create new edition"
 
-    assert page.has_content? "All bar done Edition 2"
+    assert page.has_content? 'All bar done #2'
 
   end
 

--- a/test/integration/edition_scheduled_publishing_test.rb
+++ b/test/integration/edition_scheduled_publishing_test.rb
@@ -52,7 +52,7 @@ class EditionScheduledPublishingTest < JavascriptIntegrationTest
     stub_artefact_registration(edition.slug)
 
     visit_edition edition
-    assert page.has_content?("Status: Scheduled for publishing on #{edition.publish_at.strftime('%d/%m/%Y %H:%M')}")
+    assert page.has_css?('.label', text: "Scheduled for publishing on #{edition.publish_at.strftime('%d/%m/%Y %H:%M')}")
     click_on "Publish now"
 
     within "#publish_form" do
@@ -60,14 +60,14 @@ class EditionScheduledPublishingTest < JavascriptIntegrationTest
       click_on "Send to publish"
     end
 
-    assert page.has_content?("Status: Published")
+    assert page.has_css?('.label', text: 'Published')
   end
 
   test "should cancel the publishing of a scheduled edition" do
     edition = FactoryGirl.create(:edition, :scheduled_for_publishing)
 
     visit_edition edition
-    assert page.has_content?("Status: Scheduled for publishing on #{edition.publish_at.strftime('%d/%m/%Y %H:%M')}")
+    assert page.has_css?('.label', text: "Scheduled for publishing on #{edition.publish_at.strftime('%d/%m/%Y %H:%M')}")
     click_on "Cancel scheduled publishing"
 
     within "#cancel_scheduled_publishing_form" do
@@ -75,7 +75,7 @@ class EditionScheduledPublishingTest < JavascriptIntegrationTest
       click_on "Cancel scheduled publishing"
     end
 
-    assert page.has_content?("Status: Ready")
+    assert page.has_css?('.label', text: 'Ready')
   end
 
 end

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -144,7 +144,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     assert guide.draft?
 
     visit_edition guide
-    assert page.has_content?("Status: Draft")
+    assert page.has_css?('.label', text: 'Draft')
   end
 
   test "should update progress of a guide" do
@@ -160,7 +160,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
       click_on "Send"
     end
 
-    assert page.has_content?("Status: Fact check")
+    assert page.has_css?('.label', text: 'Fact check')
 
     guide.reload
 
@@ -338,7 +338,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     send_for_fact_check guide
 
     visit_edition guide
-    assert page.has_content? "Status: Fact check"
+    assert page.has_css?('.label', text: 'Fact check')
   end
 
   test "can create a new edition from the listings screens" do
@@ -384,6 +384,6 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     click_on "Create new edition"
 
     assert page.has_content?("Another person has created a newer edition")
-    assert page.has_content?("Status: Published")
+    assert page.has_css?('.label', text: 'Published')
   end
 end

--- a/test/integration/guide_create_edit_test.rb
+++ b/test/integration/guide_create_edit_test.rb
@@ -17,7 +17,7 @@ class GuideCreateEditTest < JavascriptIntegrationTest
   should "create a new GuideEdition" do
     visit "/publications/#{@artefact.id}"
 
-    assert page.has_content? "Foo bar Edition 1"
+    assert page.has_content? 'Foo bar #1'
 
     g = GuideEdition.first
     assert_equal @artefact.id.to_s, g.panopticon_id
@@ -33,7 +33,7 @@ class GuideCreateEditTest < JavascriptIntegrationTest
 
     visit "/editions/#{guide.to_param}"
 
-    assert page.has_content? "Foo bar Edition 1"
+    assert page.has_content? 'Foo bar #1'
 
     within :css, '#parts div.part:first-of-type' do
       fill_in 'Title', :with => 'Part One'
@@ -68,7 +68,7 @@ class GuideCreateEditTest < JavascriptIntegrationTest
     visit "/editions/#{guide.to_param}"
     click_on "Create new edition"
 
-    assert page.has_content? "Foo bar Edition 2"
+    assert page.has_content? 'Foo bar #2'
 
     g2 = GuideEdition.where(:version_number => 2).first
 

--- a/test/integration/help_page_create_edit_test.rb
+++ b/test/integration/help_page_create_edit_test.rb
@@ -17,7 +17,7 @@ class HelpPageCreateEditTest < JavascriptIntegrationTest
   should "create a new HelpPageEdition" do
     visit "/publications/#{@artefact.id}"
 
-    assert page.has_content? "Foo bar Edition 1"
+    assert page.has_content? 'Foo bar #1'
 
     h = HelpPageEdition.first
     assert_equal @artefact.id.to_s, h.panopticon_id
@@ -30,7 +30,7 @@ class HelpPageCreateEditTest < JavascriptIntegrationTest
                                  :body => "Body content")
     visit "/editions/#{help_page.to_param}"
 
-    assert page.has_content? "Foo bar Edition 1"
+    assert page.has_content? 'Foo bar #1'
 
     assert page.has_field?("Title", :with => "Foo bar")
     assert page.has_field?("Body", :with => "Body content")
@@ -56,7 +56,7 @@ class HelpPageCreateEditTest < JavascriptIntegrationTest
 
     click_on "Create new edition"
 
-    assert page.has_content? "Foo bar Edition 2"
+    assert page.has_content? 'Foo bar #2'
 
     assert page.has_field?("Body", :with => "This is really helpful")
   end

--- a/test/integration/licence_create_edit_test.rb
+++ b/test/integration/licence_create_edit_test.rb
@@ -23,7 +23,7 @@ class LicenceCreateEditTest < JavascriptIntegrationTest
     fill_in "Licence identifier", :with => "AB1234"
     click_button "Create Licence"
 
-    assert page.has_content? "Foo bar Edition 1"
+    assert page.has_content? 'Foo bar #1'
 
     l = LicenceEdition.first
     assert_equal @artefact.id.to_s, l.panopticon_id
@@ -42,7 +42,7 @@ class LicenceCreateEditTest < JavascriptIntegrationTest
 
     visit "/editions/#{licence.to_param}"
 
-    assert page.has_content? "Foo bar Edition 1"
+    assert page.has_content? 'Foo bar #1'
 
     assert page.has_field?("Licence identifier", :with => "ab2345")
     assert page.has_field?("Licence short description", :with => "Short description content")
@@ -80,7 +80,7 @@ class LicenceCreateEditTest < JavascriptIntegrationTest
     visit "/editions/#{licence.to_param}"
     click_on "Create new edition"
 
-    assert page.has_content? "Foo bar Edition 2"
+    assert page.has_content? 'Foo bar #2'
 
     assert page.has_field?("Licence identifier", :with => "ab2345")
     assert page.has_field?("Licence short description", :with => "Short description content")

--- a/test/integration/local_transaction_create_edit_test.rb
+++ b/test/integration/local_transaction_create_edit_test.rb
@@ -24,7 +24,7 @@ class LocalTransactionCreateEditTest < JavascriptIntegrationTest
 
     fill_in 'Lgsl code', :with => '1'
     click_button 'Create Local transaction'
-    assert page.has_content? "Foo bar Edition 1"
+    assert page.has_content? 'Foo bar #1'
 
     assert_equal email_count_before_start + 1, ActionMailer::Base.deliveries.count
     assert_match /Created Local transaction: "Foo bar"/, ActionMailer::Base.deliveries.last.subject
@@ -46,7 +46,7 @@ class LocalTransactionCreateEditTest < JavascriptIntegrationTest
 
     fill_in 'Lgsl code', :with => '1'
     click_button 'Create Local transaction'
-    assert page.has_content? "Foo bar Edition 1"
+    assert page.has_content? 'Foo bar #1'
   end
 
   test "editing a local transaction has the LGSL and LGIL fields" do
@@ -54,7 +54,7 @@ class LocalTransactionCreateEditTest < JavascriptIntegrationTest
                                  :title => "Foo transaction", :lgsl_code => 1)
 
     visit "/editions/#{edition.to_param}"
-    assert page.has_content? "Foo transaction Edition 1"
+    assert page.has_content? 'Foo transaction #1'
 
     # For some reason capybara was having trouble matching this disabled
     # field with the has_field? matcher. Retrieving it manually seems to

--- a/test/integration/video_edition_create_edit_test.rb
+++ b/test/integration/video_edition_create_edit_test.rb
@@ -44,7 +44,7 @@ class VideoEditionCreateEditTest < JavascriptIntegrationTest
 
     visit "/editions/#{video.to_param}"
 
-    assert page.has_content? "Foo bar Edition 1"
+    assert page.has_content? 'Foo bar #1'
 
     assert page.has_field?("Video URL", :with => "http://www.youtube.com/watch?v=qySFp3qnVmM")
     assert page.has_field?("Video Summary", :with => "Coke smoothie")
@@ -76,7 +76,7 @@ class VideoEditionCreateEditTest < JavascriptIntegrationTest
     visit "/editions/#{video.to_param}"
     click_on "Create new edition"
 
-    assert page.has_content? "Foo bar Edition 2"
+    assert page.has_content? 'Foo bar #2'
 
     assert page.has_field?("Video URL", :with => "http://www.youtube.com/watch?v=qySFp3qnVmM")
     assert page.has_field?("Video Summary", :with => "Coke smoothie")


### PR DESCRIPTION
Make it clear what type of format is being viewed. 
Also shorten text used for editions and statuses.
## Before

![screen shot 2014-12-11 at 13 36 52](https://cloud.githubusercontent.com/assets/319055/5394909/dc225118-813a-11e4-9d9a-e70ca1425448.png)
## After

![screen shot 2014-12-11 at 13 36 29](https://cloud.githubusercontent.com/assets/319055/5394908/dc2138b4-813a-11e4-809f-56d1f6bfbc58.png)
