### PR TITLE
Fix timezone conversion issues

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,7 +27,7 @@ class ApplicationController < ActionController::Base
       datetime_params = params.select { |k, v| k.include? attribute_name }.values.map(&:to_i)
       params.delete_if { |k, v| k.include? attribute_name }
 
-      params[attribute_name] = DateTime.new(*datetime_params) if datetime_params.present?
+      params[attribute_name] = Time.zone.local(*datetime_params) if datetime_params.present?
     end
     params
   end

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -173,8 +173,8 @@ class EditionsControllerTest < ActionController::TestCase
     }
   end
 
-  test "should squash multiparameter attributes" do
-    EditionProgressor.any_instance.expects(:progress).with(has_key('publish_at'))
+  test "squashes multiparameter attributes into a time field that has time-zone information" do
+    EditionProgressor.any_instance.expects(:progress).with(has_entry('publish_at', Time.zone.local(2014, 3, 4, 14, 47)))
 
     publish_at_params = { "publish_at(1i)"=>"2014", "publish_at(2i)"=>"3", "publish_at(3i)"=>"4",
                           "publish_at(4i)"=>"14", "publish_at(5i)"=>"47" }
@@ -183,7 +183,7 @@ class EditionsControllerTest < ActionController::TestCase
       id: @guide.id.to_s,
       edition: {
         activity: {
-          "request_type" => 'start_work'
+          "request_type" => 'schedule_for_publishing'
           }.merge(publish_at_params)
         }
       }

--- a/test/integration/edition_scheduled_publishing_test.rb
+++ b/test/integration/edition_scheduled_publishing_test.rb
@@ -16,16 +16,19 @@ class EditionScheduledPublishingTest < JavascriptIntegrationTest
   test "should schedule publishing of an edition" do
     edition = FactoryGirl.create(:edition, state: 'ready', :assigned_to => @author)
     visit_edition edition
-
     click_on "Schedule"
+
+    tomorrow = Date.tomorrow
+    year = tomorrow.year.to_s
+    month = tomorrow.strftime("%b")
+    day = tomorrow.day.to_s
 
     within "#schedule_for_publishing_form" do
       fill_in "Comment", with: "schedule!"
 
-      tomorrow = Date.tomorrow
-      select tomorrow.year.to_s, from: "edition_activity_schedule_for_publishing_attributes_publish_at_1i"
-      select tomorrow.strftime("%B"), from: "edition_activity_schedule_for_publishing_attributes_publish_at_2i"
-      select tomorrow.day.to_s, from: "edition_activity_schedule_for_publishing_attributes_publish_at_3i"
+      select year, from: "edition_activity_schedule_for_publishing_attributes_publish_at_1i"
+      select month, from: "edition_activity_schedule_for_publishing_attributes_publish_at_2i"
+      select day, from: "edition_activity_schedule_for_publishing_attributes_publish_at_3i"
       select '12', from: "edition_activity_schedule_for_publishing_attributes_publish_at_4i"
       select '15', from: "edition_activity_schedule_for_publishing_attributes_publish_at_5i"
       click_on "Schedule for publishing"
@@ -44,7 +47,7 @@ class EditionScheduledPublishingTest < JavascriptIntegrationTest
 
     edition.reload
     assert page.has_content? edition.title
-    assert page.has_content? edition.publish_at.to_s(:govuk_date_short)
+    assert page.has_content?("12:15pm, #{day} #{month} #{year}"), 'Scheduled time is not showing-up as expected'
   end
 
   test "should allow a scheduled edition to be published now" do


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/91500052

content designers noticed that scheduling an edition at 00:01 was showing-up as 01:01 in the publishing tool.

when the edition schedule time is submitted through the form, the `ApplicationController#squash_multiparameter_datetime_attributes` method squashes multi-parameter datetime into a single attribute before saving the field in the database. this logic was ignoring the local timezone, and made all field handling logic beyond this point think that `publish_at` field is in UTC.

using `Time.zone.local` preserves the timezone information, and fixes this issue.

also correcting the integration test that was masking this issue.