### PR TITLE
Use <select multiple="multiple"> for "related areas"

### DIFF
--- a/app/assets/javascripts/views/business_support/areas_relator.js
+++ b/app/assets/javascripts/views/business_support/areas_relator.js
@@ -1,52 +1,34 @@
 $(document).ready(function() {
   "use strict";
 
-  var $relatedAreasTextArea = $("#edition_areas"),
+  var $relatedAreasSelect = $("#edition_areas"),
       bindAreasSelection = function (selector, filter) {
         $(selector).change(function () {
           var self = this;
           $('.areas-chkbx').each(function (i,e) {
             if (e !== self) $(e).prop('checked', false);
           });
-          $relatedAreasTextArea.select2("data", []);
+          $relatedAreasSelect.select2("data", []);
           if ($(this).is(':checked')) {
-            $relatedAreasTextArea.select2("data", $.map(areas, filter));
+            $relatedAreasSelect.select2("data", $.map(areas, filter));
           }
         });
       };
 
   // http://ivaynberg.github.io/select2/select-2.1.html
-  $relatedAreasTextArea.select2({
+  $relatedAreasSelect.select2({
     width: "75%",
-    multiple: true,
     placeholder: "Enter first few characters of the area name",
     minimumInputLength: 3,
-    initSelection : function (element, callback) {
-      callback(element.data('areas'));
-    },
     formatSelection : function (object) {
       return $("<span>")
                .addClass("js-area-name")
                .html(object.text)
                .wrap('<p>').parent().html();
     },
-    data : { results : areas, text : 'name' },
-    query : function (query) {
-      var area,
-          data = [],
-          queryRe = new RegExp(query.term, "i"),
-          len = areas.length;
-      for (var idx = 0; idx < len; idx++) {
-        area = areas[idx];
-        if (queryRe.test(area.text)) {
-          data.push(area);
-        }
-      }
-      query.callback({ results: data });
-    }
   });
 
-  $relatedAreasTextArea.on('select2-removed', function () {
+  $relatedAreasSelect.on('select2-removed', function () {
     $('.areas-chkbx').prop('checked', false);
   });
 

--- a/app/assets/javascripts/views/business_support/areas_relator.js
+++ b/app/assets/javascripts/views/business_support/areas_relator.js
@@ -2,18 +2,20 @@ $(document).ready(function() {
   "use strict";
 
   var $relatedAreasSelect = $("#edition_areas"),
-      bindAreasSelection = function (selector, filter) {
-        $(selector).change(function () {
-          var self = this;
-          $('.areas-chkbx').each(function (i,e) {
-            if (e !== self) $(e).prop('checked', false);
-          });
-          $relatedAreasSelect.select2("data", []);
-          if ($(this).is(':checked')) {
-            $relatedAreasSelect.select2("data", $.map(areas, filter));
-          }
-        });
-      };
+      bindAreasSelection;
+
+  bindAreasSelection = function (selector, filter) {
+    $(selector).change(function () {
+      var self = this;
+      $('.areas-chkbx').each(function (i,e) {
+        if (e !== self) $(e).prop('checked', false);
+      });
+      $relatedAreasSelect.select2("data", []);
+      if ($(this).is(':checked')) {
+        $relatedAreasSelect.select2("data", $.map(areas, filter));
+      }
+    });
+  };
 
   // http://ivaynberg.github.io/select2/select-2.1.html
   $relatedAreasSelect.select2({

--- a/app/assets/javascripts/views/business_support/areas_relator.js
+++ b/app/assets/javascripts/views/business_support/areas_relator.js
@@ -2,7 +2,21 @@ $(document).ready(function() {
   "use strict";
 
   var $relatedAreasSelect = $("#edition_areas"),
-      bindAreasSelection;
+      bindAreasSelection,
+      areas;
+
+  areas = function () {
+    return $.map($relatedAreasSelect.find("option"), function (areaOption) {
+      var $areaOption = $(areaOption);
+
+      return {
+        id: $areaOption.val(),
+        text: $areaOption.text(),
+        country: $areaOption.data("country"),
+        type: $areaOption.data("type"),
+      };
+    });
+  };
 
   bindAreasSelection = function (selector, filter) {
     $(selector).change(function () {
@@ -12,7 +26,7 @@ $(document).ready(function() {
       });
       $relatedAreasSelect.select2("data", []);
       if ($(this).is(':checked')) {
-        $relatedAreasSelect.select2("data", $.map(areas, filter));
+        $relatedAreasSelect.select2("data", $.map(areas(), filter));
       }
     });
   };

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -203,8 +203,9 @@ class EditionsController < InheritedResources::Base
     end
 
     def coerce_business_support_params
-      if (params[:edition][:areas] && !params[:edition][:areas].kind_of?(Array))
-        params[:edition][:areas] = params[:edition][:areas].split(',').map(&:strip)
+      if (params[:edition][:areas])
+        params[:edition][:areas] = params[:edition][:areas]
+          .map(&:strip).reject(&:empty?)
       end
     end
 end

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -4,7 +4,7 @@ require "edition_progressor"
 class EditionsController < InheritedResources::Base
   actions :create, :update, :destroy
   defaults :resource_class => Edition, :collection_name => 'editions', :instance_name => 'resource'
-  before_filter :setup_view_paths, :except => [:index, :new, :create, :areas]
+  before_filter :setup_view_paths, :except => [:index, :new, :create]
   after_filter :report_state_counts, :only => [:create, :duplicate, :progress, :destroy]
   before_filter :remove_blank_collections, only: [:create, :update]
 
@@ -134,13 +134,6 @@ class EditionsController < InheritedResources::Base
   def diff
     @resource = resource
     @comparison = @resource.previous_siblings.last
-  end
-
-  def areas
-    @areas = Area.all
-    respond_to do |format|
-      format.js { render :areas }
-    end
   end
 
   protected

--- a/app/helpers/areas_helper.rb
+++ b/app/helpers/areas_helper.rb
@@ -1,7 +1,16 @@
 module AreasHelper
   def edition_areas_select_options(edition)
     options_for_select(
-      Area.all.map { |area| [area.name, area.slug] },
+      Area.all.map { |area|
+        [
+          area.name,
+          area.slug,
+          {
+            "data-country" => area.country_name,
+            "data-type" => area.type,
+          },
+        ]
+      },
       Area.areas_for_edition(edition).map(&:slug),
     )
   end

--- a/app/helpers/areas_helper.rb
+++ b/app/helpers/areas_helper.rb
@@ -1,7 +1,9 @@
 module AreasHelper
-  def edition_areas_json(edition)
-    areas = Area.areas_for_edition(edition)
-    areas.map { |a| { id: a.slug, text: a.name } }.to_json
+  def edition_areas_select_options(edition)
+    options_for_select(
+      Area.all.map { |area| [area.name, area.slug] },
+      Area.areas_for_edition(edition).map(&:slug),
+    )
   end
 
   def all_regions?(edition)

--- a/app/views/business_supports/_areas.html.erb
+++ b/app/views/business_supports/_areas.html.erb
@@ -14,13 +14,16 @@
 
 <div class="related-areas fieldset-section">
   <%= f.label :areas, 'Related areas', class: "add-top-margin control-label" %>
-  <%= f.text_area :areas, size: "75x3",
-        class: "form-control",
-        placeholder: "Fill-in regions, counties and local authorities, " +
-          "separated by a comma. for example: South East, West Sussex, Horsham",
-        disabled: @resource.locked_for_edits?,
-        value: f.object.areas.present? ? f.object.areas.join(", ") : "",
-        data: { areas: edition_areas_json(f.object) } %>
+  <%= f.select :areas,
+    edition_areas_select_options(@resource),
+    {},
+    {
+      multiple: true,
+      class: "form-control",
+      placeholder: "Choose one or more regions, counties and local authorities",
+      disabled: @resource.locked_for_edits?,
+    }
+  %>
 </div>
 <hr/>
 <% content_for :extra_javascript do %>

--- a/app/views/business_supports/_areas.html.erb
+++ b/app/views/business_supports/_areas.html.erb
@@ -27,5 +27,5 @@
 </div>
 <hr/>
 <% content_for :extra_javascript do %>
-  <%= javascript_include_tag "views/business_support/areas_select", "/areas" %>
+  <%= javascript_include_tag "views/business_support/areas_select" %>
 <% end %>

--- a/app/views/editions/areas.js.erb
+++ b/app/views/editions/areas.js.erb
@@ -1,3 +1,0 @@
-var areas = <%= raw @areas.map { |a|
-  { id: a.slug, text: a.name, country: a.country_name, type: a.type }
-}.to_json %>;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,8 +38,6 @@ Publisher::Application.routes.draw do
   get 'reports/organisation-content' => 'reports#organisation_content', :as => :organisation_content_report
   get 'reports/edition-churn' => 'reports#edition_churn', as: "edition_churn_report"
 
-  get 'areas' => 'editions#areas'
-
   match 'user_search' => 'user_search#index'
 
   resources :publications

--- a/spec/javascripts/spec/areas_relator.spec.js
+++ b/spec/javascripts/spec/areas_relator.spec.js
@@ -10,7 +10,12 @@ describe('Areas relator', function() {
       <div class="related-areas">\
         <input type="checkbox" id="all_regions" class="areas-chkbx"/>\
         <input type="checkbox" id="english_regions" class="areas-chkbx"/>\
-        <textarea id="edition_areas">3456</textarea>\
+        <select id="edition_areas" multiple="multiple">\
+          <option value="london">London</option>\
+          <option value="south-east">South East</option>\
+          <option selected="selected" value="hackney-borough-council">Hackney Borough Council</option>\
+          <option value="scotland">Scotland</option>\
+        </select>\
       </div>\
     </form>\
     <script>var areas = [\
@@ -21,7 +26,6 @@ describe('Areas relator', function() {
     ];</script>\
     <script src="/assets/views/business_support/areas_relator.js"></script>');
 
-    form.find('#edition_areas').data('areas', [{"id":"hackney-borough-council","text":"Hackney Borough Council"}]);
     $('body').append(form);
   });
 

--- a/spec/javascripts/spec/areas_relator.spec.js
+++ b/spec/javascripts/spec/areas_relator.spec.js
@@ -11,19 +11,13 @@ describe('Areas relator', function() {
         <input type="checkbox" id="all_regions" class="areas-chkbx"/>\
         <input type="checkbox" id="english_regions" class="areas-chkbx"/>\
         <select id="edition_areas" multiple="multiple">\
-          <option value="london">London</option>\
-          <option value="south-east">South East</option>\
-          <option selected="selected" value="hackney-borough-council">Hackney Borough Council</option>\
-          <option value="scotland">Scotland</option>\
+          <option value="london" data-type="EUR" data-country="England">London</option>\
+          <option value="south-east" data-type="EUR" data-country="England">South East</option>\
+          <option selected="selected" value="hackney-borough-council" data-type="LBO" data-country="England">Hackney Borough Council</option>\
+          <option value="scotland" data-type="EUR" data-country="Scotland">Scotland</option>\
         </select>\
       </div>\
     </form>\
-    <script>var areas = [\
-      {"id":"london","text":"London","type":"EUR","country":"England"},\
-      {"id":"south-east","text":"South East","type":"EUR","country":"England"},\
-      {"id":"hackney-borough-council","text":"Hackney Borough Council","type":"LBO","country":"England"},\
-      {"id":"scotland","text":"Scotland","type":"EUR","country":"Scotland"},\
-    ];</script>\
     <script src="/assets/views/business_support/areas_relator.js"></script>');
 
     $('body').append(form);

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -330,22 +330,4 @@ class EditionsControllerTest < ActionController::TestCase
 
     end
   end
-
-  context "/areas" do
-    setup do
-      stub_request(:get, %r{\A#{IMMINENCE_API_ENDPOINT}/areas/\w+.json}).to_return(
-        :body => { "results" => [] }.to_json
-      )
-    end
-    should "respond with javascript" do
-      get :areas, :format => :js
-
-      assert_response :success
-    end
-    should "not respond to other formats" do
-      get :areas
-
-      assert_response :not_acceptable
-    end
-  end
 end

--- a/test/integration/business_support_create_edit_test.rb
+++ b/test/integration/business_support_create_edit_test.rb
@@ -205,7 +205,9 @@ class BusinessSupportCreateEditTest < JavascriptIntegrationTest
           select2 "Hackney Borough Council", ".related-areas"
           select2 "Camden Borough Council", ".related-areas"
         else
-          fill_in "Related areas", :with => "london, hackney-borough-council, camden-borough-council"
+          select "London", from: "Related areas"
+          select "Hackney Borough Council", from: "Related areas"
+          select "Camden Borough Council", from: "Related areas"
         end
 
         save_edition_and_assert_success

--- a/test/unit/helpers/areas_helper_test.rb
+++ b/test/unit/helpers/areas_helper_test.rb
@@ -3,18 +3,6 @@ require "test_helper"
 class AreasHelperTest < ActionView::TestCase
   include AreasHelper
 
-  def test_edition_areas_json
-    Area.stubs(:areas).returns([
-      Area.new(slug: "london", name: "London"),
-      Area.new(slug: "paris", name: "Paris"),
-      Area.new(slug: "new-york", name: "New York")
-    ])
-
-    edition = OpenStruct.new(areas: ["london","paris"])
-    assert_equal ["London", "Paris"],
-      JSON.parse(edition_areas_json(edition)).map { |a| a["text"] }
-  end
-
   def test_all_regions?
     Area.stubs(:regions).returns([
       Area.new(slug: "london", type: "EUR"),


### PR DESCRIPTION
Editors of Business Support Schemes can specify geographic areas (regions, counties, local authorities) related to a particular scheme.

Until now, this was implemented using a `<textarea>` progressively enhanced with select2. Without JavaScript enabled, an editor would need to enter a comma-separated list of the related areas' slugified names.

Using a "multiple" `<select>` instead doesn't change the JavaScript-on behaviour, but means that a user with no JavaScript can select from a list of area names.