### PR TITLE
Fix wrapping environment label with admin gem bump

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ else
 end
 
 gem 'erubis'
-gem 'govuk_admin_template', '1.4.0'
+gem 'govuk_admin_template', '1.4.2'
 gem 'select2-rails', '3.5.9.1'
 gem 'formtastic', '2.3.0'
 gem 'formtastic-bootstrap', '3.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
       kramdown (~> 1.4.1)
       nokogiri (~> 1.5.10)
       sanitize (~> 2.1.0)
-    govuk_admin_template (1.4.0)
+    govuk_admin_template (1.4.2)
       bootstrap-sass (~> 3.3.1)
       jquery-rails (~> 3.1.1)
       rails (>= 3.2.0)
@@ -342,7 +342,7 @@ DEPENDENCIES
   gds-api-adapters (= 16.4.0)
   gds-sso (= 10.0.0)
   govspeak (~> 3.1.0)
-  govuk_admin_template (= 1.4.0)
+  govuk_admin_template (= 1.4.2)
   govuk_content_models (= 27.0.0)
   has_scope
   inherited_resources


### PR DESCRIPTION
Pull in fix for wrapping environment label.
See https://github.com/alphagov/govuk_admin_template/pull/54
## Example of the bug

![screen shot 2014-12-04 at 16 41 38](https://cloud.githubusercontent.com/assets/319055/5301921/783589e2-7bd4-11e4-8fdb-933666be46c8.png)
