### PR TITLE
Associate Editions with mainstream browse pages

### DIFF
--- a/lib/csv_parser.rb
+++ b/lib/csv_parser.rb
@@ -1,0 +1,19 @@
+require 'csv'
+
+class CSVParser
+  def initialize(file)
+    @file = file
+  end
+
+  def parse
+    contents = @file.read
+
+    if contents.empty?
+      raise RuntimeError.new("can't parse an empty file")
+    end
+
+    CSV.new(contents, headers: true).to_a.map do |row|
+      row.to_hash.symbolize_keys
+    end
+  end
+end

--- a/lib/edition_tagger.rb
+++ b/lib/edition_tagger.rb
@@ -1,0 +1,14 @@
+class EditionTagger
+
+  def initialize(edition_tag_associations)
+    @edition_tag_associations = edition_tag_associations
+  end
+
+  def run
+    @edition_tag_associations.each do |association|
+      edition = Edition.where(slug: association[:slug]).first
+      edition.browse_pages << association[:tag]
+      edition.save!
+    end
+  end
+end

--- a/lib/edition_tagger.rb
+++ b/lib/edition_tagger.rb
@@ -1,14 +1,58 @@
 class EditionTagger
 
-  def initialize(edition_tag_associations)
+  def initialize(edition_tag_associations, logger)
     @edition_tag_associations = edition_tag_associations
+    @logger = logger
   end
 
   def run
     @edition_tag_associations.each do |association|
-      edition = Edition.where(slug: association[:slug]).first
-      edition.browse_pages << association[:tag]
-      edition.save!
+
+      edition = Edition.where(slug: association[:slug], state: :published).last
+      if edition_not_present?(edition)
+        import_error(association[:slug], "Slug not present in database.")
+        next
+      elsif archived_artefact?(edition)
+        import_error(association[:slug], "It is part of an archived artefact")
+        next
+      elsif duplicate_tag?(edition, association[:tag])
+        import_error(association[:slug], "Tag '#{association[:tag]}' was already present")
+        next
+      else
+        associate_tag_with_edition(edition, association[:tag])
+
+        edition.subsequent_siblings.where(state: :draft).each do |sibling|
+          associate_tag_with_edition(sibling, association[:tag])
+        end
+
+        logger.info("Edition with slug #{edition.slug} updated.")
+      end
     end
   end
+
+  private
+
+  def associate_tag_with_edition(edition, tag)
+    edition.browse_pages << tag
+    edition.save!(validate: false)
+  end
+
+  def archived_artefact?(edition)
+    edition.artefact.state == 'archived'
+  end
+
+  def duplicate_tag?(edition, tag)
+    edition.browse_pages.include?(tag)
+  end
+
+  def edition_not_present?(edition)
+    edition == nil
+  end
+
+  def import_error(slug, error)
+    logger.info(
+      "Edition with slug '#{slug}' NOT updated. #{error}"
+    )
+  end
+
 end

--- a/lib/tasks/associate_editions_with_mainstream_browse_pages.rake
+++ b/lib/tasks/associate_editions_with_mainstream_browse_pages.rake
@@ -1,0 +1,20 @@
+namespace :migrate do
+  desc "Associate Editions with mainstream browse pages using a CSV.
+
+  The CSV should be formatted respecting the following criteria:
+  - first pair of entries entries are the headers and should be 'slug' and 'tag'
+  - each following pair of entries should then made of:
+    - first: the slug of the Edition you want to update
+    - second: the tag you want to add to that Edition
+
+  ie:
+  slug,tag
+  loans-for-eu-students,loans
+  contact-dvsa,driving
+  "
+  task :associate_editions_with_mainstream_browse_pages, [:csv_path] => [:environment] do |_, args|
+    csv_file = File.new(args[:csv_path])
+    slug_associations = CSVParser.new(csv_file).parse
+    EditionTagger.new(slug_associations, Logger.new(STDOUT)).run
+  end
+end

--- a/test/unit/csv_parser_test.rb
+++ b/test/unit/csv_parser_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+require "rubygems/test_utilities"
+
+class CSVParserTest < ActiveSupport::TestCase
+
+  test "should raise an exception if the file is empty" do
+    parser = CSVParser.new(TempIO.new(""))
+
+    assert_raises(RuntimeError) { parser.parse }
+  end
+
+  test "can convert a CSV into an Array of Hash objects" do
+    csv_string = <<EOS
+slug,tag
+/foo,/bar
+EOS
+
+    parser = CSVParser.new(TempIO.new(csv_string))
+
+    assert_equal [{slug: "/foo", tag: "/bar"}], parser.parse
+  end
+end

--- a/test/unit/edition_tagger_test.rb
+++ b/test/unit/edition_tagger_test.rb
@@ -2,10 +2,36 @@ require "test_helper"
 
 class EditionTaggerTest < ActiveSupport::TestCase
   test "should assign tag to a single Edition" do
-    edition = FactoryGirl.create(:edition)
-    EditionTagger.new([{slug: edition.slug, tag: "foo"}]).run
-    edition.reload
+    edition = FactoryGirl.create(:edition, state: :published)
+    EditionTagger.new([{slug: edition.slug, tag: "foo"}], Logger.new(STDOUT)).run
 
-    assert_equal ["foo"], edition.browse_pages
+    assert_equal ["foo"], edition.published_edition.browse_pages
+  end
+
+  test "should assign tags to published and draft Editions" do
+    published_edition = FactoryGirl.create(:edition,
+      state: :published, slug: "/a-slug")
+    draft_edition = FactoryGirl.create(:edition,
+      state: :draft, slug: "/a-slug",
+      panopticon_id: published_edition.panopticon_id)
+    archived_edition = FactoryGirl.create(:edition,
+      state: :archived, slug: "/a-slug",
+      panopticon_id: published_edition.panopticon_id)
+
+    EditionTagger.new([{slug: "/a-slug", tag: "foo"}], Logger.new(STDOUT)).run
+    archived_edition.reload
+    draft_edition.reload
+    published_edition.reload
+
+    assert_equal [], archived_edition.browse_pages
+    assert_equal ["foo"], draft_edition.browse_pages
+    assert_equal ["foo"], published_edition.browse_pages
+  end
+
+  test "should not add duplicate tags" do
+    edition = FactoryGirl.create(:edition, state: :published, browse_pages: ["foo"])
+    EditionTagger.new([{slug: edition.slug, tag: "foo"}], Logger.new(STDOUT)).run
+
+    assert_equal ["foo"], edition.published_edition.browse_pages
   end
 end

--- a/test/unit/edition_tagger_test.rb
+++ b/test/unit/edition_tagger_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class EditionTaggerTest < ActiveSupport::TestCase
+  test "should assign tag to a single Edition" do
+    edition = FactoryGirl.create(:edition)
+    EditionTagger.new([{slug: edition.slug, tag: "foo"}]).run
+    edition.reload
+
+    assert_equal ["foo"], edition.browse_pages
+  end
+end


### PR DESCRIPTION
This work is required by this [ticket](https://trello.com/c/MfDxYdta/125-tag-all-content-in-publisher-with-the-childcare-tags-using-a-data-migration). 

We need to update all content in publisher which should be tagged to childcare mainstream browse pages to have those tags.  Doing this through the publisher interface would be slow, and interfere with any existing edits in progress.

To avoid this, we will write a rake task to take a list of content and the mainstream browse pages they should be tagged to, perhaps as a CSV, and apply that to the editions in publisher.

This PR adds a rake task that associates Editions with mainstream browse pages from a CSV file.

(Tested locally with a sample CSV file)