### PR TITLE
Fix local_contact_importer error with nil URLs

### DIFF
--- a/lib/local_contact_importer.rb
+++ b/lib/local_contact_importer.rb
@@ -18,7 +18,7 @@ class LocalContactImporter < LocalAuthorityDataImporter
     authority.contact_address = parse_address(row)
     authority.contact_phone = decode_broken_entities( row['Telephone Number 1'] )
     url = row['Contact page URL']
-    unless url.start_with?("http://") || url.start_with?("https://")
+    unless url.blank? || url.start_with?("http://") || url.start_with?("https://")
       url = "http://" + url
     end
     authority.contact_url = url

--- a/test/unit/local_contact_importer_test.rb
+++ b/test/unit/local_contact_importer_test.rb
@@ -133,5 +133,21 @@ South Somerset District Council,www.southsomerset.gov.uk,www.southsomerset.gov.u
       auth.reload
       assert_equal "http://www.southsomerset.gov.uk", auth.contact_url
     end
+
+    should "handle missing contact URLs" do
+      source=StringIO.new(<<-END)
+Name,Home page URL,Contact page URL,SNAC Code,Address Line 1,Address Line 2,Town,City,County,Postcode,Telephone Number 1 Description,Telephone Number 1,Telephone Number 2 Description,Telephone Number 2,Telephone Number 3 Description,Telephone Number 3,Fax,Main Contact Email,Opening Hours
+South Somerset District Council,,,40UD,Council Offices,Brympton Way,Yeovil,,Somerset,BA20 2HT,,01935 462 462,,,,,,,
+      END
+
+      auth = FactoryGirl.create(:local_authority, :snac => "40UD")
+      # Call process_row directly to bypass the top-level error rescue
+      importer = LocalContactImporter.new(nil)
+      csv = CSV.new(source, :headers => true)
+      importer.send(:process_row, csv.shift)
+
+      auth.reload
+      assert_equal nil, auth.contact_url
+    end
   end
 end


### PR DESCRIPTION
This was blowing up if the CSV didn't contain a URL entry for a
particular authority.

Fixes https://errbit.production.alphagov.co.uk/apps/5304e0520da11511b0000011/problems/54d057870da1156623003e96