### PR TITLE
Use an index for sorting on the org content report.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", '~> 28.1.0'
+  gem "govuk_content_models", '~> 28.2.0'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ GEM
       bootstrap-sass (~> 3.3.1)
       jquery-rails (~> 3.1.1)
       rails (>= 3.2.0)
-    govuk_content_models (28.1.0)
+    govuk_content_models (28.2.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 10.0.0)
@@ -350,7 +350,7 @@ DEPENDENCIES
   gds-sso (= 10.0.0)
   govspeak (~> 3.1.0)
   govuk_admin_template (= 1.4.2)
-  govuk_content_models (~> 28.1.0)
+  govuk_content_models (~> 28.2.0)
   has_scope
   inherited_resources
   jasmine (= 2.0.3)

--- a/app/presenters/organisation_content_presenter.rb
+++ b/app/presenters/organisation_content_presenter.rb
@@ -13,15 +13,16 @@ class OrganisationContentPresenter < CSVPresenter
       :need_ids
     ]
 
-    @edition_cache = {}
+    @editions = Edition
+      .where(:panopticon_id.in => scope.only(:_id).map(&:_id))
+      .desc(:created_at)
+      .group_by(&:panopticon_id)
   end
 
 private
 
   def get_value(header, artefact)
-    latest_edition = (
-      @edition_cache[artefact.id] ||= Edition.where(panopticon_id: artefact.id).desc(:created_at).last
-    )
+    latest_edition = @editions[artefact.id.to_s].last
 
     return super if latest_edition.nil?
 


### PR DESCRIPTION
Optimization to bring down the request time for the `organisation-content.csv` report.