### PR TITLE
Remove the "Archive by" column from archived publications table

### DIFF
--- a/app/views/root/_archived.html.erb
+++ b/app/views/root/_archived.html.erb
@@ -6,7 +6,6 @@
       <th scope="col"><%= sortable "updated_at", "Updated" %></th>
       <th scope="col"><%= sortable "assignee", "Assigned to" %></th>
       <th scope="col"><%= sortable "creator", "Created by" %></th>
-      <th scope="col"><%= sortable "archiver", "Archived by" %></th>
       <th scope="col">Actions</th>
     </tr>
   </thead>

--- a/app/views/root/_publication.html.erb
+++ b/app/views/root/_publication.html.erb
@@ -68,11 +68,6 @@
       <%= publication.publisher %>
     </td>
   <% end %>
-  <% if tab && tab == :archived %>
-    <td>
-      <%= publication.archiver %>
-    </td>
-  <% end %>
   <% if tab && (tab == :archived || tab == :published) %>
     <td>
       <% if publication.can_create_new_edition? %>


### PR DESCRIPTION
For every archived edition the column is empty.

![screen shot 2014-12-15 at 17 38 42](https://cloud.githubusercontent.com/assets/319055/5440527/465269bc-8481-11e4-8cd6-2bce93b95593.png)
