### PR TITLE
Allow SimpleSmartAnswer to be converted to Answer

### DIFF
--- a/app/views/shared/_admin.html.erb
+++ b/app/views/shared/_admin.html.erb
@@ -13,7 +13,7 @@
 <% if @edition.published? && @edition.can_create_new_edition? %>
   <h3 class="remove-top-margin">Change edition format</h3>
 
-  <% if [AnswerEdition, GuideEdition, LicenceEdition, ProgrammeEdition, TransactionEdition].include?(@edition.class) %>
+  <% if [AnswerEdition, GuideEdition, LicenceEdition, ProgrammeEdition, TransactionEdition, SimpleSmartAnswerEdition].include?(@edition.class) %>
     <%= render partial: "shared/clone_buttons",
       locals: {
         edition: @edition,
@@ -47,6 +47,13 @@
         edition: @edition,
         edition_class: TransactionEdition,
         to_classes: [AnswerEdition, GuideEdition, ProgrammeEdition]
+      } %>
+
+    <%= render partial: "shared/clone_buttons",
+      locals: {
+        edition: @edition,
+        edition_class: SimpleSmartAnswerEdition,
+        to_classes: [AnswerEdition]
       } %>
   <% else %>
     <p class="lead remove-bottom-margin">

--- a/test/integration/change_edition_type_test.rb
+++ b/test/integration/change_edition_type_test.rb
@@ -91,6 +91,22 @@ class ChangeEditionTypeTest < JavascriptIntegrationTest
     assert_field_contains(transaction.alternate_methods, "Body")
   end
 
+  test "should be able to convert a SimpleSmartAnswerEdition into an AnswerEdition" do
+    simple_smart_answer = FactoryGirl.create(:simple_smart_answer_edition, state: 'published')
+    visit_edition simple_smart_answer
+
+    within "div.tabbable" do
+      click_on "Admin"
+    end
+
+    assert page.has_button?("Create as new Answer edition")
+
+    click_on "Create as new Answer edition"
+
+    assert_text(simple_smart_answer.title)
+    assert_text("New edition created")
+  end
+
 # tests for changing Answer, Guide, Programme into a Transaction
 
   test "should be able to convert an AnswerEdition into a TransactionEdition" do
@@ -115,7 +131,6 @@ class ChangeEditionTypeTest < JavascriptIntegrationTest
     within :css, '#edition_more_information_input' do
       assert page.has_xpath?("//textarea[contains(text(), '#{answer.whole_body}')]"), "Expected to see: #{answer.whole_body}"
     end
-
   end
 
   test "should be able to convert an AnswerEdition into a SimpleSmartAnswerEdition" do


### PR DESCRIPTION
This is a request from the content team. These changes are similar to the ones from #399, which converts a licence to an answer.

cc @jamiecobbett @boffbowsh 

[Trello](https://trello.com/c/siIF3DDX/83-self-serve-changing-a-simple-smart-answer-to-a-quick-answer-in-mainstream-publisher-small)