### PR TITLE
Fix static file serving to work with nginx

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -10,13 +10,9 @@ Publisher::Application.configure do
   config.action_controller.perform_caching = true
 
   # Specifies the header that your server uses for sending files
-  config.action_dispatch.x_sendfile_header = "X-Sendfile"
-
-  # For nginx:
-  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect'
-
   # If you have no front-end server that supports something like X-Sendfile,
   # just comment this out and Rails will serve the files
+  config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect'
 
   # See everything in the log (default is :info)
   config.log_level = :info


### PR DESCRIPTION
We would like to offload (static file) CSV reports to be served by nginx
rather than rails. [This is possible](http://wiki.nginx.org/XSendfile) by setting
the correct header in the rails config.

The header was already set but it was configured to work with Apache, which we
no longer use.

This requires [a puppet change](https://github.gds/gds/puppet/pull/3005) to work.

/cc @alext 

The build is failing on an unrelated test (because the test relies on mongo ids increasing with subsequent insertions, as far as I can see).