### PR TITLE
Improve legibility of diff views

### DIFF
--- a/app/assets/stylesheets/diff.scss
+++ b/app/assets/stylesheets/diff.scss
@@ -17,9 +17,12 @@ $strong-removed-color: #faa;
     padding-left: 0;
 
     li {
-      margin-bottom: 1em;
+      min-height: 24px;
+      margin: 0 -15px;
+      padding: 0 15px;
       word-wrap: break-word;
       list-style: none;
+      position: relative;
 
       del,
       ins {
@@ -29,8 +32,7 @@ $strong-removed-color: #faa;
 
     li.del,
     li.ins {
-      border-radius: 3px;
-      padding: 0.2rem 0.4rem;
+      padding-top: 2px;
     }
 
     li.del {
@@ -54,21 +56,24 @@ $strong-removed-color: #faa;
     li.del:before,
     li.ins:before {
       position: absolute;
-      font-size: 26px;
       font-weight: bold;
-      margin-left: -57px;
-      margin-top: -11px;
+      margin-left: -55px;
       width: 40px;
       text-align: center;
+      min-height: 24px;
+      top: 0;
+      bottom: 0;
     }
 
     li.del:before {
-      color: $strong-removed-color;
+      color: $state-danger-text;
+      background-color: $removed-color;
       content: "-";
     }
 
     li.ins:before {
-      color: $strong-added-color;
+      color: $state-success-text;
+      background-color: $added-color;
       content: "+";
     }
   }


### PR DESCRIPTION
New lines were displaying as thin strips. Spaces between lines made making comparisons more difficult. The +/- signs were hard to read against grey text.
- Give each line in the diff a minimum height, making new lines display thicker and maintaining a vertical rhythm
- Remove space between lines, the content naturally provides this spacing
- Extend red/green highlight to edges of the view
- Use darker red and green colours for the +/- icons
## Before

![screen shot 2014-12-16 at 11 25 21](https://cloud.githubusercontent.com/assets/319055/5452750/9f10905c-8516-11e4-91b3-4ee9db199d55.png)
## After

![screen shot 2014-12-16 at 11 25 37](https://cloud.githubusercontent.com/assets/319055/5452753/a38cfb98-8516-11e4-890d-3a19cedeb800.png)
