### PR TITLE
Remove old bootstrap js tab shim

### DIFF
--- a/app/assets/javascripts/bootstrap_tabs_affix.js
+++ b/app/assets/javascripts/bootstrap_tabs_affix.js
@@ -1,9 +1,0 @@
-// Switching tabs correctly toggles the 'active' class on
-// .tab-pane elements only when .tab-pane elements are direct
-// children of .tab-content. This fix is required for our
-// scenario where .tab-pane is wrapped in the edition form.
-$('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-  $(e.target.hash).closest('.tab-content')
-    .find('.tab-pane.active:not(' + e.target.hash + ')')
-      .removeClass('active');
-});

--- a/app/assets/javascripts/modules/tab_switcher.js
+++ b/app/assets/javascripts/modules/tab_switcher.js
@@ -11,6 +11,9 @@
         // the active class from a tab-pane that is a direct child of
         // the tab-content container. See:
         // https://github.com/twbs/bootstrap/blob/master/js/tab.js#L52
+        //
+        // Works in conjunction with:
+        // https://github.com/alphagov/publisher/blob/master/app/assets/stylesheets/bootstrap_and_overrides.css.scss#L98-L110
         resetAllTabs();
       });
 


### PR DESCRIPTION
A less brittle shim is now part of the tab_switcher javascript module. See https://github.com/alphagov/publisher/commit/d6ab337dcd924445f16f2d6fd8d74228f01234ed

(Instead of removing a specific `active` class, the newer shim removes all `active` classes before Bootstrap puts it back on the now selected tab)