### PR TITLE
After adding notes, redirect back to notes tab

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -19,12 +19,12 @@ class NotesController < InheritedResources::Base
         flash[:danger] = "Note failed to save"
       end
     end
-    redirect_to edit_edition_path(parent) + '#history'
+    redirect_to history_edition_path(parent)
   end
 
   def resolve
     resolve_important_note
-    redirect_to edit_edition_path(parent) + '#history'
+    redirect_to history_edition_path(parent)
   end
 
   def resource


### PR DESCRIPTION
Now notes are linkable we can use the path directly, rather than prepending a hash which didn’t actually work.