### PR TITLE
Remove ‘Created by’ column from publication tables

### DIFF
--- a/app/views/root/_amends_needed.html.erb
+++ b/app/views/root/_amends_needed.html.erb
@@ -5,7 +5,6 @@
       <th scope="col"><%= sortable "title" %></th>
       <th scope="col"><%= sortable "updated_at", "Updated" %></th>
       <th scope="col"><%= sortable "assignee", "Assigned to" %></th>
-      <th scope="col"><%= sortable "creator", "Created by" %></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/root/_archived.html.erb
+++ b/app/views/root/_archived.html.erb
@@ -5,7 +5,6 @@
       <th scope="col"><%= sortable "title" %></th>
       <th scope="col"><%= sortable "updated_at", "Updated" %></th>
       <th scope="col"><%= sortable "assignee", "Assigned to" %></th>
-      <th scope="col"><%= sortable "creator", "Created by" %></th>
       <th scope="col">Actions</th>
     </tr>
   </thead>

--- a/app/views/root/_drafts.html.erb
+++ b/app/views/root/_drafts.html.erb
@@ -5,7 +5,6 @@
       <th scope="col"><%= sortable "title" %></th>
       <th scope="col"><%= sortable "updated_at", "Updated" %></th>
       <th scope="col"><%= sortable "assignee", "Assigned to" %></th>
-      <th scope="col"><%= sortable "creator", "Created by" %></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/root/_fact_check_received.html.erb
+++ b/app/views/root/_fact_check_received.html.erb
@@ -5,7 +5,6 @@
       <th scope="col"><%= sortable "title" %></th>
       <th scope="col"><%= sortable "updated_at", "Updated" %></th>
       <th scope="col"><%= sortable "assignee", "Assigned to" %></th>
-      <th scope="col"><%= sortable "creator", "Created by" %></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/root/_out_for_fact_check.html.erb
+++ b/app/views/root/_out_for_fact_check.html.erb
@@ -6,7 +6,6 @@
       <th scope="col"><%= sortable "updated_at", "Updated" %></th>
       <th scope="col"><%= sortable "last_fact_checked_at", "Sent Out" %></th>
       <th scope="col"><%= sortable "assignee", "Assigned to" %></th>
-      <th scope="col"><%= sortable "creator", "Created by" %></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/root/_publication.html.erb
+++ b/app/views/root/_publication.html.erb
@@ -58,11 +58,7 @@
     <td>
       <%= render partial: 'reviewer', locals: { publication: publication } %>
     </td>
-  <% else %>
-    <td>
-      <%= publication.creator %>
-    </td>
-  <% end -%>
+  <% end %>
   <% if tab && tab == :published %>
     <td>
       <%= publication.publisher %>

--- a/app/views/root/_published.html.erb
+++ b/app/views/root/_published.html.erb
@@ -5,7 +5,6 @@
       <th scope="col"><%= sortable "title" %></th>
       <th scope="col"><%= sortable "updated_at", "Updated" %></th>
       <th scope="col"><%= sortable "assignee", "Assigned to" %></th>
-      <th scope="col"><%= sortable "creator", "Created by" %></th>
       <th scope="col"><%= sortable "publisher", "Published by" %></th>
       <th scope="col">Actions</th>
     </tr>

--- a/app/views/root/_ready.html.erb
+++ b/app/views/root/_ready.html.erb
@@ -5,7 +5,6 @@
       <th scope="col"><%= sortable "title" %></th>
       <th scope="col"><%= sortable "updated_at", "Updated" %></th>
       <th scope="col"><%= sortable "assignee", "Assigned to" %></th>
-      <th scope="col"><%= sortable "creator", "Created by" %></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/root/_scheduled_for_publishing.html.erb
+++ b/app/views/root/_scheduled_for_publishing.html.erb
@@ -6,7 +6,6 @@
       <th scope="col"><%= sortable "updated_at", "Updated" %></th>
       <th scope="col"><%= sortable "publish_at", "Scheduled" %></th>
       <th scope="col"><%= sortable "assignee", "Assigned to" %></th>
-      <th scope="col"><%= sortable "creator", "Created by" %></th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
Reduce clutter on the publication table view, giving more room to read titles and slugs.

https://www.agileplannerapp.com/boards/173808/cards/9050
