### PR TITLE
Migration to set major_change values for existing editions.

### DIFF
--- a/db/migrate/20150107122901_fix_major_change_values.rb
+++ b/db/migrate/20150107122901_fix_major_change_values.rb
@@ -1,0 +1,12 @@
+class FixMajorChangeValues < Mongoid::Migration
+  def self.up
+    Edition.collection.update(
+      {"major_change" => nil},
+      {"$set" => {"major_change" => false}},
+      :multi => true
+    )
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
false is the default value for the fied on the model, however for all
the pre-existing editions, this will be set to nil (nor not even set).
This causes problems when archivind editions because the field gets
changed from nil to false, which trips up the validation that published
editions can't be changed. (This validation only allows the state and
updated_at field to be changed[1]).

This migration therefore sets all the existing editions to have a value
of false where it's not currently set.

[1] https://github.com/alphagov/govuk_content_models/blob/v26.2.0/app/models/edition.rb#L285-L297
