### PR TITLE
Bump govuk_content_models for various fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", '30.0.0'
+  gem "govuk_content_models", '31.0.0'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (30.0.0)
+    govuk_content_models (31.0.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 10.0.0)
@@ -364,7 +364,7 @@ DEPENDENCIES
   govspeak (~> 3.1.0)
   govuk-content-schema-test-helpers (= 1.3.0)
   govuk_admin_template (~> 2.3.1)
-  govuk_content_models (= 30.0.0)
+  govuk_content_models (= 31.0.0)
   has_scope
   inherited_resources
   jasmine (= 2.1.0)

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -1,6 +1,6 @@
 class PublicationsController < InheritedResources::Base
   def show
-    edition = Edition.find_or_create_from_panopticon_data(params[:id], current_user, PANOPTICON_API_CREDENTIALS)
+    edition = Edition.find_or_create_from_panopticon_data(params[:id], current_user)
 
     if edition.persisted?
       redirect_with_return_to(edition) and return


### PR DESCRIPTION
See: https://github.com/alphagov/govuk_content_models/blob/bc152f7c2d1381d685c00cba1014ccf5b6f9e143/CHANGELOG.md

I did look at removing the `PANOPTICON_API_CREDENTIALS` constant, but this is
used by [gds-api-adapters directly](https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/helpers.rb#L57-L63) to authenticate with.