### PR TITLE
Fix downtime slug links in production

### DIFF
--- a/app/views/downtimes/index.html.erb
+++ b/app/views/downtimes/index.html.erb
@@ -31,7 +31,7 @@
                                           edit_edition_downtime_path(transaction) :
                                           new_edition_downtime_path(transaction) %>
         </h4>
-        <%= link_to "/#{transaction.slug}", "#{Plek.find('www')}/#{transaction.slug}", class: 'link-muted' %>
+        <%= link_to "/#{transaction.slug}", "#{Plek.new.website_root}/#{transaction.slug}", class: 'link-muted' %>
       </td>
         <% if downtime = Downtime.for(transaction.artefact) %>
           <td>


### PR DESCRIPTION
The slugs were linking to:
https://www.production.alphagov.co.uk/apply-universal-credit

Instead of:
https://www.gov.uk/apply-universal-credit

* Use the public website root, ie the GOVUK_WEBSITE_ROOT environment variable, instead of `find(‘www’)`

https://www.pivotaltracker.com/story/show/87991876