### PR TITLE
Only save when the save button is visible and enabled

### DIFF
--- a/app/assets/javascripts/modules/ajax_save.js
+++ b/app/assets/javascripts/modules/ajax_save.js
@@ -9,7 +9,13 @@
 
       GOVUKAdmin.Data = GOVUKAdmin.Data || {};
       element.on('click', '.js-save', save);
-      Mousetrap.bindGlobal(['command+s', 'ctrl+s'], save);
+      Mousetrap.bindGlobal(['command+s', 'ctrl+s'], saveViaKeyboard);
+
+      function saveViaKeyboard(evt) {
+        if (element.find('.js-save:visible:enabled').length > 0) {
+          save(evt);
+        }
+      }
 
       function save(evt) {
         var canPreventDefault = typeof evt.preventDefault === "function";

--- a/spec/javascripts/spec/ajax_save.spec.js
+++ b/spec/javascripts/spec/ajax_save.spec.js
@@ -29,10 +29,29 @@ describe('An ajax save module', function() {
   });
 
   describe('when keying command+s', function() {
-    it('attempts to save', function() {
+    beforeEach(function() {
       spyOn($, 'ajax');
+    });
+
+    it('attempts to save', function() {
       Mousetrap.trigger('command+s');
       expect($.ajax).toHaveBeenCalled();
+    });
+
+    describe('and save button is not visible', function() {
+      it('does not save', function() {
+        element.find('.js-save').hide();
+        Mousetrap.trigger('command+s');
+        expect($.ajax).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('and save button is disabled', function() {
+      it('does not save', function() {
+        element.find('.js-save').prop('disabled', true);
+        Mousetrap.trigger('command+s');
+        expect($.ajax).not.toHaveBeenCalled();
+      });
     });
   });
 


### PR DESCRIPTION
Using keyboard shortcuts, the form could still be submitted when the save button is disabled or when it’s not visible (eg from a different tab). This behaviour was spotted via analytics events.

* Only allow keyboard shortcut to work when the save button is visible and enabled.