### PR TITLE
Allow claiming of 2i when reviewer has been reset

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -93,7 +93,7 @@ class EditionsController < InheritedResources::Base
   end
 
   def review
-    if resource.reviewer
+    if resource.reviewer.present?
       flash[:danger] = "#{resource.reviewer} has already claimed this 2i"
       redirect_to edition_path(resource)
       return

--- a/test/integration/root_overview_test.rb
+++ b/test/integration/root_overview_test.rb
@@ -173,6 +173,19 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
     assert page.has_content?("Another McPerson has already claimed this 2i")
     assert page.has_select?("Reviewer", :selected => another_user.name)
     assert page.has_select?("Assigned to", :selected => assignee.name)
+
+    select("", from: "Reviewer")
+    click_on "Save"
+
+    visit "/"
+    filter_by_user("All")
+    click_on "In review"
+
+    within("#publication-list-container tbody tr:first-child td:nth-child(6)") do
+      click_on "Claim 2i"
+    end
+
+    assert page.has_content?("You are the reviewer of this guide.")
   end
 
   test "prevents the assignee claiming 2i" do


### PR DESCRIPTION
Resetting the 2i user through the edit edition form would set the user to an empty string, rather than nil.

* Update logic to match that used in reviewer.html.erb
* Include what was a failing test

Fixes https://govuk.zendesk.com/tickets/923214
https://www.agileplannerapp.com/boards/173808/cards/9155