### PR TITLE
Alter expand/collapse text when adding/removing parts

### DIFF
--- a/app/assets/javascripts/modules/collapsible_group.js
+++ b/app/assets/javascripts/modules/collapsible_group.js
@@ -16,7 +16,7 @@
           $links = element.find('.js-toggle-all');
 
       element.on('click', '.js-toggle-all', toggleAll);
-      element.on('shown.bs.collapse hidden.bs.collapse', updateLinkText);
+      element.on('shown.bs.collapse hidden.bs.collapse nested:fieldRemoved nested:fieldAdded', updateLinkText);
 
       function toggleAll(event) {
         var action = hasOpenItems() ? 'hide' : 'show';
@@ -26,7 +26,7 @@
       }
 
       function hasOpenItems() {
-        return element.find('.collapse.in').length > 0;
+        return element.find('.collapse.in:visible').length > 0;
       }
 
       function updateLinkText() {

--- a/app/views/shared/_part.html.erb
+++ b/app/views/shared/_part.html.erb
@@ -7,7 +7,7 @@
       </a>
     </h4>
   </div>
-  <div id="<%= f.object.slug || 'untitled-part' %>" class="js-part-toggle-target panel-collapse <% if f.object.valid? %>collapse <% end %>in" aria-expanded="true">
+  <div id="<%= f.object.slug || 'untitled-part' %>" class="js-part-toggle-target panel-collapse collapse in" aria-expanded="true">
     <div class="panel-body">
         <%= f.inputs do %>
           <%= f.input :title,

--- a/spec/javascripts/spec/collapsible_group.spec.js
+++ b/spec/javascripts/spec/collapsible_group.spec.js
@@ -92,4 +92,16 @@ describe('A collapsible group module', function() {
     });
   });
 
+  describe('when a new group is added or removed', function() {
+    it('updates the link text', function() {
+      element.find('.collapse').first().addClass('in');
+      element.trigger('nested:fieldAdded');
+      expect(element.find('.js-toggle-all').text()).toBe('Collapse');
+
+      element.find('.collapse.in').first().hide();
+      element.trigger('nested:fieldRemoved');
+      expect(element.find('.js-toggle-all').text()).toBe('Expand');
+    });
+  });
+
 });


### PR DESCRIPTION
Use the events emitted by the nested form javascript to trigger changes in the link text for collapsing or expanding groups. Also remove the “if valid” check on the collapse class. All parts are shown expanded at page load, and all should be collapsible.

For example:
* When a part is added and all parts were collapsed, change text to “expand”
* When a part is removed and it was the only open part, change text to “expand”

