### PR TITLE
Add rake task for fast republishing

### DIFF
--- a/app/workers/publishing_api_notifier.rb
+++ b/app/workers/publishing_api_notifier.rb
@@ -1,20 +1,12 @@
-require "gds_api/publishing_api"
-
 class PublishingAPINotifier
   include Sidekiq::Worker
 
-  def perform(edition_id)
+  def perform(edition_id, update_type = "normal")
     edition = Edition.find(edition_id)
     presenter = PublishedEditionPresenter.new(edition)
-    document_for_publishing_api = presenter.render_for_publishing_api(republish: false)
+    document_for_publishing_api = presenter.render_for_publishing_api(republish: update_type == "republish")
     base_path = document_for_publishing_api[:base_path]
 
-    publishing_api.put_content_item(base_path, document_for_publishing_api)
-  end
-
-private
-
-  def publishing_api
-    @publishing_api ||= GdsApi::PublishingApi.new(Plek.find("publishing-api"))
+    Services.publishing_api.put_content_item(base_path, document_for_publishing_api)
   end
 end

--- a/lib/enhancements/edition.rb
+++ b/lib/enhancements/edition.rb
@@ -56,6 +56,8 @@ class Edition
   end
 
   alias_method :was_published_without_indexing, :was_published
+  # `was_published` is called from the state machine in govuk_content_models
+  # when the edition state changes to `published`
   def was_published
     was_published_without_indexing
     register_with_panopticon

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,0 +1,7 @@
+require "gds_api/publishing_api"
+
+module Services
+  def self.publishing_api
+    @publishing_api ||= GdsApi::PublishingApi.new(Plek.find("publishing-api"))
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,0 +1,11 @@
+namespace :publishing_api do
+  task :republish_content => [:environment] do
+    puts "Scheduling republishing of #{Edition.published.count} editions"
+
+    Edition.published.each do |edition|
+      PublishingAPINotifier.perform_async(edition.id, "republish")
+    end
+
+    puts "Scheduling finished"
+  end
+end


### PR DESCRIPTION
We have added a `content_id` for all artefacts owned by this application in https://github.com/alphagov/panopticon/pull/298

We'd like to send these documents to the content-store, to make sure the new `content_id` is in there as well (for example, https://www.gov.uk/api/content/check-register-rents).

This PR adds a rake task - `rake publishing_api:republish_content` to republish all published editions quickly. 

There's [a rake task named `reregister:all` that does the same but also for panopticon](https://github.com/alphagov/publisher/blob/master/lib/tasks/register.rake#L6). @rboulton and I decided against using that because we don't really know what the effect of the republishing will be on panopticon, and because it is very slow.

Trello: https://trello.com/c/rmBoBPm9/290-ensure-that-all-content-in-publisher-has-a-content-id