### PR TITLE
Department analytics profile => Service analytics profile

### DIFF
--- a/app/views/transactions/_fields.html.erb
+++ b/app/views/transactions/_fields.html.erb
@@ -33,9 +33,9 @@
               :input_html => { :rows => 4, :disabled => @resource.locked_for_edits?, :class => 'input-md-7' } %>
 
   <%= f.input :department_analytics_profile,
-              :label => 'Department analytics profile',
+              :label => 'Service analytics profile',
               :placeholder => 'UA-XXXXXX-X',
-              :hint => 'Let departments track user journeys between GOV.UK and their service using Google Analytics.',
+              :hint => 'Let service teams track user journeys between GOV.UK and their service using Google Analytics.',
               :wrapper_html => { :class => 'add-top-margin' },
               :input_html => { :rows => 4, :disabled => @resource.locked_for_edits?, :class => 'input-md-2' } %>
 <% end %>

--- a/test/integration/transaction_create_edit_test.rb
+++ b/test/integration/transaction_create_edit_test.rb
@@ -60,17 +60,17 @@ class TransactionCreateEditTest < JavascriptIntegrationTest
       assert_equal "UK Terrestrial Mars Office", t.will_continue_on
     end
 
-    should "allow only a valid department analytics profile" do
+    should "allow only a valid Service analytics profile" do
       transaction = FactoryGirl.create(:transaction_edition,
                                    :panopticon_id => @artefact.id,
                                    :title => "Register for space flight")
 
       visit "/editions/#{transaction.to_param}"
 
-      fill_in "Department analytics profile", :with => "UA-INVALID-SPACE-FLIGHT"
+      fill_in "Service analytics profile", :with => "UA-INVALID-SPACE-FLIGHT"
       save_edition_and_assert_error
 
-      fill_in "Department analytics profile", :with => "UA-00100000-1"
+      fill_in "Service analytics profile", :with => "UA-00100000-1"
       save_edition_and_assert_success
 
       t = TransactionEdition.find(transaction.id)


### PR DESCRIPTION
This label more closely matches reality. Not all services relate to a
department, and even if they do, they might be a separate profile from the
department-wide one.

I did contemplate renaming the field in the database, but it would be a lot of
work across several repos for little benefit.