### PR TITLE
Make ajax tests more rugged

### DIFF
--- a/app/views/shared/_part.html.erb
+++ b/app/views/shared/_part.html.erb
@@ -7,7 +7,7 @@
       </a>
     </h4>
   </div>
-  <div id="<%= f.object.slug || 'untitled-part' %>" class="js-part-toggle-target panel-collapse <% if f.object.valid? %>collapse <% end %>in">
+  <div id="<%= f.object.slug || 'untitled-part' %>" class="js-part-toggle-target panel-collapse <% if f.object.valid? %>collapse <% end %>in" aria-expanded="true">
     <div class="panel-body">
         <%= f.inputs do %>
           <%= f.input :title,

--- a/test/integration/adding_parts_to_guides_test.rb
+++ b/test/integration/adding_parts_to_guides_test.rb
@@ -53,25 +53,21 @@ class AddingPartsToGuidesTest < JavascriptIntegrationTest
       assert page.has_content? @random_name
     end
 
-    should "be able to hide and show parts" do
+    should "be able to hide and show edited part after saving" do
       save_edition_and_assert_success
-
-      assert page.has_css?('#part-one input.title')
-      click_on 'Part One'
-      assert page.has_no_css?('#part-one input.title')
-      click_on 'Part One'
-
+      assert page.has_css?('#part-one[aria-expanded="true"]')
       within :css, '#parts div.fields:nth-of-type(1)' do
         fill_in 'Title', :with => 'Part One (edited)'
         fill_in 'Body',  :with => 'Body text'
         fill_in 'Slug',  :with => 'part-one-edited'
       end
-
       save_edition_and_assert_success
 
-      assert page.has_css?('#part-one-edited input.title')
+      assert page.has_css?('#part-one-edited[aria-expanded="true"]')
+
+      # collapse part
       click_on 'Part One (edited)'
-      assert page.has_no_css?('#part-one-edited input.title')
+      assert page.has_css?('#part-one-edited[aria-expanded="false"]')
     end
 
     should "add the new parts only once" do

--- a/test/integration/campaign_edit_test.rb
+++ b/test/integration/campaign_edit_test.rb
@@ -99,14 +99,14 @@ class CampaignEditTest < JavascriptIntegrationTest
         attach_file("Upload image", large_image.path)
       end
 
-      save_edition
+      save_edition_and_assert_success_without_ajax
 
       assert page.has_selector?("#small-campaign-image a[href$='campaign_small.jpg']")
       assert page.has_selector?("#medium-campaign-image a[href$='campaign_medium.jpg']")
       assert page.has_selector?("#large-campaign-image a[href$='campaign_large.jpg']")
 
       # ensure files are not removed on save
-      save_edition
+      save_edition_and_assert_success_without_ajax
 
       assert page.has_selector?("#small-campaign-image a[href$='campaign_small.jpg']")
       assert page.has_selector?("#medium-campaign-image a[href$='campaign_medium.jpg']")
@@ -123,7 +123,7 @@ class CampaignEditTest < JavascriptIntegrationTest
         find('#edition_remove_large_image').set(true)
       end
 
-      save_edition
+      save_edition_and_assert_success_without_ajax
 
       assert page.has_no_selector?("#small-campaign-image a")
       assert page.has_no_selector?("#medium-campaign-image a")

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -151,7 +151,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     guide.update_attribute(:state, 'ready')
     fill_in_parts guide
 
-    click_on "Fact check"
+    page.find_link('Fact check').trigger('click')
 
     within "#send_fact_check_form" do
       fill_in "Customised message", with: "Blah"
@@ -231,7 +231,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     select("Bob", from: "Reviewer")
 
     save_edition_and_assert_error
-    
+
     assert page.has_css?(".form-group.has-error li", text: "can't be the assignee")
   end
 

--- a/test/integration/video_edition_create_edit_test.rb
+++ b/test/integration/video_edition_create_edit_test.rb
@@ -98,14 +98,14 @@ class VideoEditionCreateEditTest < JavascriptIntegrationTest
 
     assert page.has_field?("Upload a new caption file", :type => "file")
     attach_file("Upload a new caption file", file_one.path)
-    save_edition
+    save_edition_and_assert_success_without_ajax
 
     within(:css, ".uploaded-caption-file") do
       assert page.has_selector?("a[href$='captions.txt']")
     end
 
     # ensure file is not removed on save
-    save_edition
+    save_edition_and_assert_success_without_ajax
 
     within(:css, ".uploaded-caption-file") do
       assert page.has_selector?("a[href$='captions.txt']")
@@ -116,7 +116,7 @@ class VideoEditionCreateEditTest < JavascriptIntegrationTest
     GdsApi::AssetManager.any_instance.stubs(:asset).with("another_image_id").returns(asset_two)
 
     attach_file("Upload a new caption file", file_two.path)
-    save_edition
+    save_edition_and_assert_success_without_ajax
 
     within(:css, ".uploaded-caption-file") do
       assert page.has_selector?("a[href$='captions_two.txt']")
@@ -124,7 +124,7 @@ class VideoEditionCreateEditTest < JavascriptIntegrationTest
 
     # remove file
     check "Remove caption file?"
-    save_edition
+    save_edition_and_assert_success_without_ajax
 
     refute page.has_selector?(".uploaded-caption-file")
   end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -152,35 +152,50 @@ class JavascriptIntegrationTest < ActionDispatch::IntegrationTest
     # thinks there are overlapping elements
     if using_javascript?
       page.find_button('Save').trigger('click')
-      if page.has_selector?('[data-module="ajax-save"]')
-        assert page.has_selector?('.workflow-message-saving', text: 'Saving'), "Failed to trigger a dynamic saving message"
-      end
     else
       click_on 'Save'
     end
+  end
 
-    # using .trigger("click") causes race conditions,
-    # hence we need to explicitly wait till the page reloads.
-    # save button is disabled after one click, so refreshing should enable it.
-    assert page.has_selector?("input[type=submit]#save-edition:enabled"), "Failed to save edition."
+  def assert_save_attempted(with_ajax)
+    if with_ajax
+      assert page.has_selector?('.workflow-message-saving', text: 'Saving'), "Failed to trigger a dynamic saving message"
+    else
+      # using .trigger("click") causes race conditions,
+      # hence we need to explicitly wait till the page reloads.
+      # save button is disabled after one click, so refreshing should enable it.
+      assert page.has_selector?("input[type=submit]#save-edition:enabled"), "Failed to save edition."
+    end
   end
 
   def save_edition_and_assert_success
     save_edition
-    if using_javascript?
+    assert_save_attempted(saving_with_ajax?)
+    if saving_with_ajax?
       assert page.has_css?('.workflow-message', text: 'Saved'), "Edition didn’t successfully save with ajax"
     else
       assert page.has_content? "edition was successfully updated."
     end
   end
 
+  def save_edition_and_assert_success_without_ajax
+    save_edition
+    assert_save_attempted(false)
+    assert page.has_content? "edition was successfully updated."
+  end
+
   def save_edition_and_assert_error
     save_edition
-    if using_javascript?
+    assert_save_attempted(saving_with_ajax?)
+    if saving_with_ajax?
       assert page.has_css?('.workflow-message', text: 'We had some problems saving'),  "Edition didn’t error as expected when saved with ajax"
     else
       assert page.has_content? "We had some problems saving"
     end
+  end
+
+  def saving_with_ajax?
+    using_javascript? && page.has_selector?('[data-module*="ajax-save"]')
   end
 
   def clear_cookies

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -187,11 +187,7 @@ class JavascriptIntegrationTest < ActionDispatch::IntegrationTest
   def save_edition_and_assert_error
     save_edition
     assert_save_attempted(saving_with_ajax?)
-    if saving_with_ajax?
-      assert page.has_css?('.workflow-message', text: 'We had some problems saving'),  "Edition didn’t error as expected when saved with ajax"
-    else
-      assert page.has_content? "We had some problems saving"
-    end
+    assert page.has_content? "We had some problems saving"
   end
 
   def saving_with_ajax?


### PR DESCRIPTION
Fix tests that were intermittently failing due to changes not being picked up before assertions, or changes happening too quickly before assertions. Specifically:

* use aria-expanded attributes to test for open/closed parts
* be explicit about saving without ajax in video and campaign tests, and avoid save message assertion which would sometimes be missed

Tests using javascript which submit a form that cannot be saved with ajax (eg campaign image upload or video caption upload) were intermittently failing. Within save_edition there was a check for a dynamic saving message. Whilst this does show, it is likely that occasionally the form would submit and the page would change before this message appeared, leading to a failing test.

Instead pull the post-save assertions out of the save_edition method into a separate one that takes into account whether ajax is being used. Then in the video and campaign tests explicitly assert that ajax isn't used.