### PR TITLE
Make Fact Check email fetching more robust

### DIFF
--- a/script/mail_fetcher
+++ b/script/mail_fetcher
@@ -46,6 +46,9 @@ begin
   end
 rescue Redis::Lock::LockNotAcquired => e
   Rails.logger.debug("Failed to get lock for fact check processing (#{e.message}). Another process probably got there first.")
+rescue => e
+  Airbrake.notify_or_ignore(e)
+  raise
 end
 
 if handler.errors.any?


### PR DESCRIPTION
This is an attempt to make the fact check email fetcher more robust and
more transparent. It seems like errors extending the lock time in Redis
may be causing emails to not be processed correctly and exit the loop
early, so we now rescue from the after_message hook and report errors
to Errbit.

Also added a few extra instances of Errbit logging in order to find
other errors in production.

Re: https://govuk.zendesk.com/agent/tickets/1121762