### PR TITLE
Send content id to content store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", '29.1.1'
+  gem "govuk_content_models", '30.0.0'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (29.1.1)
+    govuk_content_models (30.0.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 10.0.0)
@@ -364,7 +364,7 @@ DEPENDENCIES
   govspeak (~> 3.1.0)
   govuk-content-schema-test-helpers (= 1.3.0)
   govuk_admin_template (~> 2.3.1)
-  govuk_content_models (= 29.1.1)
+  govuk_content_models (= 30.0.0)
   has_scope
   inherited_resources
   jasmine (= 2.1.0)

--- a/app/presenters/published_edition_presenter.rb
+++ b/app/presenters/published_edition_presenter.rb
@@ -1,6 +1,7 @@
 class PublishedEditionPresenter
   def initialize(edition)
     @edition = edition
+    @artefact = edition.artefact
   end
 
   def render_for_publishing_api(options={})
@@ -13,6 +14,7 @@ class PublishedEditionPresenter
       public_updated_at: @edition.public_updated_at,
       publishing_app: "publisher",
       rendering_app: "frontend",
+      content_id: @artefact.content_id,
       routes: [
         {path: base_path, type: "exact"}
       ],

--- a/test/unit/published_edition_presenter_test.rb
+++ b/test/unit/published_edition_presenter_test.rb
@@ -5,6 +5,9 @@ class PublishedEditionPresenterTest < ActiveSupport::TestCase
 
   context ".render_for_publishing_api" do
     setup do
+      artefact = FactoryGirl.create(:artefact,
+        content_id: "fd4b7ea6-5e95-489e-ac73-0d8710e894d8",
+      )
       @edition = FactoryGirl.create(:edition, :published,
         browse_pages: ["tax/vat", "tax/capital-gains"],
         primary_topic: "oil-and-gas/wells",
@@ -13,6 +16,7 @@ class PublishedEditionPresenterTest < ActiveSupport::TestCase
         updated_at: 1.minute.ago,
         change_note: 'Test',
         version_number: 2,
+        panopticon_id: artefact.id,
       )
 
       @presenter = PublishedEditionPresenter.new(@edition)
@@ -26,6 +30,7 @@ class PublishedEditionPresenterTest < ActiveSupport::TestCase
         public_updated_at: @edition.updated_at,
         publishing_app: "publisher",
         rendering_app: "frontend",
+        content_id: "fd4b7ea6-5e95-489e-ac73-0d8710e894d8",
         routes: [ { path: "/#{@edition.slug}", type: "exact" }],
         redirects: [],
         update_type: "major",


### PR DESCRIPTION
We want to use content IDs instead of slugs to represent items in curated lists, so that things like slug changes don't break the linkage. In order to do this, we need to ensure that all content in publisher has a content-id, and these content-ids are published to the publishing API.

https://trello.com/c/rmBoBPm9/290-ensure-that-all-content-in-publisher-has-a-content-id