### PR TITLE
Replace old 'script/console' by 'rails console'

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ with other apps, here's how.
 
 ### Create a user
 
-    publisher$ script/console
+    publisher$ rails console
     >> User.create name: "Your name", email: "youremail@example.com", uid: Time.zone.now.to_i, version: 1
 
 ### Run panopticon using rails s or similar


### PR DESCRIPTION
Since now Publisher is Rails 3.2.22 and `script/` is gone.