### PR TITLE
Improve behaviour of ajax saving

### DIFF
--- a/app/assets/javascripts/modules/ajax_save.js
+++ b/app/assets/javascripts/modules/ajax_save.js
@@ -64,13 +64,18 @@
       }
 
       function error(response) {
-        var responseJSON = response.responseJSON;
+        var responseJSON = response.responseJSON,
+            messageAddendum = "Please check the form above.";
 
         if (typeof responseJSON === "object") {
           showErrors(responseJSON);
+          if (typeof responseJSON.base === "object") {
+            messageAddendum = '<strong>' + responseJSON.base[0] + '</strong>.';
+          }
         }
+
         message.addClass('workflow-message-error').removeClass('workflow-message-saving');
-        message.text('We had some problems saving. Please check the form above.');
+        message.html('We had some problems saving. ' + messageAddendum);
         hideTimeout = setTimeout(hide, 4000);
 
         // Save errored, form still has unsaved changes

--- a/app/assets/javascripts/modules/ajax_save.js
+++ b/app/assets/javascripts/modules/ajax_save.js
@@ -4,6 +4,7 @@
     this.start = function(element) {
       var url = element.attr('action') + '.json',
           message = element.find('.js-status-message'),
+          requestRunning = false,
           hideTimeout;
 
       GOVUKAdmin.Data = GOVUKAdmin.Data || {};
@@ -11,23 +12,40 @@
       Mousetrap.bindGlobal(['command+s', 'ctrl+s'], save);
 
       function save(evt) {
+        var canPreventDefault = typeof evt.preventDefault === "function";
+
+        if (requestRunning) {
+          if (canPreventDefault) {
+            evt.preventDefault();
+          }
+          return;
+        }
+
         saving();
 
         if (allFieldsCanBeSavedWithAjax()) {
-          if (typeof evt.preventDefault === "function") {
+          if (canPreventDefault) {
             evt.preventDefault();
           }
           postForm();
         }
+
+        // if default not prevented, event bubbles up and form is
+        // intentionally submitted without ajax
       }
 
       function postForm() {
+        requestRunning = true;
+
         $.ajax({
           url : url,
           type : 'POST',
           data : element.serialize(),
           success : success,
-          error: error
+          error: error,
+          complete: function() {
+            requestRunning = false;
+          }
         });
       }
 

--- a/app/assets/javascripts/modules/parts.js
+++ b/app/assets/javascripts/modules/parts.js
@@ -5,6 +5,8 @@
 
       element.on('change', 'input.title', generateSlug);
       element.on('nested:fieldAdded:parts', updatePartOrders);
+      element.on('nested:fieldAdded:parts', removeValidationMessages);
+
       makePartsSortable();
 
       function generateSlug() {
@@ -41,6 +43,13 @@
         element.find('.part').each(function (i, elem) {
           $(elem).find('input.order').val(i + 1);
         });
+      }
+
+      function removeValidationMessages(evt) {
+        var $part = $(evt.target);
+
+        $part.find('.error, .has-error').removeClass('error has-error');
+        $part.find('.js-error').remove();
       }
     }
   };

--- a/app/helpers/editions_helper.rb
+++ b/app/helpers/editions_helper.rb
@@ -8,10 +8,12 @@ module EditionsHelper
 
   def resource_form(&form_definition)
     html_options = { :id => 'edition-form' }
-    if @resource.is_a?(Parted)
-      html_options['data-module'] = 'ajax-save-with-parts'
-    elsif @resource.format != 'SimpleSmartAnswer'
-      html_options['data-module'] = 'ajax-save'
+    unless @resource.locked_for_edits? or @resource.archived?
+      if @resource.is_a?(Parted)
+        html_options['data-module'] = 'ajax-save-with-parts'
+      elsif @resource.format != 'SimpleSmartAnswer'
+        html_options['data-module'] = 'ajax-save'
+      end
     end
 
     semantic_bootstrap_nested_form_for @resource, :as => :edition, :url => edition_path(@resource),

--- a/spec/javascripts/spec/ajax_save.spec.js
+++ b/spec/javascripts/spec/ajax_save.spec.js
@@ -36,6 +36,29 @@ describe('An ajax save module', function() {
     });
   });
 
+  describe('when attempting to save multiple times before a request finishes', function() {
+    it('saves only once', function() {
+      spyOn($, 'ajax');
+      element.find('.js-save').trigger('click');
+      Mousetrap.trigger('command+s');
+      Mousetrap.trigger('command+s');
+      expect($.ajax.calls.count()).toEqual(1);
+    });
+
+    it('saves again afterwards', function() {
+      var complete;
+      spyOn($, 'ajax').and.callFake(function(options) {
+        complete = options.complete;
+      });
+      Mousetrap.trigger('command+s');
+      Mousetrap.trigger('command+s');
+      expect($.ajax.calls.count()).toEqual(1);
+      complete();
+      Mousetrap.trigger('command+s');
+      expect($.ajax.calls.count()).toEqual(2);
+    });
+  });
+
   describe('when clicking a save link', function() {
     it('indicates the form is saving', function() {
       element.find('.js-save').trigger('click');
@@ -66,6 +89,7 @@ describe('An ajax save module', function() {
       GOVUKAdmin.Data.editionFormDirty = true;
       spyOn($, 'ajax').and.callFake(function(options) {
         options.success({title: 'Title'});
+        options.complete();
       });
       spyOn(window, 'setTimeout').and.callFake(function(fn, time) {
         timeoutTime = time;
@@ -107,6 +131,7 @@ describe('An ajax save module', function() {
         ajaxError = function(errors) {
           errors = errors || {};
           options.error({responseJSON: errors});
+          options.complete();
         };
 
         ajaxSuccess = options.success;

--- a/spec/javascripts/spec/ajax_save.spec.js
+++ b/spec/javascripts/spec/ajax_save.spec.js
@@ -144,6 +144,12 @@ describe('An ajax save module', function() {
       expect(element.find('#edition_test_input ul li:first').text()).toBe('must be changed');
     });
 
+    it('includes the base error in the save dialogue', function() {
+      ajaxError({base: ['Form is wholly wrong']});
+      var statusMessage = element.find('.js-status-message');
+      expect(statusMessage.text()).toBe('We had some problems saving. Form is wholly wrong.');
+    });
+
     it('ignores validation messages for fields it does not recognise', function() {
       ajaxError({not_a_field: ['nonsense']});
       expect(element.find('.has-error').length).toBe(0);

--- a/spec/javascripts/spec/parts_spec.js
+++ b/spec/javascripts/spec/parts_spec.js
@@ -62,9 +62,10 @@ describe('A parts module', function() {
     beforeEach(function() {
       element.append('<div id="part_4" class="part">\
         <div class="js-sort-handle"></div>\
-        <input class="title" name="part_4_title" type="text" value="">\
+        <input class="error has-error title" name="part_4_title" type="text" value="">\
         <input class="slug" name="part_4_slug" type="text" value="">\
         <input class="order" name="part_4_order" type="hidden" value="">\
+        <div class="js-error some-error">Error</div>\
       </div>');
       element.trigger('nested:fieldAdded:parts');
     });
@@ -84,6 +85,10 @@ describe('A parts module', function() {
         expect($('#part_3').find('.order').val()).toBe('4');
         done();
       }, 50);
+    });
+
+    it('removes validation errors on the newly added part', function() {
+      expect(element.find('.error, .has-error, .js-error, .some-error').length).toBe(0);
     });
   });
 

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -177,7 +177,7 @@ class JavascriptIntegrationTest < ActionDispatch::IntegrationTest
   def save_edition_and_assert_error
     save_edition
     if using_javascript?
-      assert page.has_css?('.workflow-message', text: 'We had some problems saving. Please check the form above.'),  "Edition didn’t error as expected when saved with ajax"
+      assert page.has_css?('.workflow-message', text: 'We had some problems saving'),  "Edition didn’t error as expected when saved with ajax"
     else
       assert page.has_content? "We had some problems saving"
     end


### PR DESCRIPTION
* When adding a new part, it would immediately display with validation errors. Remove these messages.
* Prevent loading of the ajax-save module on archived, scheduled and published editions. Neither of these can be edited so we don't need to setup all the listeners etc.
* Give better error feedback when there is a message relating to the whole form, this is a `base` error. (eg "Archived editions can't be saved")
* Prevent multiple form saves from being requested while an ajax request is in progress (unlikely from the save button as this is obscured, but a user could hit the keyboard shortcut a few times)

(Weirdly `@resource.locked_for_edits?` in content models doesn't include archived editions. Currently, and it must have been like this for a while, all form fields on archived editions appear editable but when attempting to save will raise an error.)