### PR TITLE
Bump govuk-content-schema-test-helpers to 1.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,7 @@ group :test do
 
   gem "timecop", '0.4.4'
 
-  gem 'govuk-content-schema-test-helpers', '1.1.0'
+  gem 'govuk-content-schema-test-helpers', '1.3.0'
 
   gem 'simplecov', '~> 0.6.4', :require => false
   gem 'simplecov-rcov', '~> 0.2.3', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ GEM
       kramdown (~> 1.4.1)
       nokogiri (~> 1.5.10)
       sanitize (~> 2.1.0)
-    govuk-content-schema-test-helpers (1.1.0)
+    govuk-content-schema-test-helpers (1.3.0)
       json-schema (~> 2.5.1)
     govuk_admin_template (2.1.0)
       bootstrap-sass (~> 3.3.3)
@@ -358,7 +358,7 @@ DEPENDENCIES
   gds-api-adapters (= 16.4.0)
   gds-sso (= 10.0.0)
   govspeak (~> 3.1.0)
-  govuk-content-schema-test-helpers (= 1.1.0)
+  govuk-content-schema-test-helpers (= 1.3.0)
   govuk_admin_template (= 2.1.0)
   govuk_content_models (= 28.6.1)
   has_scope


### PR DESCRIPTION
This version is forward-compatible with the new folder structure of
govuk-content-schemas. Upgrading will allow us to gracefully migrate to
the [new folder structure](https://github.com/alphagov/govuk-content-schemas/pull/60).