### PR TITLE
Save editions using ajax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,6 +95,6 @@ group :test do
 end
 
 group :development, :test do
-  gem 'jasmine', '2.0.3'
+  gem 'jasmine', '2.1.0'
   gem 'debugger'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'momentjs-rails', '2.8.3'
 gem 'formtastic', '2.3.0'
 gem 'formtastic-bootstrap', '3.0.0'
 gem 'rails_autolink', '1.1.6'
+gem 'mousetrap-rails', '1.4.6'
 
 gem "nested_form", git: 'https://github.com/alphagov/nested_form.git', branch: 'add-wrapper-class'
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", '~> 28.2.0'
+  gem "govuk_content_models", '~> 28.3.0'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,7 @@ GEM
       bundler (>= 1.0.0)
       rails (>= 3.2.0)
       railties (>= 3.2.0)
+    mousetrap-rails (1.4.6)
     multi_json (1.10.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
@@ -363,6 +364,7 @@ DEPENDENCIES
   momentjs-rails (= 2.8.3)
   mongo (= 1.7.1)
   mongoid_rails_migrations (= 1.0.0)
+  mousetrap-rails (= 1.4.6)
   nested_form!
   null_logger
   plek (= 1.9.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ GEM
       bootstrap-sass (~> 3.3.1)
       jquery-rails (~> 3.1.1)
       rails (>= 3.2.0)
-    govuk_content_models (28.2.0)
+    govuk_content_models (28.3.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 10.0.0)
@@ -351,7 +351,7 @@ DEPENDENCIES
   gds-sso (= 10.0.0)
   govspeak (~> 3.1.0)
   govuk_admin_template (= 1.4.2)
-  govuk_content_models (~> 28.2.0)
+  govuk_content_models (~> 28.3.0)
   has_scope
   inherited_resources
   jasmine (= 2.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,12 +134,12 @@ GEM
     inherited_resources (1.4.0)
       has_scope (~> 0.5.0)
       responders (~> 0.9)
-    jasmine (2.0.3)
-      jasmine-core (~> 2.0.0)
+    jasmine (2.1.0)
+      jasmine-core (~> 2.1.0)
       phantomjs
       rack (>= 1.2.1)
       rake
-    jasmine-core (2.0.2)
+    jasmine-core (2.1.3)
     journey (1.0.4)
     jquery-rails (3.1.2)
       railties (>= 3.0, < 5.0)
@@ -353,7 +353,7 @@ DEPENDENCIES
   govuk_content_models (~> 28.2.0)
   has_scope
   inherited_resources
-  jasmine (= 2.0.3)
+  jasmine (= 2.1.0)
   kaminari (= 0.13.0)
   launchy (= 2.1.1)
   logstasher (= 0.4.8)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,6 +2,7 @@
 //= require moment
 //= require mousetrap
 //= require jquery-ui.custom.min
+//= require_directory ./vendor
 //= require_directory .
 //= require_directory ./modules
 //= require jquery_nested_form

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,6 @@
 //= require select2
 //= require moment
+//= require mousetrap
 //= require jquery-ui.custom.min
 //= require_directory .
 //= require_directory ./modules

--- a/app/assets/javascripts/modules/ajax_save.js
+++ b/app/assets/javascripts/modules/ajax_save.js
@@ -6,6 +6,7 @@
           message = element.find('.js-status-message'),
           hideTimeout;
 
+      GOVUKAdmin.Data = GOVUKAdmin.Data || {};
       element.on('click', '.js-save', save);
 
       function save(evt) {
@@ -61,6 +62,9 @@
         message.addClass('workflow-message-error').removeClass('workflow-message-saving');
         message.text('Couldn’t save');
         hideTimeout = setTimeout(hide, 2000);
+
+        // Save errored, form still has unsaved changes
+        GOVUKAdmin.Data.editionFormDirty = true;
       }
 
       function showErrors(errors) {
@@ -91,6 +95,9 @@
         reset();
         message.addClass('workflow-message-saving');
         message.text('Saving…');
+
+        // Save attempt, form is no longer dirty
+        GOVUKAdmin.Data.editionFormDirty = false;
       }
 
       function hide() {

--- a/app/assets/javascripts/modules/ajax_save.js
+++ b/app/assets/javascripts/modules/ajax_save.js
@@ -53,6 +53,8 @@
         message.addClass('workflow-message-saved').removeClass('workflow-message-saving');
         message.text('Saved');
         hideTimeout = setTimeout(hide, 2000);
+
+        element.trigger('success.ajaxsave.admin', response);
       }
 
       function error(response) {
@@ -65,6 +67,8 @@
 
         // Save errored, form still has unsaved changes
         GOVUKAdmin.Data.editionFormDirty = true;
+
+        element.trigger('error.ajaxsave.admin', response);
       }
 
       function showErrors(errors) {

--- a/app/assets/javascripts/modules/ajax_save.js
+++ b/app/assets/javascripts/modules/ajax_save.js
@@ -61,12 +61,14 @@
       }
 
       function error(response) {
-        if (typeof response.responseJSON === "object") {
-          showErrors(response.responseJSON);
+        var responseJSON = response.responseJSON;
+
+        if (typeof responseJSON === "object") {
+          showErrors(responseJSON);
         }
         message.addClass('workflow-message-error').removeClass('workflow-message-saving');
-        message.text('Couldn’t save');
-        hideTimeout = setTimeout(hide, 2000);
+        message.text('We had some problems saving. Please check the form above.');
+        hideTimeout = setTimeout(hide, 4000);
 
         // Save errored, form still has unsaved changes
         GOVUKAdmin.Data.editionFormDirty = true;

--- a/app/assets/javascripts/modules/ajax_save.js
+++ b/app/assets/javascripts/modules/ajax_save.js
@@ -8,7 +8,7 @@
 
       GOVUKAdmin.Data = GOVUKAdmin.Data || {};
       element.on('click', '.js-save', save);
-      Mousetrap.bind(['command+s', 'ctrl+s'], save);
+      Mousetrap.bindGlobal(['command+s', 'ctrl+s'], save);
 
       function save(evt) {
         saving();

--- a/app/assets/javascripts/modules/ajax_save.js
+++ b/app/assets/javascripts/modules/ajax_save.js
@@ -9,9 +9,15 @@
       element.on('click', '.js-save', save);
 
       function save(evt) {
-        evt.preventDefault();
         saving();
 
+        if (allFieldsCanBeSavedWithAjax()) {
+          evt.preventDefault();
+          postForm();
+        }
+      }
+
+      function postForm() {
         $.ajax({
           url : url,
           type : 'POST',
@@ -19,6 +25,26 @@
           success : success,
           error: error
         });
+      }
+
+      function allFieldsCanBeSavedWithAjax() {
+        var ok = true;
+        element.find('.js-no-ajax, input[type="file"]').each(function() {
+          var $input = $(this),
+              value = $input.val();
+
+          if ($input.is(':checkbox')) {
+            if ($input.is(':checked')) {
+              ok = false;
+            }
+          } else {
+            if (value && value.length > 0) {
+              ok = false;
+            }
+          }
+        });
+
+        return ok;
       }
 
       function success(response) {

--- a/app/assets/javascripts/modules/ajax_save.js
+++ b/app/assets/javascripts/modules/ajax_save.js
@@ -57,6 +57,9 @@
         message.text('Saved');
         hideTimeout = setTimeout(hide, 2000);
 
+        // Save successful, form is no longer dirty
+        GOVUKAdmin.Data.editionFormDirty = false;
+
         element.trigger('success.ajaxsave.admin', response);
       }
 
@@ -99,9 +102,6 @@
         reset();
         message.addClass('workflow-message-saving');
         message.text('Saving…');
-
-        // Save attempt, form is no longer dirty
-        GOVUKAdmin.Data.editionFormDirty = false;
       }
 
       function hide() {

--- a/app/assets/javascripts/modules/ajax_save.js
+++ b/app/assets/javascripts/modules/ajax_save.js
@@ -8,12 +8,15 @@
 
       GOVUKAdmin.Data = GOVUKAdmin.Data || {};
       element.on('click', '.js-save', save);
+      Mousetrap.bind(['command+s', 'ctrl+s'], save);
 
       function save(evt) {
         saving();
 
         if (allFieldsCanBeSavedWithAjax()) {
-          evt.preventDefault();
+          if (typeof evt.preventDefault === "function") {
+            evt.preventDefault();
+          }
           postForm();
         }
       }

--- a/app/assets/javascripts/modules/ajax_save.js
+++ b/app/assets/javascripts/modules/ajax_save.js
@@ -29,7 +29,9 @@
       }
 
       function error(response) {
-        showErrors(response.responseJSON);
+        if (typeof response.responseJSON === "object") {
+          showErrors(response.responseJSON);
+        }
         message.addClass('workflow-message-error').removeClass('workflow-message-saving');
         message.text('Couldn’t save');
         hideTimeout = setTimeout(hide, 2000);

--- a/app/assets/javascripts/modules/ajax_save.js
+++ b/app/assets/javascripts/modules/ajax_save.js
@@ -1,0 +1,81 @@
+(function(Modules) {
+  "use strict";
+  Modules.AjaxSave = function() {
+    this.start = function(element) {
+      var url = element.attr('action') + '.json',
+          message = element.find('.js-status-message'),
+          hideTimeout;
+
+      element.on('click', '.js-save', save);
+
+      function save(evt) {
+        evt.preventDefault();
+        saving();
+
+        $.ajax({
+          url : url,
+          type : 'POST',
+          data : element.serialize(),
+          success : success,
+          error: error
+        });
+      }
+
+      function success(response) {
+        hideErrors();
+        message.addClass('workflow-message-saved').removeClass('workflow-message-saving');
+        message.text('Saved');
+        hideTimeout = setTimeout(hide, 2000);
+      }
+
+      function error(response) {
+        showErrors(response.responseJSON);
+        message.addClass('workflow-message-error').removeClass('workflow-message-saving');
+        message.text('Couldn’t save');
+        hideTimeout = setTimeout(hide, 2000);
+      }
+
+      function showErrors(errors) {
+        var keys = Object.keys(errors);
+
+        for(var i = 0, l = keys.length; i < l; i++) {
+
+          var errorElement = element.find('#edition_' + keys[i] + '_input'),
+              errorMessages = errors[keys[i]],
+              $list = $('<ul class="help-block js-error"></ul>');
+
+          errorElement.addClass('has-error');
+
+          for(var j = 0, m = errorMessages.length; j < m; j++) {
+            $list.append('<li>' + errorMessages[j] + '</li>');
+          }
+
+          errorElement.append($list);
+        }
+      }
+
+      function hideErrors() {
+        element.find('.js-error').remove();
+        element.find('.has-error').removeClass('has-error');
+      }
+
+      function saving() {
+        reset();
+        message.addClass('workflow-message-saving');
+        message.text('Saving…');
+      }
+
+      function hide() {
+        message.addClass('workflow-message-hide');
+      }
+
+      function reset() {
+        hideErrors();
+        clearTimeout(hideTimeout);
+        message.removeClass(function (index, css) {
+          return (css.match(/(^|\s)workflow-message-\S+/g) || []).join(' ');
+        });
+      }
+    }
+  };
+})(window.GOVUKAdmin.Modules);

--- a/app/assets/javascripts/modules/ajax_save.js
+++ b/app/assets/javascripts/modules/ajax_save.js
@@ -77,22 +77,17 @@
       }
 
       function showErrors(errors) {
-        var keys = Object.keys(errors);
-
-        for(var i = 0, l = keys.length; i < l; i++) {
-
-          var errorElement = element.find('#edition_' + keys[i] + '_input'),
-              errorMessages = errors[keys[i]],
+        $.each(errors, function(errorKey, errorMessages) {
+          var errorElement = element.find('#edition_' + errorKey + '_input'),
               $list = $('<ul class="help-block js-error"></ul>');
 
           errorElement.addClass('has-error');
-
           for(var j = 0, m = errorMessages.length; j < m; j++) {
             $list.append('<li>' + errorMessages[j] + '</li>');
           }
 
           errorElement.append($list);
-        }
+        });
       }
 
       function hideErrors() {

--- a/app/assets/javascripts/modules/ajax_save_with_parts.js
+++ b/app/assets/javascripts/modules/ajax_save_with_parts.js
@@ -18,7 +18,7 @@
       }
 
       function updatePart(part) {
-        var $partContainer = identifyPartContainer(part),
+        var $partContainer = identifyPartContainer(part._id, part.order),
             $hiddenInputId = $partContainer.find('input[value="'+part._id+'"]');
 
         $partContainer.find('.js-part-title').text(part.title);
@@ -30,18 +30,18 @@
         }
       }
 
-      function identifyPartContainer(part) {
-        var $hiddenIdInput = element.find('input[value="'+part._id+'"]'),
-            $title;
+      function identifyPartContainer(id, order) {
+        var $hiddenIdInput = element.find('input[value="' + id + '"]'),
+            $order;
 
         if ($hiddenIdInput.length > 0) {
           return $hiddenIdInput.parents('.fields');
         } else {
-          $title = element.find('input.title').filter(function() {
-            return this.value == part.title
+          $order = element.find('input.order').filter(function() {
+            return this.value == order;
           });
 
-          return $title.parents('.fields');
+          return $order.parents('.fields');
         }
       }
 

--- a/app/assets/javascripts/modules/ajax_save_with_parts.js
+++ b/app/assets/javascripts/modules/ajax_save_with_parts.js
@@ -1,0 +1,71 @@
+(function(Modules) {
+  "use strict";
+  Modules.AjaxSaveWithParts = function() {
+    this.start = function(element) {
+      var ajaxSave = new GOVUKAdmin.Modules.AjaxSave();
+
+      element.on('success.ajaxsave.admin', success);
+      //element.on('error.ajaxsave.admin', error);
+      ajaxSave.start(element);
+
+      function success(evt, response) {
+        var parts = response.parts;
+        if (parts) {
+          for (var i = 0, l = parts.length; i < l; i++) {
+            updatePart(parts[i]);
+          }
+        }
+      }
+
+      function updatePart(part) {
+        var $partContainer = identifyPartContainer(part),
+            $hiddenInputId = $partContainer.find('input[value="'+part._id+'"]');
+
+        $partContainer.find('.js-part-title').text(part.title);
+        $partContainer.find('.js-part-toggle-target').attr('id', part.slug);
+        $partContainer.find('.js-part-toggle').attr('href', '#' + part.slug);
+
+        if ($hiddenInputId.length == 0) {
+          generateHiddenIdInput($partContainer, part._id);
+        }
+      }
+
+      function identifyPartContainer(part) {
+        var $hiddenIdInput = element.find('input[value="'+part._id+'"]'),
+            $title;
+
+        if ($hiddenIdInput.length > 0) {
+          return $hiddenIdInput.parents('.fields');
+        } else {
+          $title = element.find('input.title').filter(function() {
+            return this.value == part.title
+          });
+
+          return $title.parents('.fields');
+        }
+      }
+
+      /* To prevent parts being added multiple times, once added and saved
+         they must have a hidden element that contains their server
+         generated ID */
+      function generateHiddenIdInput($partContainer, id) {
+        var $hiddenInputId = $('<input type="hidden">'),
+            $titleInput = $partContainer.find('input.title'),
+            namePrefix = $titleInput.attr('name').replace(/\[title\]/,''),
+            idPrefix = $titleInput.attr('id').replace(/_title/,'');
+
+        $hiddenInputId.attr('value', id);
+        $hiddenInputId.attr('id', idPrefix + '_id');
+        $hiddenInputId.attr('name', namePrefix + '[id]');
+
+        /* <input
+              id="edition_parts_attributes_123456_id"
+              name="edition[parts_attributes][123456][id]"
+              type="hidden"
+              value="54b8d0f7759b7477d5000011"> */
+        $partContainer.append($hiddenInputId);
+      }
+
+    }
+  };
+})(window.GOVUKAdmin.Modules);

--- a/app/assets/javascripts/modules/ajax_save_with_parts.js
+++ b/app/assets/javascripts/modules/ajax_save_with_parts.js
@@ -5,7 +5,7 @@
       var ajaxSave = new GOVUKAdmin.Modules.AjaxSave();
 
       element.on('success.ajaxsave.admin', success);
-      //element.on('error.ajaxsave.admin', error);
+      element.on('error.ajaxsave.admin', error);
       ajaxSave.start(element);
 
       function success(evt, response) {
@@ -15,6 +15,34 @@
             updatePart(parts[i]);
           }
         }
+      }
+
+      function error(evt, response) {
+        var responseJSON = response.responseJSON,
+            partErrors = typeof responseJSON === "object" && responseJSON.parts;
+
+        if (partErrors) {
+          $.each(partErrors[0], showPartErrors);
+        }
+      }
+
+      function showPartErrors(partKey, partErrors) {
+        var partKeyParts = partKey.split(':'),
+            id = partKeyParts[0],
+            order = partKeyParts[1],
+            $partContainer = identifyPartContainer(id, order);
+
+        $partContainer.find('.collapse').collapse('show');
+        $.each(partErrors, function(fieldKey, messages) {
+          var $errorElement = $partContainer.find('[id*=' + fieldKey + '_input]'),
+              $list = $('<ul class="help-block js-error"></ul>');
+
+          $errorElement.addClass('has-error');
+          for(var j = 0, m = messages.length; j < m; j++) {
+            $list.append('<li>' + messages[j] + '</li>');
+          }
+          $errorElement.append($list);
+        });
       }
 
       function updatePart(part) {

--- a/app/assets/javascripts/publications.js
+++ b/app/assets/javascripts/publications.js
@@ -1,25 +1,28 @@
 // Javascript that may be used on every publication show/edit page
-
 $(function () {
+  "use strict";
 
   /*
     Mark the edition form as dirty to prevent accidental navigation away from
     the edition form (such as by clicking the "Edit in Panopticon" link)
   */
-  var edition_form_dirty = false;
+  GOVUKAdmin.Data = GOVUKAdmin.Data || {};
+  GOVUKAdmin.Data.editionFormDirty = false;
 
-  $('#edition-form').change(function () {
-    edition_form_dirty = true;
+  var $editionForm = $('#edition-form');
+
+  $editionForm.change(function () {
+    GOVUKAdmin.Data.editionFormDirty = true;
   });
 
-  $('#edition-form').submit(function() {
-    edition_form_dirty = false;
+  $editionForm.submit(function() {
+    GOVUKAdmin.Data.editionFormDirty = false;
     /* prevent multiple form submissions */
     $("#save-edition").attr('disabled', true);
   });
 
   $(window).bind('beforeunload', function() {
-    if (edition_form_dirty) {
+    if (GOVUKAdmin.Data.editionFormDirty) {
       return 'You have unsaved changes to this edition.';
     }
   });

--- a/app/assets/javascripts/vendor/mousetrap-global-bind.js
+++ b/app/assets/javascripts/vendor/mousetrap-global-bind.js
@@ -1,0 +1,38 @@
+/**
+ * adds a bindGlobal method to Mousetrap that allows you to
+ * bind specific keyboard shortcuts that will still work
+ * inside a text input field
+ *
+ * usage:
+ * Mousetrap.bindGlobal('ctrl+s', _saveChanges);
+ *
+ * https://github.com/ccampbell/mousetrap/tree/master/plugins/global-bind
+ */
+/* global Mousetrap:true */
+Mousetrap = (function(Mousetrap) {
+    var _globalCallbacks = {},
+        _originalStopCallback = Mousetrap.stopCallback;
+
+    Mousetrap.stopCallback = function(e, element, combo, sequence) {
+        if (_globalCallbacks[combo] || _globalCallbacks[sequence]) {
+            return false;
+        }
+
+        return _originalStopCallback(e, element, combo);
+    };
+
+    Mousetrap.bindGlobal = function(keys, callback, action) {
+        Mousetrap.bind(keys, callback, action);
+
+        if (keys instanceof Array) {
+            for (var i = 0; i < keys.length; i++) {
+                _globalCallbacks[keys[i]] = true;
+            }
+            return;
+        }
+
+        _globalCallbacks[keys] = true;
+    };
+
+    return Mousetrap;
+}) (Mousetrap);

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,7 @@
 @import 'panel_part';
 @import 'diff';
 @import 'notes';
+@import 'workflow';
 
 // Pages
 @import 'downtime';

--- a/app/assets/stylesheets/bootstrap_and_overrides.css.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.scss
@@ -1,22 +1,3 @@
-// Increase padding on footer to account for
-// fixed navbar
-.page-footer {
-  margin-bottom: 63px;
-}
-
-.workflow-buttons form {
-  display: inline-block;
-}
-
-.navbar-inverse .workflow-buttons {
-  color: $gray-light;
-}
-
-button.send-fact-check {
-  /* add one column margin to the Fact Check workflow button since we can't use .offset1 on the preview button */
-  margin-left: 70px;
-}
-
 .alert .modal {
   color: $text-color;
 }

--- a/app/assets/stylesheets/workflow.css.scss
+++ b/app/assets/stylesheets/workflow.css.scss
@@ -1,0 +1,18 @@
+// Increase padding on footer to account for
+// fixed navbar
+.page-footer {
+  margin-bottom: 63px;
+}
+
+.workflow-buttons form {
+  display: inline-block;
+}
+
+.navbar-inverse .workflow-buttons {
+  color: $gray-light;
+}
+
+button.send-fact-check {
+  /* add one column margin to the Fact Check workflow button since we can't use .offset1 on the preview button */
+  margin-left: 70px;
+}

--- a/app/assets/stylesheets/workflow.css.scss
+++ b/app/assets/stylesheets/workflow.css.scss
@@ -4,6 +4,10 @@
   margin-bottom: 63px;
 }
 
+/* ==========================================================================
+   Workflow buttons
+   ========================================================================== */
+
 .workflow-buttons form {
   display: inline-block;
 }
@@ -15,4 +19,49 @@
 button.send-fact-check {
   /* add one column margin to the Fact Check workflow button since we can't use .offset1 on the preview button */
   margin-left: 70px;
+}
+
+/* ==========================================================================
+   Workflow 'saving' messages
+   ========================================================================== */
+
+.workflow-message {
+  padding: 12px 0;
+  border-top: 5px solid $table-border-color;
+  font-size: 18px;
+  background: #eee;
+
+  text-align: center;
+  position: fixed;
+  bottom: -57px;
+  left: 0;
+  right: 0;
+
+  -webkit-transition: bottom 200ms;
+  transition: bottom 200ms;
+
+  /* Must display above navbar */
+  z-index: 1031;
+
+  &.workflow-message-hide {
+    bottom: -57px;
+  }
+}
+
+.workflow-message-saving {
+  bottom: 0;
+}
+
+.workflow-message-saved {
+  background: $state-success-bg;
+  color: $state-success-text;
+  border-color: #53ad53;
+  bottom: 0;
+}
+
+.workflow-message-error {
+  background: $state-danger-bg;
+  color: $state-danger-text;
+  border-color: #d9534f;
+  bottom: 0;
 }

--- a/app/helpers/editions_helper.rb
+++ b/app/helpers/editions_helper.rb
@@ -7,8 +7,13 @@ module EditionsHelper
   end
 
   def resource_form(&form_definition)
+    html_options = { :id => 'edition-form' }
+    unless @resource.format == 'SimpleSmartAnswer'
+      html_options['data-module'] = 'ajax-save'
+    end
+
     semantic_bootstrap_nested_form_for @resource, :as => :edition, :url => edition_path(@resource),
-      :html => { :id => 'edition-form', 'data-module' => 'ajax-save' }, &form_definition
+      :html => html_options, &form_definition
   end
 
   def browse_options_for_select(grouped_collections)

--- a/app/helpers/editions_helper.rb
+++ b/app/helpers/editions_helper.rb
@@ -8,7 +8,7 @@ module EditionsHelper
 
   def resource_form(&form_definition)
     semantic_bootstrap_nested_form_for @resource, :as => :edition, :url => edition_path(@resource),
-      :html => { :id => 'edition-form' }, &form_definition
+      :html => { :id => 'edition-form', 'data-module' => 'ajax-save' }, &form_definition
   end
 
   def browse_options_for_select(grouped_collections)

--- a/app/helpers/editions_helper.rb
+++ b/app/helpers/editions_helper.rb
@@ -8,7 +8,9 @@ module EditionsHelper
 
   def resource_form(&form_definition)
     html_options = { :id => 'edition-form' }
-    unless @resource.format == 'SimpleSmartAnswer'
+    if @resource.is_a?(Parted)
+      html_options['data-module'] = 'ajax-save-with-parts'
+    elsif @resource.format != 'SimpleSmartAnswer'
       html_options['data-module'] = 'ajax-save'
     end
 

--- a/app/views/campaigns/_image_upload.html.erb
+++ b/app/views/campaigns/_image_upload.html.erb
@@ -14,7 +14,7 @@
           <% end %>
         </p>
       <% end %>
-      <p><%= label_tag do %>Remove image? <%= check_box_tag "edition[remove_#{format}_image]", "1", false, disabled: @resource.locked_for_edits? %><% end %></p>
+      <p><%= label_tag do %>Remove image? <%= check_box_tag "edition[remove_#{format}_image]", "1", false, disabled: @resource.locked_for_edits?, class: 'js-no-ajax' %><% end %></p>
     <% end %>
     <%= f.input "#{format}_image".to_sym, :as => :file, :label => "Upload image:", input_html: { disabled: @resource.locked_for_edits? } %>
   </td>

--- a/app/views/editions/_reviewer_field.html.erb
+++ b/app/views/editions/_reviewer_field.html.erb
@@ -3,7 +3,7 @@
   <label for="edition_reviewer" class="control-label">Reviewer</label>
   <%= f.select :reviewer, User.enabled.order_by([[:name, :asc]]).collect{ |p| [p.name, p.name] }, { :include_blank => true }, { :class => "form-control input-md-3 #{error_class}", :disabled => @resource.locked_for_edits?, "data-module" => 'assignee-select'} %>
   <% if @resource.errors.has_key?(:reviewer) -%>
-    <ul class="help-block">
+    <ul class="help-block js-error">
     <% @resource.errors[:reviewer].each do |error| -%>
       <li><%= error %></li>
     <% end -%>

--- a/app/views/editions/_reviewer_field.html.erb
+++ b/app/views/editions/_reviewer_field.html.erb
@@ -1,5 +1,5 @@
 <% error_class = @resource.errors.has_key?(:reviewer) ? ' error has-error' : '' -%>
-<div class="form-group<%= error_class %>">
+<div id="edition_reviewer_input" class="form-group<%= error_class %>">
   <label for="edition_reviewer" class="control-label">Reviewer</label>
   <%= f.select :reviewer, User.enabled.order_by([[:name, :asc]]).collect{ |p| [p.name, p.name] }, { :include_blank => true }, { :class => "form-control input-md-3 #{error_class}", :disabled => @resource.locked_for_edits?, "data-module" => 'assignee-select'} %>
   <% if @resource.errors.has_key?(:reviewer) -%>
@@ -10,4 +10,3 @@
     </ul>
   <% end -%>
 </div>
-

--- a/app/views/shared/_common_edition_tags.html.erb
+++ b/app/views/shared/_common_edition_tags.html.erb
@@ -10,8 +10,8 @@
       <li>Specialist sector ➤ Topic</li>
     </ul>
 
-    <div class="form-group">
-      <%= f.label :browse_pages, "Mainstream browse pages", class: 'remove-bottom-margin' %>
+    <div class="form-group" id="edition_browse_pages_input">
+      <%= f.label :browse_pages, "Mainstream browse pages", class: 'control-label remove-bottom-margin' %>
       <p class="help-block">The first mainstream browse page will form the content’s breadcrumb</p>
       <%= f.select :browse_pages,
                       browse_options_for_select(Collections.grouped_mainstream_browse_pages),
@@ -21,8 +21,8 @@
                         disabled: @resource.locked_for_edits?,
                         data: { placeholder: 'Choose mainstream browse pages…' } } %>
     </div>
-    <div class="form-group">
-      <%= f.label :primary_topic %>
+    <div class="form-group" id="edition_primary_topic_input">
+      <%= f.label :primary_topic, class: 'control-label' %>
       <%= f.select :primary_topic,
                       browse_options_for_select(Collections.grouped_topics),
                       { include_blank: true },
@@ -30,8 +30,8 @@
                         disabled: @resource.locked_for_edits?,
                         data: { placeholder: 'Choose primary topic…' } } %>
     </div>
-    <div class="form-group">
-      <%= f.label :additional_topics %>
+    <div class="form-group" id="edition_additional_topics_input">
+      <%= f.label :additional_topics, class: 'control-label' %>
       <%= f.select :additional_topics,
                       browse_options_for_select(Collections.grouped_topics),
                       {},

--- a/app/views/shared/_part.html.erb
+++ b/app/views/shared/_part.html.erb
@@ -1,13 +1,13 @@
 <div class="panel panel-part part">
   <div class="panel-heading js-sort-handle">
     <h4 class="panel-title">
-      <a data-toggle="collapse" data-parent="#parts" href="#<%= f.object.slug || 'untitled-part' %>">
+      <a class="js-part-toggle" data-toggle="collapse" data-parent="#parts" href="#<%= f.object.slug || 'untitled-part' %>">
         <i class="glyphicon glyphicon-chevron-down pull-left add-right-margin"></i>
-        <%= f.object.title.present? ? f.object.title : 'Untitled part' %>
+        <span class="js-part-title"><%= f.object.title.present? ? f.object.title : 'Untitled part' %></span>
       </a>
     </h4>
   </div>
-  <div id="<%= f.object.slug || 'untitled-part' %>" class="panel-collapse <% if f.object.valid? %>collapse <% end %>in">
+  <div id="<%= f.object.slug || 'untitled-part' %>" class="js-part-toggle-target panel-collapse <% if f.object.valid? %>collapse <% end %>in">
     <div class="panel-body">
         <%= f.inputs do %>
           <%= f.input :title,

--- a/app/views/shared/_workflow_buttons.html.erb
+++ b/app/views/shared/_workflow_buttons.html.erb
@@ -13,7 +13,7 @@
           <% end %>
           <%= progress_buttons(@resource, skip_disabled_buttons: true) %>
         <% else %>
-          <%= f.submit 'Save', id: 'save-edition', class: 'btn btn-success btn-large' %>
+          <%= f.submit 'Save', id: 'save-edition', class: 'btn btn-success btn-large js-save' %>
           <%= preview_button(@resource) %>
           <%= progress_buttons(@resource) %>
         <% end %>
@@ -21,3 +21,5 @@
     </div><!--/.container-fluid -->
   </div><!--/.navbar-inner -->
 </div><!--/.navbar -->
+
+<div class="workflow-message js-status-message"></div>

--- a/app/views/videos/_fields.html.erb
+++ b/app/views/videos/_fields.html.erb
@@ -16,7 +16,7 @@
       <div class="uploaded-caption-file">
         <h4>Current caption file</h4>
         <p><%= link_to @edition.caption_file.name, @edition.caption_file.file_url %></p>
-        <p><%= label_tag do %>Remove caption file? <%= check_box_tag "edition[remove_caption_file]", "1", false, disabled: @resource.locked_for_edits? %><% end %></p>
+        <p><%= label_tag do %>Remove caption file? <%= check_box_tag "edition[remove_caption_file]", "1", false, disabled: @resource.locked_for_edits?, class: 'js-no-ajax' %><% end %></p>
       </div>
 
       <h4>Replace caption file</h4>

--- a/config/initializers/formtastic.rb
+++ b/config/initializers/formtastic.rb
@@ -45,7 +45,7 @@ Formtastic::FormBuilder.inline_errors = :list
 # If you override the class here, please ensure to override it in your formtastic_changes.css stylesheet as well
 # Formtastic::SemanticFormBuilder.default_hint_class = "inline-hints"
 # Formtastic::SemanticFormBuilder.default_inline_error_class = "inline-errors"
-Formtastic::FormBuilder.default_error_list_class = "help-block"
+Formtastic::FormBuilder.default_error_list_class = "help-block js-error"
 
 # Set the method to call on label text to transform or format it for human-friendly
 # reading when formtastic is used without object. Defaults to :humanize.

--- a/spec/javascripts/spec/ajax_save.spec.js
+++ b/spec/javascripts/spec/ajax_save.spec.js
@@ -126,7 +126,7 @@ describe('An ajax save module', function() {
     it('says that it couldn’t save' , function() {
       ajaxError();
       var statusMessage = element.find('.js-status-message');
-      expect(statusMessage.text()).toBe('Couldn’t save');
+      expect(statusMessage.text()).toBe('We had some problems saving. Please check the form above.');
       expect(statusMessage.is('.workflow-message-error')).toBe(true);
     });
 

--- a/spec/javascripts/spec/ajax_save.spec.js
+++ b/spec/javascripts/spec/ajax_save.spec.js
@@ -61,7 +61,7 @@ describe('An ajax save module', function() {
 
     beforeEach(function() {
       spyOn($, 'ajax').and.callFake(function(options) {
-        options.success({});
+        options.success({title: 'Title'});
       });
       spyOn(window, 'setTimeout').and.callFake(function(fn, time) {
         timeoutTime = time;
@@ -79,6 +79,15 @@ describe('An ajax save module', function() {
     it('the save message disappears after a short while', function() {
       expect(timeoutTime).toBe(2000);
       expect(element.find('.js-status-message').is('.workflow-message-hide'));
+    });
+
+    it('triggers a success.ajaxsave.admin dom event', function() {
+      var successResponse = false;
+      element.on('success.ajaxsave.admin', function(evt, response) {
+        successResponse = response;
+      });
+      element.find('.js-save').trigger('click');
+      expect(successResponse).toEqual({title: 'Title'});
     });
   });
 
@@ -143,6 +152,15 @@ describe('An ajax save module', function() {
       expect(element.find('#edition_another_input').is('.has-error')).toBe(true);
       expect(element.find('#edition_another_input ul li').length).toBe(1);
       expect(element.find('#edition_another_input ul li:first').text()).toBe('must rhyme');
+    });
+
+    it('triggers an error.ajaxsave.admin dom event', function() {
+      var errorResponse = false;
+      element.on('error.ajaxsave.admin', function(evt, response) {
+        errorResponse = response;
+      });
+      ajaxError({not_a_field: ['nonsense']});
+      expect(errorResponse).toEqual({responseJSON: {not_a_field: ['nonsense']}});
     });
 
     describe('when the form is saved again', function() {

--- a/spec/javascripts/spec/ajax_save.spec.js
+++ b/spec/javascripts/spec/ajax_save.spec.js
@@ -28,6 +28,14 @@ describe('An ajax save module', function() {
     element.remove();
   });
 
+  describe('when keying command+s', function() {
+    it('attempts to save', function() {
+      spyOn($, 'ajax');
+      Mousetrap.trigger('command+s');
+      expect($.ajax).toHaveBeenCalled();
+    });
+  });
+
   describe('when clicking a save link', function() {
     it('indicates the form is saving' , function() {
       element.find('.js-save').trigger('click');

--- a/spec/javascripts/spec/ajax_save.spec.js
+++ b/spec/javascripts/spec/ajax_save.spec.js
@@ -14,6 +14,8 @@ describe('An ajax save module', function() {
       <div id="edition_another_input">\
         <input type="text" name="another" value="another value">\
       </div>\
+      <input class="js-no-ajax" type="text" name="fake-file-input">\
+      <input class="js-no-ajax" type="checkbox" name="remove-file-checkbox" value="1">\
       <input type="submit" class="js-save" value="Save">\
     </form>');
 
@@ -45,7 +47,7 @@ describe('An ajax save module', function() {
       expect($.ajax).toHaveBeenCalled();
       expect(ajaxOptions.type).toBe('POST');
       expect(ajaxOptions.url).toBe('some/url.json');
-      expect(ajaxOptions.data).toBe('test=prefilled+value&another=another+value');
+      expect(ajaxOptions.data).toBe('test=prefilled+value&another=another+value&fake-file-input=');
     });
   });
 
@@ -74,7 +76,6 @@ describe('An ajax save module', function() {
       expect(element.find('.js-status-message').is('.workflow-message-hide'));
     });
   });
-
 
   describe('when an ajax save errors with validation messages', function() {
     var timeoutTime, ajaxError, ajaxSuccess;
@@ -145,4 +146,42 @@ describe('An ajax save module', function() {
     });
 
   });
+
+  /* Cannot simulate a file input with a value, instead test this feature by proxy
+     using an input which has the class 'js-no-ajax' and setting a value on it */
+  describe('when submitting a form with fields that need a full page reload', function() {
+
+    it('still indicates the form is saving', function() {
+      element.find('.js-no-ajax[name="fake-file-input"]').val('has value as if file was selected');
+      element.find('.js-save').trigger('click');
+
+      var statusMessage = element.find('.js-status-message');
+      expect(statusMessage.text()).toBe('Saving…');
+      expect(statusMessage.is('.workflow-message-saving')).toBe(true);
+    });
+
+    it('avoids ajax if a non-ajax text input has a value' , function() {
+      var ajaxOptions;
+      spyOn($, 'ajax');
+      element.find('.js-no-ajax[name="fake-file-input"]').val('has value as if file was selected');
+      element.find('.js-save').trigger('click');
+
+      expect($.ajax).not.toHaveBeenCalled();
+
+      element.find('.js-no-ajax[name="fake-file-input"]').val('');
+      element.find('.js-save').trigger('click');
+
+      expect($.ajax).toHaveBeenCalled();
+    });
+
+    it('avoids ajax if a non-ajax checkbox is checked' , function() {
+      var ajaxOptions;
+      spyOn($, 'ajax');
+      element.find('.js-no-ajax[name="remove-file-checkbox"]').attr('checked', true);
+      element.find('.js-save').trigger('click');
+
+      expect($.ajax).not.toHaveBeenCalled();
+    });
+  });
+
 });

--- a/spec/javascripts/spec/ajax_save.spec.js
+++ b/spec/javascripts/spec/ajax_save.spec.js
@@ -132,7 +132,7 @@ describe('An ajax save module', function() {
 
     it('the error message disappears after a short while', function() {
       ajaxError();
-      expect(timeoutTime).toBe(2000);
+      expect(timeoutTime).toBe(4000);
       expect(element.find('.js-status-message').is('.workflow-message-hide'));
     });
 

--- a/spec/javascripts/spec/ajax_save.spec.js
+++ b/spec/javascripts/spec/ajax_save.spec.js
@@ -45,11 +45,6 @@ describe('An ajax save module', function() {
       expect(statusMessage.is('.workflow-message-saving')).toBe(true);
     });
 
-    it('resets the form’s dirty state', function() {
-      element.find('.js-save').trigger('click');
-      expect(GOVUKAdmin.Data.editionFormDirty).toBe(false);
-    });
-
     it('posts the form using ajax', function() {
       var ajaxOptions;
       spyOn($, 'ajax').and.callFake(function(options) {
@@ -68,6 +63,7 @@ describe('An ajax save module', function() {
     var timeoutTime;
 
     beforeEach(function() {
+      GOVUKAdmin.Data.editionFormDirty = true;
       spyOn($, 'ajax').and.callFake(function(options) {
         options.success({title: 'Title'});
       });
@@ -82,6 +78,10 @@ describe('An ajax save module', function() {
       var statusMessage = element.find('.js-status-message');
       expect(statusMessage.text()).toBe('Saved');
       expect(statusMessage.is('.workflow-message-saved')).toBe(true);
+    });
+
+    it('marks the form as clean', function() {
+      expect(GOVUKAdmin.Data.editionFormDirty).toBe(false);
     });
 
     it('the save message disappears after a short while', function() {
@@ -119,6 +119,7 @@ describe('An ajax save module', function() {
     });
 
     it('marks the form as dirty', function() {
+      GOVUKAdmin.Data.editionFormDirty = false;
       ajaxError();
       expect(GOVUKAdmin.Data.editionFormDirty).toBe(true);
     });

--- a/spec/javascripts/spec/ajax_save.spec.js
+++ b/spec/javascripts/spec/ajax_save.spec.js
@@ -1,0 +1,148 @@
+describe('An ajax save module', function() {
+  "use strict";
+
+  var ajaxSave,
+      element;
+
+  beforeEach(function() {
+
+    element = $('<form action="some/url">\
+      <div class="js-status-message"></div>\
+      <div id="edition_test_input">\
+        <input type="text" name="test" value="prefilled value">\
+      </div>\
+      <div id="edition_another_input">\
+        <input type="text" name="another" value="another value">\
+      </div>\
+      <input type="submit" class="js-save" value="Save">\
+    </form>');
+
+    $('body').append(element);
+    ajaxSave = new GOVUKAdmin.Modules.AjaxSave();
+    ajaxSave.start(element);
+  });
+
+  afterEach(function() {
+    element.remove();
+  });
+
+  describe('when clicking a save link', function() {
+    it('indicates the form is saving' , function() {
+      element.find('.js-save').trigger('click');
+
+      var statusMessage = element.find('.js-status-message');
+      expect(statusMessage.text()).toBe('Saving…');
+      expect(statusMessage.is('.workflow-message-saving')).toBe(true);
+    });
+
+    it('posts the form using ajax' , function() {
+      var ajaxOptions;
+      spyOn($, 'ajax').and.callFake(function(options) {
+        ajaxOptions = options;
+      });
+      element.find('.js-save').trigger('click');
+
+      expect($.ajax).toHaveBeenCalled();
+      expect(ajaxOptions.type).toBe('POST');
+      expect(ajaxOptions.url).toBe('some/url.json');
+      expect(ajaxOptions.data).toBe('test=prefilled+value&another=another+value');
+    });
+  });
+
+  describe('when an ajax save is successful', function() {
+    var timeoutTime;
+
+    beforeEach(function() {
+      spyOn($, 'ajax').and.callFake(function(options) {
+        options.success({});
+      });
+      spyOn(window, 'setTimeout').and.callFake(function(fn, time) {
+        timeoutTime = time;
+        fn();
+      });
+      element.find('.js-save').trigger('click');
+    });
+
+    it('says that it has saved' , function() {
+      var statusMessage = element.find('.js-status-message');
+      expect(statusMessage.text()).toBe('Saved');
+      expect(statusMessage.is('.workflow-message-saved')).toBe(true);
+    });
+
+    it('the save message disappears after a short while', function() {
+      expect(timeoutTime).toBe(2000);
+      expect(element.find('.js-status-message').is('.workflow-message-hide'));
+    });
+  });
+
+
+  describe('when an ajax save errors with validation messages', function() {
+    var timeoutTime, ajaxError, ajaxSuccess;
+
+    beforeEach(function() {
+      spyOn($, 'ajax').and.callFake(function(options) {
+        ajaxError = function(errors) {
+          errors = errors || {};
+          options.error({responseJSON: errors});
+        };
+
+        ajaxSuccess = options.success;
+      });
+      spyOn(window, 'setTimeout').and.callFake(function(fn, time) {
+        timeoutTime = time;
+        fn();
+      });
+      element.find('.js-save').trigger('click');
+    });
+
+    it('says that it couldn’t save' , function() {
+      ajaxError();
+      var statusMessage = element.find('.js-status-message');
+      expect(statusMessage.text()).toBe('Couldn’t save');
+      expect(statusMessage.is('.workflow-message-error')).toBe(true);
+    });
+
+    it('the error message disappears after a short while', function() {
+      ajaxError();
+      expect(timeoutTime).toBe(2000);
+      expect(element.find('.js-status-message').is('.workflow-message-hide'));
+    });
+
+    it('shows the error alongside the erroring field', function() {
+      ajaxError({test: ['must be changed']});
+      expect(element.find('#edition_test_input').is('.has-error')).toBe(true);
+      expect(element.find('#edition_test_input ul li').length).toBe(1);
+      expect(element.find('#edition_test_input ul li:first').text()).toBe('must be changed');
+    });
+
+    it('ignores validation messages for fields it does not recognise', function() {
+      ajaxError({not_a_field: ['nonsense']});
+      expect(element.find('.has-error').length).toBe(0);
+      expect(element.find('.js-error').length).toBe(0);
+    });
+
+    it('can show multiple errors', function() {
+      ajaxError({test: ['must be changed', 'must be blue'], another: ['must rhyme']});
+
+      expect(element.find('#edition_test_input').is('.has-error')).toBe(true);
+      expect(element.find('#edition_test_input ul li').length).toBe(2);
+      expect(element.find('#edition_test_input ul li:first').text()).toBe('must be changed');
+      expect(element.find('#edition_test_input ul li:last').text()).toBe('must be blue');
+
+      expect(element.find('#edition_another_input').is('.has-error')).toBe(true);
+      expect(element.find('#edition_another_input ul li').length).toBe(1);
+      expect(element.find('#edition_another_input ul li:first').text()).toBe('must rhyme');
+    });
+
+    describe('when the form is saved again', function() {
+      it('removes all errors', function() {
+        ajaxError({test: ['must be changed', 'must be blue'], another: ['must rhyme']});
+        element.find('.js-save').trigger('click');
+
+        expect(element.find('.has-error').length).toBe(0);
+        expect(element.find('.js-error').length).toBe(0);
+      });
+    });
+
+  });
+});

--- a/spec/javascripts/spec/ajax_save.spec.js
+++ b/spec/javascripts/spec/ajax_save.spec.js
@@ -37,6 +37,11 @@ describe('An ajax save module', function() {
       expect(statusMessage.is('.workflow-message-saving')).toBe(true);
     });
 
+    it('resets the form’s dirty state' , function() {
+      element.find('.js-save').trigger('click');
+      expect(GOVUKAdmin.Data.editionFormDirty).toBe(false);
+    });
+
     it('posts the form using ajax' , function() {
       var ajaxOptions;
       spyOn($, 'ajax').and.callFake(function(options) {
@@ -94,6 +99,11 @@ describe('An ajax save module', function() {
         fn();
       });
       element.find('.js-save').trigger('click');
+    });
+
+    it('marks the form as dirty' , function() {
+      ajaxError();
+      expect(GOVUKAdmin.Data.editionFormDirty).toBe(true);
     });
 
     it('says that it couldn’t save' , function() {

--- a/spec/javascripts/spec/ajax_save.spec.js
+++ b/spec/javascripts/spec/ajax_save.spec.js
@@ -37,7 +37,7 @@ describe('An ajax save module', function() {
   });
 
   describe('when clicking a save link', function() {
-    it('indicates the form is saving' , function() {
+    it('indicates the form is saving', function() {
       element.find('.js-save').trigger('click');
 
       var statusMessage = element.find('.js-status-message');
@@ -45,12 +45,12 @@ describe('An ajax save module', function() {
       expect(statusMessage.is('.workflow-message-saving')).toBe(true);
     });
 
-    it('resets the form’s dirty state' , function() {
+    it('resets the form’s dirty state', function() {
       element.find('.js-save').trigger('click');
       expect(GOVUKAdmin.Data.editionFormDirty).toBe(false);
     });
 
-    it('posts the form using ajax' , function() {
+    it('posts the form using ajax', function() {
       var ajaxOptions;
       spyOn($, 'ajax').and.callFake(function(options) {
         ajaxOptions = options;
@@ -78,7 +78,7 @@ describe('An ajax save module', function() {
       element.find('.js-save').trigger('click');
     });
 
-    it('says that it has saved' , function() {
+    it('says that it has saved', function() {
       var statusMessage = element.find('.js-status-message');
       expect(statusMessage.text()).toBe('Saved');
       expect(statusMessage.is('.workflow-message-saved')).toBe(true);
@@ -118,12 +118,12 @@ describe('An ajax save module', function() {
       element.find('.js-save').trigger('click');
     });
 
-    it('marks the form as dirty' , function() {
+    it('marks the form as dirty', function() {
       ajaxError();
       expect(GOVUKAdmin.Data.editionFormDirty).toBe(true);
     });
 
-    it('says that it couldn’t save' , function() {
+    it('says that it couldn’t save', function() {
       ajaxError();
       var statusMessage = element.find('.js-status-message');
       expect(statusMessage.text()).toBe('We had some problems saving. Please check the form above.');
@@ -196,7 +196,7 @@ describe('An ajax save module', function() {
       expect(statusMessage.is('.workflow-message-saving')).toBe(true);
     });
 
-    it('avoids ajax if a non-ajax text input has a value' , function() {
+    it('avoids ajax if a non-ajax text input has a value', function() {
       var ajaxOptions;
       spyOn($, 'ajax');
       element.find('.js-no-ajax[name="fake-file-input"]').val('has value as if file was selected');
@@ -210,7 +210,7 @@ describe('An ajax save module', function() {
       expect($.ajax).toHaveBeenCalled();
     });
 
-    it('avoids ajax if a non-ajax checkbox is checked' , function() {
+    it('avoids ajax if a non-ajax checkbox is checked', function() {
       var ajaxOptions;
       spyOn($, 'ajax');
       element.find('.js-no-ajax[name="remove-file-checkbox"]').attr('checked', true);

--- a/spec/javascripts/spec/ajax_save_with_parts.spec.js
+++ b/spec/javascripts/spec/ajax_save_with_parts.spec.js
@@ -14,6 +14,7 @@ describe('An ajax save with parts module', function() {
         </a>\
         <div class="js-part-toggle-target" id="slug">\
           <input class="title" type="text" id="edition_part_100_title" name="edition[part][100][title]" value="Title">\
+          <input class="order" type="hidden" id="edition_part_100_order" name="edition[part][100][order]" value="1">\
           <input class="slug" type="text" id="edition_part_100_slug" name="edition[part][100][slug]" value="slug">\
           <input type="hidden" id="edition_part_100_id" name="edition[part][100][id]" value="5f00000001">\
         </div>\
@@ -24,6 +25,7 @@ describe('An ajax save with parts module', function() {
         </a>\
         <div class="js-part-toggle-target" id="slug-2">\
           <input class="title" type="text" id="edition_part_101_title" name="edition[part][101][title]" value="Title 2">\
+          <input class="order" type="hidden" id="edition_part_101_order" name="edition[part][101][order]" value="2">\
           <input class="slug" type="text" id="edition_part_101_slug" name="edition[part][101][slug]" value="slug-2">\
           <input type="hidden" id="edition_part_101_id" name="edition[part][101][id]" value="5f00000002">\
         </div>\
@@ -34,6 +36,7 @@ describe('An ajax save with parts module', function() {
         </a>\
         <div class="js-part-toggle-target" id="untitled-part">\
           <input class="title" type="text" id="edition_part_4535667_title" name="edition[part][4535667][title]" value="Updated title 3">\
+          <input class="order" type="hidden" id="edition_part_4535667_order" name="edition[part][4535667][order]" value="3">\
           <input class="slug" type="text" id="edition_part_4535667_slug" name="edition[part][4535667][slug]" value="">\
         </div>\
       </div>\
@@ -62,8 +65,8 @@ describe('An ajax save with parts module', function() {
   describe('when the form is saved successfully', function() {
     beforeEach(function() {
       element.trigger('success.ajaxsave.admin', {parts:
-        [{_id: '5f00000001', slug: 'updated-title-1', title: 'Updated title 1'},
-         {_id: '5f00000002', slug: 'updated-title-2', title: 'Updated title 2'}]
+        [{_id: '5f00000001', order: 1, slug: 'updated-title-1', title: 'Updated title 1'},
+         {_id: '5f00000002', order: 2, slug: 'updated-title-2', title: 'Updated title 2'}]
       });
     });
 
@@ -83,13 +86,13 @@ describe('An ajax save with parts module', function() {
   describe('when a new part is added and the form is saved', function() {
     beforeEach(function() {
       element.trigger('success.ajaxsave.admin', {parts:
-        [{_id: '5f00000001', slug: 'updated-title-1', title: 'Updated title 1'},
-         {_id: '5f00000002', slug: 'updated-title-2', title: 'Updated title 2'},
-         {_id: '5f00000003', slug: 'updated-title-3', title: 'Updated title 3'}]
+        [{_id: '5f00000001', order: 1, slug: 'updated-title-1', title: 'Updated title 1'},
+         {_id: '5f00000002', order: 2, slug: 'updated-title-2', title: 'Updated title 2'},
+         {_id: '5f00000003', order: 3, slug: 'updated-title-3', title: 'Updated title 3'}]
       });
     });
 
-    it('adds a hidden id input based on a part’s title', function() {
+    it('adds a hidden input containing the part’s new ID', function() {
       var $input = element.find('input[value="5f00000003"]');
 
       expect($input.length).toBe(1);

--- a/spec/javascripts/spec/ajax_save_with_parts.spec.js
+++ b/spec/javascripts/spec/ajax_save_with_parts.spec.js
@@ -13,9 +13,13 @@ describe('An ajax save with parts module', function() {
           <span class="js-part-title">Title</span>\
         </a>\
         <div class="js-part-toggle-target" id="slug">\
-          <input class="title" type="text" id="edition_part_100_title" name="edition[part][100][title]" value="Title">\
+          <div id="edition_parts_attributes_100_title_input">\
+            <input class="title" type="text" id="edition_part_100_title" name="edition[part][100][title]" value="Title">\
+          </div>\
           <input class="order" type="hidden" id="edition_part_100_order" name="edition[part][100][order]" value="1">\
-          <input class="slug" type="text" id="edition_part_100_slug" name="edition[part][100][slug]" value="slug">\
+          <div id="edition_parts_attributes_100_slug_input">\
+            <input class="slug" type="text" id="edition_part_100_slug" name="edition[part][100][slug]" value="slug">\
+          </div>\
           <input type="hidden" id="edition_part_100_id" name="edition[part][100][id]" value="5f00000001">\
         </div>\
       </div>\
@@ -24,9 +28,13 @@ describe('An ajax save with parts module', function() {
           <span class="js-part-title">Title 2</span>\
         </a>\
         <div class="js-part-toggle-target" id="slug-2">\
-          <input class="title" type="text" id="edition_part_101_title" name="edition[part][101][title]" value="Title 2">\
+          <div id="edition_parts_attributes_101_title_input">\
+            <input class="title" type="text" id="edition_part_101_title" name="edition[part][101][title]" value="Title 2">\
+          </div>\
           <input class="order" type="hidden" id="edition_part_101_order" name="edition[part][101][order]" value="2">\
-          <input class="slug" type="text" id="edition_part_101_slug" name="edition[part][101][slug]" value="slug-2">\
+          <div id="edition_parts_attributes_101_slug_input">\
+            <input class="slug" type="text" id="edition_part_101_slug" name="edition[part][101][slug]" value="slug-2">\
+          </div>\
           <input type="hidden" id="edition_part_101_id" name="edition[part][101][id]" value="5f00000002">\
         </div>\
       </div>\
@@ -35,9 +43,13 @@ describe('An ajax save with parts module', function() {
           <span class="js-part-title">Untitled part</span>\
         </a>\
         <div class="js-part-toggle-target" id="untitled-part">\
-          <input class="title" type="text" id="edition_part_4535667_title" name="edition[part][4535667][title]" value="Updated title 3">\
+          <div id="edition_parts_attributes_4535667_title_input">\
+            <input class="title" type="text" id="edition_part_4535667_title" name="edition[part][4535667][title]" value="Updated title 3">\
+          </div>\
           <input class="order" type="hidden" id="edition_part_4535667_order" name="edition[part][4535667][order]" value="3">\
-          <input class="slug" type="text" id="edition_part_4535667_slug" name="edition[part][4535667][slug]" value="">\
+          <div id="edition_parts_attributes_4535667_slug_input">\
+            <input class="slug" type="text" id="edition_part_4535667_slug" name="edition[part][4535667][slug]" value="">\
+          </div>\
         </div>\
       </div>\
       <input type="submit" class="js-save" value="Save">\
@@ -107,6 +119,38 @@ describe('An ajax save with parts module', function() {
     it('updates the toggle href and target based on its slug', function() {
       expect(element.find('.js-part-toggle-target').eq(2).attr('id')).toBe('updated-title-3');
       expect(element.find('.js-part-toggle').eq(2).attr('href')).toBe('#updated-title-3');
+    });
+  });
+
+  describe('when the form save errors', function() {
+    beforeEach(function() {
+      element.trigger('error.ajaxsave.admin', {responseJSON: {"parts":
+        [
+          {
+            "5f00000001:1":{"slug":["can't be blank","is invalid"]},
+            "5f00000002:2":{"title":["can't be blank"]},
+            "unknownid:3" :{"title":["must not walk on the grass"]}
+          }
+        ]
+      }});
+    });
+
+    it('shows the error messages', function() {
+      expect(element.find('.has-error').length).toBe(3);
+      expect(element.find('ul.js-error').length).toBe(3);
+
+      expect(element.find('#edition_parts_attributes_100_slug_input').is('.has-error')).toBe(true);
+      expect(element.find('#edition_parts_attributes_100_slug_input ul li').length).toBe(2);
+      expect(element.find('#edition_parts_attributes_100_slug_input ul li:first').text()).toBe('can\'t be blank');
+      expect(element.find('#edition_parts_attributes_100_slug_input ul li:last').text()).toBe('is invalid');
+
+      expect(element.find('#edition_parts_attributes_101_title_input').is('.has-error')).toBe(true);
+      expect(element.find('#edition_parts_attributes_101_title_input ul li').length).toBe(1);
+      expect(element.find('#edition_parts_attributes_101_title_input ul li:first').text()).toBe('can\'t be blank');
+
+      expect(element.find('#edition_parts_attributes_4535667_title_input').is('.has-error')).toBe(true);
+      expect(element.find('#edition_parts_attributes_4535667_title_input ul li').length).toBe(1);
+      expect(element.find('#edition_parts_attributes_4535667_title_input ul li:first').text()).toBe('must not walk on the grass');
     });
   });
 });

--- a/spec/javascripts/spec/ajax_save_with_parts.spec.js
+++ b/spec/javascripts/spec/ajax_save_with_parts.spec.js
@@ -1,0 +1,109 @@
+describe('An ajax save with parts module', function() {
+  "use strict";
+
+  var ajaxSaveWithParts,
+      element;
+
+  beforeEach(function() {
+
+    element = $('<form action="some/url">\
+      <div class="js-status-message"></div>\
+      <div class="fields">\
+        <a href="#" class="js-part-toggle">\
+          <span class="js-part-title">Title</span>\
+        </a>\
+        <div class="js-part-toggle-target" id="slug">\
+          <input class="title" type="text" id="edition_part_100_title" name="edition[part][100][title]" value="Title">\
+          <input class="slug" type="text" id="edition_part_100_slug" name="edition[part][100][slug]" value="slug">\
+          <input type="hidden" id="edition_part_100_id" name="edition[part][100][id]" value="5f00000001">\
+        </div>\
+      </div>\
+      <div class="fields">\
+        <a href="#" class="js-part-toggle">\
+          <span class="js-part-title">Title 2</span>\
+        </a>\
+        <div class="js-part-toggle-target" id="slug-2">\
+          <input class="title" type="text" id="edition_part_101_title" name="edition[part][101][title]" value="Title 2">\
+          <input class="slug" type="text" id="edition_part_101_slug" name="edition[part][101][slug]" value="slug-2">\
+          <input type="hidden" id="edition_part_101_id" name="edition[part][101][id]" value="5f00000002">\
+        </div>\
+      </div>\
+      <div class="fields">\
+        <a href="#" class="js-part-toggle">\
+          <span class="js-part-title">Untitled part</span>\
+        </a>\
+        <div class="js-part-toggle-target" id="untitled-part">\
+          <input class="title" type="text" id="edition_part_4535667_title" name="edition[part][4535667][title]" value="Updated title 3">\
+          <input class="slug" type="text" id="edition_part_4535667_slug" name="edition[part][4535667][slug]" value="">\
+        </div>\
+      </div>\
+      <input type="submit" class="js-save" value="Save">\
+    </form>');
+
+    $('body').append(element);
+    ajaxSaveWithParts = new GOVUKAdmin.Modules.AjaxSaveWithParts();
+    ajaxSaveWithParts.start(element);
+  });
+
+  afterEach(function() {
+    element.remove();
+  });
+
+  describe('it does everything ajax save does', function() {
+    describe('ie when clicking a save link', function() {
+      it('posts the form using ajax', function() {
+        spyOn($, 'ajax');
+        element.find('.js-save').trigger('click');
+        expect($.ajax).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when the form is saved successfully', function() {
+    beforeEach(function() {
+      element.trigger('success.ajaxsave.admin', {parts:
+        [{_id: '5f00000001', slug: 'updated-title-1', title: 'Updated title 1'},
+         {_id: '5f00000002', slug: 'updated-title-2', title: 'Updated title 2'}]
+      });
+    });
+
+    it('updates the part titles based on their IDs', function() {
+      expect(element.find('.js-part-title').eq(0).text()).toBe('Updated title 1');
+      expect(element.find('.js-part-title').eq(1).text()).toBe('Updated title 2');
+    });
+
+    it('updates the toggle href and target based on its slug', function() {
+      expect(element.find('.js-part-toggle-target').eq(0).attr('id')).toBe('updated-title-1');
+      expect(element.find('.js-part-toggle-target').eq(1).attr('id')).toBe('updated-title-2')
+      expect(element.find('.js-part-toggle').eq(0).attr('href')).toBe('#updated-title-1');
+      expect(element.find('.js-part-toggle').eq(1).attr('href')).toBe('#updated-title-2');
+    });
+  });
+
+  describe('when a new part is added and the form is saved', function() {
+    beforeEach(function() {
+      element.trigger('success.ajaxsave.admin', {parts:
+        [{_id: '5f00000001', slug: 'updated-title-1', title: 'Updated title 1'},
+         {_id: '5f00000002', slug: 'updated-title-2', title: 'Updated title 2'},
+         {_id: '5f00000003', slug: 'updated-title-3', title: 'Updated title 3'}]
+      });
+    });
+
+    it('adds a hidden id input based on a part’s title', function() {
+      var $input = element.find('input[value="5f00000003"]');
+
+      expect($input.length).toBe(1);
+      expect($input.attr('id')).toBe('edition_part_4535667_id');
+      expect($input.attr('name')).toBe('edition[part][4535667][id]');
+    });
+
+    it('updates the part’s title', function() {
+      expect(element.find('.js-part-title').eq(2).text()).toBe('Updated title 3');
+    });
+
+    it('updates the toggle href and target based on its slug', function() {
+      expect(element.find('.js-part-toggle-target').eq(2).attr('id')).toBe('updated-title-3');
+      expect(element.find('.js-part-toggle').eq(2).attr('href')).toBe('#updated-title-3');
+    });
+  });
+});

--- a/test/integration/adding_parts_to_guides_test.rb
+++ b/test/integration/adding_parts_to_guides_test.rb
@@ -148,6 +148,41 @@ class AddingPartsToGuidesTest < JavascriptIntegrationTest
         assert_correct_parts(1)
       end
     end
+
+    context 'when entering invalid parts' do
+      setup do
+        save_edition_and_assert_success
+        visit current_path
+      end
+
+      should 'not save when a part is invalid' do
+        within :css, '#parts div.fields:nth-of-type(2)' do
+          fill_in 'Slug',  :with => ''
+        end
+
+        within :css, '#parts div.fields:nth-of-type(3)' do
+          fill_in 'Title',  :with => ''
+          fill_in 'Slug',  :with => 'part-three'
+        end
+
+        save_edition_and_assert_error
+
+        assert page.has_css?('#parts .has-error', count: 2)
+
+        within :css, '#parts div.fields:nth-of-type(2)' do
+          assert page.has_css?('.has-error[id*="slug"]')
+          assert page.has_css?('.js-error li', count: 2)
+          assert page.has_css?('.js-error li', text: 'can\'t be blank')
+          assert page.has_css?('.js-error li', text: 'is invalid')
+        end
+
+        within :css, '#parts div.fields:nth-of-type(3)' do
+          assert page.has_css?('.has-error[id*="title"]')
+          assert page.has_css?('.js-error li', count: 1)
+          assert page.has_css?('.js-error li', text: 'can\'t be blank')
+        end
+      end
+    end
   end
 
   test "slug for new parts should be automatically generated" do

--- a/test/integration/adding_parts_to_guides_test.rb
+++ b/test/integration/adding_parts_to_guides_test.rb
@@ -90,6 +90,64 @@ class AddingPartsToGuidesTest < JavascriptIntegrationTest
       visit current_path
       assert_correct_parts
     end
+
+    context 'removing parts' do
+      setup do
+        save_edition_and_assert_success
+        visit current_path
+      end
+
+      should 'remove the appropriate part' do
+        within :css, '#parts div.fields:nth-of-type(3)' do
+          click_on 'Remove this part'
+        end
+
+        save_edition_and_assert_success
+        assert_correct_parts(2)
+
+        visit current_path
+        assert_correct_parts(2)
+
+        within :css, '#parts div.fields:nth-of-type(2)' do
+          click_on 'Remove this part'
+        end
+
+        save_edition_and_assert_success
+        assert_correct_parts(1)
+
+        visit current_path
+        assert_correct_parts(1)
+      end
+    end
+
+    context 'when removing parts' do
+      setup do
+        save_edition_and_assert_success
+        visit current_path
+      end
+
+      should 'remove the appropriate part' do
+        within :css, '#parts div.fields:nth-of-type(3)' do
+          click_on 'Remove this part'
+        end
+
+        save_edition_and_assert_success
+        assert_correct_parts(2)
+
+        visit current_path
+        assert_correct_parts(2)
+
+        within :css, '#parts div.fields:nth-of-type(2)' do
+          click_on 'Remove this part'
+        end
+
+        save_edition_and_assert_success
+        assert_correct_parts(1)
+
+        visit current_path
+        assert_correct_parts(1)
+      end
+    end
   end
 
   test "slug for new parts should be automatically generated" do
@@ -129,18 +187,24 @@ class AddingPartsToGuidesTest < JavascriptIntegrationTest
     end
   end
 
-  def assert_correct_parts
-    assert page.has_css?('#parts .panel-part', count: 3)
-    assert page.has_css?('#parts .panel-title', count: 3)
-    assert page.has_css?('#parts .panel-body', count: 3)
+  def assert_correct_parts(count = 3)
+    assert page.has_css?('#parts .panel-part', count: count)
+    assert page.has_css?('#parts .panel-title', count: count)
+    assert page.has_css?('#parts .panel-body', count: count)
 
-    assert page.has_css?('#part-one', count: 1)
-    assert_equal page.find('#part-one input.title').value, 'Part One'
+    if (count > 0)
+      assert page.has_css?('#part-one', count: 1)
+      assert_equal page.find('#part-one input.title').value, 'Part One'
+    end
 
-    assert page.has_css?('#part-two', count: 1)
-    assert_equal page.find('#part-two input.title').value, 'Part Two'
+    if (count > 1)
+      assert page.has_css?('#part-two', count: 1)
+      assert_equal page.find('#part-two input.title').value, 'Part Two'
+    end
 
-    assert page.has_css?('#part-three', count: 1)
-    assert_equal page.find('#part-three input.title').value, 'Part Three'
+    if (count > 2)
+      assert page.has_css?('#part-three', count: 1)
+      assert_equal page.find('#part-three input.title').value, 'Part Three'
+    end
   end
 end

--- a/test/integration/adding_parts_to_guides_test.rb
+++ b/test/integration/adding_parts_to_guides_test.rb
@@ -6,49 +6,90 @@ class AddingPartsToGuidesTest < JavascriptIntegrationTest
     stub_collections
   end
 
-  test "Publishing a guide" do
-    random_name = (0...8).map{65.+(rand(25)).chr}.join + " GUIDE"
+  context 'creating a guide with parts' do
+    setup do
+      @random_name = (0...8).map{65.+(rand(25)).chr}.join + " GUIDE"
 
-    guide = FactoryGirl.create(:guide_edition, :title => random_name, :slug => 'test-guide')
-    guide.save!
-    guide.update_attribute(:state, 'draft')
+      guide = FactoryGirl.create(:guide_edition, :title => @random_name, :slug => 'test-guide')
+      guide.save!
+      guide.update_attribute(:state, 'draft')
 
-    panopticon_has_metadata("id" => '2356')
+      panopticon_has_metadata("id" => '2356')
+      visit_edition guide
 
-    visit    "/editions/#{guide.to_param}"
+      add_new_part
+      within :css, '#parts div.fields:first-of-type' do
+        fill_in 'Title', :with => 'Part One'
+        fill_in 'Body',  :with => 'Body text'
+        fill_in 'Slug',  :with => 'part-one'
+      end
 
-    add_new_part
-    within :css, '#parts div.fields:first-of-type' do
-      fill_in 'Title', :with => 'Part One'
-      fill_in 'Body',  :with => 'Body text'
-      fill_in 'Slug',  :with => 'part-one'
+      assert page.has_css?('#parts div.fields', count: 1)
+
+      add_new_part
+      within :css, '#parts div.fields:nth-of-type(2)' do
+        fill_in 'Title', :with => 'Part Two'
+        fill_in 'Body',  :with => 'Body text'
+        fill_in 'Slug',  :with => 'part-two'
+      end
+
+      assert page.has_css?('#parts div.fields', count: 2)
+
+      add_new_part
+      within :css, '#parts div.fields:nth-of-type(3)' do
+        fill_in 'Title', :with => 'Part Three'
+        fill_in 'Body',  :with => 'Body text'
+        fill_in 'Slug',  :with => 'part-three'
+      end
     end
 
-    assert page.has_css?('#parts div.fields', count: 1)
+    should "save the guide and parts using ajax" do
+      save_edition_and_assert_success
+      assert_correct_parts
+      visit current_path
+      assert_correct_parts
 
-    add_new_part
-    within :css, '#parts div.fields:nth-of-type(2)' do
-      fill_in 'Title', :with => 'Part Two'
-      fill_in 'Body',  :with => 'Body text'
-      fill_in 'Slug',  :with => 'part-two'
+      visit "/?user_filter=all&list=drafts"
+      assert page.has_content? @random_name
     end
 
-    assert page.has_css?('#parts div.fields', count: 2)
+    should "be able to hide and show parts" do
+      save_edition_and_assert_success
 
-    add_new_part
-    within :css, '#parts div.fields:nth-of-type(3)' do
-      fill_in 'Title', :with => 'Part Three'
-      fill_in 'Body',  :with => 'Body text'
-      fill_in 'Slug',  :with => 'part-three'
+      assert page.has_css?('#part-one input.title')
+      click_on 'Part One'
+      assert page.has_no_css?('#part-one input.title')
+      click_on 'Part One'
+
+      within :css, '#parts div.fields:nth-of-type(1)' do
+        fill_in 'Title', :with => 'Part One (edited)'
+        fill_in 'Body',  :with => 'Body text'
+        fill_in 'Slug',  :with => 'part-one-edited'
+      end
+
+      save_edition_and_assert_success
+
+      assert page.has_css?('#part-one-edited input.title')
+      click_on 'Part One (edited)'
+      assert page.has_no_css?('#part-one-edited input.title')
     end
-    save_edition
 
-    assert page.has_css?('section#parts div#part-one', count: 1)
-    assert page.has_css?('section#parts div#part-two', count: 1)
-    assert page.has_css?('section#parts div#part-three', count: 1)
+    should "add the new parts only once" do
+      save_edition_and_assert_success
+      save_edition_and_assert_success
+      save_edition_and_assert_success
+      assert_correct_parts
 
-    visit "/?user_filter=all&list=drafts"
-    assert page.has_content? random_name
+      visit current_path
+      assert_correct_parts
+
+      save_edition_and_assert_success
+      save_edition_and_assert_success
+      assert_correct_parts
+
+      visit current_path
+      assert_correct_parts
+    end
   end
 
   test "slug for new parts should be automatically generated" do
@@ -60,7 +101,7 @@ class AddingPartsToGuidesTest < JavascriptIntegrationTest
 
     panopticon_has_metadata("id" => '2356')
 
-    visit    "/editions/#{guide.to_param}"
+    visit_edition guide
 
     add_new_part
     within :css, '#parts .fields:first-of-type .part' do
@@ -88,4 +129,18 @@ class AddingPartsToGuidesTest < JavascriptIntegrationTest
     end
   end
 
+  def assert_correct_parts
+    assert page.has_css?('#parts .panel-part', count: 3)
+    assert page.has_css?('#parts .panel-title', count: 3)
+    assert page.has_css?('#parts .panel-body', count: 3)
+
+    assert page.has_css?('#part-one', count: 1)
+    assert_equal page.find('#part-one input.title').value, 'Part One'
+
+    assert page.has_css?('#part-two', count: 1)
+    assert_equal page.find('#part-two input.title').value, 'Part Two'
+
+    assert page.has_css?('#part-three', count: 1)
+    assert_equal page.find('#part-three input.title').value, 'Part Three'
+  end
 end

--- a/test/integration/business_support_create_edit_test.rb
+++ b/test/integration/business_support_create_edit_test.rb
@@ -149,8 +149,7 @@ class BusinessSupportCreateEditTest < JavascriptIntegrationTest
         check "edition_sectors_manufacturing"
         uncheck "edition_support_types_loan"
 
-        save_edition
-        assert page.has_content? "Business support edition was successfully updated."
+        save_edition_and_assert_success
 
         @bs.reload
 
@@ -182,8 +181,7 @@ class BusinessSupportCreateEditTest < JavascriptIntegrationTest
         fill_in "Max value", :with => "£10,000"
         fill_in "Max employees", :with => "1,000"
 
-        save_edition
-        assert page.has_content?("We had some problems saving")
+        save_edition_and_assert_error
 
         within '#edition_min_value_input' do
           assert page.has_content?("is not a number")
@@ -210,8 +208,7 @@ class BusinessSupportCreateEditTest < JavascriptIntegrationTest
           fill_in "Related areas", :with => "london, hackney-borough-council, camden-borough-council"
         end
 
-        save_edition
-        assert page.has_content? "Business support edition was successfully updated."
+        save_edition_and_assert_success
 
         if using_javascript?
           within(".related-areas") do

--- a/test/integration/campaign_edit_test.rb
+++ b/test/integration/campaign_edit_test.rb
@@ -23,44 +23,112 @@ class CampaignEditTest < JavascriptIntegrationTest
     assert_equal @artefact.id.to_s, c.panopticon_id
   end
 
-  should "allow editing a CampaignEdition" do
-    campaign = FactoryGirl.create(:campaign_edition,
-                                 :panopticon_id => @artefact.id,
-                                 :title => "Singin' in the campaign",
-                                 :body => "I'm singin' in the campaign",
-                                 :organisation_formatted_name => "Driver & Vehicle\nLicensing\nAgency",
-                                 :organisation_crest => "single-identity",
-                                 :organisation_url => "/government/organisations/driver-and-vehicle-licensing-agency",
-                                 :organisation_brand_colour => "department-for-transport")
-    visit "/editions/#{campaign.to_param}"
+  with_and_without_javascript do
+    should "allow editing a CampaignEdition" do
+      campaign = FactoryGirl.create(:campaign_edition,
+                                   :panopticon_id => @artefact.id,
+                                   :title => "Singin' in the campaign",
+                                   :body => "I'm singin' in the campaign",
+                                   :organisation_formatted_name => "Driver & Vehicle\nLicensing\nAgency",
+                                   :organisation_crest => "single-identity",
+                                   :organisation_url => "/government/organisations/driver-and-vehicle-licensing-agency",
+                                   :organisation_brand_colour => "department-for-transport")
+      visit "/editions/#{campaign.to_param}"
 
-    assert page.has_content? 'Singin\' in the campaign #1'
+      assert page.has_content? 'Singin\' in the campaign #1'
+      assert page.has_field?("Title", :with => "Singin' in the campaign")
+      assert page.has_field?("Body", :with => "I'm singin' in the campaign")
+      assert page.has_field?("Organisation formatted name", :with => "Driver & Vehicle\nLicensing\nAgency")
+      assert page.has_field?("Organisation URL", :with => "/government/organisations/driver-and-vehicle-licensing-agency")
+      assert page.has_select?('Organisation crest', :selected => 'Single identity')
+      assert page.has_select?('Organisation brand colour', :selected => 'department-for-transport')
 
-    assert page.has_field?("Title", :with => "Singin' in the campaign")
-    assert page.has_field?("Body", :with => "I'm singin' in the campaign")
-    assert page.has_field?("Organisation formatted name", :with => "Driver & Vehicle\nLicensing\nAgency")
-    assert page.has_field?("Organisation URL", :with => "/government/organisations/driver-and-vehicle-licensing-agency")
+      fill_in "Body", :with => "I'm dancin' in the campaign"
+      fill_in "Organisation formatted name", :with => "Ministry\nof Magic"
+      fill_in "Organisation URL", :with => "/government/organisations/ministry-of-magic"
 
-    assert page.has_select?('Organisation crest', :selected => 'Single identity')
-    assert page.has_select?('Organisation brand colour', :selected => 'department-for-transport')
+      select "Portcullis", :from => "Organisation crest"
+      select "cabinet-office", :from => "Organisation brand colour"
 
-    fill_in "Body", :with => "I'm dancin' in the campaign"
-    fill_in "Organisation formatted name", :with => "Ministry\nof Magic"
-    fill_in "Organisation URL", :with => "/government/organisations/ministry-of-magic"
+      save_edition_and_assert_success
 
-    select "Portcullis", :from => "Organisation crest"
-    select "cabinet-office", :from => "Organisation brand colour"
+      c = CampaignEdition.find(campaign.id)
+      assert_equal "I'm dancin' in the campaign", c.body
+      assert_equal "Ministry\r\nof Magic", c.organisation_formatted_name
+      assert_equal "/government/organisations/ministry-of-magic", c.organisation_url
+      assert_equal "portcullis", c.organisation_crest
+      assert_equal "cabinet-office", c.organisation_brand_colour
+    end
 
-    save_edition
+    should "manage images for a CampaignEdition" do
+      c = FactoryGirl.create(:campaign_edition,
+                               :panopticon_id => @artefact.id,
+                               :state => 'draft',
+                               :title => "Max Campaign",
+                               :body => "Foo")
 
-    assert page.has_content? "Campaign edition was successfully updated."
+      small_image = File.open(Rails.root.join("test","fixtures","uploads","campaign_small.jpg"))
+      medium_image = File.open(Rails.root.join("test","fixtures","uploads","campaign_medium.jpg"))
+      large_image = File.open(Rails.root.join("test","fixtures","uploads","campaign_large.jpg"))
 
-    c = CampaignEdition.find(campaign.id)
-    assert_equal "I'm dancin' in the campaign", c.body
-    assert_equal "Ministry\r\nof Magic", c.organisation_formatted_name
-    assert_equal "/government/organisations/ministry-of-magic", c.organisation_url
-    assert_equal "portcullis", c.organisation_crest
-    assert_equal "cabinet-office", c.organisation_brand_colour
+      asset_one = OpenStruct.new(:id => 'http://asset-manager.dev.gov.uk/assets/asset_one', :file_url => 'http://path/to/campaign_small.jpg')
+      asset_two = OpenStruct.new(:id => 'http://asset-manager.dev.gov.uk/assets/asset_two', :file_url => 'http://path/to/campaign_medium.jpg')
+      asset_three = OpenStruct.new(:id => 'http://asset-manager.dev.gov.uk/assets/asset_three', :file_url => 'http://path/to/campaign_large.jpg')
+
+      # This matches against the original_filename attribute on ActionDispatch::Http::UploadedFile
+      GdsApi::AssetManager.any_instance.stubs(:create_asset).with(has_entry(:file => responds_with(:original_filename, "campaign_small.jpg"))).returns(asset_one)
+      GdsApi::AssetManager.any_instance.stubs(:create_asset).with(has_entry(:file => responds_with(:original_filename, "campaign_medium.jpg"))).returns(asset_two)
+      GdsApi::AssetManager.any_instance.stubs(:create_asset).with(has_entry(:file => responds_with(:original_filename, "campaign_large.jpg"))).returns(asset_three)
+
+      GdsApi::AssetManager.any_instance.stubs(:asset).with("asset_one").returns(asset_one)
+      GdsApi::AssetManager.any_instance.stubs(:asset).with("asset_two").returns(asset_two)
+      GdsApi::AssetManager.any_instance.stubs(:asset).with("asset_three").returns(asset_three)
+
+      visit "/editions/#{c.to_param}"
+
+      within(:css, "#small-campaign-image") do
+        assert page.has_field?("Upload image", :type => "file")
+        attach_file("Upload image", small_image.path)
+      end
+      within(:css, "#medium-campaign-image") do
+        assert page.has_field?("Upload image", :type => "file")
+        attach_file("Upload image", medium_image.path)
+      end
+      within(:css, "#large-campaign-image") do
+        assert page.has_field?("Upload image", :type => "file")
+        attach_file("Upload image", large_image.path)
+      end
+
+      save_edition
+
+      assert page.has_selector?("#small-campaign-image a[href$='campaign_small.jpg']")
+      assert page.has_selector?("#medium-campaign-image a[href$='campaign_medium.jpg']")
+      assert page.has_selector?("#large-campaign-image a[href$='campaign_large.jpg']")
+
+      # ensure files are not removed on save
+      save_edition
+
+      assert page.has_selector?("#small-campaign-image a[href$='campaign_small.jpg']")
+      assert page.has_selector?("#medium-campaign-image a[href$='campaign_medium.jpg']")
+      assert page.has_selector?("#large-campaign-image a[href$='campaign_large.jpg']")
+
+      # remove file
+      if using_javascript?
+        find('#edition_remove_small_image').trigger('click')
+        find('#edition_remove_medium_image').trigger('click')
+        find('#edition_remove_large_image').trigger('click')
+      else
+        find('#edition_remove_small_image').set(true)
+        find('#edition_remove_medium_image').set(true)
+        find('#edition_remove_large_image').set(true)
+      end
+
+      save_edition
+
+      assert page.has_no_selector?("#small-campaign-image a")
+      assert page.has_no_selector?("#medium-campaign-image a")
+      assert page.has_no_selector?("#large-campaign-image a")
+    end
   end
 
   should "allow creating a new version of a CampaignEdition" do
@@ -85,72 +153,6 @@ class CampaignEditTest < JavascriptIntegrationTest
     assert page.has_field?("Organisation URL", :with => "/government/organisations/driver-and-vehicle-licensing-agency")
     assert page.has_select?('Organisation crest', :selected => 'Single identity')
     assert page.has_select?('Organisation brand colour', :selected => 'department-for-transport')
-  end
-
-  should "manage images for a CampaignEdition" do
-    c = FactoryGirl.create(:campaign_edition,
-                             :panopticon_id => @artefact.id,
-                             :state => 'draft',
-                             :title => "Max Campaign",
-                             :body => "Foo")
-
-    small_image = File.open(Rails.root.join("test","fixtures","uploads","campaign_small.jpg"))
-    medium_image = File.open(Rails.root.join("test","fixtures","uploads","campaign_medium.jpg"))
-    large_image = File.open(Rails.root.join("test","fixtures","uploads","campaign_large.jpg"))
-
-    asset_one = OpenStruct.new(:id => 'http://asset-manager.dev.gov.uk/assets/asset_one', :file_url => 'http://path/to/campaign_small.jpg')
-    asset_two = OpenStruct.new(:id => 'http://asset-manager.dev.gov.uk/assets/asset_two', :file_url => 'http://path/to/campaign_medium.jpg')
-    asset_three = OpenStruct.new(:id => 'http://asset-manager.dev.gov.uk/assets/asset_three', :file_url => 'http://path/to/campaign_large.jpg')
-
-    # This matches against the original_filename attribute on ActionDispatch::Http::UploadedFile
-    GdsApi::AssetManager.any_instance.stubs(:create_asset).with(has_entry(:file => responds_with(:original_filename, "campaign_small.jpg"))).returns(asset_one)
-    GdsApi::AssetManager.any_instance.stubs(:create_asset).with(has_entry(:file => responds_with(:original_filename, "campaign_medium.jpg"))).returns(asset_two)
-    GdsApi::AssetManager.any_instance.stubs(:create_asset).with(has_entry(:file => responds_with(:original_filename, "campaign_large.jpg"))).returns(asset_three)
-
-    GdsApi::AssetManager.any_instance.stubs(:asset).with("asset_one").returns(asset_one)
-    GdsApi::AssetManager.any_instance.stubs(:asset).with("asset_two").returns(asset_two)
-    GdsApi::AssetManager.any_instance.stubs(:asset).with("asset_three").returns(asset_three)
-
-    visit "/editions/#{c.to_param}"
-
-    within(:css, "#small-campaign-image") do
-      assert page.has_field?("Upload image", :type => "file")
-      attach_file("Upload image", small_image.path)
-    end
-    within(:css, "#medium-campaign-image") do
-      assert page.has_field?("Upload image", :type => "file")
-      attach_file("Upload image", medium_image.path)
-    end
-    within(:css, "#large-campaign-image") do
-      assert page.has_field?("Upload image", :type => "file")
-      attach_file("Upload image", large_image.path)
-    end
-
-    save_edition
-
-    assert page.has_content?("Campaign edition was successfully updated.")
-
-    assert page.has_selector?("#small-campaign-image a[href$='campaign_small.jpg']")
-    assert page.has_selector?("#medium-campaign-image a[href$='campaign_medium.jpg']")
-    assert page.has_selector?("#large-campaign-image a[href$='campaign_large.jpg']")
-
-    # ensure files are not removed on save
-    save_edition
-
-    assert page.has_selector?("#small-campaign-image a[href$='campaign_small.jpg']")
-    assert page.has_selector?("#medium-campaign-image a[href$='campaign_medium.jpg']")
-    assert page.has_selector?("#large-campaign-image a[href$='campaign_large.jpg']")
-
-    # remove file
-    find('#edition_remove_small_image').trigger('click')
-    find('#edition_remove_medium_image').trigger('click')
-    find('#edition_remove_large_image').trigger('click')
-
-    save_edition
-
-    refute page.has_selector?("#small-campaign-image a")
-    refute page.has_selector?("#medium-campaign-image a")
-    refute page.has_selector?("#large-campaign-image a")
   end
 
   should "disable fields for a published edition" do

--- a/test/integration/completed_transactions_create_edit_test.rb
+++ b/test/integration/completed_transactions_create_edit_test.rb
@@ -23,22 +23,23 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
     assert_equal @artefact.id.to_s, t.panopticon_id
   end
 
-  should "allow editing CompletedTransactionEdition" do
-    completed_transaction = FactoryGirl.create(:completed_transaction_edition,
-                                 :panopticon_id => @artefact.id,
-                                 :title => "All bar done")
+  with_and_without_javascript do
+    should "allow editing CompletedTransactionEdition" do
+      completed_transaction = FactoryGirl.create(:completed_transaction_edition,
+                                   :panopticon_id => @artefact.id,
+                                   :title => "All bar done")
 
-    visit "/editions/#{completed_transaction.to_param}"
+      visit "/editions/#{completed_transaction.to_param}"
 
-    assert page.has_content? 'All bar done #1'
+      assert page.has_content? 'All bar done #1'
+      assert page.has_field?("Title", :with => "All bar done")
+      fill_in "Title", :with => "Changed title"
 
-    assert page.has_field?("Title", :with => "All bar done")
+      save_edition_and_assert_success
 
-    save_edition
-
-    assert page.has_content? "Completed transaction edition was successfully updated."
-
-    assert page.has_css?('.label', text: 'Draft')
+      assert page.has_css?('.label', text: 'Draft')
+      assert 'Changed title', completed_transaction.title
+    end
   end
 
   should "allow creating a new version of a CompletedTransactionEdition" do

--- a/test/integration/edition_tab_test.rb
+++ b/test/integration/edition_tab_test.rb
@@ -28,38 +28,34 @@ class EditionTabTest < JavascriptIntegrationTest
     assert page.has_css?("##{name}.tab-pane.active"), 'Tab content not active'
   end
 
-  should "show the edit tab by default" do
-    visit_edition @guide
-    assert_tab_active('edit', 'Edit')
-  end
-
-  should "show the edit tab after saving whether successful or not" do
-    visit_edition @guide
-    fill_in 'Title', :with => 'New title'
-    save_edition
-
-    assert page.has_content? "Guide edition was successfully updated."
-    assert_tab_active('edit', 'Edit')
-
-    fill_in 'Title', :with => ''
-    save_edition
-
-    assert page.has_content? "We had some problems saving."
-    assert_tab_active('edit', 'Edit')
-  end
-
-  should "show the correct tab when visiting tab links" do
-    visit_tab('metadata')
-    assert_tab_active('metadata', 'Metadata')
-
-    visit_tab('admin')
-    assert_tab_active('admin', 'Admin')
-
-    visit_tab('history')
-    assert_tab_active('history', 'History and notes')
-  end
-
   with_and_without_javascript do
+    should "show the edit tab by default" do
+      visit_edition @guide
+      assert_tab_active('edit', 'Edit')
+    end
+
+    should "show the edit tab after saving whether successful or not" do
+      visit_edition @guide
+      fill_in 'Title', :with => 'New title'
+      save_edition_and_assert_success
+      assert_tab_active('edit', 'Edit')
+
+      fill_in 'Title', :with => ''
+      save_edition_and_assert_error
+      assert_tab_active('edit', 'Edit')
+    end
+
+    should "show the correct tab when visiting tab links" do
+      visit_tab('metadata')
+      assert_tab_active('metadata', 'Metadata')
+
+      visit_tab('admin')
+      assert_tab_active('admin', 'Admin')
+
+      visit_tab('history')
+      assert_tab_active('history', 'History and notes')
+    end
+
     should "show the correct tab when clicking tabs" do
       visit_edition @guide
 

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -22,9 +22,8 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     visit_edition guide
 
     select user, from: "Assigned to"
-    save_edition
+    save_edition_and_assert_success
 
-    assert page.has_content?("successfully updated")
     guide.reload
   end
 
@@ -230,9 +229,8 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     visit_edition guide
 
     select("Bob", from: "Reviewer")
-    save_edition
 
-    assert page.has_content?("We had some problems saving")
+    save_edition_and_assert_error
     assert page.has_css?(".form-group.error ul.help-block li", text: "can't be the assignee")
   end
 
@@ -247,9 +245,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     visit_edition guide
 
     select("", from: "Reviewer")
-    save_edition
-
-    assert page.has_content?("Guide edition was successfully updated")
+    save_edition_and_assert_success
   end
 
   test "can unassign the guide" do
@@ -278,9 +274,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     visit_edition guide
 
     select("Charlie", from: "Reviewer")
-    save_edition
-
-    assert page.has_content?("Guide edition was successfully updated")
+    save_edition_and_assert_success
   end
 
   test "can review another's guide" do

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -231,7 +231,8 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     select("Bob", from: "Reviewer")
 
     save_edition_and_assert_error
-    assert page.has_css?(".form-group.error ul.help-block li", text: "can't be the assignee")
+    
+    assert page.has_css?(".form-group.has-error li", text: "can't be the assignee")
   end
 
   test "can deselect the guide reviewer" do

--- a/test/integration/guide_create_edit_test.rb
+++ b/test/integration/guide_create_edit_test.rb
@@ -49,9 +49,7 @@ class GuideCreateEditTest < JavascriptIntegrationTest
       fill_in 'Slug',  :with => 'part-two'
     end
 
-    save_edition
-
-    assert page.has_content? "Guide edition was successfully updated."
+    save_edition_and_assert_success
 
     g = GuideEdition.find(guide.id)
     assert_equal ['Part One', 'Part Two'], g.parts.map(&:title)

--- a/test/integration/licence_create_edit_test.rb
+++ b/test/integration/licence_create_edit_test.rb
@@ -30,40 +30,40 @@ class LicenceCreateEditTest < JavascriptIntegrationTest
     assert_equal 'AB1234', l.licence_identifier
   end
 
-  should "allow editing LicenceEdition" do
-    licence = FactoryGirl.create(:licence_edition,
-                                 :panopticon_id => @artefact.id,
-                                 :title => "Foo bar",
-                                 :licence_identifier => "ab2345",
-                                 :licence_short_description => "Short description content",
-                                 :licence_overview => "Licence overview content",
-                                 :will_continue_on => "The HMRC website",
-                                 :continuation_link => "http://www.hmrc.gov.uk")
+  with_and_without_javascript do
+    should "allow editing LicenceEdition" do
+      licence = FactoryGirl.create(:licence_edition,
+                                   :panopticon_id => @artefact.id,
+                                   :title => "Foo bar",
+                                   :licence_identifier => "ab2345",
+                                   :licence_short_description => "Short description content",
+                                   :licence_overview => "Licence overview content",
+                                   :will_continue_on => "The HMRC website",
+                                   :continuation_link => "http://www.hmrc.gov.uk")
 
-    visit "/editions/#{licence.to_param}"
+      visit "/editions/#{licence.to_param}"
 
-    assert page.has_content? 'Foo bar #1'
+      assert page.has_content? 'Foo bar #1'
 
-    assert page.has_field?("Licence identifier", :with => "ab2345")
-    assert page.has_field?("Licence short description", :with => "Short description content")
-    assert page.has_field?("Licence overview", :with => "Licence overview content")
-    assert page.has_field?("Will continue on", :with => "The HMRC website")
-    assert page.has_field?("Link to competent authority", :with => "http://www.hmrc.gov.uk")
+      assert page.has_field?("Licence identifier", :with => "ab2345")
+      assert page.has_field?("Licence short description", :with => "Short description content")
+      assert page.has_field?("Licence overview", :with => "Licence overview content")
+      assert page.has_field?("Will continue on", :with => "The HMRC website")
+      assert page.has_field?("Link to competent authority", :with => "http://www.hmrc.gov.uk")
 
-    fill_in "Licence identifier", :with => "5432de"
-    fill_in "Licence short description", :with => "New short description"
-    fill_in "Licence overview", :with => "New Overview content"
-    fill_in "Will continue on", :with => "The DVLA website"
-    fill_in "Link to competent authority", :with => "http://www.dvla.gov.uk"
+      fill_in "Licence identifier", :with => "5432de"
+      fill_in "Licence short description", :with => "New short description"
+      fill_in "Licence overview", :with => "New Overview content"
+      fill_in "Will continue on", :with => "The DVLA website"
+      fill_in "Link to competent authority", :with => "http://www.dvla.gov.uk"
 
-    save_edition
+      save_edition_and_assert_success
 
-    assert page.has_content? "Licence edition was successfully updated."
-
-    l = LicenceEdition.find(licence.id)
-    assert_equal "5432de", l.licence_identifier
-    assert_equal "New short description", l.licence_short_description
-    assert_equal "New Overview content", l.licence_overview
+      l = LicenceEdition.find(licence.id)
+      assert_equal "5432de", l.licence_identifier
+      assert_equal "New short description", l.licence_short_description
+      assert_equal "New Overview content", l.licence_overview
+    end
   end
 
   should "allow creating a new version of a LicenceEdition" do

--- a/test/integration/mark_edition_in_beta_test.rb
+++ b/test/integration/mark_edition_in_beta_test.rb
@@ -6,34 +6,35 @@ class MarkEditionInBetaTest < JavascriptIntegrationTest
     stub_collections
   end
 
-  should "allow marking an edition as in beta" do
-    edition = FactoryGirl.create(:edition)
+  with_and_without_javascript do
+    should "allow marking an edition as in beta" do
+      edition = FactoryGirl.create(:edition)
+      visit_edition edition
 
-    visit "/editions/#{edition.to_param}"
-    refute find('#edition_in_beta').checked?
+      refute find('#edition_in_beta').checked?
+      check 'Content is in beta'
 
-    check 'Content is in beta'
-    save_edition
+      save_edition_and_assert_success
 
-    assert find('#edition_in_beta').checked?
+      assert find('#edition_in_beta').checked?
 
-    visit "/?user_filter=all"
-    assert page.has_text?("#{edition.title} beta")
+      visit "/?user_filter=all"
+      assert page.has_text?("#{edition.title} beta")
+    end
+
+    should "allow marking an edition as not in beta" do
+      edition = FactoryGirl.create(:edition, in_beta: true)
+      visit_edition edition
+
+      assert find('#edition_in_beta').checked?
+      uncheck 'Content is in beta'
+
+      save_edition_and_assert_success
+
+      refute find('#edition_in_beta').checked?
+
+      visit "/?user_filter=all"
+      refute page.has_text?("#{edition.title} beta")
+    end
   end
-
-  should "allow marking an edition as not in beta" do
-    edition = FactoryGirl.create(:edition, in_beta: true)
-
-    visit "/editions/#{edition.to_param}"
-    assert find('#edition_in_beta').checked?
-
-    uncheck 'Content is in beta'
-    save_edition
-
-    refute find('#edition_in_beta').checked?
-
-    visit "/?user_filter=all"
-    refute page.has_text?("#{edition.title} (Ed. 1) beta")
-  end
-
 end

--- a/test/integration/programme_editions_test.rb
+++ b/test/integration/programme_editions_test.rb
@@ -28,12 +28,13 @@ class ProgrammeEditionsTest < JavascriptIntegrationTest
         fill_in "Slug",  :with => "imagine-this-is-welsh"
       end
     end
-    save_edition
 
-    assert_includes page.body, "Programme edition was successfully updated."
-
+    save_edition_and_assert_success
     assert_includes page.body, "Imagine this is Welsh"
     refute_includes page.body, "imagine-this-is-welsh"
+
+    visit current_path
+    assert_includes page.body, "Imagine this is Welsh"
   end
 
   should "disable fields for a published edition" do

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -359,6 +359,14 @@ class SimpleSmartAnswersTest < JavascriptIntegrationTest
       @edition.save!
     end
 
+    should "not save using ajax" do
+      visit "/editions/#{@edition.id}"
+      save_edition
+
+      assert page.has_no_css?('.workflow-message', text: 'Saving')
+      assert page.has_no_css?('.workflow-message', text: 'Saved')
+    end
+
     should "correctly render the form" do
       visit "/editions/#{@edition.id}"
 

--- a/test/integration/tagging_to_collections_test.rb
+++ b/test/integration/tagging_to_collections_test.rb
@@ -26,7 +26,6 @@ class TaggingToCollectionsTest < JavascriptIntegrationTest
     visit edition_path(edition)
 
     select 'Oil and Gas: Wells', from: 'Primary topic'
-
     select 'Oil and Gas: Fields', from: 'Additional topics'
     select 'Oil and Gas: Distillation (draft)', from: 'Additional topics'
 
@@ -35,5 +34,19 @@ class TaggingToCollectionsTest < JavascriptIntegrationTest
 
     assert_equal 'oil-and-gas/wells', edition.primary_topic
     assert_equal ['oil-and-gas/fields', 'oil-and-gas/distillation'], edition.additional_topics
+  end
+
+  test "Mistagging primary and additional topics with the same tag" do
+    edition = FactoryGirl.create(:guide_edition)
+    visit edition_path(edition)
+
+    select 'Oil and Gas: Wells', from: 'Primary topic'
+    select 'Oil and Gas: Wells', from: 'Additional topics'
+    select 'Oil and Gas: Distillation (draft)', from: 'Additional topics'
+
+    save_edition_and_assert_error
+
+    assert page.has_css?('#edition_additional_topics_input.has-error')
+    assert page.has_content?("can't have the primary topic set as an additional topic")
   end
 end

--- a/test/integration/tagging_to_collections_test.rb
+++ b/test/integration/tagging_to_collections_test.rb
@@ -14,8 +14,7 @@ class TaggingToCollectionsTest < JavascriptIntegrationTest
     select 'Tax: VAT', from: 'Mainstream browse pages'
     select 'Tax: RTI (draft)', from: 'Mainstream browse pages'
 
-    save_edition
-
+    save_edition_and_assert_success
     edition.reload
 
     assert_equal ['tax/vat', 'tax/rti'], edition.browse_pages
@@ -31,8 +30,7 @@ class TaggingToCollectionsTest < JavascriptIntegrationTest
     select 'Oil and Gas: Fields', from: 'Additional topics'
     select 'Oil and Gas: Distillation (draft)', from: 'Additional topics'
 
-    save_edition
-
+    save_edition_and_assert_success
     edition.reload
 
     assert_equal 'oil-and-gas/wells', edition.primary_topic

--- a/test/integration/video_edition_create_edit_test.rb
+++ b/test/integration/video_edition_create_edit_test.rb
@@ -13,55 +13,54 @@ class VideoEditionCreateEditTest < JavascriptIntegrationTest
     stub_collections
   end
 
-  should "edit a new VideoEdition" do
-    visit "/publications/#{@artefact.id}"
+  with_and_without_javascript do
+    should "edit a new VideoEdition" do
+      visit "/publications/#{@artefact.id}"
 
-    assert page.has_content? @artefact.name
+      assert page.has_content? @artefact.name
 
-    fill_in "Video URL", :with => "http://www.youtube.com/watch?v=Wrcklaselbo"
-    fill_in "Video Summary", :with => "A simple fried plantain recipe"
-    fill_in "Body", :with => "Description of video"
+      fill_in "Video URL", :with => "http://www.youtube.com/watch?v=Wrcklaselbo"
+      fill_in "Video Summary", :with => "A simple fried plantain recipe"
+      fill_in "Body", :with => "Description of video"
 
-    save_edition
+      save_edition_and_assert_success
 
-    assert page.has_content? @artefact.name
+      assert page.has_content? @artefact.name
 
-    video = VideoEdition.first
-    assert_equal @artefact.id.to_s, video.panopticon_id
+      video = VideoEdition.first
+      assert_equal @artefact.id.to_s, video.panopticon_id
 
-    assert_equal "http://www.youtube.com/watch?v=Wrcklaselbo", video.video_url
-    assert_equal "A simple fried plantain recipe", video.video_summary
-    assert_equal "Description of video", video.body
-  end
+      assert_equal "http://www.youtube.com/watch?v=Wrcklaselbo", video.video_url
+      assert_equal "A simple fried plantain recipe", video.video_summary
+      assert_equal "Description of video", video.body
+    end
 
-  should "allow editing a VideoEdition" do
-    video = FactoryGirl.create(:video_edition,
-                                 :panopticon_id => @artefact.id,
-                                 :title => "Foo bar",
-                                 :video_url => "http://www.youtube.com/watch?v=qySFp3qnVmM",
-                                 :video_summary => "Coke smoothie",
-                                 :body => "Old description")
+    should "allow editing a VideoEdition" do
+      video = FactoryGirl.create(:video_edition,
+                                   :panopticon_id => @artefact.id,
+                                   :title => "Foo bar",
+                                   :video_url => "http://www.youtube.com/watch?v=qySFp3qnVmM",
+                                   :video_summary => "Coke smoothie",
+                                   :body => "Old description")
 
-    visit "/editions/#{video.to_param}"
+      visit "/editions/#{video.to_param}"
 
-    assert page.has_content? 'Foo bar #1'
+      assert page.has_content? 'Foo bar #1'
+      assert page.has_field?("Video URL", :with => "http://www.youtube.com/watch?v=qySFp3qnVmM")
+      assert page.has_field?("Video Summary", :with => "Coke smoothie")
+      assert page.has_field?("Body", :with => "Old description")
 
-    assert page.has_field?("Video URL", :with => "http://www.youtube.com/watch?v=qySFp3qnVmM")
-    assert page.has_field?("Video Summary", :with => "Coke smoothie")
-    assert page.has_field?("Body", :with => "Old description")
+      fill_in "Video URL", :with => "http://www.youtube.com/watch?v=Wrcklaselbo"
+      fill_in "Video Summary", :with => "A simple fried plantain recipe"
+      fill_in "Body", :with => "Description of video"
 
-    fill_in "Video URL", :with => "http://www.youtube.com/watch?v=Wrcklaselbo"
-    fill_in "Video Summary", :with => "A simple fried plantain recipe"
-    fill_in "Body", :with => "Description of video"
+      save_edition_and_assert_success
 
-    save_edition
-
-    assert page.has_content? "Video edition was successfully updated."
-
-    v = VideoEdition.find(video.id)
-    assert_equal "http://www.youtube.com/watch?v=Wrcklaselbo", v.video_url
-    assert_equal "A simple fried plantain recipe", v.video_summary
-    assert_equal "Description of video", v.body
+      v = VideoEdition.find(video.id)
+      assert_equal "http://www.youtube.com/watch?v=Wrcklaselbo", v.video_url
+      assert_equal "A simple fried plantain recipe", v.video_summary
+      assert_equal "Description of video", v.body
+    end
   end
 
   should "allow creating a new version of a VideoEdition" do

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -177,7 +177,7 @@ class JavascriptIntegrationTest < ActionDispatch::IntegrationTest
   def save_edition_and_assert_error
     save_edition
     if using_javascript?
-      assert page.has_css?('.workflow-message', text: 'Couldn’t save'),  "Edition didn’t error as expected when saved with ajax"
+      assert page.has_css?('.workflow-message', text: 'We had some problems saving. Please check the form above.'),  "Edition didn’t error as expected when saved with ajax"
     else
       assert page.has_content? "We had some problems saving"
     end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -124,9 +124,8 @@ class JavascriptIntegrationTest < ActionDispatch::IntegrationTest
       fill_in 'Body',  with: 'Body text'
       fill_in 'Slug',  with: 'part-one'
     end
-    save_edition
 
-    assert page.has_content?("was successfully updated"), "No successful update message"
+    save_edition_and_assert_success
 
     guide.reload
   end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -153,7 +153,9 @@ class JavascriptIntegrationTest < ActionDispatch::IntegrationTest
     # thinks there are overlapping elements
     if using_javascript?
       page.find_button('Save').trigger('click')
-      assert page.has_selector?('.workflow-message-saving', text: 'Saving'), "Failed to trigger a dynamic saving message"
+      if page.has_selector?('[data-module="ajax-save"]')
+        assert page.has_selector?('.workflow-message-saving', text: 'Saving'), "Failed to trigger a dynamic saving message"
+      end
     else
       click_on 'Save'
     end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require 'test_helper'
 require 'capybara/rails'
 require 'capybara/poltergeist'
@@ -151,6 +153,7 @@ class JavascriptIntegrationTest < ActionDispatch::IntegrationTest
     # thinks there are overlapping elements
     if using_javascript?
       page.find_button('Save').trigger('click')
+      assert page.has_selector?('.workflow-message-saving', text: 'Saving'), "Failed to trigger a dynamic saving message"
     else
       click_on 'Save'
     end
@@ -159,6 +162,24 @@ class JavascriptIntegrationTest < ActionDispatch::IntegrationTest
     # hence we need to explicitly wait till the page reloads.
     # save button is disabled after one click, so refreshing should enable it.
     assert page.has_selector?("input[type=submit]#save-edition:enabled"), "Failed to save edition."
+  end
+
+  def save_edition_and_assert_success
+    save_edition
+    if using_javascript?
+      assert page.has_css?('.workflow-message', text: 'Saved'), "Edition didn’t successfully save with ajax"
+    else
+      assert page.has_content? "edition was successfully updated."
+    end
+  end
+
+  def save_edition_and_assert_error
+    save_edition
+    if using_javascript?
+      assert page.has_css?('.workflow-message', text: 'Couldn’t save'),  "Edition didn’t error as expected when saved with ajax"
+    else
+      assert page.has_content? "We had some problems saving"
+    end
   end
 
   def clear_cookies

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -74,6 +74,7 @@ class EditionTest < ActiveSupport::TestCase
     edition.parts.first.update_attribute(:body, "[register your vehicle](registering-an-imported-vehicle)")
 
     exception = assert_raises(StateMachine::InvalidTransition) { edition.publish_anonymously! }
-    assert_equal "Cannot transition state via :publish from :ready (Reason(s): Parts is invalid)", exception.message
+    assert_match "Cannot transition state via :publish from :ready (Reason(s): Parts", exception.message
+    assert_match "Internal links must start with a forward slash", exception.message
   end
 end


### PR DESCRIPTION
Allow all editions except Simple Smart Answers to be saved over ajax, allowing users to save as they go and to not lose their place or context. eg when making small changes whilst 2i reviewing something.

* Allow saving via keyboard shortcuts ctrl+s and cmd+s
* Test editing of editions with and without javascript to ensure feature parity
* Allow adding, removing and rearranging of parts to be saved over ajax
* Prevent saving with ajax when a form field wouldn't allow it, (eg a file upload), or a change of state that needs a page refresh (eg deleting a video caption file)
* Keep the form's "dirty" state until the page has been saved successfully, preventing users from accidentally leaving unsaved changes mid ajax request or if validation fails

https://www.agileplannerapp.com/boards/173808/cards/9007
https://www.agileplannerapp.com/boards/173808/cards/9006
https://www.agileplannerapp.com/boards/244464/cards/8227

Suggest reviewing with `?w=1` as test changes lead to indentations.

![ajax-saving-parts](https://cloud.githubusercontent.com/assets/319055/5875634/4f2e4534-a307-11e4-8f3d-91e266624034.gif)