### PR TITLE
Allow users to clear selects with include_blank

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,7 @@
 $(function () {
   $('a.preview').attr("target","_blank");
   $('form.preview').attr("target","_blank");
-  $(".select2").select2();
+  $(".select2").select2({ allowClear: true });
 })
 
 // System wide library functions


### PR DESCRIPTION
Currently, even if a select dropdown has a blank option (`include_blank: true`), there is no way to clear the selection.

To enable this we have to specify `allowClear: true` in select2's config.

Fixes a particular problem whereby users cannot undo their "Primary topic" selection.

Note that when include_blank: false (the rails default), the clear button will not show up. Only selects where it was explicitly set will allow clearing after this commit.

## Before

![screen shot 2015-05-27 at 13 25 20](https://cloud.githubusercontent.com/assets/233676/7836107/bc6b42bc-0475-11e5-8b6d-d0b3d192bb40.png)

## After

![screen shot 2015-05-27 at 13 25 11](https://cloud.githubusercontent.com/assets/233676/7836110/c2837098-0475-11e5-875c-103083165ff4.png)

### Trello

> Once you've assigned a primary sub-topic to a piece of mainstream content, there's no way of getting rid of it. Where we've selected something from the drop-down in error or later realised it's not quite right, and there's no suitable alternative, we're having to assign a dummy topic that doesn't appear on the front end as a workaround. eg, on a document like https://publisher.preview.alphagov.co.uk/editions/5551c270ed915d2ec80002d1, if you add an entry to "Primary topic", there's no way to unset it.

https://trello.com/c/Y21ZBE9R/105-no-way-to-delete-primary-sub-topic-in-mainstream-publisher
