### PR TITLE
Add a rake task to generate a CSV of Local Transactions

### DIFF
--- a/lib/tasks/export_local_transactions.rake
+++ b/lib/tasks/export_local_transactions.rake
@@ -1,0 +1,15 @@
+desc "Export Local Transactions' slugs, names, LGSL and optional LGIL codes as CSV"
+
+task :export_local_transactions => :environment do
+  require "csv"
+
+  csv_string = CSV.generate do |csv|
+    csv << ["slug","lgsl","lgil","title"]
+
+    Edition.where(_type: "LocalTransactionEdition").each do |lte|
+      csv << [lte.slug,lte.lgsl_code,lte.lgil_override,lte.title]
+    end
+  end
+
+  puts csv_string
+end


### PR DESCRIPTION
- Generates a CSV of the form "slug","lgsl","lgil","title".
- This might need to be done again in future, and across environments,
  hence the rake task.

Trello: https://trello.com/c/IycgidgH/52-export-list-of-local-transaction-formats-from-publisher