### PR TITLE
Gss codes for business support editions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", '31.0.0'
+  gem "govuk_content_models", '31.1.0'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (31.0.0)
+    govuk_content_models (31.1.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 10.0.0)
@@ -364,7 +364,7 @@ DEPENDENCIES
   govspeak (~> 3.1.0)
   govuk-content-schema-test-helpers (= 1.3.0)
   govuk_admin_template (~> 2.3.1)
-  govuk_content_models (= 31.0.0)
+  govuk_content_models (= 31.1.0)
   has_scope
   inherited_resources
   jasmine (= 2.1.0)

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -204,7 +204,24 @@ class EditionsController < InheritedResources::Base
 
     def coerce_business_support_params
       if (params[:edition][:areas] && !params[:edition][:areas].kind_of?(Array))
-        params[:edition][:areas] = params[:edition][:areas].split(',').map(&:strip)
+        area_slugs = []
+        area_gss_codes = []
+
+        business_support_area_identifier_pairs.each do |area_slug, area_gss_code|
+          area_slugs << area_slug
+          area_gss_codes << area_gss_code
+        end
+
+        params[:edition][:area_gss_codes] = area_gss_codes.compact
+        params[:edition][:areas] = area_slugs.compact
       end
+    end
+
+    def business_support_area_identifier_pairs
+        params[:edition][:areas]
+          .split(',')
+          .map { |slug_and_gss_code|
+            slug_and_gss_code.split(';').map(&:strip)
+          }
     end
 end

--- a/app/views/editions/areas.js.erb
+++ b/app/views/editions/areas.js.erb
@@ -1,3 +1,3 @@
 var areas = <%= raw @areas.map { |a|
-  { id: a.slug, text: a.name, country: a.country_name, type: a.type }
+  { id: "#{a.slug};#{a.codes["gss"]}", text: a.name, country: a.country_name, type: a.type }
 }.to_json %>;

--- a/db/migrate/20150828153331_change_business_support_edition_areas_to_gss_codes.rb
+++ b/db/migrate/20150828153331_change_business_support_edition_areas_to_gss_codes.rb
@@ -1,0 +1,23 @@
+class ChangeBusinessSupportEditionAreasToGssCodes < Mongoid::Migration
+  def self.up
+    # Editing of an edition with an Archived artefact is not allowed
+    Edition.skip_callback(:save, :before, :check_for_archived_artefact)
+
+    BusinessSupportEdition.all.each do |edition|
+      edition.area_gss_codes = Area.areas_for_edition(edition).map { |area|
+        area.codes["gss"]
+      }.compact
+
+      edition.save!(validate: false) # Published editions can't be edited.
+    end
+  end
+
+  def self.down
+    # If this needs rolling back permanently, the area_gss_codes field should
+    # probably just be removed from GOV.UK Content Models.
+
+    BusinessSupportEdition.all.each do |edition|
+      edition.unset(:area_gss_codes)
+    end
+  end
+end

--- a/spec/javascripts/spec/areas_relator.spec.js
+++ b/spec/javascripts/spec/areas_relator.spec.js
@@ -1,12 +1,12 @@
 describe('Areas relator', function() {
   "use strict";
 
-  var form,
+  var $form,
       areasData = []
 
   beforeEach(function() {
 
-    form = $('<form>\
+    $form = $('<form>\
       <div class="related-areas">\
         <input type="checkbox" id="all_regions" class="areas-chkbx"/>\
         <input type="checkbox" id="english_regions" class="areas-chkbx"/>\
@@ -21,71 +21,71 @@ describe('Areas relator', function() {
     ];</script>\
     <script src="/assets/views/business_support/areas_relator.js"></script>');
 
-    form.find('#edition_areas').data('areas', [{"id":"hackney-borough-council;E09000012","text":"Hackney Borough Council"}]);
-    $('body').append(form);
+    $form.find('#edition_areas').data('areas', [{"id":"hackney-borough-council;E09000012","text":"Hackney Borough Council"}]);
+    $('body').append($form);
   });
 
   afterEach(function() {
-    form.remove();
+    $form.remove();
   });
 
   describe('initialising a select2 element', function() {
     it('should add areas data to the select2' , function() {
-      expect(form.find('.select2-choices li').length).toBe(2);
-      expect(form.find('.select2-choices .js-area-name').text()).toEqual("Hackney Borough Council");
+      expect($form.find('.select2-choices li').length).toBe(2);
+      expect($form.find('.select2-choices .js-area-name').text()).toEqual("Hackney Borough Council");
     });
   });
 
   describe('checking the all UK areas checkbox', function() {
     it('should add all areas the target select2 element' , function() {
-      form.find('#all_regions').trigger('click');
-      expect(form.find('.select2-choices li').length).toBe(4);
-      expect(form.find('.select2-choices li:first-child .js-area-name').text()).toEqual("London");
-      expect(form.find('.select2-choices li:nth-child(2) .js-area-name').text()).toEqual("South East");
-      expect(form.find('.select2-choices li:nth-child(3) .js-area-name').text()).toEqual("Scotland");
+      $form.find('#all_regions').trigger('click');
+      expect($form.find('.select2-choices li').length).toBe(4);
+      expect($form.find('.select2-choices li:first-child .js-area-name').text()).toEqual("London");
+      expect($form.find('.select2-choices li:nth-child(2) .js-area-name').text()).toEqual("South East");
+      expect($form.find('.select2-choices li:nth-child(3) .js-area-name').text()).toEqual("Scotland");
     });
   });
 
   describe('checking the english areas checkbox', function() {
     it('should add english areas to the target select2 element' , function() {
-      form.find('#english_regions').trigger('click');
-      expect(form.find('.select2-choices li').length).toBe(3);
-      expect(form.find('.select2-choices li:first-child .js-area-name').text()).toEqual("London");
-      expect(form.find('.select2-choices li:nth-child(2) .js-area-name').text()).toEqual("South East");
+      $form.find('#english_regions').trigger('click');
+      expect($form.find('.select2-choices li').length).toBe(3);
+      expect($form.find('.select2-choices li:first-child .js-area-name').text()).toEqual("London");
+      expect($form.find('.select2-choices li:nth-child(2) .js-area-name').text()).toEqual("South East");
     });
   });
 
   describe('checking english areas when uk areas is checked', function() {
     it('should deselect uk areas' , function() {
-      form.find('#all_regions').prop('checked', true);
-      form.find('#english_regions').trigger('click');
-      expect(form.find('#all_regions').prop('checked')).toBeFalsy();
+      $form.find('#all_regions').prop('checked', true);
+      $form.find('#english_regions').trigger('click');
+      expect($form.find('#all_regions').prop('checked')).toBeFalsy();
     });
   });
 
   describe('checking uk areas when english areas is checked', function() {
     it('should deselect english areas' , function() {
-      form.find('#english_regions').prop('checked', true);
-      form.find('#all_regions').trigger('click');
-      expect(form.find('#english_regions').prop('checked')).toBeFalsy();
+      $form.find('#english_regions').prop('checked', true);
+      $form.find('#all_regions').trigger('click');
+      expect($form.find('#english_regions').prop('checked')).toBeFalsy();
     });
   });
 
   describe('removing an area when uk areas is checked', function() {
     it('should deselect uk areas' , function() {
-      form.find('#all_regions').trigger('click');
-      expect(form.find('#all_regions').prop('checked')).toBeTruthy();
-      form.find('.select2-choices li:first-child .select2-search-choice-close').trigger('click');
-      expect(form.find('#all_regions').prop('checked')).toBeFalsy();
+      $form.find('#all_regions').trigger('click');
+      expect($form.find('#all_regions').prop('checked')).toBeTruthy();
+      $form.find('.select2-choices li:first-child .select2-search-choice-close').trigger('click');
+      expect($form.find('#all_regions').prop('checked')).toBeFalsy();
     });
   });
 
   describe('removing an area when english areas is checked', function() {
     it('should deselect english areas' , function() {
-      form.find('#english_regions').trigger('click');
-      expect(form.find('#english_regions').prop('checked')).toBeTruthy();
-      form.find('.select2-choices li:first-child .select2-search-choice-close').trigger('click');
-      expect(form.find('#english_regions').prop('checked')).toBeFalsy();
+      $form.find('#english_regions').trigger('click');
+      expect($form.find('#english_regions').prop('checked')).toBeTruthy();
+      $form.find('.select2-choices li:first-child .select2-search-choice-close').trigger('click');
+      expect($form.find('#english_regions').prop('checked')).toBeFalsy();
     });
   });
 });

--- a/spec/javascripts/spec/areas_relator.spec.js
+++ b/spec/javascripts/spec/areas_relator.spec.js
@@ -14,14 +14,14 @@ describe('Areas relator', function() {
       </div>\
     </form>\
     <script>var areas = [\
-      {"id":"london","text":"London","type":"EUR","country":"England"},\
-      {"id":"south-east","text":"South East","type":"EUR","country":"England"},\
-      {"id":"hackney-borough-council","text":"Hackney Borough Council","type":"LBO","country":"England"},\
-      {"id":"scotland","text":"Scotland","type":"EUR","country":"Scotland"},\
+      {"id":"london;E15000007","text":"London","type":"EUR","country":"England"},\
+      {"id":"south-east;E15000008","text":"South East","type":"EUR","country":"England"},\
+      {"id":"hackney-borough-council;E09000012","text":"Hackney Borough Council","type":"LBO","country":"England"},\
+      {"id":"scotland;S15000001","text":"Scotland","type":"EUR","country":"Scotland"},\
     ];</script>\
     <script src="/assets/views/business_support/areas_relator.js"></script>');
 
-    form.find('#edition_areas').data('areas', [{"id":"hackney-borough-council","text":"Hackney Borough Council"}]);
+    form.find('#edition_areas').data('areas', [{"id":"hackney-borough-council;E09000012","text":"Hackney Borough Council"}]);
     $('body').append(form);
   });
 

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -225,7 +225,7 @@ class EditionsControllerTest < ActionController::TestCase
       )
 
       update_params = {
-        "areas" => "northern-ireland,yorkshire-and-the-humber",
+        "areas" => "northern-ireland;N07000001,yorkshire-and-the-humber;E15000003",
       }
 
       post :update,
@@ -238,6 +238,11 @@ class EditionsControllerTest < ActionController::TestCase
     should "update area slugs" do
       assert_equal ["northern-ireland", "yorkshire-and-the-humber"],
         @business_support_edition.areas
+    end
+
+    should "update area GSS codes" do
+      assert_equal ["N07000001", "E15000003"],
+        @business_support_edition.area_gss_codes
     end
   end
 

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -215,6 +215,32 @@ class EditionsControllerTest < ActionController::TestCase
     assert_equal ["oil-and-gas/wells"], edition.additional_topics
   end
 
+  context "with Business Support areas" do
+    setup do
+      artefact = FactoryGirl.create(:artefact)
+
+      @business_support_edition = FactoryGirl.create(
+        :business_support_edition,
+        panopticon_id: artefact.id,
+      )
+
+      update_params = {
+        "areas" => "northern-ireland,yorkshire-and-the-humber",
+      }
+
+      post :update,
+        :id => @business_support_edition.id,
+        :edition => update_params
+
+      @business_support_edition.reload
+    end
+
+    should "update area slugs" do
+      assert_equal ["northern-ireland", "yorkshire-and-the-humber"],
+        @business_support_edition.areas
+    end
+  end
+
   test "destroy transaction" do
     assert @transaction.can_destroy?
     assert_difference('TransactionEdition.count', -1) do

--- a/test/imminence_areas_test_helper.rb
+++ b/test/imminence_areas_test_helper.rb
@@ -19,12 +19,18 @@ module ImminenceAreasTestHelper
         name: "London",
         type: "EUR",
         country_name: "England",
+        codes: {
+          "gss" => "E15000007",
+        },
       },
       {
         slug: "scotland",
         name: "Scotland",
         type: "EUR",
         country_name: "Scotland",
+        codes: {
+          "gss" => "S15000001",
+        },
       },
     ]
   end
@@ -35,11 +41,17 @@ module ImminenceAreasTestHelper
         slug: "west-sussex-county-council",
         name: "West Sussex County Council",
         type: "CTY",
+        codes: {
+          "gss" => "E10000032",
+        },
       },
       {
         slug: "devon-county-council",
         name: "Devon County Council",
         type: "CTY",
+        codes: {
+          "gss" => "E10000008",
+        },
       },
     ]
   end
@@ -50,11 +62,17 @@ module ImminenceAreasTestHelper
         slug: "wycombe-district-council",
         name: "Wycombe District Council",
         type: "DIS",
+        codes: {
+          "gss" => "E07000007",
+        },
       },
       {
         slug: "south-bucks-district-council",
         name: "South Bucks District Council",
         type: "DIS",
+        codes: {
+          "gss" => "E07000006",
+        },
       },
     ]
   end
@@ -65,11 +83,17 @@ module ImminenceAreasTestHelper
         slug: "hackney-borough-council",
         name: "Hackney Borough Council",
         type: "LBO",
+        codes: {
+          "gss" => "E09000012",
+        },
       },
       {
         slug: "camden-borough-council",
         name: "Camden Borough Council",
         type: "LBO",
+        codes: {
+          "gss" => "E09000007",
+        },
       },
     ]
   end
@@ -80,11 +104,17 @@ module ImminenceAreasTestHelper
         slug: "derry-city-council",
         name: "Derry City Council",
         type: "LGD",
+        codes: {
+          "gss" => "N09000005",
+        },
       },
       {
         slug: "belfast-city-council",
         name: "Belfast City Council",
         type: "LGD",
+        codes: {
+          "gss" => "N09000003",
+        },
       },
     ]
   end
@@ -95,11 +125,17 @@ module ImminenceAreasTestHelper
         slug: "birmingham-city-council",
         name: "Birmingham City Council",
         type: "MTD",
+        codes: {
+          "gss" => "E08000025",
+        },
       },
       {
         slug: "leeds-city-council",
         name: "Leeds City Council",
         type: "MTD",
+        codes: {
+          "gss" => "E08000035",
+        },
       },
     ]
   end
@@ -110,11 +146,17 @@ module ImminenceAreasTestHelper
         slug: "glasgow-city-council",
         name: "Glasgow City Council",
         type: "UTA",
+        codes: {
+          "gss" => "S12000046",
+        },
       },
       {
         slug: "cardiff-council",
         name: "Cardiff Council",
         type: "UTA",
+        codes: {
+          "gss" => "W06000015",
+        },
       },
     ]
   end

--- a/test/imminence_areas_test_helper.rb
+++ b/test/imminence_areas_test_helper.rb
@@ -13,38 +13,110 @@ module ImminenceAreasTestHelper
   end
 
   def regions
-    [{slug: "london", name: "London", type: "EUR", country_name: "England"},
-     {slug: "scotland", name: "Scotland", type: "EUR", country_name: "Scotland"}]
+    [
+      {
+        slug: "london",
+        name: "London",
+        type: "EUR",
+        country_name: "England",
+      },
+      {
+        slug: "scotland",
+        name: "Scotland",
+        type: "EUR",
+        country_name: "Scotland",
+      },
+    ]
   end
 
   def counties
-    [{slug: "west-sussex-county-council", name: "West Sussex County Council", type: "CTY"},
-    {slug: "devon-county-council", name: "Devon County Council", type: "CTY"}]
+    [
+      {
+        slug: "west-sussex-county-council",
+        name: "West Sussex County Council",
+        type: "CTY",
+      },
+      {
+        slug: "devon-county-council",
+        name: "Devon County Council",
+        type: "CTY",
+      },
+    ]
   end
 
   def districts
-    [{slug: "wycombe-district-council", name: "Wycombe District Council", type: "DIS"},
-    {slug: "south-bucks-district-council", name: "South Bucks District Council", type: "DIS"}]
+    [
+      {
+        slug: "wycombe-district-council",
+        name: "Wycombe District Council",
+        type: "DIS",
+      },
+      {
+        slug: "south-bucks-district-council",
+        name: "South Bucks District Council",
+        type: "DIS",
+      },
+    ]
   end
 
   def london_boroughs
-    [{slug: "hackney-borough-council", name: "Hackney Borough Council", type: "LBO"},
-    {slug: "camden-borough-council", name: "Camden Borough Council", type: "LBO"}]
+    [
+      {
+        slug: "hackney-borough-council",
+        name: "Hackney Borough Council",
+        type: "LBO",
+      },
+      {
+        slug: "camden-borough-council",
+        name: "Camden Borough Council",
+        type: "LBO",
+      },
+    ]
   end
 
   def ni_councils
-    [{slug: "derry-city-council", name: "Derry City Council", type: "LGD"},
-    {slug: "belfast-city-council", name: "Belfast City Council", type: "LGD"}]
+    [
+      {
+        slug: "derry-city-council",
+        name: "Derry City Council",
+        type: "LGD",
+      },
+      {
+        slug: "belfast-city-council",
+        name: "Belfast City Council",
+        type: "LGD",
+      },
+    ]
   end
 
   def metropolitan_councils
-    [{slug: "birmingham-city-council", name: "Birmingham City Council", type: "MTD"},
-    {slug: "leeds-city-council", name: "Leeds City Council", type: "MTD"}]
+    [
+      {
+        slug: "birmingham-city-council",
+        name: "Birmingham City Council",
+        type: "MTD",
+      },
+      {
+        slug: "leeds-city-council",
+        name: "Leeds City Council",
+        type: "MTD",
+      },
+    ]
   end
 
   def unitary_authorities
-    [{slug: "glasgow-city-council", name: "Glasgow City Council", type: "UTA"},
-    {slug: "cardiff-council", name: "Cardiff Council", type: "UTA"}]
+    [
+      {
+        slug: "glasgow-city-council",
+        name: "Glasgow City Council",
+        type: "UTA",
+      },
+      {
+        slug: "cardiff-council",
+        name: "Cardiff Council",
+        type: "UTA",
+      },
+    ]
   end
 
   def stub_mapit_areas_requests(endpoint)


### PR DESCRIPTION
We're working on removing BusinessSupportEdition's dependence on 'area slugs' in favour of referring to areas by their (more stable) GSS codes (http://www.ons.gov.uk/ons/guide-method/geography/products/names--codes-and-look-ups/standard-names-and-codes/index.html).

Since the migration involves multiple applications and gems, we've decided to first add the GSS Codes to the BusinessSupportEditions, then think about removing the current area slugs after.

I've explained the reasoning behind these changes in the commit messages.

Changes of particular interest are in areas.js.erb and the EditionsController. I'm not 100% happy with how using Area slugs and GSS codes side-by-side is being handled, but as a temporary measure, it works and is tested.