### PR TITLE
Upgrade Bootstrap to 3.3.2 and manage analytics via admin gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ else
 end
 
 gem 'erubis'
-gem 'govuk_admin_template', '2.0.0'
+gem 'govuk_admin_template', '2.1.0'
 gem 'select2-rails', '3.5.9.1'
 gem 'momentjs-rails', '2.8.3'
 gem 'formtastic', '2.3.0'

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ else
 end
 
 gem 'erubis'
-gem 'govuk_admin_template', '1.4.2'
+gem 'govuk_admin_template', '2.0.0'
 gem 'select2-rails', '3.5.9.1'
 gem 'momentjs-rails', '2.8.3'
 gem 'formtastic', '2.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ GEM
       kramdown (~> 1.4.1)
       nokogiri (~> 1.5.10)
       sanitize (~> 2.1.0)
-    govuk_admin_template (2.0.0)
+    govuk_admin_template (2.1.0)
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.1)
       rails (>= 3.2.0)
@@ -354,7 +354,7 @@ DEPENDENCIES
   gds-api-adapters (= 16.4.0)
   gds-sso (= 10.0.0)
   govspeak (~> 3.1.0)
-  govuk_admin_template (= 2.0.0)
+  govuk_admin_template (= 2.1.0)
   govuk_content_models (~> 28.3.0)
   has_scope
   inherited_resources

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,11 +42,15 @@ GEM
       multi_json
     ansi (1.4.3)
     arel (3.0.3)
+    autoprefixer-rails (5.1.5)
+      execjs
+      json
     bootstrap-kaminari-views (0.0.3)
       kaminari (>= 0.13)
       rails (>= 3.1)
-    bootstrap-sass (3.3.1.0)
-      sass (~> 3.2)
+    bootstrap-sass (3.3.3)
+      autoprefixer-rails (>= 5.0.0.1)
+      sass (>= 3.2.19)
     bourne (1.5.0)
       mocha (>= 0.13.2, < 0.15)
     bson (1.7.1)
@@ -113,8 +117,8 @@ GEM
       kramdown (~> 1.4.1)
       nokogiri (~> 1.5.10)
       sanitize (~> 2.1.0)
-    govuk_admin_template (1.4.2)
-      bootstrap-sass (~> 3.3.1)
+    govuk_admin_template (2.0.0)
+      bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.1)
       rails (>= 3.2.0)
     govuk_content_models (28.3.0)
@@ -350,7 +354,7 @@ DEPENDENCIES
   gds-api-adapters (= 16.4.0)
   gds-sso (= 10.0.0)
   govspeak (~> 3.1.0)
-  govuk_admin_template (= 1.4.2)
+  govuk_admin_template (= 2.0.0)
   govuk_content_models (~> 28.3.0)
   has_scope
   inherited_resources

--- a/app/assets/javascripts/modules/ajax_save.js
+++ b/app/assets/javascripts/modules/ajax_save.js
@@ -83,7 +83,7 @@
 
         // Save successful, form is no longer dirty
         GOVUKAdmin.Data.editionFormDirty = false;
-        window.GOVUKAdmin.track('ajax-save-success');
+        window.GOVUKAdmin.trackEvent('ajax-save-success');
 
         element.trigger('success.ajaxsave.admin', response);
       }
@@ -100,7 +100,7 @@
             messageAddendum = '<strong>' + responseJSON.base[0] + '</strong>.';
           }
         } else {
-          window.GOVUKAdmin.track('ajax-save-error', textStatus + ': ' + errorThrown);
+          window.GOVUKAdmin.trackEvent('ajax-save-error', textStatus + ': ' + errorThrown);
         }
 
         message.addClass('workflow-message-error').removeClass('workflow-message-saving');
@@ -130,7 +130,7 @@
       function trackErrors(label) {
         // Normalise parts errors, eg "54c0db08e5274000cc:10": to "part":
         label = label.replace(/"[0-9a-fA-F]+:\d{1,2}":/g, '"part":');
-        window.GOVUKAdmin.track('ajax-save-error', label);
+        window.GOVUKAdmin.trackEvent('ajax-save-error', label);
       }
 
       function hideErrors() {

--- a/app/assets/javascripts/modules/tab_switcher.js
+++ b/app/assets/javascripts/modules/tab_switcher.js
@@ -9,10 +9,7 @@
           window.history.replaceState(null, null, tabHref);
 
           // Track tab switch as pageview
-          // https://developers.google.com/analytics/devguides/collection/analyticsjs/pages
-          if (typeof ga === "function") {
-            ga('send', 'pageview', tabHref);
-          }
+          window.GOVUKAdmin.trackPageview(tabHref);
         }
 
         // Shim Boostrap tabs, which are only capabable of removing

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,17 +50,6 @@
 <% content_for :body_end do %>
   <%= javascript_include_tag "application" %>
   <%= yield :extra_javascript %>
-  <% if Rails.env.production? %>
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-26179049-6', 'alphagov.co.uk');
-      ga('send', 'pageview');
-    </script>
-  <% end %>
 <% end %>
 
 <%# use the govuk_admin_template layout %>

--- a/spec/javascripts/spec/ajax_save.spec.js
+++ b/spec/javascripts/spec/ajax_save.spec.js
@@ -147,10 +147,10 @@ describe('An ajax save module', function() {
       spyOn($, 'ajax').and.callFake(function(options) {
         options.error({}, 'abort', 'Not Found');
       });
-      spyOn(window.GOVUKAdmin, 'track');
+      spyOn(window.GOVUKAdmin, 'trackEvent');
       element.find('.js-save').trigger('click');
 
-      expect(window.GOVUKAdmin.track).toHaveBeenCalledWith('ajax-save-error', 'abort: Not Found');
+      expect(window.GOVUKAdmin.trackEvent).toHaveBeenCalledWith('ajax-save-error', 'abort: Not Found');
     });
   });
 
@@ -235,7 +235,7 @@ describe('An ajax save module', function() {
     });
 
     it('tracks the error (and normalises part IDs)', function() {
-      spyOn(window.GOVUKAdmin, 'track');
+      spyOn(window.GOVUKAdmin, 'trackEvent');
       ajaxError({"parts":
         [
           {
@@ -246,7 +246,7 @@ describe('An ajax save module', function() {
         ]
       });
 
-      expect(window.GOVUKAdmin.track).toHaveBeenCalledWith('ajax-save-error', '{"parts":[{"part":{"slug":["can\'t be blank","is invalid"]},"part":{"title":["can\'t be blank"]},"part":{"title":["must not walk on the grass"]}}]}');
+      expect(window.GOVUKAdmin.trackEvent).toHaveBeenCalledWith('ajax-save-error', '{"parts":[{"part":{"slug":["can\'t be blank","is invalid"]},"part":{"title":["can\'t be blank"]},"part":{"title":["must not walk on the grass"]}}]}');
     });
 
     describe('when the form is saved again', function() {


### PR DESCRIPTION
* Upgrade Bootstrap to 3.3.2 (via bootstrap-sass 3.3.3)
  * Includes autoprefixer rails which is a new Bootstrap dependency
* Include Google analytics managed by gem https://github.com/alphagov/govuk_admin_template/pull/59
  * Remove existing snippet
  * Update analytics usage to match new API

https://github.com/alphagov/govuk_admin_template/blob/master/CHANGELOG.md