### PR TITLE
Fix republishing bug

### DIFF
--- a/lib/republish_content.rb
+++ b/lib/republish_content.rb
@@ -1,7 +1,7 @@
 class RepublishContent
   def self.schedule_republishing
     Edition.published.each do |edition|
-      PublishingAPINotifier.perform_async(edition.id, "republish")
+      PublishingAPINotifier.perform_async(edition.id.to_s, "republish")
     end
   end
 end

--- a/lib/republish_content.rb
+++ b/lib/republish_content.rb
@@ -1,0 +1,7 @@
+class RepublishContent
+  def self.schedule_republishing
+    Edition.published.each do |edition|
+      PublishingAPINotifier.perform_async(edition.id, "republish")
+    end
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -2,9 +2,7 @@ namespace :publishing_api do
   task :republish_content => [:environment] do
     puts "Scheduling republishing of #{Edition.published.count} editions"
 
-    Edition.published.each do |edition|
-      PublishingAPINotifier.perform_async(edition.id, "republish")
-    end
+    RepublishContent.schedule_republishing
 
     puts "Scheduling finished"
   end

--- a/test/unit/republish_content_test.rb
+++ b/test/unit/republish_content_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class RepublishContentTest < ActiveSupport::TestCase
+  should "send all published items to sidekiq" do
+    FactoryGirl.create(:edition, state: 'draft')
+    FactoryGirl.create(:edition, state: 'published')
+
+    Sidekiq::Testing.fake! do
+      RepublishContent.schedule_republishing
+
+      assert_equal 1, PublishingAPINotifier.jobs.size
+    end
+  end
+end

--- a/test/unit/republish_content_test.rb
+++ b/test/unit/republish_content_test.rb
@@ -11,4 +11,13 @@ class RepublishContentTest < ActiveSupport::TestCase
       assert_equal 1, PublishingAPINotifier.jobs.size
     end
   end
+
+  should "does not error when running the sidekiq with the arguments" do
+    request = stub_request(:put, %r[#{Plek.find('publishing-api')}/*])
+    FactoryGirl.create(:edition, state: 'published')
+
+    RepublishContent.schedule_republishing
+
+    assert_requested(request)
+  end
 end


### PR DESCRIPTION
`edition.id` returns a `BSON::ObjectId` object and not a string.

When Sidekiq gets this object as an argument it calls `.to_json` on it and that will crash the `PublishingAPINotifier` because it expects a string with the ID. `BSON::ObjectId#to_s` returns the ID we want.

PR includes a simple test to verify that the `PublishingAPINotifier` can handle whatever arguments we're sending it.

Trello: https://trello.com/c/rmBoBPm9
