### PR TITLE
Organ donor registration on Completed Transaction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", git: 'https://github.com/alphagov/govuk_content_models.git', branch: 'edition-has-display-toggles'
+  gem "govuk_content_models", '28.6.0'
 end
 
 if ENV['API_DEV']

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", '~> 28.3.0'
+  gem "govuk_content_models", git: 'https://github.com/alphagov/govuk_content_models.git', branch: 'edition-has-display-toggles'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,4 @@
 GIT
-  remote: https://github.com/alphagov/govuk_content_models.git
-  revision: c0255a9a3caae30b3d2b8e6195ad089a4e85baa8
-  branch: edition-has-display-toggles
-  specs:
-    govuk_content_models (28.5.0)
-      bson_ext
-      gds-api-adapters (>= 10.9.0)
-      gds-sso (>= 10.0.0)
-      govspeak (~> 3.1.0)
-      mongoid (~> 2.5)
-      plek
-      state_machine
-
-GIT
   remote: https://github.com/alphagov/nested_form.git
   revision: ac43d8fe0cd3805b7309169ca8fbdd6a1527d9b5
   branch: add-wrapper-class
@@ -135,6 +121,14 @@ GEM
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.1)
       rails (>= 3.2.0)
+    govuk_content_models (28.6.0)
+      bson_ext
+      gds-api-adapters (>= 10.9.0)
+      gds-sso (>= 10.0.0)
+      govspeak (~> 3.1.0)
+      mongoid (~> 2.5)
+      plek
+      state_machine
     has_scope (0.5.1)
     hashie (3.3.2)
     hike (1.2.3)
@@ -361,7 +355,7 @@ DEPENDENCIES
   gds-sso (= 10.0.0)
   govspeak (~> 3.1.0)
   govuk_admin_template (= 2.1.0)
-  govuk_content_models!
+  govuk_content_models (= 28.6.0)
   has_scope
   inherited_resources
   jasmine (= 2.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,18 @@
 GIT
+  remote: https://github.com/alphagov/govuk_content_models.git
+  revision: c0255a9a3caae30b3d2b8e6195ad089a4e85baa8
+  branch: edition-has-display-toggles
+  specs:
+    govuk_content_models (28.5.0)
+      bson_ext
+      gds-api-adapters (>= 10.9.0)
+      gds-sso (>= 10.0.0)
+      govspeak (~> 3.1.0)
+      mongoid (~> 2.5)
+      plek
+      state_machine
+
+GIT
   remote: https://github.com/alphagov/nested_form.git
   revision: ac43d8fe0cd3805b7309169ca8fbdd6a1527d9b5
   branch: add-wrapper-class
@@ -121,14 +135,6 @@ GEM
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.1)
       rails (>= 3.2.0)
-    govuk_content_models (28.3.0)
-      bson_ext
-      gds-api-adapters (>= 10.9.0)
-      gds-sso (>= 10.0.0)
-      govspeak (~> 3.1.0)
-      mongoid (~> 2.5)
-      plek
-      state_machine
     has_scope (0.5.1)
     hashie (3.3.2)
     hike (1.2.3)
@@ -355,7 +361,7 @@ DEPENDENCIES
   gds-sso (= 10.0.0)
   govspeak (~> 3.1.0)
   govuk_admin_template (= 2.1.0)
-  govuk_content_models (~> 28.3.0)
+  govuk_content_models!
   has_scope
   inherited_resources
   jasmine (= 2.1.0)

--- a/app/assets/javascripts/modules/checkbox_toggle.js
+++ b/app/assets/javascripts/modules/checkbox_toggle.js
@@ -1,0 +1,18 @@
+(function(Modules) {
+  "use strict";
+
+  Modules.CheckboxToggle = function() {
+
+    var that = this;
+
+    that.start = function(element) {
+      element.on('change', '.js-checkbox-toggle', toggle);
+
+      function toggle(event) {
+        element.find('.js-checkbox-toggle-target').toggle(element.find('.js-checkbox-toggle').is(':checked'));
+      }
+      toggle();
+    };
+  };
+
+})(window.GOVUKAdmin.Modules);

--- a/app/assets/javascripts/modules/checkbox_toggle.js
+++ b/app/assets/javascripts/modules/checkbox_toggle.js
@@ -9,7 +9,8 @@
       element.on('change', '.js-checkbox-toggle', toggle);
 
       function toggle(event) {
-        element.find('.js-checkbox-toggle-target').toggle(element.find('.js-checkbox-toggle').is(':checked'));
+        var isCheckboxChecked = element.find('.js-checkbox-toggle').is(':checked');
+        element.find('.js-checkbox-toggle-target').toggle(isCheckboxChecked);
       }
       toggle();
     };

--- a/app/views/completed_transactions/_fields.html.erb
+++ b/app/views/completed_transactions/_fields.html.erb
@@ -10,17 +10,17 @@
 
 <hr />
 <div class="row">
-  <div class="col-md-8 edition-tags" data-module="checkbox-toggle">
+  <div class="col-md-8" data-module="checkbox-toggle">
     <h3 class="remove-top-margin">Promote organ donor registration</h3>
     <p class="help-block add-bottom-margin">
-      Displays the organ donor registration promotion above the completed transaction satisfaction survey
+      Display a promotion above the satisfaction survey
     </p>
 
     <div class="form-group">
       <%= f.input :promote_organ_donor_registration,
         as: :boolean,
         input_html: { disabled: @resource.locked_for_edits?, class: "js-checkbox-toggle" },
-        wrapper_html: { class: "form-group input-md-8" } %>
+        wrapper_html: { class: "form-group input-md-8 emphasised-field" } %>
 
       <%= f.input :organ_donor_registration_url,
           required: false,

--- a/app/views/completed_transactions/_fields.html.erb
+++ b/app/views/completed_transactions/_fields.html.erb
@@ -17,16 +17,15 @@
     </p>
 
     <div class="form-group">
-      <% f.object.presentation_toggles.each do |toggle_name, toggle_attributes| %>
-        <% toggle_attributes.each do |toggle_attribute_key, toggle_attribute_value|
-          boolean_field = toggle_attribute_value.is_a?(Boolean) %>
-          <%= f.input toggle_attribute_key,
-              as: boolean_field ? :boolean : :string,
-              required: false,
-              input_html: { disabled: @resource.locked_for_edits?, class: "#{'js-checkbox-toggle' if boolean_field}" },
-              wrapper_html: { class: "form-group input-md-8 #{'js-checkbox-toggle-target' if !boolean_field}" } %>
-        <% end %>
-      <% end %>
+      <%= f.input :promote_organ_donor_registration,
+        as: :boolean,
+        input_html: { disabled: @resource.locked_for_edits?, class: "js-checkbox-toggle" },
+        wrapper_html: { class: "form-group input-md-8" } %>
+
+      <%= f.input :organ_donor_registration_url,
+          required: false,
+          input_html: { disabled: @resource.locked_for_edits? },
+          wrapper_html: { class: "form-group input-md-8 js-checkbox-toggle-target" } %>
     </div>
   </div>
 </div>

--- a/app/views/completed_transactions/_fields.html.erb
+++ b/app/views/completed_transactions/_fields.html.erb
@@ -7,4 +7,28 @@
 <% end %>
 
 <%= render partial: 'shared/common_edition_tags', locals: {f: f} %>
+
+<hr />
+<div class="row">
+  <div class="col-md-8 edition-tags" data-module="checkbox-toggle">
+    <h3 class="remove-top-margin">Promote organ donor registration</h3>
+    <p class="help-block add-bottom-margin">
+      Displays the organ donor registration promotion above the completed transaction satisfaction survey
+    </p>
+
+    <div class="form-group">
+      <% f.object.presentation_toggles.each do |toggle_name, toggle_attributes| %>
+        <% toggle_attributes.each do |toggle_attribute_key, toggle_attribute_value|
+          boolean_field = toggle_attribute_value.is_a?(Boolean) %>
+          <%= f.input toggle_attribute_key,
+              as: boolean_field ? :boolean : :string,
+              required: false,
+              input_html: { disabled: @resource.locked_for_edits?, class: "#{'js-checkbox-toggle' if boolean_field}" },
+              wrapper_html: { class: "form-group input-md-8 #{'js-checkbox-toggle-target' if !boolean_field}" } %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>
+
 <%= render partial: 'shared/workflow_buttons', locals: { f: f } %>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -8,3 +8,7 @@
 #   inflect.irregular 'person', 'people'
 #   inflect.uncountable %w( fish sheep )
 # end
+
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.acronym 'URL'
+end

--- a/test/integration/completed_transactions_create_edit_test.rb
+++ b/test/integration/completed_transactions_create_edit_test.rb
@@ -65,4 +65,19 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
     visit "/editions/#{edition.to_param}"
     assert_all_edition_fields_disabled(page)
   end
+
+  should "allow controlling display of promotions on this page" do
+    edition = FactoryGirl.create(:completed_transaction_edition, :panopticon_id => @artefact.id)
+    organ_donor_registration_promotion_url = "https://www.organdonation.nhs.uk/how_to_become_a_donor/registration/consent.asp?campaign=2244&v=7"
+
+    visit "/editions/#{edition.to_param}"
+    assert page.has_unchecked_field? "Promote organ donor registration"
+
+    check "Promote organ donor registration"
+    fill_in "Organ donor registration URL", with: organ_donor_registration_promotion_url
+    save_edition_and_assert_success
+
+    assert page.has_checked_field? "Promote organ donor registration"
+    assert page.has_field? 'Organ donor registration URL', with: organ_donor_registration_promotion_url
+  end
 end


### PR DESCRIPTION
https://trello.com/c/caDndyIX

Completed transaction pages need to optionally show organ donor registration promotion. Form fields are stored as `presentation_toggles` on `Edition`: https://github.com/alphagov/govuk_content_models/pull/292


![screen shot 2015-03-18 at 14 00 27](https://cloud.githubusercontent.com/assets/230074/6705102/43b2e256-cd77-11e4-9047-685d680074f9.png)

Checking "Promote organ donor registration" shows the URL text input:
![screen shot 2015-03-18 at 14 00 50](https://cloud.githubusercontent.com/assets/230074/6705103/43b3f538-cd77-11e4-8d4b-c945f90f53ea.png)

If you've chosen to promote, entering the URL is mandatory:
![screen shot 2015-03-18 at 14 02 12](https://cloud.githubusercontent.com/assets/230074/6705120/78dd97b4-cd77-11e4-8d3c-2c3c5e071d15.png)
