### PR TITLE
Track flash messages in analytics

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,8 +35,11 @@
         alert_class = k
       end
     %>
-    <div class="alert alert-<%= alert_class %>">
-      <%= flash[k] %>
+    <div class="alert alert-<%= alert_class %>"
+      data-module="auto-track-event"
+      data-track-action="alert-<%= alert_class %>"
+      data-track-label="<%= strip_tags(flash[k]) %>">
+        <%= flash[k] %>
     </div>
   <% end %>
   <%= yield %>


### PR DESCRIPTION
Keep track of the success, error and warning messages displayed to
users by using events.

* Track the alert type as the action
* Track the alert message as the label
* The page URL is captured as the event category automatically.

This will allow tracking of edition saves that happen without ajax.