### PR TITLE
Bump govuk_admin_template to 3.0.0 for GA fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ else
 end
 
 gem 'erubis'
-gem 'govuk_admin_template', '~> 2.3.1'
+gem 'govuk_admin_template', '3.0.0'
 gem 'select2-rails', '3.5.9.1'
 gem 'jquery-ui-rails', '~> 5.0.3'
 gem 'selectize-rails', '0.12.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,15 +42,15 @@ GEM
       multi_json
     ansi (1.4.3)
     arel (3.0.3)
-    autoprefixer-rails (5.2.0.1)
+    autoprefixer-rails (6.0.3)
       execjs
       json
     bootstrap-kaminari-views (0.0.3)
       kaminari (>= 0.13)
       rails (>= 3.1)
-    bootstrap-sass (3.3.5)
+    bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
-      sass (>= 3.2.19)
+      sass (>= 3.3.0)
     bourne (1.5.0)
       mocha (>= 0.13.2, < 0.15)
     bson (1.7.1)
@@ -77,7 +77,7 @@ GEM
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
-    execjs (2.5.2)
+    execjs (2.6.0)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.5.0)
@@ -115,7 +115,7 @@ GEM
       sanitize (~> 2.1.0)
     govuk-content-schema-test-helpers (1.3.0)
       json-schema (~> 2.5.1)
-    govuk_admin_template (2.3.1)
+    govuk_admin_template (3.0.0)
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
@@ -145,7 +145,7 @@ GEM
       rake
     jasmine-core (2.1.3)
     journey (1.0.4)
-    jquery-rails (3.1.3)
+    jquery-rails (3.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (5.0.5)
@@ -268,7 +268,7 @@ GEM
     safe_yaml (1.0.4)
     sanitize (2.1.0)
       nokogiri (>= 1.4.4)
-    sass (3.4.14)
+    sass (3.4.18)
     sass-rails (3.2.6)
       railties (~> 3.2.0)
       sass (>= 3.1.10)
@@ -363,7 +363,7 @@ DEPENDENCIES
   gds-sso (= 10.0.0)
   govspeak (~> 3.1.0)
   govuk-content-schema-test-helpers (= 1.3.0)
-  govuk_admin_template (~> 2.3.1)
+  govuk_admin_template (= 3.0.0)
   govuk_content_models (= 31.0.0)
   has_scope
   inherited_resources


### PR DESCRIPTION
Trello: https://trello.com/c/1dS5tgTg/125-fix-analytics-in-all-16-admin-tools

Ensures the Analytics domain is set to the 
`GOVUK_APP_DOMAIN` env variable rather than 
being hardcoded.