### PR TITLE
Don't let ‘Claim 2i’ work when an edition is already claimed

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -90,6 +90,12 @@ class EditionsController < InheritedResources::Base
   end
 
   def review
+    if resource.reviewer
+      flash[:danger] = "#{resource.reviewer} has already claimed this 2i"
+      redirect_to edition_path(resource)
+      return
+    end
+
     resource.reviewer = params[:edition][:reviewer]
     if resource.save!
       flash[:success] = "You are the reviewer of this #{description(resource).downcase}."

--- a/test/integration/root_overview_test.rb
+++ b/test/integration/root_overview_test.rb
@@ -150,6 +150,31 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
     assert page.has_select?("Assigned to", :selected => assignee.name)
   end
 
+  test "prevents claiming 2i when someone else has" do
+    stub_collections
+    user = FactoryGirl.create(:user)
+    assignee = FactoryGirl.create(:user)
+    another_user = FactoryGirl.create(:user, name: 'Another McPerson')
+    edition = FactoryGirl.create(:guide_edition, :title => "XXX", :state => 'in_review',
+                                 :review_requested_at => Time.zone.now, :assigned_to => assignee)
+
+    visit "/"
+    filter_by_user("All")
+    click_on "In review"
+
+    edition.reviewer = another_user.name
+    edition.save!
+
+    within("#publication-list-container tbody tr:first-child td:nth-child(6)") do
+      click_on "Claim 2i"
+    end
+
+    assert edition_url(edition), current_url
+    assert page.has_content?("Another McPerson has already claimed this 2i")
+    assert page.has_select?("Reviewer", :selected => another_user.name)
+    assert page.has_select?("Assigned to", :selected => assignee.name)
+  end
+
   test "prevents the assignee claiming 2i" do
     user = FactoryGirl.create(:user)
     edition = FactoryGirl.create(:guide_edition, :title => "XXX", :state => 'in_review',


### PR DESCRIPTION
If a user opens the “In review” list and leaves it for a while, they may come back to it and click “Claim 2i” later, eg if they’ve finished reviewing something else.

If in the meantime someone had already claimed the edition, the old behaviour would overwrite that reviewer. The old reviewer wouldn’t be notified, and the new reviewer wouldn’t know to tell them.

* Prevent claiming of 2i when there’s already a reviewer