### PR TITLE
Let publishers self serve cross-domain analytics tracking

### DIFF
--- a/app/views/transactions/_fields.html.erb
+++ b/app/views/transactions/_fields.html.erb
@@ -31,6 +31,13 @@
               :label => 'What you need to know',
               :wrapper_html => { :class => 'add-top-margin' },
               :input_html => { :rows => 4, :disabled => @resource.locked_for_edits?, :class => 'input-md-7' } %>
+
+  <%= f.input :department_analytics_profile,
+              :label => 'Department analytics profile',
+              :placeholder => 'UA-XXXXXX-X',
+              :hint => 'Let departments track user journeys between GOV.UK and their service using Google Analytics.',
+              :wrapper_html => { :class => 'add-top-margin' },
+              :input_html => { :rows => 4, :disabled => @resource.locked_for_edits?, :class => 'input-md-2' } %>
 <% end %>
 
 <%= render partial: 'shared/common_edition_tags', locals: {f: f} %>

--- a/db/migrate/20150715113301_add_analytics_profiles.rb
+++ b/db/migrate/20150715113301_add_analytics_profiles.rb
@@ -1,0 +1,20 @@
+class AddAnalyticsProfiles < Mongoid::Migration
+  def self.up
+    profiles = {
+      'register-to-vote' => 'UA-23066786-5',
+      'accelerated-possession-eviction' => 'UA-37377084-12',
+      'renewtaxcredits' => 'UA-43414424-1',
+      'registered-traveller' => 'UA-47583357-4',
+    }
+
+    profiles.each do |slug, profile|
+      editions = TransactionEdition.where(slug: slug, :state.ne => 'archived')
+      editions.each do |edition|
+        edition.set(:department_analytics_profile, profile)
+      end
+    end
+  end
+
+  def self.down
+  end
+end

--- a/test/integration/transaction_create_edit_test.rb
+++ b/test/integration/transaction_create_edit_test.rb
@@ -1,0 +1,73 @@
+# encoding: utf-8
+require 'integration_test_helper'
+
+class TransactionCreateEditTest < JavascriptIntegrationTest
+  setup do
+    @artefact = FactoryGirl.create(:artefact,
+      slug: "register-for-space-flight",
+      kind: "transaction",
+      name: "Register for space flight",
+      owning_app: "publisher",
+    )
+
+    setup_users
+    stub_collections
+  end
+
+  with_and_without_javascript do
+    should "edit a new TransactionEdition" do
+      visit "/publications/#{@artefact.id}"
+
+      assert page.has_content? @artefact.name
+
+      fill_in "Introductory paragraph", :with => "Become a space pilot"
+      fill_in "Will continue on", :with => "UK Space Recruitment"
+      fill_in "More information", :with => "Take part in the final frontier"
+
+      save_edition_and_assert_success
+      assert page.has_content? @artefact.name
+
+      transaction = TransactionEdition.first
+      assert_equal @artefact.id.to_s, transaction.panopticon_id
+
+      assert_equal "Become a space pilot", transaction.introduction
+      assert_equal "UK Space Recruitment", transaction.will_continue_on
+      assert_equal "Take part in the final frontier", transaction.more_information
+    end
+
+    should "allow editing a TransactionEdition" do
+      transaction = FactoryGirl.create(:transaction_edition,
+                                   :panopticon_id => @artefact.id,
+                                   :title => "Register for space flight",
+                                   :introduction => "Become a space pilot",
+                                   :will_continue_on => "UK Space Recruitment",)
+
+      visit "/editions/#{transaction.to_param}"
+
+      assert page.has_content? 'Register for space flight'
+      assert page.has_field?("Introductory paragraph", :with => "Become a space pilot")
+      assert page.has_field?("Will continue on", :with => "UK Space Recruitment")
+
+      fill_in "Introductory paragraph", :with => "Get your licence to fly to Mars"
+      fill_in "Will continue on", :with => "UK Terrestrial Mars Office"
+
+      save_edition_and_assert_success
+
+      t = TransactionEdition.find(transaction.id)
+      assert_equal "Get your licence to fly to Mars", t.introduction
+      assert_equal "UK Terrestrial Mars Office", t.will_continue_on
+    end
+  end
+
+  should "disable fields for a published edition" do
+    edition = FactoryGirl.create(:transaction_edition,
+                                  :panopticon_id => @artefact.id,
+                                  :state => 'published',
+                                  :slug => @artefact.slug,
+                                  :title => "Foo transaction"
+                                )
+
+    visit "/editions/#{edition.to_param}"
+    assert_all_edition_fields_disabled(page)
+  end
+end

--- a/test/integration/transaction_create_edit_test.rb
+++ b/test/integration/transaction_create_edit_test.rb
@@ -12,6 +12,8 @@ class TransactionCreateEditTest < JavascriptIntegrationTest
 
     setup_users
     stub_collections
+
+    login_as @author
   end
 
   with_and_without_javascript do
@@ -56,6 +58,23 @@ class TransactionCreateEditTest < JavascriptIntegrationTest
       t = TransactionEdition.find(transaction.id)
       assert_equal "Get your licence to fly to Mars", t.introduction
       assert_equal "UK Terrestrial Mars Office", t.will_continue_on
+    end
+
+    should "allow only a valid department analytics profile" do
+      transaction = FactoryGirl.create(:transaction_edition,
+                                   :panopticon_id => @artefact.id,
+                                   :title => "Register for space flight")
+
+      visit "/editions/#{transaction.to_param}"
+
+      fill_in "Department analytics profile", :with => "UA-INVALID-SPACE-FLIGHT"
+      save_edition_and_assert_error
+
+      fill_in "Department analytics profile", :with => "UA-00100000-1"
+      save_edition_and_assert_success
+
+      t = TransactionEdition.find(transaction.id)
+      assert_equal "UA-00100000-1", t.department_analytics_profile
     end
   end
 


### PR DESCRIPTION
Add a "Department analytics profile" field to transaction editions so that publishers can self serve, and migrate existing cross domain analytics (from https://github.com/alphagov/frontend/blob/d940889b5bb779ca72266c03c7458bb296e010af/app/helpers/cross_domain_analytics_helper.rb).

> As a government editor, I need to be able to add cross-domain tracking to my service start page, so that I can measure the entire user journey for my service, and measure the success of any promotional efforts for my service.

<img width="649" alt="screen shot 2015-07-15 at 12 12 20" src="https://cloud.githubusercontent.com/assets/319055/8697182/ef806a60-2aea-11e5-9a86-efa5d72c3308.png">

https://trello.com/c/QyHwb1Zu/

Related: https://github.com/alphagov/govuk_content_models/pull/307