### PR TITLE
Add an Edition's state to the local transaction export CSV

### DIFF
--- a/lib/tasks/export_local_transactions.rake
+++ b/lib/tasks/export_local_transactions.rake
@@ -4,10 +4,10 @@ task :export_local_transactions => :environment do
   require "csv"
 
   csv_string = CSV.generate do |csv|
-    csv << ["slug","lgsl","lgil","title"]
+    csv << ["slug","lgsl","lgil","title","state"]
 
     Edition.where(_type: "LocalTransactionEdition").each do |lte|
-      csv << [lte.slug,lte.lgsl_code,lte.lgil_override,lte.title]
+      csv << [lte.slug,lte.lgsl_code,lte.lgil_override,lte.title,lte.state]
     end
   end
 


### PR DESCRIPTION
- Duplicates were appearing in the output of this because it was
  checking all editions and not differentiating between published and
  archived editions. As per
  https://github.com/alphagov/publisher/pull/398#discussion_r34978263,
  display the `state` of an edition to guard against this confusion and
  provide opportunities for filtering.