### PR TITLE
Delete downtime once end_time has passed

### DIFF
--- a/app/workers/expired_downtime_cleaner.rb
+++ b/app/workers/expired_downtime_cleaner.rb
@@ -1,0 +1,21 @@
+class ExpiredDowntimeCleaner
+  include Sidekiq::Worker
+
+  def self.enqueue(downtime)
+    dequeue_existing_jobs(downtime)
+    perform_at(downtime.end_time, downtime.id.to_s)
+  end
+
+  def self.dequeue_existing_jobs(downtime)
+    Sidekiq::ScheduledSet.new.select do |job|
+      job['class'] == self.name && job.args.first == downtime.id.to_s
+    end.map(&:delete)
+  end
+
+  def perform(downtime_id)
+    downtime = Downtime.find(downtime_id)
+    return if downtime.end_time.future?
+
+    downtime.destroy
+  end
+end

--- a/app/workers/expired_downtime_cleaner.rb
+++ b/app/workers/expired_downtime_cleaner.rb
@@ -3,7 +3,7 @@ class ExpiredDowntimeCleaner
 
   def self.enqueue(downtime)
     dequeue_existing_jobs(downtime)
-    perform_at(downtime.end_time, downtime.id.to_s)
+    perform_at(downtime.end_time + 15.seconds, downtime.id.to_s)
   end
 
   def self.dequeue_existing_jobs(downtime)
@@ -13,8 +13,8 @@ class ExpiredDowntimeCleaner
   end
 
   def perform(downtime_id)
-    downtime = Downtime.find(downtime_id)
-    return if downtime.end_time.future?
+    downtime = Downtime.where(_id: downtime_id).first
+    return if downtime.nil? || downtime.end_time.future?
 
     downtime.destroy
   end

--- a/test/integration/downtime_test.rb
+++ b/test/integration/downtime_test.rb
@@ -1,47 +1,62 @@
 require 'integration_test_helper'
 
 class DowntimeTest < JavascriptIntegrationTest
+  teardown do
+    Sidekiq::ScheduledSet.new.clear
+  end
+
   test "scheduling and removing downtime" do
-    setup_users
+    Sidekiq::Testing.disable! do
+      setup_users
 
-    transaction = FactoryGirl.create(:transaction_edition, :published,
-      title: 'Apply to become a driving instructor', slug: 'apply-to-become-a-driving-instructor')
+      transaction = FactoryGirl.create(:transaction_edition, :published,
+        title: 'Apply to become a driving instructor', slug: 'apply-to-become-a-driving-instructor')
 
-    visit root_path
-    click_link 'Downtime'
-    click_link 'Apply to become a driving instructor'
+      visit root_path
+      click_link 'Downtime'
+      click_link 'Apply to become a driving instructor'
 
-    tomorrow = Date.tomorrow
-    select tomorrow.year.to_s, from: 'downtime_start_time_1i'
-    select tomorrow.strftime('%B'), from: 'downtime_start_time_2i'
-    select tomorrow.day.to_s, from: 'downtime_start_time_3i'
-    select '12', from: 'downtime_start_time_4i'
-    select '00', from: 'downtime_start_time_5i'
+      tomorrow = Date.tomorrow
+      select tomorrow.year.to_s, from: 'downtime_start_time_1i'
+      select tomorrow.strftime('%B'), from: 'downtime_start_time_2i'
+      select tomorrow.day.to_s, from: 'downtime_start_time_3i'
+      select '12', from: 'downtime_start_time_4i'
+      select '00', from: 'downtime_start_time_5i'
 
-    select tomorrow.year.to_s, from: 'downtime_end_time_1i'
-    select tomorrow.strftime('%B'), from: 'downtime_end_time_2i'
-    select tomorrow.day.to_s, from: 'downtime_end_time_3i'
-    select '18', from: 'downtime_end_time_4i'
-    select '00', from: 'downtime_end_time_5i'
-    assert_match("midday to 6pm on #{tomorrow.strftime('%A')} #{tomorrow.day} #{tomorrow.strftime('%b')}", page.find_field('Message').value)
-    click_on 'Schedule downtime'
+      select tomorrow.year.to_s, from: 'downtime_end_time_1i'
+      select tomorrow.strftime('%B'), from: 'downtime_end_time_2i'
+      select tomorrow.day.to_s, from: 'downtime_end_time_3i'
+      select '18', from: 'downtime_end_time_4i'
+      select '00', from: 'downtime_end_time_5i'
+      assert_match("midday to 6pm on #{tomorrow.strftime('%A')} #{tomorrow.day} #{tomorrow.strftime('%b')}", page.find_field('Message').value)
+      click_on 'Schedule downtime'
 
-    assert page.has_content?('Apply to become a driving instructor downtime message scheduled')
-    assert page.has_content?('Scheduled downtime')
-    assert page.has_content?("midday to 6pm on #{tomorrow.day} #{tomorrow.strftime('%b')}")
+      assert_equal 1, Sidekiq::ScheduledSet.new.size
+      assert_equal [Downtime.last.id.to_s], Sidekiq::ScheduledSet.new.first.args
 
-    click_link 'Edit downtime'
-    select '21', from: 'downtime_end_time_4i'
-    select '30', from: 'downtime_end_time_5i'
-    assert_match("midday to 9:30pm on #{tomorrow.strftime('%A')} #{tomorrow.day} #{tomorrow.strftime('%b')}", page.find_field('Message').value)
-    click_on 'Re-schedule downtime message'
+      assert page.has_content?('Apply to become a driving instructor downtime message scheduled')
+      assert page.has_content?('Scheduled downtime')
+      assert page.has_content?("midday to 6pm on #{tomorrow.day} #{tomorrow.strftime('%b')}")
 
-    assert page.has_content?('Apply to become a driving instructor downtime message re-scheduled')
-    assert page.has_content?("midday to 9:30pm on #{tomorrow.day} #{tomorrow.strftime('%b')}")
+      click_link 'Edit downtime'
+      select '21', from: 'downtime_end_time_4i'
+      select '30', from: 'downtime_end_time_5i'
+      assert_match("midday to 9:30pm on #{tomorrow.strftime('%A')} #{tomorrow.day} #{tomorrow.strftime('%b')}", page.find_field('Message').value)
+      click_on 'Re-schedule downtime message'
 
-    click_link 'Edit downtime'
-    click_on 'Cancel downtime'
-    assert page.has_content?('Apply to become a driving instructor downtime message cancelled')
-    refute page.has_content?("midday to 9:30pm on #{tomorrow.day} #{tomorrow.strftime('%b')}")
+      assert_equal 1, Sidekiq::ScheduledSet.new.size
+      assert_equal [Downtime.last.id.to_s], Sidekiq::ScheduledSet.new.first.args
+
+      assert page.has_content?('Apply to become a driving instructor downtime message re-scheduled')
+      assert page.has_content?("midday to 9:30pm on #{tomorrow.day} #{tomorrow.strftime('%b')}")
+
+      click_link 'Edit downtime'
+      click_on 'Cancel downtime'
+
+      assert_equal 0, Sidekiq::ScheduledSet.new.size
+
+      assert page.has_content?('Apply to become a driving instructor downtime message cancelled')
+      refute page.has_content?("midday to 9:30pm on #{tomorrow.day} #{tomorrow.strftime('%b')}")
+    end
   end
 end

--- a/test/unit/workers/expired_downtime_cleaner_test.rb
+++ b/test/unit/workers/expired_downtime_cleaner_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class ExpiredDowntimeCleanerTest < ActiveSupport::TestCase
-  context ".perform" do
+  context "#perform" do
     should "delete downtime" do
       downtime = Downtime.new(FactoryGirl.attributes_for(:downtime, start_time: 2.days.ago, end_time: 1.day.ago))
       downtime.save(validate: false)
@@ -15,6 +15,10 @@ class ExpiredDowntimeCleanerTest < ActiveSupport::TestCase
 
       ExpiredDowntimeCleaner.new.perform(downtime.id.to_s)
       assert downtime.reload
+    end
+
+    should "fail gracefully if the downtime doesn't exist" do
+      assert_nothing_raised { ExpiredDowntimeCleaner.new.perform(BSON::ObjectId.new.to_s) }
     end
   end
 end

--- a/test/unit/workers/expired_downtime_cleaner_test.rb
+++ b/test/unit/workers/expired_downtime_cleaner_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class ExpiredDowntimeCleanerTest < ActiveSupport::TestCase
+  context ".perform" do
+    should "delete downtime" do
+      downtime = Downtime.new(FactoryGirl.attributes_for(:downtime, start_time: 2.days.ago, end_time: 1.day.ago))
+      downtime.save(validate: false)
+
+      ExpiredDowntimeCleaner.new.perform(downtime.id.to_s)
+      assert_raises(Mongoid::Errors::DocumentNotFound) { downtime.reload }
+    end
+
+    should "not delete downtime if end_time is in future" do
+      downtime = FactoryGirl.create(:downtime, end_time: 2.days.from_now)
+
+      ExpiredDowntimeCleaner.new.perform(downtime.id.to_s)
+      assert downtime.reload
+    end
+  end
+end


### PR DESCRIPTION
https://www.agileplannerapp.com/boards/173808/cards/9233

we're using Sidekiq's `perform_at` to minimise the gap between downtime's `end_time` and the time that it gets deleted. this will ensure all information showed in Publisher related to downtimes is realtime. the other option is to use cron which will have to be run very frequently to achieve the same level of realtime. given there aren't many downtime objects running cron that frequently is not worth it.