### PR TITLE
Update govuk_content_models to 29.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", '29.0.0'
+  gem "govuk_content_models", '29.1.1'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (29.0.0)
+    govuk_content_models (29.1.1)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 10.0.0)
@@ -364,7 +364,7 @@ DEPENDENCIES
   govspeak (~> 3.1.0)
   govuk-content-schema-test-helpers (= 1.3.0)
   govuk_admin_template (~> 2.3.1)
-  govuk_content_models (= 29.0.0)
+  govuk_content_models (= 29.1.1)
   has_scope
   inherited_resources
   jasmine (= 2.1.0)


### PR DESCRIPTION
This fixes a bug where Simple Smart Answers question option slugs get out of
sync with their labels, thus forcing Content team to redo questions from
scratch to get correct url slugs.

More info: https://github.com/alphagov/govuk_content_models/pull/317