### PR TITLE
Downtime manager

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", git: 'https://github.com/alphagov/govuk_content_models.git', branch: 'add-downtime-schedule'
+  gem "govuk_content_models", '~> 28.1.0'
 end
 
 if ENV['API_DEV']

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ end
 gem 'erubis'
 gem 'govuk_admin_template', '1.4.2'
 gem 'select2-rails', '3.5.9.1'
+gem 'momentjs-rails', '2.8.3'
 gem 'formtastic', '2.3.0'
 gem 'formtastic-bootstrap', '3.0.0'
 gem 'rails_autolink', '1.1.6'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", "28.0.0"
+  gem "govuk_content_models", git: 'https://github.com/alphagov/govuk_content_models.git', branch: 'add-downtime-schedule'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,18 @@
 GIT
+  remote: https://github.com/alphagov/govuk_content_models.git
+  revision: 75ad66677c471ad66102d878488ffe11d580bd86
+  branch: add-downtime-schedule
+  specs:
+    govuk_content_models (28.0.0)
+      bson_ext
+      gds-api-adapters (>= 10.9.0)
+      gds-sso (>= 10.0.0)
+      govspeak (~> 3.1.0)
+      mongoid (~> 2.5)
+      plek
+      state_machine
+
+GIT
   remote: https://github.com/alphagov/nested_form.git
   revision: ac43d8fe0cd3805b7309169ca8fbdd6a1527d9b5
   branch: add-wrapper-class
@@ -86,7 +100,7 @@ GEM
       railties (>= 3.0.0)
     faker (1.1.2)
       i18n (~> 0.5)
-    faraday (0.9.0)
+    faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
     formtastic (2.3.0)
       actionpack (>= 3.0)
@@ -117,14 +131,6 @@ GEM
       bootstrap-sass (~> 3.3.1)
       jquery-rails (~> 3.1.1)
       rails (>= 3.2.0)
-    govuk_content_models (28.0.0)
-      bson_ext
-      gds-api-adapters (>= 10.9.0)
-      gds-sso (>= 10.0.0)
-      govspeak (~> 3.1.0)
-      mongoid (~> 2.5)
-      plek
-      state_machine
     has_scope (0.5.1)
     hashie (3.3.2)
     hike (1.2.3)
@@ -144,7 +150,7 @@ GEM
     jquery-rails (3.1.2)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.1)
+    json (1.8.2)
     jwt (1.2.0)
     kaminari (0.13.0)
       actionpack (>= 3.0.0)
@@ -219,7 +225,7 @@ GEM
       rack (>= 0.4)
     rack-ssl (1.3.4)
       rack
-    rack-test (0.6.2)
+    rack-test (0.6.3)
       rack (>= 1.0)
     rails (3.2.18)
       actionmailer (= 3.2.18)
@@ -348,7 +354,7 @@ DEPENDENCIES
   gds-sso (= 10.0.0)
   govspeak (~> 3.1.0)
   govuk_admin_template (= 1.4.2)
-  govuk_content_models (= 28.0.0)
+  govuk_content_models!
   has_scope
   inherited_resources
   jasmine (= 2.0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
     hike (1.2.3)
     hitimes (1.2.2)
     htmlentities (4.3.2)
-    i18n (0.6.11)
+    i18n (0.7.0)
     inherited_resources (1.4.0)
       has_scope (~> 0.5.0)
       responders (~> 0.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,4 @@
 GIT
-  remote: https://github.com/alphagov/govuk_content_models.git
-  revision: 75ad66677c471ad66102d878488ffe11d580bd86
-  branch: add-downtime-schedule
-  specs:
-    govuk_content_models (28.0.0)
-      bson_ext
-      gds-api-adapters (>= 10.9.0)
-      gds-sso (>= 10.0.0)
-      govspeak (~> 3.1.0)
-      mongoid (~> 2.5)
-      plek
-      state_machine
-
-GIT
   remote: https://github.com/alphagov/nested_form.git
   revision: ac43d8fe0cd3805b7309169ca8fbdd6a1527d9b5
   branch: add-wrapper-class
@@ -131,6 +117,14 @@ GEM
       bootstrap-sass (~> 3.3.1)
       jquery-rails (~> 3.1.1)
       rails (>= 3.2.0)
+    govuk_content_models (28.1.0)
+      bson_ext
+      gds-api-adapters (>= 10.9.0)
+      gds-sso (>= 10.0.0)
+      govspeak (~> 3.1.0)
+      mongoid (~> 2.5)
+      plek
+      state_machine
     has_scope (0.5.1)
     hashie (3.3.2)
     hike (1.2.3)
@@ -356,7 +350,7 @@ DEPENDENCIES
   gds-sso (= 10.0.0)
   govspeak (~> 3.1.0)
   govuk_admin_template (= 1.4.2)
-  govuk_content_models!
+  govuk_content_models (~> 28.1.0)
   has_scope
   inherited_resources
   jasmine (= 2.0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,8 @@ GEM
       redis
     mocha (0.13.3)
       metaclass (~> 0.0.1)
+    momentjs-rails (2.8.3)
+      railties (>= 3.1)
     mongo (1.7.1)
       bson (~> 1.7.1)
     mongoid (2.6.0)
@@ -364,6 +366,7 @@ DEPENDENCIES
   minitest (= 3.3.0)
   mlanett-redis-lock (= 0.2.2)
   mocha (= 0.13.3)
+  momentjs-rails (= 2.8.3)
   mongo (= 1.7.1)
   mongoid_rails_migrations (= 1.0.0)
   nested_form!

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,5 @@
 //= require select2
+//= require moment
 //= require jquery-ui.custom.min
 //= require_directory .
 //= require_directory ./modules

--- a/app/assets/javascripts/modules/downtime_message.js
+++ b/app/assets/javascripts/modules/downtime_message.js
@@ -1,0 +1,110 @@
+(function(Modules) {
+  "use strict";
+  Modules.DowntimeMessage = function() {
+    this.start = function(element) {
+
+      var $startTimeFields = element.find('.js-start-time select'),
+          $stopTimeFields  = element.find('.js-stop-time select'),
+          $downtimeMessage = element.find('.js-downtime-message'),
+          $scheduleMessage = element.find('.js-schedule-message');
+
+      element.on('change', 'select', updateMessages);
+      updateMessages();
+
+      function updateMessages() {
+
+        var startDate = getDateFromFields($startTimeFields),
+            stopDate = getDateFromFields($stopTimeFields);
+
+        $downtimeMessage.val(downtimeMessage(startDate, stopDate));
+        $scheduleMessage.text(scheduleMessage(startDate));
+      }
+
+      function getDateFromFields(fields) {
+        var year,
+            month,
+            day,
+            hours,
+            minutes,
+            date;
+
+        fields.each(function(i) {
+          var value = parseInt($(this).val(), 10);
+
+          switch(i) {
+            case 4:
+              year = value;
+              break;
+            case 3:
+              month = value - 1;
+              break;
+            case 2:
+              day = value;
+              break;
+            case 1:
+              minutes = value;
+              break;
+            case 0:
+              hours = value;
+              break;
+            }
+        });
+
+        date = new Date(year, month, day, hours, minutes);
+        return moment(date);
+      }
+
+      function downtimeMessage(startDate, stopDate) {
+        var message = "This service will be unavailable from ",
+            startTime = getTime(startDate),
+            startDay = getDay(startDate),
+            stopTime = getTime(stopDate),
+            stopDay = getDay(stopDate),
+            sameDay = isSameDay(startDate, stopDate);
+
+        if (!isValidSchedule(startDate, stopDate)) {
+          return '';
+        }
+
+        if (sameDay) {
+          message = message + startTime + ' to ' + stopTime + ' on ' + startDay + '.';
+        } else {
+          message = message + startTime + ' on ' + startDay
+            + ' to ' + stopTime + ' on ' + stopDay + '.';
+        }
+
+        return message;
+      }
+
+      function scheduleMessage(startDate) {
+        var message = "A downtime message will show from ",
+            beginShowingDate = startDate.clone().subtract(1, 'day'),
+            beginTime = getTime(beginShowingDate),
+            beginDay = getDay(beginShowingDate);
+
+        return message + beginTime + ' on ' + beginDay + ' (one day before the downtime)';
+      }
+
+      function isSameDay(startDate, stopDate) {
+        // Treat a midnight stop date as being on the same day as
+        // the hours before it. eg
+        // Unavailable from 10pm to midnight on Thursday 8 January
+        return startDate.isSame(stopDate.clone().subtract(1, 'minute'), 'day');
+      }
+
+      function getTime(moment) {
+        var time = moment.format('h:mma');
+        return time.replace(/:00/, '').replace(/12am/, 'midnight').replace(/12pm/, 'midday');
+      }
+
+      function getDay(moment) {
+        var day = moment.format('dddd D MMMM');
+        return day;
+      }
+
+      function isValidSchedule(startDate, stopDate) {
+        return !startDate.isSame(stopDate) && !stopDate.isBefore(startDate);
+      }
+    }
+  };
+})(window.GOVUKAdmin.Modules);

--- a/app/assets/javascripts/modules/downtime_message.js
+++ b/app/assets/javascripts/modules/downtime_message.js
@@ -6,15 +6,34 @@
       var $startTimeFields = element.find('.js-start-time select'),
           $stopTimeFields  = element.find('.js-stop-time select'),
           $downtimeMessage = element.find('.js-downtime-message'),
-          $scheduleMessage = element.find('.js-schedule-message');
+          $scheduleMessage = element.find('.js-schedule-message'),
+          $submit          = element.find('.js-submit');
 
-      element.on('change', 'select', updateMessages);
+      element.on('change', 'select', updateFormAndMessages);
+      updateForm();
 
-      function updateMessages() {
+      function updateFormAndMessages() {
+        updateForm(true);
+      }
 
+      function updateForm(andMessages) {
         var startDate = getDateFromFields($startTimeFields),
             stopDate = getDateFromFields($stopTimeFields);
 
+        if (isValidSchedule(startDate, stopDate)) {
+          enableForm();
+          if (andMessages) {
+            updateMessages(startDate, stopDate);
+          }
+        } else {
+          if (andMessages) {
+            $downtimeMessage.val('');
+          }
+          disableForm();
+        }
+      }
+
+      function updateMessages(startDate, stopDate) {
         $downtimeMessage.val(downtimeMessage(startDate, stopDate));
         $scheduleMessage.text(scheduleMessage(startDate));
       }
@@ -97,13 +116,24 @@
       }
 
       function getDay(moment) {
-        var day = moment.format('dddd D MMMM');
-        return day;
+        return moment.format('dddd D MMMM');
       }
 
       function isValidSchedule(startDate, stopDate) {
-        return !startDate.isSame(stopDate) && !stopDate.isBefore(startDate);
+        return stopDate.isAfter(startDate);
       }
+
+      function disableForm() {
+        $submit.attr('disabled','disabled');
+        $downtimeMessage.attr('disabled','disabled');
+        $scheduleMessage.text('Please select a valid date range');
+      }
+
+      function enableForm() {
+        $submit.removeAttr('disabled');
+        $downtimeMessage.removeAttr('disabled');
+      }
+
     }
   };
 })(window.GOVUKAdmin.Modules);

--- a/app/assets/javascripts/modules/downtime_message.js
+++ b/app/assets/javascripts/modules/downtime_message.js
@@ -9,7 +9,6 @@
           $scheduleMessage = element.find('.js-schedule-message');
 
       element.on('change', 'select', updateMessages);
-      updateMessages();
 
       function updateMessages() {
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,4 +14,5 @@
 @import 'notes';
 
 // Pages
+@import 'downtime';
 @import 'smart_answer_builder';

--- a/app/assets/stylesheets/downtime.scss
+++ b/app/assets/stylesheets/downtime.scss
@@ -1,0 +1,9 @@
+.help-note {
+  font-weight: bold;
+
+  .glyphicon {
+    float: left;
+    font-size: $font-size-large;
+    margin-right: $default-horizontal-margin;
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,4 +21,15 @@ class ApplicationController < ActionController::Base
   def record_not_found
     render :text => "404 Not Found", :status => 404
   end
+
+  def squash_multiparameter_datetime_attributes(params, attribute_names)
+    attribute_names.each do |attribute_name|
+      datetime_params = params.select { |k, v| k.include? attribute_name }.values.map(&:to_i)
+      params.delete_if { |k, v| k.include? attribute_name }
+
+      params[attribute_name] = DateTime.new(*datetime_params) if datetime_params.present?
+    end
+    params
+  end
+
 end

--- a/app/controllers/downtimes_controller.rb
+++ b/app/controllers/downtimes_controller.rb
@@ -15,7 +15,7 @@ class DowntimesController < ApplicationController
 
     if @downtime.save
       link = view_context.link_to(@edition.title, edit_edition_downtime_path(@edition), class: 'link-inherit bold')
-      flash[:success] = "#{link} downtime message scheduled (from #{@downtime.datetime_string})".html_safe
+      flash[:success] = "#{link} downtime message scheduled (from #{view_context.downtime_datetime(@downtime)})".html_safe
       redirect_to downtimes_path
     else
       render :new
@@ -39,7 +39,7 @@ class DowntimesController < ApplicationController
 
     if @downtime.update_attributes(params[:downtime])
       link = view_context.link_to(@edition.title, edit_edition_downtime_path(@edition), class: 'link-inherit bold')
-      flash[:success] = "#{link} downtime message re-scheduled (from #{@downtime.datetime_string})".html_safe
+      flash[:success] = "#{link} downtime message re-scheduled (from #{view_context.downtime_datetime(@downtime)})".html_safe
       redirect_to downtimes_path
     else
       render :edit

--- a/app/controllers/downtimes_controller.rb
+++ b/app/controllers/downtimes_controller.rb
@@ -1,0 +1,7 @@
+class DowntimesController < ApplicationController
+
+  def index
+    @transactions = TransactionEdition.published
+  end
+
+end

--- a/app/controllers/downtimes_controller.rb
+++ b/app/controllers/downtimes_controller.rb
@@ -14,8 +14,9 @@ class DowntimesController < ApplicationController
     @downtime = Downtime.new(params[:downtime])
 
     if @downtime.save
-      flash[:success] = 'Successfully scheduled downtime'
-      redirect_to edit_edition_downtime_path(@edition)
+      link = view_context.link_to(@edition.title, edit_edition_downtime_path(@edition), class: 'link-inherit bold')
+      flash[:success] = "#{link} downtime message scheduled (from #{@downtime.datetime_string})".html_safe
+      redirect_to downtimes_path
     else
       render :new
     end
@@ -30,13 +31,15 @@ class DowntimesController < ApplicationController
 
     if params['commit'] == 'Cancel downtime'
       @downtime.destroy
-      flash[:success] = 'Successfully cancelled downtime'
+      link = view_context.link_to(@edition.title, new_edition_downtime_path(@edition), class: 'link-inherit bold')
+      flash[:success] = "#{link} downtime message cancelled".html_safe
       redirect_to downtimes_path
       return
     end
 
     if @downtime.update_attributes(params[:downtime])
-      flash[:success] = 'Successfully updated downtime'
+      link = view_context.link_to(@edition.title, edit_edition_downtime_path(@edition), class: 'link-inherit bold')
+      flash[:success] = "#{link} downtime message re-scheduled (from #{@downtime.datetime_string})".html_safe
       redirect_to downtimes_path
     else
       render :edit

--- a/app/controllers/downtimes_controller.rb
+++ b/app/controllers/downtimes_controller.rb
@@ -1,7 +1,55 @@
 class DowntimesController < ApplicationController
+  before_filter :load_edition, except: [:index]
+  before_filter :process_params, only: [:create, :update]
 
   def index
-    @transactions = TransactionEdition.published
+    @transactions = TransactionEdition.published.order_by([:title, :asc])
   end
 
+  def new
+    @downtime = Downtime.new(artefact: @edition.artefact)
+  end
+
+  def create
+    @downtime = Downtime.new(params[:downtime])
+
+    if @downtime.save
+      flash[:success] = 'Successfully scheduled downtime'
+      redirect_to edit_edition_downtime_path(@edition)
+    else
+      render :new
+    end
+  end
+
+  def edit
+    @downtime = Downtime.for(@edition.artefact)
+  end
+
+  def update
+    @downtime = Downtime.for(@edition.artefact)
+
+    if params['commit'] == 'Remove downtime'
+      @downtime.destroy
+      flash[:success] = 'Successfully removed downtime'
+      redirect_to downtimes_path
+      return
+    end
+
+    if @downtime.update_attributes(params[:downtime])
+      flash[:success] = 'Successfully updated downtime'
+      redirect_to downtimes_path
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def load_edition
+    @edition = Edition.find(params[:edition_id])
+  end
+
+  def process_params
+    squash_multiparameter_datetime_attributes(params[:downtime], ['start_time', 'end_time'])
+  end
 end

--- a/app/controllers/downtimes_controller.rb
+++ b/app/controllers/downtimes_controller.rb
@@ -28,9 +28,9 @@ class DowntimesController < ApplicationController
   def update
     @downtime = Downtime.for(@edition.artefact)
 
-    if params['commit'] == 'Remove downtime'
+    if params['commit'] == 'Cancel downtime'
       @downtime.destroy
-      flash[:success] = 'Successfully removed downtime'
+      flash[:success] = 'Successfully cancelled downtime'
       redirect_to downtimes_path
       return
     end

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -155,14 +155,6 @@ class EditionsController < InheritedResources::Base
     end
 
   private
-    def squash_multiparameter_datetime_attributes(params)
-      datetime_params = params.select { |k, v| k.include? 'publish_at' }.values.map(&:to_i)
-      params.delete_if { |k, v| k.include? 'publish_at' }
-
-      params['publish_at'] = DateTime.new(*datetime_params) if datetime_params.present?
-      params
-    end
-
     def attempted_activity_params(attempted_activity)
       params[:edition]["activity_#{attempted_activity}_attributes"]
     end
@@ -191,7 +183,7 @@ class EditionsController < InheritedResources::Base
 
     def progress_edition(edition, activity_params)
       @command = EditionProgressor.new(resource, current_user)
-      @command.progress(squash_multiparameter_datetime_attributes(activity_params))
+      @command.progress(squash_multiparameter_datetime_attributes(activity_params, ['publish_at']))
     end
 
     def report_state_counts

--- a/app/helpers/downtimes_helper.rb
+++ b/app/helpers/downtimes_helper.rb
@@ -1,0 +1,17 @@
+module DowntimesHelper
+
+  def downtime_datetime(downtime)
+    start_time, end_time = downtime.start_time, downtime.end_time
+    time_format, date_format = '%l:%M%P', 'on %e %B'
+    datetime_format = "#{time_format} #{date_format}"
+
+    strings = if start_time.to_date == (end_time - 1.second).to_date
+      ["#{start_time.strftime(time_format).strip} to #{end_time.strftime(time_format).strip}"] << start_time.strftime(date_format)
+    else
+      ["#{start_time.strftime(datetime_format).strip} to #{end_time.strftime(datetime_format).strip}"]
+    end
+
+    strings.join(' ').gsub(':00', '').gsub('12pm', 'midday').gsub('12am', 'midnight')
+  end
+
+end

--- a/app/helpers/editions_helper.rb
+++ b/app/helpers/editions_helper.rb
@@ -26,9 +26,4 @@ module EditionsHelper
       [parent_title, collections]
     end
   end
-
-  def display_scheduled_downtime(downtime)
-    datetime_format = '%l:%M%P on %e %b'
-    "#{downtime.start_time.strftime(datetime_format)} to #{downtime.end_time.strftime(datetime_format)}".gsub(':00', '')
-  end
 end

--- a/app/helpers/editions_helper.rb
+++ b/app/helpers/editions_helper.rb
@@ -26,4 +26,9 @@ module EditionsHelper
       [parent_title, collections]
     end
   end
+
+  def display_scheduled_downtime(downtime)
+    datetime_format = '%l:%M%P on %e %b'
+    "#{downtime.start_time.strftime(datetime_format)} to #{downtime.end_time.strftime(datetime_format)}".gsub(':00', '')
+  end
 end

--- a/app/views/downtimes/_form.html.erb
+++ b/app/views/downtimes/_form.html.erb
@@ -1,0 +1,38 @@
+<%= f.hidden_field :artefact_id %>
+
+<% if @downtime.errors.any? %>
+   <p class="alert alert-danger">
+     Errors: <%= @downtime.errors.full_messages.to_sentence %>
+   </p>
+<% end %>
+
+<div class="form-group form-inline">
+  <%= f.label :start_time, 'Starts' %><br />
+  <span class="add-right-margin">
+  <%= f.time_select :start_time, { default: 1.hour.from_now.beginning_of_hour }, { class: 'date form-control' } %>
+  </span>
+  <%= f.date_select :start_time, { order: [:day, :month, :year], default: Date.tomorrow,
+    start_year: Date.today.year, end_year: Date.today.year.next }, { class: 'date form-control' } %>
+</div>
+
+<div class="form-group form-inline">
+  <%= f.label :end_time, 'Ends' %><br />
+  <span class="add-right-margin">
+  <%= f.time_select :end_time, { default: 1.hour.from_now.beginning_of_hour }, { class: 'date form-control' } %>
+  </span>
+  <%= f.date_select :end_time, { order: [:day, :month, :year], default: Date.tomorrow,
+    start_year: Date.today.year, end_year: Date.today.year.next }, { class: 'date form-control' } %>
+</div>
+
+<p class="text-muted add-top-margin">
+  Dates should be for the service’s planned downtime.
+  <br />Messages appear on the start page one day before the downtime is due.
+</p>
+
+<div class="form-group">
+  <%= f.label :message %>
+  <%= f.text_area :message, class: 'form-control input-md-8', rows: 3 %>
+  <p class="text-muted">
+    A message will be generated if left blank.
+  </p>
+</div>

--- a/app/views/downtimes/_form.html.erb
+++ b/app/views/downtimes/_form.html.erb
@@ -6,20 +6,22 @@
    </p>
 <% end %>
 
-  <%= f.label :start_time, 'Service will be unavailable from' %><br />
-  <span class="add-right-margin">
 <div class="form-group form-inline js-start-time">
+  <%= f.label :start_time, 'This service will be unavailable from' %><br />
+  <span>
   <%= f.time_select :start_time, { default: 1.hour.from_now.beginning_of_hour }, { class: 'date form-control' } %>
-  </span>
+</span>
+  <b class="add-left-margin add-right-margin">on</b>
   <%= f.date_select :start_time, { order: [:day, :month, :year], default: Date.tomorrow,
     start_year: Date.today.year, end_year: Date.today.year.next }, { class: 'date form-control' } %>
 </div>
 
 <div class="form-group form-inline js-stop-time">
   <%= f.label :end_time, 'to' %><br />
-  <span class="add-right-margin">
+  <span>
   <%= f.time_select :end_time, { default: 1.hour.from_now.beginning_of_hour }, { class: 'date form-control' } %>
   </span>
+  <b class="add-left-margin add-right-margin">on</b>
   <%= f.date_select :end_time, { order: [:day, :month, :year], default: Date.tomorrow,
     start_year: Date.today.year, end_year: Date.today.year.next }, { class: 'date form-control' } %>
 </div>

--- a/app/views/downtimes/_form.html.erb
+++ b/app/views/downtimes/_form.html.erb
@@ -33,8 +33,9 @@
   <%= f.text_area :message, class: 'form-control input-md-8 js-downtime-message', rows: 3 %>
 </div>
 
-<p class="input-md-8 add-bottom-margin">
-  <span class="glyphicon glyphicon-exclamation-sign pull-left add-right-margin" style="font-size: 20px"></span>
-  <b class="js-schedule-message">Messages appear on the start page one day before the downtime is due.</b></p>
+<p class="add-bottom-margin help-note">
+  <span class="glyphicon glyphicon-exclamation-sign"></span>
+  <span class="js-schedule-message">Messages appear on the start page one day before the downtime is due.</span>
+</p>
 
 <hr />

--- a/app/views/downtimes/_form.html.erb
+++ b/app/views/downtimes/_form.html.erb
@@ -30,7 +30,7 @@
 
 <div class="form-group">
   <%= f.label :message %>
-  <%= f.text_area :message, class: 'form-control input-md-8 js-downtime-message', rows: 3 %>
+  <%= f.text_area :message, class: 'form-control input-md-6 js-downtime-message', rows: 5 %>
 </div>
 
 <p class="add-bottom-margin help-note">

--- a/app/views/downtimes/_form.html.erb
+++ b/app/views/downtimes/_form.html.erb
@@ -6,16 +6,16 @@
    </p>
 <% end %>
 
-<div class="form-group form-inline">
   <%= f.label :start_time, 'Service will be unavailable from' %><br />
   <span class="add-right-margin">
+<div class="form-group form-inline js-start-time">
   <%= f.time_select :start_time, { default: 1.hour.from_now.beginning_of_hour }, { class: 'date form-control' } %>
   </span>
   <%= f.date_select :start_time, { order: [:day, :month, :year], default: Date.tomorrow,
     start_year: Date.today.year, end_year: Date.today.year.next }, { class: 'date form-control' } %>
 </div>
 
-<div class="form-group form-inline">
+<div class="form-group form-inline js-stop-time">
   <%= f.label :end_time, 'to' %><br />
   <span class="add-right-margin">
   <%= f.time_select :end_time, { default: 1.hour.from_now.beginning_of_hour }, { class: 'date form-control' } %>
@@ -24,14 +24,15 @@
     start_year: Date.today.year, end_year: Date.today.year.next }, { class: 'date form-control' } %>
 </div>
 
-<p class="text-muted add-top-margin">
-  Messages appear on the start page one day before the downtime is due.
-</p>
+<hr />
 
 <div class="form-group">
   <%= f.label :message %>
-  <%= f.text_area :message, class: 'form-control input-md-8', rows: 3 %>
-  <p class="text-muted">
-    A message will be generated if left blank.
-  </p>
+  <%= f.text_area :message, class: 'form-control input-md-8 js-downtime-message', rows: 3 %>
 </div>
+
+<p class="input-md-8 add-bottom-margin">
+  <span class="glyphicon glyphicon-exclamation-sign pull-left add-right-margin" style="font-size: 20px"></span>
+  <b class="js-schedule-message">Messages appear on the start page one day before the downtime is due.</b></p>
+
+<hr />

--- a/app/views/downtimes/_form.html.erb
+++ b/app/views/downtimes/_form.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <div class="form-group form-inline">
-  <%= f.label :start_time, 'Starts' %><br />
+  <%= f.label :start_time, 'Service will be unavailable from' %><br />
   <span class="add-right-margin">
   <%= f.time_select :start_time, { default: 1.hour.from_now.beginning_of_hour }, { class: 'date form-control' } %>
   </span>
@@ -16,7 +16,7 @@
 </div>
 
 <div class="form-group form-inline">
-  <%= f.label :end_time, 'Ends' %><br />
+  <%= f.label :end_time, 'to' %><br />
   <span class="add-right-margin">
   <%= f.time_select :end_time, { default: 1.hour.from_now.beginning_of_hour }, { class: 'date form-control' } %>
   </span>
@@ -25,8 +25,7 @@
 </div>
 
 <p class="text-muted add-top-margin">
-  Dates should be for the service’s planned downtime.
-  <br />Messages appear on the start page one day before the downtime is due.
+  Messages appear on the start page one day before the downtime is due.
 </p>
 
 <div class="form-group">

--- a/app/views/downtimes/edit.html.erb
+++ b/app/views/downtimes/edit.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title, 'Edit scheduled downtime' %>
+
+<ul class="breadcrumb">
+  <li class="crumb"><%= link_to 'Downtime', downtimes_path %></li>
+  <li class="active"><%= @downtime.artefact.name %></li>
+</ul>
+
+<div class="page-title">
+  <h1>
+    <span class="small"><%= @downtime.artefact.name %></span>
+    Edit scheduled downtime
+  </h1>
+</div>
+
+<%= semantic_form_for @downtime, url: edition_downtime_path(@edition), html: { class: 'form well remove-top-margin' } do |f| %>
+  <%= render 'form', f: f %>
+  <%= f.submit 'Save changes and re-schedule', class: 'btn btn-success' %>
+  <%= f.submit 'Remove downtime', class: 'add-left-margin btn btn-danger' %>
+<% end %>

--- a/app/views/downtimes/edit.html.erb
+++ b/app/views/downtimes/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, 'Edit scheduled downtime message' %>
+<% content_for :page_title, 'Re-schedule downtime message' %>
 
 <ul class="breadcrumb">
   <li class="crumb"><%= link_to 'Downtime', downtimes_path %></li>
@@ -8,12 +8,12 @@
 <div class="page-title">
   <h1>
     <span class="small"><%= @downtime.artefact.name %></span>
-    Edit scheduled downtime message
+    Re-schedule downtime message
   </h1>
 </div>
 
 <%= semantic_form_for @downtime, url: edition_downtime_path(@edition), html: { class: 'form well remove-top-margin', 'data-module' => 'downtime-message' } do |f| %>
   <%= render 'form', f: f %>
-  <%= f.submit 'Save changes and re-schedule', class: 'btn btn-success' %>
-  <%= f.submit 'Remove downtime', class: 'add-left-margin btn btn-danger' %>
+  <%= f.submit 'Re-schedule downtime message', class: 'btn btn-success' %>
+  <%= f.submit 'Cancel downtime', class: 'add-left-margin btn btn-danger' %>
 <% end %>

--- a/app/views/downtimes/edit.html.erb
+++ b/app/views/downtimes/edit.html.erb
@@ -14,6 +14,6 @@
 
 <%= semantic_form_for @downtime, url: edition_downtime_path(@edition), html: { class: 'form well remove-top-margin', 'data-module' => 'downtime-message' } do |f| %>
   <%= render 'form', f: f %>
-  <%= f.submit 'Re-schedule downtime message', class: 'btn btn-success' %>
+  <%= f.submit 'Re-schedule downtime message', class: 'js-submit btn btn-success' %>
   <%= f.submit 'Cancel downtime', class: 'add-left-margin btn btn-danger' %>
 <% end %>

--- a/app/views/downtimes/edit.html.erb
+++ b/app/views/downtimes/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, 'Edit scheduled downtime' %>
+<% content_for :page_title, 'Edit scheduled downtime message' %>
 
 <ul class="breadcrumb">
   <li class="crumb"><%= link_to 'Downtime', downtimes_path %></li>
@@ -8,7 +8,7 @@
 <div class="page-title">
   <h1>
     <span class="small"><%= @downtime.artefact.name %></span>
-    Edit scheduled downtime
+    Edit scheduled downtime message
   </h1>
 </div>
 

--- a/app/views/downtimes/edit.html.erb
+++ b/app/views/downtimes/edit.html.erb
@@ -12,7 +12,7 @@
   </h1>
 </div>
 
-<%= semantic_form_for @downtime, url: edition_downtime_path(@edition), html: { class: 'form well remove-top-margin' } do |f| %>
+<%= semantic_form_for @downtime, url: edition_downtime_path(@edition), html: { class: 'form well remove-top-margin', 'data-module' => 'downtime-message' } do |f| %>
   <%= render 'form', f: f %>
   <%= f.submit 'Save changes and re-schedule', class: 'btn btn-success' %>
   <%= f.submit 'Remove downtime', class: 'add-left-margin btn btn-danger' %>

--- a/app/views/downtimes/index.html.erb
+++ b/app/views/downtimes/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :page_title, 'Downtime' %>
+
 <div class="page-title">
   <h1>Downtime</h1>
 </div>
@@ -5,12 +7,12 @@
 <table class="table table-bordered table-striped" data-module="filterable-table">
   <thead>
     <tr class="table-header">
-      <td>Service start page</td>
-      <td>Service status</td>
-      <td>Action</td>
+      <th>Service start page</th>
+      <th>Service status</th>
+      <th>Action</th>
     </tr>
     <tr class="if-no-js-hide table-header-secondary">
-      <td colspan="5">
+      <td colspan="3">
         <form>
           <label for="table-filter" class="rm">Filter services</label>
           <input id="table-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter services">
@@ -32,10 +34,10 @@
         <% if downtime = Downtime.for(transaction.artefact) %>
           <td>
             Scheduled downtime<br />
-            <span class="text-muted"><%= display_scheduled_downtime(downtime) %></span>
+            <span class="text-muted"><%= downtime.datetime_string %></span>
           </td>
           <td>
-            <%= link_to 'Edit downtime', edit_edition_downtime_path(transaction), class: 'btn btn-default' %>
+            <%= link_to 'Edit downtime', edit_edition_downtime_path(transaction), class: 'btn btn-info' %>
           </td>
         <% else %>
           <td>Live</td>

--- a/app/views/downtimes/index.html.erb
+++ b/app/views/downtimes/index.html.erb
@@ -36,7 +36,7 @@
         <% if downtime = Downtime.for(transaction.artefact) %>
           <td>
             Scheduled downtime<br />
-            <span class="text-muted"><%= downtime.datetime_string %></span>
+            <span class="text-muted"><%= downtime_datetime(downtime) %></span>
           </td>
           <td>
             <%= link_to 'Edit downtime', edit_edition_downtime_path(transaction), class: 'btn btn-info' %>

--- a/app/views/downtimes/index.html.erb
+++ b/app/views/downtimes/index.html.erb
@@ -23,14 +23,26 @@
     <tr>
       <td>
         <h4 class="publication-table-title">
-          <%= link_to transaction.title, 'downtime/schedule' %>
+          <%= link_to transaction.title, Downtime.for(transaction.artefact).present? ?
+                                          edit_edition_downtime_path(transaction) :
+                                          new_edition_downtime_path(transaction) %>
         </h4>
         <%= link_to "/#{transaction.slug}", "#{Plek.find('www')}/#{transaction.slug}", class: 'link-muted' %>
       </td>
-      <td>Live</td>
-      <td>
-        <%= link_to 'Add downtime', 'downtime/schedule', class: 'btn btn-default' %>
-      </td>
+        <% if downtime = Downtime.for(transaction.artefact) %>
+          <td>
+            Scheduled downtime<br />
+            <span class="text-muted"><%= display_scheduled_downtime(downtime) %></span>
+          </td>
+          <td>
+            <%= link_to 'Edit downtime', edit_edition_downtime_path(transaction), class: 'btn btn-default' %>
+          </td>
+        <% else %>
+          <td>Live</td>
+          <td>
+            <%= link_to 'Add downtime', new_edition_downtime_path(transaction), class: 'btn btn-default' %>
+          </td>
+        <% end %>
     </tr>
     <% end %>
   </tbody>

--- a/app/views/downtimes/index.html.erb
+++ b/app/views/downtimes/index.html.erb
@@ -1,9 +1,11 @@
-<% content_for :page_title, 'Downtime' %>
+<% content_for :page_title, 'Downtime messages' %>
 
 <div class="page-title">
-  <h1>Downtime</h1>
+  <h1>Downtime messages</h1>
+  <p class="lead">Show a message on a published transaction start page for a specific time.</p>
 </div>
 
+<h2 class="add-bottom-margin">Services</h2>
 <table class="table table-bordered table-striped" data-module="filterable-table">
   <thead>
     <tr class="table-header">
@@ -15,7 +17,7 @@
       <td colspan="3">
         <form>
           <label for="table-filter" class="rm">Filter services</label>
-          <input id="table-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter services">
+          <input id="table-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter services (eg ‘driving’ or ‘scheduled downtime’)">
         </form>
       </td>
     </tr>

--- a/app/views/downtimes/index.html.erb
+++ b/app/views/downtimes/index.html.erb
@@ -1,0 +1,37 @@
+<div class="page-title">
+  <h1>Downtime</h1>
+</div>
+
+<table class="table table-bordered table-striped" data-module="filterable-table">
+  <thead>
+    <tr class="table-header">
+      <td>Service start page</td>
+      <td>Service status</td>
+      <td>Action</td>
+    </tr>
+    <tr class="if-no-js-hide table-header-secondary">
+      <td colspan="5">
+        <form>
+          <label for="table-filter" class="rm">Filter services</label>
+          <input id="table-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter services">
+        </form>
+      </td>
+    </tr>
+  </thead>
+  <tbody>
+    <% @transactions.each do |transaction| %>
+    <tr>
+      <td>
+        <h4 class="publication-table-title">
+          <%= link_to transaction.title, 'downtime/schedule' %>
+        </h4>
+        <%= link_to "/#{transaction.slug}", "#{Plek.find('www')}/#{transaction.slug}", class: 'link-muted' %>
+      </td>
+      <td>Live</td>
+      <td>
+        <%= link_to 'Add downtime', 'downtime/schedule', class: 'btn btn-default' %>
+      </td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/downtimes/new.html.erb
+++ b/app/views/downtimes/new.html.erb
@@ -8,7 +8,7 @@
 <div class="page-title">
   <h1>
     <span class="small"><%= @downtime.artefact.name %></span>
-    Schedule downtime
+    Schedule a downtime message
   </h1>
 </div>
 

--- a/app/views/downtimes/new.html.erb
+++ b/app/views/downtimes/new.html.erb
@@ -14,5 +14,5 @@
 
 <%= semantic_form_for @downtime, url: edition_downtime_path(@edition), html: { class: 'form well remove-top-margin', 'data-module' => 'downtime-message' } do |f| %>
   <%= render 'form', f: f %>
-  <%= f.submit 'Schedule downtime', class: 'btn btn-success' %>
+  <%= f.submit 'Schedule downtime message', class: 'btn btn-success' %>
 <% end %>

--- a/app/views/downtimes/new.html.erb
+++ b/app/views/downtimes/new.html.erb
@@ -12,7 +12,7 @@
   </h1>
 </div>
 
-<%= semantic_form_for @downtime, url: edition_downtime_path(@edition), html: { class: 'form well remove-top-margin' } do |f| %>
+<%= semantic_form_for @downtime, url: edition_downtime_path(@edition), html: { class: 'form well remove-top-margin', 'data-module' => 'downtime-message' } do |f| %>
   <%= render 'form', f: f %>
   <%= f.submit 'Schedule downtime', class: 'btn btn-success' %>
 <% end %>

--- a/app/views/downtimes/new.html.erb
+++ b/app/views/downtimes/new.html.erb
@@ -14,5 +14,5 @@
 
 <%= semantic_form_for @downtime, url: edition_downtime_path(@edition), html: { class: 'form well remove-top-margin', 'data-module' => 'downtime-message' } do |f| %>
   <%= render 'form', f: f %>
-  <%= f.submit 'Schedule downtime message', class: 'btn btn-success' %>
+  <%= f.submit 'Schedule downtime message', class: 'js-submit btn btn-success' %>
 <% end %>

--- a/app/views/downtimes/new.html.erb
+++ b/app/views/downtimes/new.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title, 'Schedule downtime' %>
+
+<ul class="breadcrumb">
+  <li class="crumb"><%= link_to 'Downtime', downtimes_path %></li>
+  <li class="active"><%= @downtime.artefact.name %></li>
+</ul>
+
+<div class="page-title">
+  <h1>
+    <span class="small"><%= @downtime.artefact.name %></span>
+    Schedule downtime
+  </h1>
+</div>
+
+<%= semantic_form_for @downtime, url: edition_downtime_path(@edition), html: { class: 'form well remove-top-margin' } do |f| %>
+  <%= render 'form', f: f %>
+  <%= f.submit 'Schedule downtime', class: 'btn btn-success' %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
 
 <% content_for :navbar_items do %>
   <%= nav_link 'Publications', root_path %>
+  <%= nav_link 'Downtime', downtimes_path %>
   <%= nav_link 'Reports', reports_path %>
   <%= nav_link 'Search by user', user_search_path %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,8 @@ Publisher::Application.routes.draw do
             }
           }
     end
+
+    resource :downtime, only: [:new, :create, :edit, :update, :destroy]
   end
 
   match 'reports' => 'reports#index', as: :reports

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Publisher::Application.routes.draw do
     put 'resolve', on: :member
   end
 
+  get 'downtimes' => 'downtimes#index'
+
   resources :editions do
     member do
       get 'diff'

--- a/spec/javascripts/spec/downtime_message.spec.js
+++ b/spec/javascripts/spec/downtime_message.spec.js
@@ -94,8 +94,8 @@ describe('A downtime message module', function() {
       <form>\
         <div class="js-start-time">'+ formHTML +'</div>\
         <div class="js-stop-time">'+ formHTML +'</div>\
-        <textarea class="js-downtime-message">x</textarea>\
-        <div class="js-schedule-message">x</div>\
+        <textarea class="js-downtime-message">starting message</textarea>\
+        <div class="js-schedule-message">starting message</div>\
       </form>'
     );
 
@@ -107,6 +107,13 @@ describe('A downtime message module', function() {
 
   afterEach(function() {
     form.remove();
+  });
+
+  describe('when starting', function() {
+    it('leaves the existing messages alone' , function() {
+      expectDowntimeMessageToMatch('starting message');
+      expectScheduleMessageToMatch('starting message');
+    });
   });
 
   describe('when selecting dates', function() {

--- a/spec/javascripts/spec/downtime_message.spec.js
+++ b/spec/javascripts/spec/downtime_message.spec.js
@@ -96,6 +96,7 @@ describe('A downtime message module', function() {
         <div class="js-stop-time">'+ formHTML +'</div>\
         <textarea class="js-downtime-message">starting message</textarea>\
         <div class="js-schedule-message">starting message</div>\
+        <input type="submit" class="js-submit">\
       </form>'
     );
 
@@ -110,9 +111,12 @@ describe('A downtime message module', function() {
   });
 
   describe('when starting', function() {
-    it('leaves the existing messages alone' , function() {
+    it('leaves any existing downtime message alone' , function() {
       expectDowntimeMessageToMatch('starting message');
-      expectScheduleMessageToMatch('starting message');
+    });
+
+    it('disables the form if the preloaded dates aren’t valid' , function() {
+      expectDisabledForm();
     });
   });
 
@@ -126,18 +130,38 @@ describe('A downtime message module', function() {
       selectStopDate({hour: '03'});
       expectDowntimeMessageToMatch('from 1am to 3am on Thursday 1 January.');
       expectScheduleMessageToMatch('from 1am on Wednesday 31 December');
+
+      expectEnabledForm();
     });
 
-    it('doesn’t generate a message if the start and end dates are the same', function() {
-      selectStartDate();
-      selectStopDate();
-      expectDowntimeMessageToBe('');
+    describe('that are the same', function() {
+      beforeEach(function() {
+        selectStartDate();
+        selectStopDate();
+      });
+
+      it('doesn’t generate a message', function() {
+        expectDowntimeMessageToBe('');
+      });
+
+      it('disables the form', function() {
+        expectDisabledForm();
+      });
     });
 
-    it('doesn’t generate a message if the end date is before the start date', function() {
-      selectStartDate({hour: '03'});
-      selectStopDate({hour: '01'});
-      expectDowntimeMessageToBe('');
+    describe('with a stop date before the start date', function() {
+      beforeEach(function() {
+        selectStartDate({hour: '03'});
+        selectStopDate({hour: '01'});
+      });
+
+      it('doesn’t generate a message', function() {
+        expectDowntimeMessageToBe('');
+      });
+
+      it('disables the form', function() {
+        expectDisabledForm();
+      });
     });
 
     describe('the generated messages', function() {
@@ -146,6 +170,7 @@ describe('A downtime message module', function() {
         selectStopDate({hour: '15'});
         expectDowntimeMessageToMatch('from 11am to 3pm on Thursday 1 January.');
         expectScheduleMessageToMatch('from 11am on Wednesday 31 December');
+        expectEnabledForm();
       });
 
       it('use midnight instead of 12am' , function() {
@@ -187,6 +212,7 @@ describe('A downtime message module', function() {
         selectStopDate({day: '5', month: '3'});
         expectDowntimeMessageToMatch('from 1am on Sunday 1 March to 1am on Thursday 5 March.');
         expectScheduleMessageToMatch('from 1am on Saturday 28 February');
+        expectEnabledForm();
       });
     });
   });
@@ -201,6 +227,17 @@ describe('A downtime message module', function() {
 
   function expectScheduleMessageToMatch(text) {
     expect(form.find('.js-schedule-message').text()).toMatch(text);
+  }
+
+  function expectDisabledForm() {
+    expect(form.find('.js-submit:disabled').length).toBe(1);
+    expect(form.find('.js-downtime-message:disabled').length).toBe(1);
+    expectScheduleMessageToMatch('Please select a valid date range');
+  }
+
+  function expectEnabledForm() {
+    expect(form.find('.js-submit:disabled').length).toBe(0);
+    expect(form.find('.js-downtime-message:disabled').length).toBe(0);
   }
 
   function selectStartDate(dateObj) {

--- a/spec/javascripts/spec/downtime_message.spec.js
+++ b/spec/javascripts/spec/downtime_message.spec.js
@@ -1,0 +1,218 @@
+describe('A downtime message module', function() {
+  "use strict";
+
+  var downtimeMessage,
+      form;
+
+  beforeEach(function() {
+
+    var formHTML = '<select>\
+      <option value="00">00</option>\
+      <option value="01">01</option>\
+      <option value="02">02</option>\
+      <option value="03">03</option>\
+      <option value="04">04</option>\
+      <option value="05">05</option>\
+      <option value="06">06</option>\
+      <option value="07">07</option>\
+      <option value="08">08</option>\
+      <option value="09">09</option>\
+      <option value="10">10</option>\
+      <option value="11">11</option>\
+      <option value="12">12</option>\
+      <option value="13">13</option>\
+      <option value="14">14</option>\
+      <option value="15">15</option>\
+      <option value="16">16</option>\
+      <option value="17">17</option>\
+      <option value="18">18</option>\
+      <option value="19">19</option>\
+      <option value="20">20</option>\
+      <option value="21">21</option>\
+      <option value="22">22</option>\
+      <option value="23">23</option>\
+    </select>\
+    <select>\
+      <option value="00">00</option>\
+      <option value="15">15</option>\
+      <option value="30">30</option>\
+      <option value="45">45</option>\
+    </select>\
+    <select>\
+      <option value="1">1</option>\
+      <option value="2">2</option>\
+      <option value="3">3</option>\
+      <option value="4">4</option>\
+      <option value="5">5</option>\
+      <option value="6">6</option>\
+      <option value="7">7</option>\
+      <option value="8">8</option>\
+      <option value="9">9</option>\
+      <option value="10">10</option>\
+      <option value="11">11</option>\
+      <option value="12">12</option>\
+      <option value="13">13</option>\
+      <option value="14">14</option>\
+      <option value="15">15</option>\
+      <option value="16">16</option>\
+      <option value="17">17</option>\
+      <option value="18">18</option>\
+      <option value="19">19</option>\
+      <option value="20">20</option>\
+      <option value="21">21</option>\
+      <option value="22">22</option>\
+      <option value="23">23</option>\
+      <option value="24">24</option>\
+      <option value="25">25</option>\
+      <option value="26">26</option>\
+      <option value="27">27</option>\
+      <option value="28">28</option>\
+      <option value="29">29</option>\
+      <option value="30">30</option>\
+      <option value="31">31</option>\
+    </select>\
+    <select>\
+      <option value="1">January</option>\
+      <option value="2">February</option>\
+      <option value="3">March</option>\
+      <option value="4">April</option>\
+      <option value="5">May</option>\
+      <option value="6">June</option>\
+      <option value="7">July</option>\
+      <option value="8">August</option>\
+      <option value="9">September</option>\
+      <option value="10">October</option>\
+      <option value="11">November</option>\
+      <option value="12">December</option>\
+    </select>\
+    <select>\
+      <option value="2015"></option>\
+      <option value="2016"></option>\
+    </select>';
+
+    form = $('\
+      <form>\
+        <div class="js-start-time">'+ formHTML +'</div>\
+        <div class="js-stop-time">'+ formHTML +'</div>\
+        <textarea class="js-downtime-message">x</textarea>\
+        <div class="js-schedule-message">x</div>\
+      </form>'
+    );
+
+    $('body').append(form);
+
+    downtimeMessage = new GOVUKAdmin.Modules.DowntimeMessage();
+    downtimeMessage.start(form);
+  });
+
+  afterEach(function() {
+    form.remove();
+  });
+
+  describe('when selecting dates', function() {
+    it('generates a downtime message and a schedule message' , function() {
+      selectStartDate();
+      selectStopDate({hour: '02'});
+      expectDowntimeMessageToMatch('This service will be unavailable from 1am to 2am on Thursday 1 January.');
+      expectScheduleMessageToMatch('A downtime message will show from 1am on Wednesday 31 December');
+
+      selectStopDate({hour: '03'});
+      expectDowntimeMessageToMatch('from 1am to 3am on Thursday 1 January.');
+      expectScheduleMessageToMatch('from 1am on Wednesday 31 December');
+    });
+
+    it('doesn’t generate a message if the start and end dates are the same', function() {
+      selectStartDate();
+      selectStopDate();
+      expectDowntimeMessageToBe('');
+    });
+
+    it('doesn’t generate a message if the end date is before the start date', function() {
+      selectStartDate({hour: '03'});
+      selectStopDate({hour: '01'});
+      expectDowntimeMessageToBe('');
+    });
+
+    describe('the generated messages', function() {
+      it('use a 12 hour clock' , function() {
+        selectStartDate({hour: '11'});
+        selectStopDate({hour: '15'});
+        expectDowntimeMessageToMatch('from 11am to 3pm on Thursday 1 January.');
+        expectScheduleMessageToMatch('from 11am on Wednesday 31 December');
+      });
+
+      it('use midnight instead of 12am' , function() {
+        selectStartDate({hour: '00'});
+        selectStopDate({hour: '02'});
+        expectDowntimeMessageToMatch('from midnight to 2am on Thursday 1 January.');
+        expectScheduleMessageToMatch('from midnight on Wednesday 31 December');
+      });
+
+      it('use midday instead of 12pm' , function() {
+        selectStartDate({hour: '12'});
+        selectStopDate({hour: '14'});
+        expectDowntimeMessageToMatch('from midday to 2pm on Thursday 1 January.');
+        expectScheduleMessageToMatch('from midday on Wednesday 31 December');
+      });
+
+      it('includes minutes when they are not 0' , function() {
+        selectStartDate({hour: '00', minutes: '15'});
+        selectStopDate({hour: '02', minutes: '45'});
+        expectDowntimeMessageToMatch('from 12:15am to 2:45am on Thursday 1 January.');
+        expectScheduleMessageToMatch('from 12:15am on Wednesday 31 December');
+      });
+
+      it('includes both dates when they differ' , function() {
+        selectStartDate();
+        selectStopDate({day: '2', hour: '03'});
+        expectDowntimeMessageToMatch('from 1am on Thursday 1 January to 3am on Friday 2 January.');
+      });
+
+      it('treats midnight on the next consecutive day as the same date' , function() {
+        selectStartDate({hour: '22', day: '1'});
+        selectStopDate({hour: '00', day: '2'});
+        expectDowntimeMessageToMatch('from 10pm to midnight on Thursday 1 January.');
+        expectScheduleMessageToMatch('from 10pm on Wednesday 31 December');
+      });
+
+      it('handles incorrect dates in the same way as rails', function() {
+        selectStartDate({day: '29', month: '2'});
+        selectStopDate({day: '5', month: '3'});
+        expectDowntimeMessageToMatch('from 1am on Sunday 1 March to 1am on Thursday 5 March.');
+        expectScheduleMessageToMatch('from 1am on Saturday 28 February');
+      });
+    });
+  });
+
+  function expectDowntimeMessageToMatch(text) {
+    expect(form.find('.js-downtime-message').val()).toMatch(text);
+  }
+
+  function expectDowntimeMessageToBe(text) {
+    expect(form.find('.js-downtime-message').val()).toBe(text);
+  }
+
+  function expectScheduleMessageToMatch(text) {
+    expect(form.find('.js-schedule-message').text()).toMatch(text);
+  }
+
+  function selectStartDate(dateObj) {
+    selectDate('.js-start-time', dateObj);
+  }
+
+  function selectStopDate(dateObj) {
+    selectDate('.js-stop-time', dateObj);
+  }
+
+  function selectDate(selector, dateObj) {
+    var selects = $(selector + ' select');
+
+    dateObj = dateObj || {};
+
+    selects.eq(0).val(dateObj.hour || '01');
+    selects.eq(1).val(dateObj.minutes || '00');
+    selects.eq(2).val(dateObj.day || '1');
+    selects.eq(3).val(dateObj.month || '1');
+    selects.eq(4).val(dateObj.year || '2015').trigger('change');
+  }
+});

--- a/test/functional/downtimes_controller_test.rb
+++ b/test/functional/downtimes_controller_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class DowntimesControllerTest < ActionController::TestCase
+  setup do
+    login_as_stub_user
+  end
+
+  test "should list all published transaction editions" do
+    unpublished_transaction_edition = FactoryGirl.create(:transaction_edition)
+    transaction_editions = FactoryGirl.create_list(:transaction_edition, 2, :published)
+
+    get :index
+
+    assert_response :ok
+    assert_select 'h4.publication-table-title', { count: 0, text: unpublished_transaction_edition.title }
+    transaction_editions.each do |edition|
+      assert_select 'h4.publication-table-title', { text: edition.title }
+    end
+  end
+end

--- a/test/integration/downtime_test.rb
+++ b/test/integration/downtime_test.rb
@@ -26,9 +26,7 @@ class DowntimeTest < JavascriptIntegrationTest
     assert_match("midday to 6pm on #{tomorrow.strftime('%A')} #{tomorrow.day} #{tomorrow.strftime('%b')}", page.find_field('Message').value)
     click_on 'Schedule downtime'
 
-    assert page.has_content?('Successfully scheduled downtime')
-
-    visit downtimes_path
+    assert page.has_content?('Apply to become a driving instructor downtime message scheduled')
     assert page.has_content?('Scheduled downtime')
     assert page.has_content?("midday to 6pm on #{tomorrow.day} #{tomorrow.strftime('%b')}")
 
@@ -37,16 +35,13 @@ class DowntimeTest < JavascriptIntegrationTest
     select '30', from: 'downtime_end_time_5i'
     assert_match("midday to 9:30pm on #{tomorrow.strftime('%A')} #{tomorrow.day} #{tomorrow.strftime('%b')}", page.find_field('Message').value)
     click_on 'Re-schedule downtime message'
-    assert page.has_content?('Successfully updated downtime')
 
-    visit downtimes_path
+    assert page.has_content?('Apply to become a driving instructor downtime message re-scheduled')
     assert page.has_content?("midday to 9:30pm on #{tomorrow.day} #{tomorrow.strftime('%b')}")
 
     click_link 'Edit downtime'
     click_on 'Cancel downtime'
-    assert page.has_content?('Successfully cancelled downtime')
-
-    visit downtimes_path
+    assert page.has_content?('Apply to become a driving instructor downtime message cancelled')
     refute page.has_content?("midday to 9:30pm on #{tomorrow.day} #{tomorrow.strftime('%b')}")
   end
 end

--- a/test/integration/downtime_test.rb
+++ b/test/integration/downtime_test.rb
@@ -1,6 +1,6 @@
 require 'integration_test_helper'
 
-class DowntimeTest < ActionDispatch::IntegrationTest
+class DowntimeTest < JavascriptIntegrationTest
   test "scheduling and removing downtime" do
     setup_users
 
@@ -23,6 +23,7 @@ class DowntimeTest < ActionDispatch::IntegrationTest
     select tomorrow.day.to_s, from: 'downtime_end_time_3i'
     select '18', from: 'downtime_end_time_4i'
     select '00', from: 'downtime_end_time_5i'
+    assert_match("midday to 6pm on #{tomorrow.strftime('%A')} #{tomorrow.day} #{tomorrow.strftime('%b')}", page.find_field('Message').value)
     click_on 'Schedule downtime'
 
     assert page.has_content?('Successfully scheduled downtime')
@@ -34,6 +35,7 @@ class DowntimeTest < ActionDispatch::IntegrationTest
     click_link 'Edit downtime'
     select '21', from: 'downtime_end_time_4i'
     select '30', from: 'downtime_end_time_5i'
+    assert_match("midday to 9:30pm on #{tomorrow.strftime('%A')} #{tomorrow.day} #{tomorrow.strftime('%b')}", page.find_field('Message').value)
     click_on 'Re-schedule downtime message'
     assert page.has_content?('Successfully updated downtime')
 

--- a/test/integration/downtime_test.rb
+++ b/test/integration/downtime_test.rb
@@ -1,0 +1,32 @@
+require 'integration_test_helper'
+
+class ChangeEditionTypeTest < ActionDispatch::IntegrationTest
+  test "doesn't show change note until an edition has been published" do
+    pending 'WIP'
+
+    transaction = FactoryGirl.create(:transaction_edition, :published,
+      title: 'Apply to become a driving instructor', slug: 'apply-to-become-a-driving-instructor')
+
+    visit root_path
+    click_link 'Downtime'
+    click_link 'Apply to become a driving instructor'
+
+    tomorrow = Date.tomorrow
+    select tomorrow.year.to_s, from: 'downtime_start_time_1i'
+    select tomorrow.strftime('%B'), from: 'downtime_start_time_2i'
+    select tomorrow.day.to_s, from: 'downtime_start_time_3i'
+    select '12', from: 'downtime_start_time_4i'
+    select '00', from: 'downtime_start_time_5i'
+
+    select tomorrow.year.to_s, from: 'downtime_end_time_1i'
+    select tomorrow.strftime('%B'), from: 'downtime_end_time_2i'
+    select tomorrow.day.to_s, from: 'downtime_end_time_3i'
+    select '18', from: 'downtime_end_time_4i'
+    select '00', from: 'downtime_end_time_5i'
+    click_on 'Schedule downtime'
+
+    visit downtimes_path
+    assert page.has_content?('Scheduled downtime')
+    assert page.has_content?("12:00 #{tomorrow.day} #{tomorrow.strftime('%b')} to 18:00 #{tomorrow.day} #{tomorrow.strftime('%b')}")
+  end
+end

--- a/test/integration/downtime_test.rb
+++ b/test/integration/downtime_test.rb
@@ -1,8 +1,8 @@
 require 'integration_test_helper'
 
-class ChangeEditionTypeTest < ActionDispatch::IntegrationTest
-  test "doesn't show change note until an edition has been published" do
-    pending 'WIP'
+class DowntimeTest < ActionDispatch::IntegrationTest
+  test "scheduling and removing downtime" do
+    setup_users
 
     transaction = FactoryGirl.create(:transaction_edition, :published,
       title: 'Apply to become a driving instructor', slug: 'apply-to-become-a-driving-instructor')
@@ -25,8 +25,26 @@ class ChangeEditionTypeTest < ActionDispatch::IntegrationTest
     select '00', from: 'downtime_end_time_5i'
     click_on 'Schedule downtime'
 
+    assert page.has_content?('Successfully scheduled downtime')
+
     visit downtimes_path
     assert page.has_content?('Scheduled downtime')
-    assert page.has_content?("12:00 #{tomorrow.day} #{tomorrow.strftime('%b')} to 18:00 #{tomorrow.day} #{tomorrow.strftime('%b')}")
+    assert page.has_content?("midday to 6pm on #{tomorrow.day} #{tomorrow.strftime('%b')}")
+
+    click_link 'Edit downtime'
+    select '21', from: 'downtime_end_time_4i'
+    select '30', from: 'downtime_end_time_5i'
+    click_on 'Save changes and re-schedule'
+    assert page.has_content?('Successfully updated downtime')
+
+    visit downtimes_path
+    assert page.has_content?("midday to 9:30pm on #{tomorrow.day} #{tomorrow.strftime('%b')}")
+
+    click_link 'Edit downtime'
+    click_on 'Remove downtime'
+    assert page.has_content?('Successfully removed downtime')
+
+    visit downtimes_path
+    refute page.has_content?("midday to 9:30pm on #{tomorrow.day} #{tomorrow.strftime('%b')}")
   end
 end

--- a/test/integration/downtime_test.rb
+++ b/test/integration/downtime_test.rb
@@ -34,15 +34,15 @@ class DowntimeTest < ActionDispatch::IntegrationTest
     click_link 'Edit downtime'
     select '21', from: 'downtime_end_time_4i'
     select '30', from: 'downtime_end_time_5i'
-    click_on 'Save changes and re-schedule'
+    click_on 'Re-schedule downtime message'
     assert page.has_content?('Successfully updated downtime')
 
     visit downtimes_path
     assert page.has_content?("midday to 9:30pm on #{tomorrow.day} #{tomorrow.strftime('%b')}")
 
     click_link 'Edit downtime'
-    click_on 'Remove downtime'
-    assert page.has_content?('Successfully removed downtime')
+    click_on 'Cancel downtime'
+    assert page.has_content?('Successfully cancelled downtime')
 
     visit downtimes_path
     refute page.has_content?("midday to 9:30pm on #{tomorrow.day} #{tomorrow.strftime('%b')}")

--- a/test/unit/helpers/downtimes_helper_test.rb
+++ b/test/unit/helpers/downtimes_helper_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class DowntimesHelperTest < ActionView::TestCase
+  include DowntimesHelper
+
+  def setup
+    @next_year = 1.year.from_now.year
+  end
+
+  test "#downtime_datetime should be a short string representation start and end time" do
+    downtime = FactoryGirl.build(:downtime, start_time: DateTime.new(@next_year, 10, 10, 15), end_time: DateTime.new(@next_year, 10, 11, 18))
+    assert_equal "3pm on 10 October to 6pm on 11 October", downtime_datetime(downtime)
+  end
+
+  test "#downtime_datetime should not repeat date if start and end times are on the same day" do
+    downtime = FactoryGirl.build(:downtime, start_time: DateTime.new(@next_year, 10, 11, 15), end_time: DateTime.new(@next_year, 10, 11, 18))
+    assert_equal "3pm to 6pm on 11 October", downtime_datetime(downtime)
+  end
+
+  test "#downtime_datetime should not repeat date if downtime ends at midnight on next day" do
+    downtime = FactoryGirl.build(:downtime, start_time: DateTime.new(@next_year, 10, 10, 21), end_time: DateTime.new(@next_year, 10, 11, 0))
+    assert_equal "9pm to midnight on 10 October", downtime_datetime(downtime)
+  end
+end


### PR DESCRIPTION
www.agileplannerapp.com/boards/173808/cards/8805

As a content designer
I want a better way to indicate on start pages when a service is down for planned maintenance
So that I don't have to re-edition multiple pages and push these through workflow, then repeat the process again once the downtime is over

related:
https://github.com/alphagov/govuk_content_models/pull/277
https://github.com/alphagov/govuk_content_api/pull/209
https://github.com/alphagov/frontend/pull/728

![screen shot 2014-12-23 at 10 47 42](https://cloud.githubusercontent.com/assets/319055/5536936/3269fbd4-8a91-11e4-988c-a23ad9cb213f.png)
![screen shot 2014-12-23 at 10 47 29](https://cloud.githubusercontent.com/assets/319055/5536935/3268c6ec-8a91-11e4-87d1-a6cb2bbf8de6.png)
