### PR TITLE
Make integration tests more reliable

### DIFF
--- a/test/integration/campaign_edit_test.rb
+++ b/test/integration/campaign_edit_test.rb
@@ -99,14 +99,13 @@ class CampaignEditTest < JavascriptIntegrationTest
         attach_file("Upload image", large_image.path)
       end
 
-      save_edition_and_assert_success_without_ajax
+      save_edition_and_assert_success_slow
 
       assert page.has_selector?("#small-campaign-image a[href$='campaign_small.jpg']")
       assert page.has_selector?("#medium-campaign-image a[href$='campaign_medium.jpg']")
       assert page.has_selector?("#large-campaign-image a[href$='campaign_large.jpg']")
 
-      # ensure files are not removed on save
-      save_edition_and_assert_success_without_ajax
+      save_edition_and_assert_success_slow
 
       assert page.has_selector?("#small-campaign-image a[href$='campaign_small.jpg']")
       assert page.has_selector?("#medium-campaign-image a[href$='campaign_medium.jpg']")
@@ -123,7 +122,7 @@ class CampaignEditTest < JavascriptIntegrationTest
         find('#edition_remove_large_image').set(true)
       end
 
-      save_edition_and_assert_success_without_ajax
+      save_edition_and_assert_success_slow
 
       assert page.has_no_selector?("#small-campaign-image a")
       assert page.has_no_selector?("#medium-campaign-image a")

--- a/test/integration/video_edition_create_edit_test.rb
+++ b/test/integration/video_edition_create_edit_test.rb
@@ -83,7 +83,7 @@ class VideoEditionCreateEditTest < JavascriptIntegrationTest
   end
 
   should "manage caption files for a video edition" do
-    @edition = FactoryGirl.create(:video_edition, :state => 'draft')
+    edition = FactoryGirl.create(:video_edition, :state => 'draft')
 
     file_one = File.open(Rails.root.join("test","fixtures","uploads","captions.txt"))
     file_two = File.open(Rails.root.join("test","fixtures","uploads","captions_two.txt"))
@@ -94,18 +94,18 @@ class VideoEditionCreateEditTest < JavascriptIntegrationTest
     GdsApi::AssetManager.any_instance.stubs(:create_asset).returns(asset_one)
     GdsApi::AssetManager.any_instance.stubs(:asset).with("an_image_id").returns(asset_one)
 
-    visit "/editions/#{@edition.to_param}"
+    visit "/editions/#{edition.to_param}"
 
     assert page.has_field?("Upload a new caption file", :type => "file")
     attach_file("Upload a new caption file", file_one.path)
-    save_edition_and_assert_success_without_ajax
+    save_edition_and_assert_success_slow
 
     within(:css, ".uploaded-caption-file") do
       assert_selector("a[href$='captions.txt']")
     end
 
     # ensure file is not removed on save
-    save_edition_and_assert_success_without_ajax
+    save_edition_and_assert_success_slow
 
     within(:css, ".uploaded-caption-file") do
       assert_selector("a[href$='captions.txt']")
@@ -116,7 +116,7 @@ class VideoEditionCreateEditTest < JavascriptIntegrationTest
     GdsApi::AssetManager.any_instance.stubs(:asset).with("another_image_id").returns(asset_two)
 
     attach_file("Upload a new caption file", file_two.path)
-    save_edition_and_assert_success_without_ajax
+    save_edition_and_assert_success_slow
 
     within(:css, ".uploaded-caption-file") do
       assert_selector("a[href$='captions_two.txt']")
@@ -124,7 +124,7 @@ class VideoEditionCreateEditTest < JavascriptIntegrationTest
 
     # remove file
     check "Remove caption file?"
-    save_edition_and_assert_success_without_ajax
+    save_edition_and_assert_success_slow
 
     assert_no_selector(".uploaded-caption-file")
   end


### PR DESCRIPTION
Attempt to improve the reliability of two integration tests (`campaign_edit_test` and `video_edition_create_edit_test`) as they fail regularly on CI.

These changes seem to make the test suite a lot more stable - Famous Last Words.
