### PR TITLE
Improve display of important note changes

### DIFF
--- a/app/assets/stylesheets/notes.scss
+++ b/app/assets/stylesheets/notes.scss
@@ -24,6 +24,10 @@
   margin-top: 50px;
 }
 
+/* ==========================================================================
+   Important notes
+   ========================================================================== */
+
 .callout-important-note {
   padding-top: 16px;
   border-left: 5px solid $state-danger-text;
@@ -41,4 +45,9 @@
 
 .callout-important-note-detail {
   color: $text-muted;
+}
+
+.important-notes-date-col,
+.important-notes-author-col {
+  width: 150px;
 }

--- a/app/assets/stylesheets/notes.scss
+++ b/app/assets/stylesheets/notes.scss
@@ -23,3 +23,15 @@
 .original-message {
   margin-top: 50px;
 }
+
+.callout-important-note {
+  font-weight: bold;
+  padding-top: 16px;
+  color: $state-danger-text;
+  border-left: 5px solid $state-danger-text;
+}
+
+.callout-important-note-detail {
+  font-weight: normal;
+  color: $text-muted;
+}

--- a/app/assets/stylesheets/notes.scss
+++ b/app/assets/stylesheets/notes.scss
@@ -25,13 +25,20 @@
 }
 
 .callout-important-note {
-  font-weight: bold;
   padding-top: 16px;
-  color: $state-danger-text;
   border-left: 5px solid $state-danger-text;
+
+  .callout-body {
+    color: $state-danger-text;
+    font-weight: bold;
+
+    a {
+      color: inherit;
+      text-decoration: underline;
+    }
+  }
 }
 
 .callout-important-note-detail {
-  font-weight: normal;
   color: $text-muted;
 }

--- a/app/helpers/action_helper.rb
+++ b/app/helpers/action_helper.rb
@@ -1,6 +1,8 @@
 module ActionHelper
   def edition_actions(edition)
-    edition.actions.reverse
+    edition.actions.reverse.delete_if do |a|
+      [Action::IMPORTANT_NOTE, Action::IMPORTANT_NOTE_RESOLVED].include?(a.request_type)
+    end
   end
 
   def action_note?(action)

--- a/app/helpers/important_note_helper.rb
+++ b/app/helpers/important_note_helper.rb
@@ -1,0 +1,9 @@
+module ImportantNoteHelper
+  def important_notes(edition)
+    edition.actions.reverse.select{|a| a.request_type == Action::IMPORTANT_NOTE }
+  end
+
+  def important_note_has_history?(edition)
+    important_notes(edition).size > 1
+  end
+end

--- a/app/views/shared/_edition_header.html.erb
+++ b/app/views/shared/_edition_header.html.erb
@@ -10,20 +10,13 @@
 </div>
 <% important_note = @resource.important_note %>
 <% unless important_note.blank? %>
-  <div class="callout callout-danger add-bottom-margin">
-    <div class="add-label-margin normal">
-      <time datetime="<%= important_note.created_at %>" class="text-muted add-label-margin">
-        <%= important_note.created_at.to_s(:govuk_date) %>
-      </time>
-    </div>
-    <h2 class="callout-title">
-      Important note
-      <% if important_note.requester.present? %>
-        by <%= mail_to important_note.requester.email, important_note.requester.name, { class: 'link-inherit' }  %>
-      <% end %>
-    </h2>
-    <div class="callout-body">
+  <div class="callout callout-important-note add-bottom-margin">
+    <div class="callout-body add-label-margin">
       <%= @resource.important_note.comment %>
+    </div>
+    <div class="callout-important-note-detail">
+      Note updated <time datetime="<%= important_note.created_at %>"><%= important_note.created_at.to_date.to_s(:govuk_date_short) %></time>
+      <% if important_note.requester.present? %> by <%= mail_to important_note.requester.email, important_note.requester.name, { class: 'link-inherit' }  %><% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/shared/_edition_header.html.erb
+++ b/app/views/shared/_edition_header.html.erb
@@ -9,17 +9,7 @@
   </span>
 </div>
 <% important_note = @resource.important_note %>
-<% unless important_note.blank? %>
-  <div class="callout callout-important-note add-bottom-margin">
-    <div class="callout-body add-label-margin">
-      <%= @resource.important_note.comment %>
-    </div>
-    <div class="callout-important-note-detail">
-      Note updated <time datetime="<%= important_note.created_at %>"><%= important_note.created_at.to_date.to_s(:govuk_date_short) %></time>
-      <% if important_note.requester.present? %> by <%= mail_to important_note.requester.email, important_note.requester.name, { class: 'link-inherit' }  %><% end %>
-    </div>
-  </div>
-<% end %>
+<%= render partial: 'shared/important_note', locals: {important_note: @resource.important_note} %>
 <% if @resource.artefact.state == "archived" %>
   <div class="callout callout-danger add-bottom-margin">
     <h2 class="callout-title">You can’t edit this publication</h2>

--- a/app/views/shared/_important_note.html.erb
+++ b/app/views/shared/_important_note.html.erb
@@ -1,7 +1,7 @@
 <% unless important_note.blank? %>
 <div class="callout callout-important-note add-bottom-margin">
   <div class="callout-body add-label-margin">
-    <%= @resource.important_note.comment %>
+    <%= action_note(@resource.important_note) %>
   </div>
   <div class="callout-important-note-detail">
     Note updated <time datetime="<%= important_note.created_at %>"><%= important_note.created_at.to_date.to_s(:govuk_date_short) %></time>

--- a/app/views/shared/_important_note.html.erb
+++ b/app/views/shared/_important_note.html.erb
@@ -1,11 +1,36 @@
 <% unless important_note.blank? %>
-<div class="callout callout-important-note add-bottom-margin">
+<% with_history = important_note_has_history?(@resource) %>
+<div class="callout callout-important-note add-bottom-margin" <% if with_history %>data-module="toggle"<% end %>>
   <div class="callout-body add-label-margin">
     <%= action_note(@resource.important_note) %>
   </div>
   <div class="callout-important-note-detail">
-    Note updated <time datetime="<%= important_note.created_at %>"><%= important_note.created_at.to_date.to_s(:govuk_date_short) %></time>
+    Note <%= with_history ? 'updated' : 'created' %> <time datetime="<%= important_note.created_at %>"><%= important_note.created_at.to_date.to_s(:govuk_date_short) %></time>
     <% if important_note.requester.present? %> by <%= mail_to important_note.requester.email, important_note.requester.name, { class: 'link-inherit' }  %><% end %>
+    <% if with_history %>
+     <span class="if-no-js-hide"> – <a href="#" class="js-toggle link-muted">See history</a></span>
+    <% end %>
   </div>
+
+  <% if with_history %>
+    <table class="table table-bordered table-striped add-top-margin remove-bottom-margin if-js-hide js-toggle-target">
+      <thead>
+        <tr class="table-header">
+          <th class="important-notes-date-col">Date</th>
+          <th class="important-notes-author-col">Author</th>
+          <th class="important-notes-note-col">Note</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% important_notes(@resource).each do |action| %>
+          <tr>
+            <td><%= action.created_at.to_date.to_s(:govuk_date) %></td>
+            <td><%= mail_to action.requester.email, action.requester.name if action.requester %></td>
+            <td><%= action_note(action) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
 </div>
 <% end %>

--- a/app/views/shared/_important_note.html.erb
+++ b/app/views/shared/_important_note.html.erb
@@ -1,0 +1,11 @@
+<% unless important_note.blank? %>
+<div class="callout callout-important-note add-bottom-margin">
+  <div class="callout-body add-label-margin">
+    <%= @resource.important_note.comment %>
+  </div>
+  <div class="callout-important-note-detail">
+    Note updated <time datetime="<%= important_note.created_at %>"><%= important_note.created_at.to_date.to_s(:govuk_date_short) %></time>
+    <% if important_note.requester.present? %> by <%= mail_to important_note.requester.email, important_note.requester.name, { class: 'link-inherit' }  %><% end %>
+  </div>
+</div>
+<% end %>

--- a/test/integration/edition_history_test.rb
+++ b/test/integration/edition_history_test.rb
@@ -22,8 +22,9 @@ class EditionHistoryTest < JavascriptIntegrationTest
       @guide.new_action(@author, Action::RECEIVE_FACT_CHECK, {:comment => "fifth"})
       @guide.new_action(@author, Action::PUBLISH, {:comment => "sixth"})
       @guide.new_action(@author, Action::NOTE, {:comment => "link http://www.some-link.com"})
+      @guide.new_action(@author, Action::IMPORTANT_NOTE, {:comment => "Important note"})
 
-      assert_equal ["fourth", "fifth", "sixth", "link http://www.some-link.com"], @guide.actions.map(&:comment)
+      assert_equal ["fourth", "fifth", "sixth", "link http://www.some-link.com", "Important note"], @guide.actions.map(&:comment)
     end
 
     should "have the first history actions visible" do
@@ -120,6 +121,15 @@ class EditionHistoryTest < JavascriptIntegrationTest
         within "#update-important-note" do
           assert_field_contains("", "Important note")
         end
+      end
+
+      should "not show important notes in edition history" do
+        add_important_note("Note")
+        add_important_note("")
+        add_important_note("Another note")
+
+        assert page.has_no_css?('.action-important-note')
+        assert page.has_no_css?('.action-important-note-resolved')
       end
     end
   end

--- a/test/integration/edition_history_test.rb
+++ b/test/integration/edition_history_test.rb
@@ -105,6 +105,11 @@ class EditionHistoryTest < JavascriptIntegrationTest
         assert page.has_no_css?('.callout-important-note')
       end
 
+      should "have clickable links and zendesk tickets" do
+        add_important_note("Note http://www.google.com zen 123456")
+        assert page.has_css?('.callout-important-note .callout-body a', count: 2)
+      end
+
       should "not be carried forward to new editions" do
         @edition = FactoryGirl.create(:answer_edition,
                                       :state => "published")

--- a/test/integration/edition_history_test.rb
+++ b/test/integration/edition_history_test.rb
@@ -22,9 +22,8 @@ class EditionHistoryTest < JavascriptIntegrationTest
       @guide.new_action(@author, Action::RECEIVE_FACT_CHECK, {:comment => "fifth"})
       @guide.new_action(@author, Action::PUBLISH, {:comment => "sixth"})
       @guide.new_action(@author, Action::NOTE, {:comment => "link http://www.some-link.com"})
-      @guide.new_action(@author, Action::IMPORTANT_NOTE, {:comment => "Important note"})
 
-      assert_equal ["fourth", "fifth", "sixth", "link http://www.some-link.com", "Important note"], @guide.actions.map(&:comment)
+      assert_equal ["fourth", "fifth", "sixth", "link http://www.some-link.com"], @guide.actions.map(&:comment)
     end
 
     should "have the first history actions visible" do
@@ -136,6 +135,20 @@ class EditionHistoryTest < JavascriptIntegrationTest
 
         assert page.has_no_css?('.action-important-note')
         assert page.has_no_css?('.action-important-note-resolved')
+      end
+
+      should "shows a history of important notes behind a toggle when there are modifications" do
+        add_important_note("First note")
+        assert page.has_content?('Note created')
+
+        add_important_note("An updated note")
+        assert page.has_content?('Note updated')
+        assert page.has_no_css?('.callout-important-note table')
+
+        click_on "See history"
+        assert page.has_css?('.callout-important-note table tbody tr', count: 2)
+        assert page.has_css?('.callout-important-note tr:last-child td', text: 'First note')
+        assert page.has_css?('.callout-important-note tr:first-child td', text: 'An updated note')
       end
     end
   end

--- a/test/integration/edition_history_test.rb
+++ b/test/integration/edition_history_test.rb
@@ -78,11 +78,12 @@ class EditionHistoryTest < JavascriptIntegrationTest
 
         visit "/editions/#{@guide.id}"
         assert page.has_content? "This is an important note. Take note."
+        assert page.has_css?('.callout-important-note')
 
         click_on "History and notes"
         click_on "Delete important note"
         visit "/editions/#{@guide.id}"
-        assert page.has_no_css?('.important-note')
+        assert page.has_no_css?('.callout-important-note')
       end
 
       should "prepopulate with an existing note" do
@@ -101,7 +102,7 @@ class EditionHistoryTest < JavascriptIntegrationTest
         add_important_note("Note")
         add_important_note("")
 
-        assert page.has_no_css?('.important-note')
+        assert page.has_no_css?('.callout-important-note')
       end
 
       should "not be carried forward to new editions" do


### PR DESCRIPTION
* Remove important note changes from edition history, important notes don't need to be visible within an edition’s audit trail.
* When an important note has been modified, include details of who changed it and when in a table, hidden behind a toggle until it’s needed.
* Make links and zendesk tickets in important notes clickable
* Make important note content bigger and bolder

https://www.agileplannerapp.com/boards/173808/cards/9004
https://govuk.zendesk.com/tickets/898008

Prototype: https://github.com/alphagov/publisher/commit/9254fada1f72de5ae86eba8991839912817808b3#commitcomment-9174019

# Before
![screen shot 2015-01-12 at 18 45 58](https://cloud.githubusercontent.com/assets/319055/5708708/5594f334-9a8b-11e4-8c72-bd3977ac3bd1.png)

# After

![screen shot 2015-01-12 at 18 25 32](https://cloud.githubusercontent.com/assets/319055/5708669/06792dec-9a8b-11e4-8ddd-c3f896075e42.png)
![screen shot 2015-01-12 at 18 25 41](https://cloud.githubusercontent.com/assets/319055/5708668/06768920-9a8b-11e4-8a1f-74845fa99721.png)
