### PR TITLE
Rename "east-of-england" area to "eastern"

### DIFF
--- a/db/migrate/20151012154512_rename_east_of_england_area.rb
+++ b/db/migrate/20151012154512_rename_east_of_england_area.rb
@@ -1,0 +1,20 @@
+class RenameEastOfEnglandArea < Mongoid::Migration
+  def self.up
+    # Editing of an edition with an Archived artefact is not allowed
+    Edition.skip_callback(:save, :before, :check_for_archived_artefact)
+
+    BusinessSupportEdition.where(areas: "east-of-england").each do |edition|
+      edition.areas = edition.areas.map { |area_slug|
+        area_slug == "east-of-england" ? "eastern" : area_slug
+      }
+
+      edition.save!(validate: false) # Published editions can't be edited.
+    end
+  end
+
+  def self.down
+    # This was a lossy migration. There were already plenty of
+    # BusinessSupportEditions with the area "eastern", which we now can't
+    # differentiate from our updated fields :)
+  end
+end


### PR DESCRIPTION
Our MapIt doesn't recognise the "east-of-england" area, it has data for the "eastern" area instead.

This migration updates those editions that don't already use the "eastern" area to use it.

Is there a better way of doing this? E.g. a MongoDB update command I should be using and/or a better way to substitute an element in an array?

(This was originally done https://github.com/alphagov/publisher/pull/327, but that didn't update archived editions.)