### PR TITLE
Fix the organisation content report

### DIFF
--- a/app/presenters/organisation_content_presenter.rb
+++ b/app/presenters/organisation_content_presenter.rb
@@ -22,7 +22,7 @@ class OrganisationContentPresenter < CSVPresenter
 private
 
   def get_value(header, artefact)
-    latest_edition = @editions[artefact.id.to_s].last
+    latest_edition = @editions.fetch(artefact.id.to_s, []).last
 
     return super if latest_edition.nil?
 

--- a/test/integration/organisation_content_report_test.rb
+++ b/test/integration/organisation_content_report_test.rb
@@ -36,4 +36,21 @@ class OrganisationContentReportTest < ActionDispatch::IntegrationTest
     assert_equal "HMRC", data[0]["Organisation"]
     assert_equal "123456,123321,654321", data[0]["Need ids"]
   end
+
+  should "handle artefacts without editions" do
+    document = FactoryGirl.create(:artefact,
+      name: "Important document",
+      department: "DfE",
+      need_ids: ["123456"]
+    )
+
+    get "/reports/organisation-content"
+
+    assert last_response.ok?
+
+
+    data = CSV.parse(last_response.body, :headers => true)
+
+    assert_equal "Important document", data[0]["Name"]
+  end
 end


### PR DESCRIPTION
This report was generating an error when it encountered an artefact without any
editions.

This commit doesn't address the fact that the report takes a very long time to
generate and so users aren't able to access them because nginx times out first. The solution to that is probably to generate the reports off-line.