### PR TITLE
Claiming 2i should update via a distinct action.

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -86,6 +86,16 @@ class EditionsController < InheritedResources::Base
     end
   end
 
+  def review
+    resource.reviewer = params[:edition][:reviewer]
+    if resource.save!
+      flash[:success] = "You are the reviewer of this #{description(resource).downcase}."
+    else
+      flash[:danger] = "Something went wrong when attempting to claim 2i."
+    end
+    redirect_to edition_path(resource)
+  end
+
   def destroy
     if resource.can_destroy?
       destroy! do

--- a/app/views/root/_reviewer.html.erb
+++ b/app/views/root/_reviewer.html.erb
@@ -1,7 +1,7 @@
 <% if publication.reviewer and publication.reviewer.present? -%>
   <%= publication.reviewer %>
 <% elsif current_user != publication.assigned_to -%>
-  <%= form_for :edition, url: edition_path(publication._id), method: :put do |f| %>
+  <%= form_for :edition, url: review_edition_path(publication._id), method: :put do |f| %>
     <%= f.hidden_field :reviewer, value: current_user.name %>
     <%= f.submit "Claim 2i", class: "btn btn-primary" %>
   <% end -%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Publisher::Application.routes.draw do
       get 'diff'
       post 'duplicate'
       post 'progress'
+      put 'review'
       post 'skip_fact_check', to: 'editions#progress',
         edition: {
           activity: {

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -93,6 +93,17 @@ class EditionsControllerTest < ActionController::TestCase
     assert_equal 1, @guide.actions.select { |a| a.request_type == Action::ASSIGN }.length
   end
 
+  test "should update the reviewer" do
+    bob = User.create
+
+    put :review,
+      :id       => @guide.id,
+      :edition  => { :reviewer => bob.name }
+
+    @guide.reload
+    assert_equal bob.name, @guide.reviewer
+  end
+
   test "should show the edit page again if updating fails" do
     panopticon_has_metadata(
       "id" => "test"

--- a/test/integration/root_overview_test.rb
+++ b/test/integration/root_overview_test.rb
@@ -131,8 +131,9 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
   test "allows a user to claim 2i" do
     stub_collections
     user = FactoryGirl.create(:user)
+    assignee = FactoryGirl.create(:user)
     edition = FactoryGirl.create(:guide_edition, :title => "XXX", :state => 'in_review',
-                                 :review_requested_at => Time.zone.now)
+                                 :review_requested_at => Time.zone.now, :assigned_to => assignee)
 
     visit "/"
     filter_by_user("All")
@@ -144,8 +145,9 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
     end
 
     assert edition_url(edition), current_url
-    assert page.has_content?("edition was successfully updated")
+    assert page.has_content?("You are the reviewer of this guide.")
     assert page.has_select?("Reviewer", :selected => user.name)
+    assert page.has_select?("Assigned to", :selected => assignee.name)
   end
 
   test "prevents the assignee claiming 2i" do


### PR DESCRIPTION
In order to fix a couple of bugs introduced by the 'Claim 2i' and
unassign workflow updates the action for claiming 2i is now a distinct action.

https://www.agileplannerapp.com/boards/173808/cards/9013
