### PR TITLE
Improve edition tagger

### DIFF
--- a/lib/edition_tagger.rb
+++ b/lib/edition_tagger.rb
@@ -14,6 +14,8 @@ class EditionTagger
 
 private
 
+  attr_reader :logger
+
   def add_mainstream_browse_tag(slug, tag)
     non_archived_editions = Edition.where(:slug => slug, :state.ne => 'archived')
 
@@ -25,6 +27,10 @@ private
     non_archived_editions.each do |edition|
       add_mainstream_browse_tag_to_edition(edition, tag)
     end
+
+    # We republish whether we've made changes or not, since a previous run
+    # might have made the changes, but then received errors when publishing
+    republish(slug)
   end
 
   def add_mainstream_browse_tag_to_edition(edition, tag)
@@ -63,4 +69,10 @@ private
     )
   end
 
+  def republish(slug)
+    logger.info "Republishing"
+
+    registerer = PublishedSlugRegisterer.new(logger, [slug])
+    registerer.run
+  end
 end

--- a/test/unit/edition_tagger_test.rb
+++ b/test/unit/edition_tagger_test.rb
@@ -8,6 +8,16 @@ class EditionTaggerTest < ActiveSupport::TestCase
     assert_equal ["foo"], edition.published_edition.browse_pages
   end
 
+  test "should assign tags to draft edition when no published edition" do
+    draft_edition = FactoryGirl.create(:edition,
+      state: :draft, slug: "/a-slug")
+
+    EditionTagger.new([{slug: "/a-slug", tag: "foo"}], @logger).run
+    draft_edition.reload
+
+    assert_equal ["foo"], draft_edition.browse_pages
+  end
+
   test "should assign tags to published and draft Editions" do
     published_edition = FactoryGirl.create(:edition,
       state: :published, slug: "/a-slug")


### PR DESCRIPTION
This PR makes two main changes to the rake task which adds mainstream browse page tags to editions (`migrate:associate_editions_with_mainstream_browse_pages`):

 - ensure that all non-archived editions are tagged (fixes a bug where if no edition of the document had yet been published, the edition wasn't tagged).

 - republish to panopticon and the publishing-api after changing the tagging, so that search is updated correctly.

There are separate commits to make each of these changes - this is probably the easiest way to review.