### PR TITLE
Fix offline generation of Publisher reports

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -34,7 +34,7 @@ class ReportsController < ApplicationController
   helper_method :report_last_updated
 
   def mtime_for(report)
-    mtime = File.stat(report_location(report)).mtime
+    mtime = File.stat(report_location(report)).mtime.in_time_zone(Time.zone)
   rescue Errno::ENOENT
     nil
   end

--- a/lib/csv_report_generator.rb
+++ b/lib/csv_report_generator.rb
@@ -2,7 +2,7 @@ require 'redis'
 require 'redis-lock'
 
 class CsvReportGenerator
-  CSV_PATH = "#{Rails.root}/reports"
+  CSV_PATH = "#{ENV['GOVUK_APP_ROOT'] || Rails.root}/reports"
 
   def run!
     redis.lock("publisher:#{Rails.env}:report_generation_lock", :life => 15.minutes) do

--- a/test/functional/reports_controller_test.rb
+++ b/test/functional/reports_controller_test.rb
@@ -12,7 +12,7 @@ class ReportsControllerTest < ActionController::TestCase
     @controller.view_paths.each { |path| FakeFS::FileSystem.clone(path) }
 
     FileUtils.mkdir_p(CsvReportGenerator::CSV_PATH)
-    Timecop.freeze(Time.mktime(2015,1,1)) do
+    Timecop.freeze(Time.mktime(2015,6,1)) do
       File.open(path, "w") { |f| f.write("foo,bar") }
     end
   end
@@ -25,7 +25,7 @@ class ReportsControllerTest < ActionController::TestCase
     get :progress
 
     assert_equal "foo,bar", response.body
-    assert_equal 'attachment; filename="editorial_progress-20150101000000.csv"',
+    assert_equal 'attachment; filename="editorial_progress-20150601010000.csv"',
       response.header["Content-Disposition"]
     assert_equal "text/csv", response.header["Content-Type"]
   end
@@ -39,6 +39,6 @@ class ReportsControllerTest < ActionController::TestCase
   test "shows the mtime on the index page" do
     get :index
 
-    assert_match /Generated 12:00am, 1 January 2015/,  response.body
+    assert_match /Generated 1:00am, 1 June 2015/,  response.body
   end
 end

--- a/test/unit/edition_churn_presenter_test.rb
+++ b/test/unit/edition_churn_presenter_test.rb
@@ -28,7 +28,7 @@ class EditionChurnPresenterTest < ActionDispatch::IntegrationTest
     )
 
     csv = EditionChurnPresenter.new(
-      Edition.not_in(state: ["archived"]).order(:title)).to_csv
+      Edition.not_in(state: ["archived"]).order(:title.asc)).to_csv
 
     data = CSV.parse(csv, :headers => true)
 


### PR DESCRIPTION
Addresses the comments in https://trello.com/c/QqiFmXZ3/10-reports-in-publisher-shouldn-t-time-out-medium:

- The "weird redirect" was caused by Rails trying to send e.g. `/data/vhost/publisher.preview.alphagov.co.uk/releases/20150706083530/re
ports/organisation_content.csv` because the filename was based on `Rails.root`. Nginx is only configured to server `/var/apps/publisher/reports`, so use that as the CSV path.
- Ensure "Generated" times are displayed as Local time. This seems to be the only way to achieve this - mtime is reported as being in local time, but with a UTC offset of 0. So we have to explicitly convert this to local time, which currently means being in BST. 
- Fixes a randomly-failing test. The sort order needs to be explicitly specified in the test.

There is another randomly failing test in the integration section. Fixing that seems like it doesn't belong in this PR, will fix it as part of https://trello.com/c/jI6B7tDa/19-upgrade-apps-to-supported-ruby-versions-publisher-large