### PR TITLE
Improve auto generation of slugs

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,14 +7,8 @@
 
 // System wide behaviours
 $(function () {
-
   $('a.preview').attr("target","_blank");
   $('form.preview').attr("target","_blank");
-
-  $('.confirm form').submit(function(){
-      return confirm('Woah. Scary action, cannot be undone. Continue?');
-  });
-
   $(".select2").select2();
 })
 

--- a/app/assets/javascripts/modules/parts.js
+++ b/app/assets/javascripts/modules/parts.js
@@ -3,7 +3,18 @@
   Modules.Parts = function() {
     this.start = function(element) {
 
+      element.on('change', 'input.title', generateSlug);
       makePartsSortable();
+
+      function generateSlug() {
+        var $titleInput = $(this),
+            value       = $titleInput.val(),
+            $slugInput  = $titleInput.closest('.part').find('.slug');
+
+        if ($slugInput.text() === '') {
+          $slugInput.val(GovUKGuideUtils.convertToSlug(value));
+        }
+      }
 
       function makePartsSortable() {
         var accordionSelector = ".js-sort-handle",

--- a/app/assets/javascripts/modules/parts.js
+++ b/app/assets/javascripts/modules/parts.js
@@ -7,7 +7,7 @@
 
       function makePartsSortable() {
         var accordionSelector = ".js-sort-handle",
-            sortable_opts = {
+            sortableOptions = {
               axis: "y",
               handle: accordionSelector,
               stop: function(event, ui) {
@@ -18,7 +18,7 @@
               }
             };
 
-        element.sortable(sortable_opts);
+        element.sortable(sortableOptions);
       }
     }
   };

--- a/app/assets/javascripts/modules/parts.js
+++ b/app/assets/javascripts/modules/parts.js
@@ -19,7 +19,6 @@
             };
 
         element.sortable(sortable_opts);
-        element.find(accordionSelector).css({cursor: 'move'});
       }
     }
   };

--- a/app/assets/javascripts/modules/parts.js
+++ b/app/assets/javascripts/modules/parts.js
@@ -13,8 +13,9 @@
               stop: function(event, ui) {
                 element.find('.part').each(function (i, elem) {
                   $(elem).find('input.order').val(i + 1);
-                  ui.item.find(accordionSelector).addClass("yellow-fade");
                 });
+
+                ui.item.find(accordionSelector).addClass("yellow-fade");
               }
             };
 

--- a/app/assets/javascripts/modules/parts.js
+++ b/app/assets/javascripts/modules/parts.js
@@ -15,6 +15,11 @@
         if ($slugInput.val() === '' || $slugInput.data('accepts-generated-value')) {
           $slugInput.data('accepts-generated-value', true);
           $slugInput.val(GovUKGuideUtils.convertToSlug(value));
+          $slugInput.addClass("yellow-fade");
+
+          setTimeout(function() {
+            $slugInput.removeClass("yellow-fade");
+          }, 2000)
         }
       }
 

--- a/app/assets/javascripts/modules/parts.js
+++ b/app/assets/javascripts/modules/parts.js
@@ -1,0 +1,26 @@
+(function(Modules) {
+  "use strict";
+  Modules.Parts = function() {
+    this.start = function(element) {
+
+      makePartsSortable();
+
+      function makePartsSortable() {
+        var accordionSelector = ".js-sort-handle",
+            sortable_opts = {
+              axis: "y",
+              handle: accordionSelector,
+              stop: function(event, ui) {
+                element.find('.part').each(function (i, elem) {
+                  $(elem).find('input.order').val(i + 1);
+                  ui.item.find(accordionSelector).addClass("yellow-fade");
+                });
+              }
+            };
+
+        element.sortable(sortable_opts);
+        element.find(accordionSelector).css({cursor: 'move'});
+      }
+    }
+  };
+})(window.GOVUKAdmin.Modules);

--- a/app/assets/javascripts/modules/parts.js
+++ b/app/assets/javascripts/modules/parts.js
@@ -11,7 +11,8 @@
             value       = $titleInput.val(),
             $slugInput  = $titleInput.closest('.part').find('.slug');
 
-        if ($slugInput.text() === '') {
+        if ($slugInput.val() === '' || $slugInput.data('accepts-generated-value')) {
+          $slugInput.data('accepts-generated-value', true);
           $slugInput.val(GovUKGuideUtils.convertToSlug(value));
         }
       }

--- a/app/assets/javascripts/modules/parts.js
+++ b/app/assets/javascripts/modules/parts.js
@@ -4,6 +4,7 @@
     this.start = function(element) {
 
       element.on('change', 'input.title', generateSlug);
+      element.on('nested:fieldAdded:parts', updatePartOrders);
       makePartsSortable();
 
       function generateSlug() {
@@ -23,15 +24,18 @@
               axis: "y",
               handle: accordionSelector,
               stop: function(event, ui) {
-                element.find('.part').each(function (i, elem) {
-                  $(elem).find('input.order').val(i + 1);
-                });
-
+                updatePartOrders();
                 ui.item.find(accordionSelector).addClass("yellow-fade");
               }
             };
 
         element.sortable(sortableOptions);
+      }
+
+      function updatePartOrders() {
+        element.find('.part').each(function (i, elem) {
+          $(elem).find('input.order').val(i + 1);
+        });
       }
     }
   };

--- a/app/assets/javascripts/multi-part.js
+++ b/app/assets/javascripts/multi-part.js
@@ -3,21 +3,3 @@ $(document).on('nested:fieldAdded:parts', function(event){
   // Populate order field on newly created subform.
   $('.order', event.field).val($('#parts .fields').size());
 });
-
-function addAutoSlugGeneration() {
-
-  $('#parts').on('change', 'input.title', function() {
-    var elem = $(this);
-    var value = elem.val();
-
-    // Set slug on change.
-    var slug_field = elem.closest('.part').find('.slug');
-    if (slug_field.text() === '') {
-      slug_field.val(GovUKGuideUtils.convertToSlug(value));
-    }
-  });
-}
-
-$(function() {
-  addAutoSlugGeneration();
-});

--- a/app/assets/javascripts/multi-part.js
+++ b/app/assets/javascripts/multi-part.js
@@ -1,28 +1,21 @@
 // Javascript specific to guide admin
-// When we add a new part, ensure we add the auto slug generator handler
 $(document).on('nested:fieldAdded:parts', function(event){
-  addAutoSlugGeneration();
-
   // Populate order field on newly created subform.
   $('.order', event.field).val($('#parts .fields').size());
 });
 
 function addAutoSlugGeneration() {
-  $('input.title').
-    on('change', function () {
-      var elem = $(this);
-      var value = elem.val();
 
-      // Set slug on change.
-      var slug_field = elem.closest('.part').find('.slug');
-      if (slug_field.text() === '') {
-        slug_field.val(GovUKGuideUtils.convertToSlug(value));
-      }
+  $('#parts').on('change', 'input.title', function() {
+    var elem = $(this);
+    var value = elem.val();
 
-      // Set header on change.
-      var header = elem.closest('fieldset').prev('h3').find('a');
-      header.text(value);
-    });
+    // Set slug on change.
+    var slug_field = elem.closest('.part').find('.slug');
+    if (slug_field.text() === '') {
+      slug_field.val(GovUKGuideUtils.convertToSlug(value));
+    }
+  });
 }
 
 $(function() {

--- a/app/assets/javascripts/multi-part.js
+++ b/app/assets/javascripts/multi-part.js
@@ -26,18 +26,5 @@ function addAutoSlugGeneration() {
 }
 
 $(function() {
-  var accordionSelector = ".js-sort-handle";
-  var sortable_opts = {
-    axis: "y",
-    handle: accordionSelector,
-    stop: function(event, ui) {
-      $('.part').each(function (i, elem) {
-        $(elem).find('input.order').val(i + 1);
-        ui.item.find(accordionSelector).addClass("yellow-fade");
-      });
-    }
-  }
-  $('#parts').sortable(sortable_opts)
-      .find(accordionSelector).css({cursor: 'move'});
   addAutoSlugGeneration();
 });

--- a/app/assets/javascripts/multi-part.js
+++ b/app/assets/javascripts/multi-part.js
@@ -1,5 +1,0 @@
-// Javascript specific to guide admin
-$(document).on('nested:fieldAdded:parts', function(event){
-  // Populate order field on newly created subform.
-  $('.order', event.field).val($('#parts .fields').size());
-});

--- a/app/assets/stylesheets/panel_part.scss
+++ b/app/assets/stylesheets/panel_part.scss
@@ -5,6 +5,10 @@
     background-color: darken($gray-lighter, 5%);
   }
 
+  .js & .panel-heading {
+    cursor: move;
+  }
+
   // Nudge chevron within panel heading down slightly
   // for better alignment with text
   .panel-heading .glyphicon-chevron-down {

--- a/app/views/guides/_fields.html.erb
+++ b/app/views/guides/_fields.html.erb
@@ -16,7 +16,7 @@
       <a href="#" class="js-toggle-all">Collapse all parts</a>
     </p>
 
-    <section class="panel-group" id="parts">
+    <section class="panel-group" id="parts" data-module="parts">
       <%= f.semantic_fields_for :parts, @ordered_parts do |part| %>
         <%= render :partial => '/shared/part', :locals => {:f => part, :editable => ! @resource.locked_for_edits? } %>
       <% end %>

--- a/app/views/programmes/_fields.html.erb
+++ b/app/views/programmes/_fields.html.erb
@@ -16,7 +16,7 @@
       <a href="#" class="js-toggle-all">Collapse all parts</a>
     </p>
 
-    <section class="panel-group" id="parts">
+    <section class="panel-group" id="parts" data-module="parts">
       <%= f.semantic_fields_for :parts, @ordered_parts do |part| %>
         <%= render :partial => '/shared/part', :locals => { :f => part, :editable => false } %>
       <% end %>

--- a/app/views/shared/_part.html.erb
+++ b/app/views/shared/_part.html.erb
@@ -15,8 +15,15 @@
                       :hint => false,
                       :required => true %>
 
+          <%
+            slug_input_html = { :class => 'slug', :disabled => ! editable }
+            if @resource.version_number == 1
+              slug_input_html['data-accepts-generated-value'] = true
+            end
+          %>
+
           <%= f.input :slug,
-                      :input_html => { :class => 'slug', :disabled => ! editable },
+                      :input_html => slug_input_html,
                       :hint => true,
                       :required => true %>
 

--- a/spec/javascripts/helpers/jquery.simulate.drag-sortable.js
+++ b/spec/javascripts/helpers/jquery.simulate.drag-sortable.js
@@ -1,0 +1,235 @@
+(function($) {
+  /*
+   * Simulate drag of a JQuery UI sortable list
+   * Repository: https://github.com/mattheworiordan/jquery.simulate.drag-sortable.js
+   * Author: http://mattheworiordan.com
+   *
+   * options are:
+   * - move: move item up (positive) or down (negative) by Integer amount
+   * - dropOn: move item to a new linked list, move option now represents position in the new list (zero indexed)
+   * - handle: selector for the draggable handle element (optional)
+   * - listItem: selector to limit which sibling items can be used for reordering
+   * - placeHolder: if a placeholder is used during dragging, we need to consider it's height
+   * - tolerance: (optional) number of pixels to overlap by instead of the default 50% of the element height
+   *
+   */
+  $.fn.simulateDragSortable = function(options) {
+    // build main options before element iteration
+    var opts = $.extend({}, $.fn.simulateDragSortable.defaults, options);
+
+    applyDrag = function(options) {
+      // allow for a drag handle if item is not draggable
+      var that = this,
+          options = options || opts, // default to plugin opts unless options explicitly provided
+          handle = options.handle ? $(this).find(options.handle)[0] : $(this)[0],
+          listItem = options.listItem,
+          placeHolder = options.placeHolder,
+          sibling = $(this),
+          moveCounter = Math.floor(options.move),
+          direction = moveCounter > 0 ? 'down' : 'up',
+          moveVerticalAmount = 0,
+          initialVerticalPosition = 0,
+          extraDrag = !isNaN(parseInt(options.tolerance, 10)) ? function() { return Number(options.tolerance); } : function(obj) { return ($(obj).outerHeight() / 2) + 5; },
+          dragPastBy = 0, // represents the additional amount one drags past an element and bounce back
+          dropOn = options.dropOn ? $(options.dropOn) : false,
+          center = findCenter(handle),
+          x = Math.floor(center.x),
+          y = Math.floor(center.y),
+          mouseUpAfter = (opts.debug ? 2500 : 10);
+
+      if (dropOn) {
+        if (dropOn.length === 0) {
+          if (console && console.log) { console.log('simulate.drag-sortable.js ERROR: Drop on target could not be found'); console.log(options.dropOn); }
+          return;
+        }
+        sibling = dropOn.find('>*:last');
+        moveCounter = -(dropOn.find('>*').length + 1) + (moveCounter + 1); // calculate length of list after this move, use moveCounter as a positive index position in list to reverse back up
+        if (dropOn.offset().top - $(this).offset().top < 0) {
+          // moving to a list above this list, so move to just above top of last item (tried moving to top but JQuery UI wouldn't bite)
+          initialVerticalPosition = sibling.offset().top - $(this).offset().top - extraDrag(this);
+        } else {
+          // moving to a list below this list, so move to bottom and work up (JQuery UI does not trigger new list below unless you move past top item first)
+          initialVerticalPosition = sibling.offset().top - $(this).offset().top - $(this).height();
+        }
+      } else if (moveCounter === 0) {
+        if (console && console.log) { console.log('simulate.drag-sortable.js WARNING: Drag with move set to zero has no effect'); }
+        return;
+      } else {
+        while (moveCounter !== 0) {
+          if (direction === 'down') {
+            if (sibling.next(listItem).length) {
+              sibling = sibling.next(listItem);
+              moveVerticalAmount += sibling.outerHeight();
+            }
+            moveCounter -= 1;
+          } else {
+            if (sibling.prev(listItem).length) {
+              sibling = sibling.prev(listItem);
+              moveVerticalAmount -= sibling.outerHeight();
+            }
+            moveCounter += 1;
+          }
+        }
+      }
+
+      dispatchEvent(handle, 'mousedown', createEvent('mousedown', handle, { clientX: x, clientY: y }));
+      // simulate drag start
+      dispatchEvent(document, 'mousemove', createEvent('mousemove', document, { clientX: x+1, clientY: y+1 }));
+
+      if (dropOn) {
+        // jump to top or bottom of new list but do it in increments so that JQuery UI registers the drag events
+        slideUpTo(x, y, initialVerticalPosition);
+
+        // reset y position to top or bottom of list and move from there
+        y += initialVerticalPosition;
+
+        // now call regular shift/down in a list
+        options = jQuery.extend(options, { move: moveCounter });
+        delete options.dropOn;
+
+        // add some delays to allow JQuery UI to catch up
+        setTimeout(function() {
+          dispatchEvent(document, 'mousemove', createEvent('mousemove', document, { clientX: x, clientY: y }));
+        }, 5);
+        setTimeout(function() {
+          dispatchEvent(handle, 'mouseup', createEvent('mouseup', handle, { clientX: x, clientY: y }));
+          setTimeout(function() {
+            if (options.move) {
+              applyDrag.call(that, options);
+            }
+          }, 5);
+        }, mouseUpAfter);
+
+        // stop execution as applyDrag has been called again
+        return;
+      }
+
+      // Sortable is using a fixed height placeholder meaning items jump up and down as you drag variable height items into fixed height placeholder
+      placeHolder = placeHolder && $(this).parent().find(placeHolder);
+
+      if (!placeHolder && (direction === 'down')) {
+        // need to move at least as far as this item and or the last sibling
+        if ($(this).outerHeight() > $(sibling).outerHeight()) {
+          moveVerticalAmount += $(this).outerHeight() - $(sibling).outerHeight();
+        }
+        moveVerticalAmount += extraDrag(sibling);
+        dragPastBy += extraDrag(sibling);
+      } else if (direction === 'up') {
+        // move a little extra to ensure item clips into next position
+        moveVerticalAmount -= Math.max(extraDrag(this), 5);
+      } else if (direction === 'down') {
+        // moving down with a place holder
+        if (placeHolder.height() < $(this).height()) {
+          moveVerticalAmount += Math.max(placeHolder.height(), 5);
+        } else {
+          moveVerticalAmount += extraDrag(sibling);
+        }
+      }
+
+      if (sibling[0] !== $(this)[0]) {
+        // step through so that the UI controller can determine when to show the placeHolder
+        slideUpTo(x, y, moveVerticalAmount, dragPastBy);
+      } else {
+        if (window.console) {
+          console.log('simulate.drag-sortable.js WARNING: Could not move as at top or bottom already');
+        }
+      }
+
+      setTimeout(function() {
+        dispatchEvent(document, 'mousemove', createEvent('mousemove', document, { clientX: x, clientY: y + moveVerticalAmount }));
+      }, 5);
+      setTimeout(function() {
+        dispatchEvent(handle, 'mouseup', createEvent('mouseup', handle, { clientX: x, clientY: y + moveVerticalAmount }));
+      }, mouseUpAfter);
+    };
+
+    // iterate and move each matched element
+    return this.each(applyDrag);
+  };
+
+  // fire mouse events, go half way, then the next half, so small mouse movements near target and big at the start
+  function slideUpTo(x, y, targetOffset, goPastBy) {
+    var moveBy, offset;
+
+    if (!goPastBy) { goPastBy = 0; }
+    if ((targetOffset < 0) && (goPastBy > 0)) { goPastBy = -goPastBy; } // ensure go past is in the direction as often passed in from object height so always positive
+
+    // go forwards including goPastBy
+    for (offset = 0; Math.abs(offset) + 1 < Math.abs(targetOffset + goPastBy); offset += ((targetOffset + goPastBy - offset)/2) ) {
+      dispatchEvent(document, 'mousemove', createEvent('mousemove', document, { clientX: x, clientY: y + Math.ceil(offset) }));
+    }
+    offset = targetOffset + goPastBy;
+    dispatchEvent(document, 'mousemove', createEvent('mousemove', document, { clientX: x, clientY: y + offset }));
+
+    // now bounce back
+    for (; Math.abs(offset) - 1 >= Math.abs(targetOffset); offset += ((targetOffset - offset)/2) ) {
+      dispatchEvent(document, 'mousemove', createEvent('mousemove', document, { clientX: x, clientY: y + Math.ceil(offset) }));
+    }
+    dispatchEvent(document, 'mousemove', createEvent('mousemove', document, { clientX: x, clientY: y + targetOffset }));
+  }
+
+  function createEvent(type, target, options) {
+    var evt;
+    var e = $.extend({
+      target: target,
+      preventDefault: function() { },
+      stopImmediatePropagation: function() { },
+      stopPropagation: function() { },
+      isPropagationStopped: function() { return true; },
+      isImmediatePropagationStopped: function() { return true; },
+      isDefaultPrevented: function() { return true; },
+      bubbles: true,
+      cancelable: (type != "mousemove"),
+      view: window,
+      detail: 0,
+      screenX: 0,
+      screenY: 0,
+      clientX: 0,
+      clientY: 0,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: false,
+      metaKey: false,
+      button: 0,
+      relatedTarget: undefined
+    }, options || {});
+
+    if ($.isFunction(document.createEvent)) {
+      evt = document.createEvent("MouseEvents");
+      evt.initMouseEvent(type, e.bubbles, e.cancelable, e.view, e.detail,
+        e.screenX, e.screenY, e.clientX, e.clientY,
+        e.ctrlKey, e.altKey, e.shiftKey, e.metaKey,
+        e.button, e.relatedTarget || document.body.parentNode);
+    } else if (document.createEventObject) {
+      evt = document.createEventObject();
+      $.extend(evt, e);
+        evt.button = { 0:1, 1:4, 2:2 }[evt.button] || evt.button;
+    }
+    return evt;
+  }
+
+  function dispatchEvent(el, type, evt) {
+    if (el.dispatchEvent) {
+      el.dispatchEvent(evt);
+    } else if (el.fireEvent) {
+      el.fireEvent('on' + type, evt);
+    }
+    return evt;
+  }
+
+  function findCenter(el) {
+    var elm = $(el),
+        o = elm.offset();
+    return {
+      x: o.left + elm.outerWidth() / 2,
+      y: o.top + elm.outerHeight() / 2
+    };
+  }
+
+  //
+  // plugin defaults
+  //
+  $.fn.simulateDragSortable.defaults = {
+    move: 0
+  };
+})(jQuery);

--- a/spec/javascripts/spec/parts_spec.js
+++ b/spec/javascripts/spec/parts_spec.js
@@ -1,0 +1,60 @@
+describe('A parts module', function() {
+  "use strict";
+
+  var parts,
+      element;
+
+  beforeEach(function() {
+
+    element = $('<div>\
+      <div id="part_1" class="part">\
+        <div class="js-sort-handle">Part title 1</div>\
+        <input class="title" name="part_1_title" type="text" value="Part title 1">\
+        <input class="slug" name="part_1_slug" type="text" value="part-title-1">\
+        <input class="order" name="part_1_order" type="hidden" value="1">\
+      </div>\
+      <div id="part_2" class="part">\
+        <div class="js-sort-handle">Part title 2</div>\
+        <input class="title" name="part_2_title" type="text" value="Part title 2">\
+        <input class="slug" name="part_2_slug" type="text" value="part-title-2">\
+        <input class="order" name="part_2_order" type="hidden" value="2">\
+      </div>\
+      <div id="part_3" class="part">\
+        <div class="js-sort-handle">Part title 3</div>\
+        <input class="title" name="part_3_title" type="text" value="Part title 3">\
+        <input class="slug" name="part_3_slug" type="text" value="part-title-3">\
+        <input class="order" name="part_3_order" type="hidden" value="3">\
+      </div>\
+    </div>');
+
+    $('body').append(element);
+    parts = new GOVUKAdmin.Modules.Parts();
+    parts.start(element);
+  });
+
+  afterEach(function() {
+    element.remove();
+  });
+
+  describe('when sorting parts', function() {
+    beforeEach(function(done) {
+      $('#part_1').simulateDragSortable({ move: 2, handle: '.js-sort-handle' });
+
+      // Wait briefly until jquery ui has done its thing
+      setTimeout(function() {
+        done();
+      }, 50)
+    });
+
+    it('saves their order in the hidden order input', function() {
+      expect($('#part_1').find('.order').val()).toBe('3');
+      expect($('#part_2').find('.order').val()).toBe('1');
+      expect($('#part_3').find('.order').val()).toBe('2');
+    });
+
+    it('adds a yellow fade class to the element moved', function() {
+      expect(element.find('.js-sort-handle.yellow-fade').length).toBe(1);
+      expect($('#part_1').find('.js-sort-handle.yellow-fade').length).toBe(1);
+    });
+  });
+});

--- a/spec/javascripts/spec/parts_spec.js
+++ b/spec/javascripts/spec/parts_spec.js
@@ -59,12 +59,33 @@ describe('A parts module', function() {
   });
 
   describe('when editing a part’s title', function() {
-    it('updates that part’s slug', function() {
+    it('updates that part’s slug if it was empty', function() {
+      $('#part_1').find('.slug').val('');
       $('#part_1').find('.title').val('New title').trigger('change');
 
       expect($('#part_1').find('.slug').val()).toBe('new-title');
       expect($('#part_2').find('.slug').val()).toBe('part-title-2');
       expect($('#part_3').find('.slug').val()).toBe('part-title-3');
+    });
+
+    it('updates that part’s slug if the slug accepts generated values', function() {
+      $('#part_1').find('.slug').data('accepts-generated-value', true);
+      $('#part_1').find('.title').val('New title').trigger('change');
+
+      expect($('#part_1').find('.slug').val()).toBe('new-title');
+    });
+
+    it('continues to update a slug if it begun empty', function() {
+      $('#part_1').find('.slug').val('');
+      $('#part_1').find('.title').val('New title').trigger('change');
+      $('#part_1').find('.title').val('Another change').trigger('change');
+
+      expect($('#part_1').find('.slug').val()).toBe('another-change');
+    });
+
+    it('leaves alone slugs that didn’t begin as empty', function() {
+      $('#part_1').find('.title').val('New title').trigger('change');
+      expect($('#part_1').find('.slug').val()).toBe('part-title-1');
     });
   });
 });

--- a/spec/javascripts/spec/parts_spec.js
+++ b/spec/javascripts/spec/parts_spec.js
@@ -43,18 +43,47 @@ describe('A parts module', function() {
       // Wait briefly until jquery ui has done its thing
       setTimeout(function() {
         done();
-      }, 50)
+      }, 50);
     });
 
     it('saves their order in the hidden order input', function() {
-      expect($('#part_1').find('.order').val()).toBe('3');
       expect($('#part_2').find('.order').val()).toBe('1');
       expect($('#part_3').find('.order').val()).toBe('2');
+      expect($('#part_1').find('.order').val()).toBe('3');
     });
 
     it('adds a yellow fade class to the element moved', function() {
       expect(element.find('.js-sort-handle.yellow-fade').length).toBe(1);
       expect($('#part_1').find('.js-sort-handle.yellow-fade').length).toBe(1);
+    });
+  });
+
+  describe('when adding a part', function() {
+    beforeEach(function() {
+      element.append('<div id="part_4" class="part">\
+        <div class="js-sort-handle"></div>\
+        <input class="title" name="part_4_title" type="text" value="">\
+        <input class="slug" name="part_4_slug" type="text" value="">\
+        <input class="order" name="part_4_order" type="hidden" value="">\
+      </div>');
+      element.trigger('nested:fieldAdded:parts');
+    });
+
+    it('updates the part orders', function() {
+      expect($('#part_4').find('.order').val()).toBe('4');
+    });
+
+    it('allows the part to be sortable', function(done) {
+      $('#part_4').simulateDragSortable({ move: -2, handle: '.js-sort-handle' });
+
+      // Wait briefly until jquery ui has done its thing
+      setTimeout(function() {
+        expect($('#part_1').find('.order').val()).toBe('1');
+        expect($('#part_4').find('.order').val()).toBe('2');
+        expect($('#part_2').find('.order').val()).toBe('3');
+        expect($('#part_3').find('.order').val()).toBe('4');
+        done();
+      }, 50);
     });
   });
 

--- a/spec/javascripts/spec/parts_spec.js
+++ b/spec/javascripts/spec/parts_spec.js
@@ -57,4 +57,14 @@ describe('A parts module', function() {
       expect($('#part_1').find('.js-sort-handle.yellow-fade').length).toBe(1);
     });
   });
+
+  describe('when editing a part’s title', function() {
+    it('updates that part’s slug', function() {
+      $('#part_1').find('.title').val('New title').trigger('change');
+
+      expect($('#part_1').find('.slug').val()).toBe('new-title');
+      expect($('#part_2').find('.slug').val()).toBe('part-title-2');
+      expect($('#part_3').find('.slug').val()).toBe('part-title-3');
+    });
+  });
 });

--- a/test/integration/adding_parts_to_guides_test.rb
+++ b/test/integration/adding_parts_to_guides_test.rb
@@ -51,7 +51,7 @@ class AddingPartsToGuidesTest < JavascriptIntegrationTest
     assert page.has_content? random_name
   end
 
-  test "slug for parts should be automatically generated" do
+  test "slug for new parts should be automatically generated" do
     random_name = (0...8).map{65.+(rand(25)).chr}.join + " GUIDE"
 
     guide = FactoryGirl.create(:guide_edition, :title => random_name, :slug => 'test-guide')
@@ -67,6 +67,10 @@ class AddingPartsToGuidesTest < JavascriptIntegrationTest
       fill_in 'Title', :with => 'Part One'
       fill_in 'Body',  :with => 'Body text'
       assert_equal 'part-one', find(:css, ".slug").value
+
+      fill_in 'Title', :with => 'Part One changed'
+      fill_in 'Body',  :with => 'Body text'
+      assert_equal 'part-one-changed', find(:css, ".slug").value
     end
   end
 end

--- a/test/integration/adding_parts_to_guides_test.rb
+++ b/test/integration/adding_parts_to_guides_test.rb
@@ -63,7 +63,7 @@ class AddingPartsToGuidesTest < JavascriptIntegrationTest
     visit    "/editions/#{guide.to_param}"
 
     add_new_part
-    within :css, '#parts div.part:first-of-type' do
+    within :css, '#parts .fields:first-of-type .part' do
       fill_in 'Title', :with => 'Part One'
       fill_in 'Body',  :with => 'Body text'
       assert_equal 'part-one', find(:css, ".slug").value
@@ -73,4 +73,19 @@ class AddingPartsToGuidesTest < JavascriptIntegrationTest
       assert_equal 'part-one-changed', find(:css, ".slug").value
     end
   end
+
+  test "slug for edition which has been previously published shouldn't be generated" do
+    guide = FactoryGirl.create(:guide_edition_with_two_parts, :state => 'published', :title => "Foo bar")
+    guide.save!
+    visit_edition guide
+    click_on "Create new edition"
+
+    within :css, '#parts .fields:first-of-type .part' do
+      assert_equal 'part-one', find(:css, ".slug").value
+      fill_in 'Title', :with => 'Part One changed'
+      fill_in 'Body',  :with => 'Body text'
+      assert_equal 'part-one', find(:css, ".slug").value
+    end
+  end
+
 end


### PR DESCRIPTION
When editing part titles on new editions of published guides, the slug was auto updating. This change of slug would go unnoticed and lead to those old URLs no longer working (they redirect to the guide's first page rather than 404ing). This breaks a lot of cross-linking between editions and can take a user out of the context of what they are doing.

Change the auto slug generation behaviour to:
* only update the slug if the slug is empty or has a data attribute "accepts-generated-value"
* use this data attribute to continue auto generating slug values on first editions
* if the slug started empty (eg a new part), then all subsequent changes before saving continue to generate slugs (eg typo correction in title)

This PR also moves a lot of the parts javascript into a module with tests. It includes:
* testing part re-ordering using `jquery.simulate.drag-sortable.js` as a helper
* testing part re-ordering after adding parts

https://www.agileplannerapp.com/boards/244464/cards/8236