### PR TITLE
GSS codes for Business Support Editions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", '31.0.0'
+  gem "govuk_content_models", '31.1.0'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (31.0.0)
+    govuk_content_models (31.1.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (>= 10.0.0)
@@ -366,7 +366,7 @@ DEPENDENCIES
   govspeak (~> 3.4.0)
   govuk-content-schema-test-helpers (= 1.3.0)
   govuk_admin_template (= 3.0.0)
-  govuk_content_models (= 31.0.0)
+  govuk_content_models (= 31.1.0)
   has_scope
   inherited_resources
   jasmine (= 2.1.0)

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -197,8 +197,22 @@ class EditionsController < InheritedResources::Base
 
     def coerce_business_support_params
       if (params[:edition][:areas])
-        params[:edition][:areas] = params[:edition][:areas]
-          .map(&:strip).reject(&:empty?)
+        area_slugs = []
+        area_gss_codes = []
+
+        business_support_area_identifier_pairs.each do |area_slug, area_gss_code|
+          area_slugs << area_slug
+          area_gss_codes << area_gss_code
+        end
+
+        params[:edition][:area_gss_codes] = area_gss_codes.compact.reject(&:empty?)
+        params[:edition][:areas] = area_slugs.compact.reject(&:empty?)
       end
+    end
+
+    def business_support_area_identifier_pairs
+      params[:edition][:areas].map { |slug_and_gss_code|
+        slug_and_gss_code.split(';').map(&:strip).reject(&:empty?)
+      }
     end
 end

--- a/app/helpers/areas_helper.rb
+++ b/app/helpers/areas_helper.rb
@@ -4,14 +4,16 @@ module AreasHelper
       Area.all.map { |area|
         [
           area.name,
-          area.slug,
+          "#{area.slug};#{area.codes["gss"]}",
           {
             "data-country" => area.country_name,
             "data-type" => area.type,
           },
         ]
       },
-      Area.areas_for_edition(edition).map(&:slug),
+      Area.areas_for_edition(edition).map { |area|
+        "#{area.slug};#{area.codes["gss"]}"
+      },
     )
   end
 

--- a/db/migrate/20151014153331_change_business_support_edition_areas_to_gss_codes.rb
+++ b/db/migrate/20151014153331_change_business_support_edition_areas_to_gss_codes.rb
@@ -1,0 +1,23 @@
+class ChangeBusinessSupportEditionAreasToGssCodes < Mongoid::Migration
+  def self.up
+    # Editing of an edition with an Archived artefact is not allowed
+    Edition.skip_callback(:save, :before, :check_for_archived_artefact)
+
+    BusinessSupportEdition.all.each do |edition|
+      edition.area_gss_codes = Area.areas_for_edition(edition).map { |area|
+        area.codes["gss"]
+      }.compact
+
+      edition.save!(validate: false) # Published editions can't be edited.
+    end
+  end
+
+  def self.down
+    # If this needs rolling back permanently, the area_gss_codes field should
+    # probably just be removed from GOV.UK Content Models.
+
+    BusinessSupportEdition.all.each do |edition|
+      edition.unset(:area_gss_codes)
+    end
+  end
+end

--- a/spec/javascripts/spec/areas_relator.spec.js
+++ b/spec/javascripts/spec/areas_relator.spec.js
@@ -11,10 +11,10 @@ describe('Areas relator', function() {
         <input type="checkbox" id="all_regions" class="areas-chkbx"/>\
         <input type="checkbox" id="english_regions" class="areas-chkbx"/>\
         <select id="edition_areas" multiple="multiple">\
-          <option value="london" data-type="EUR" data-country="England">London</option>\
-          <option value="south-east" data-type="EUR" data-country="England">South East</option>\
-          <option selected="selected" value="hackney-borough-council" data-type="LBO" data-country="England">Hackney Borough Council</option>\
-          <option value="scotland" data-type="EUR" data-country="Scotland">Scotland</option>\
+          <option value="london;E15000007" data-type="EUR" data-country="England">London</option>\
+          <option value="south-east;E15000008" data-type="EUR" data-country="England">South East</option>\
+          <option selected="selected" value="hackney-borough-council;E09000012" data-type="LBO" data-country="England">Hackney Borough Council</option>\
+          <option value="scotland;S15000001" data-type="EUR" data-country="Scotland">Scotland</option>\
         </select>\
       </div>\
     </form>\

--- a/spec/javascripts/spec/areas_relator.spec.js
+++ b/spec/javascripts/spec/areas_relator.spec.js
@@ -1,12 +1,10 @@
 describe('Areas relator', function() {
   "use strict";
 
-  var form,
-      areasData = []
+  var $form;
 
   beforeEach(function() {
-
-    form = $('<form>\
+    $form = $('<form>\
       <div class="related-areas">\
         <input type="checkbox" id="all_regions" class="areas-chkbx"/>\
         <input type="checkbox" id="english_regions" class="areas-chkbx"/>\
@@ -20,70 +18,70 @@ describe('Areas relator', function() {
     </form>\
     <script src="/assets/views/business_support/areas_relator.js"></script>');
 
-    $('body').append(form);
+    $('body').append($form);
   });
 
   afterEach(function() {
-    form.remove();
+    $form.remove();
   });
 
   describe('initialising a select2 element', function() {
-    it('should add areas data to the select2' , function() {
-      expect(form.find('.select2-choices li').length).toBe(2);
-      expect(form.find('.select2-choices .js-area-name').text()).toEqual("Hackney Borough Council");
+    it('should add areas data to the select2', function() {
+      expect($form.find('.select2-choices li').length).toBe(2);
+      expect($form.find('.select2-choices .js-area-name').text()).toEqual("Hackney Borough Council");
     });
   });
 
   describe('checking the all UK areas checkbox', function() {
-    it('should add all areas the target select2 element' , function() {
-      form.find('#all_regions').trigger('click');
-      expect(form.find('.select2-choices li').length).toBe(4);
-      expect(form.find('.select2-choices li:first-child .js-area-name').text()).toEqual("London");
-      expect(form.find('.select2-choices li:nth-child(2) .js-area-name').text()).toEqual("South East");
-      expect(form.find('.select2-choices li:nth-child(3) .js-area-name').text()).toEqual("Scotland");
+    it('should add all areas the target select2 element', function() {
+      $form.find('#all_regions').trigger('click');
+      expect($form.find('.select2-choices li').length).toBe(4);
+      expect($form.find('.select2-choices li:first-child .js-area-name').text()).toEqual("London");
+      expect($form.find('.select2-choices li:nth-child(2) .js-area-name').text()).toEqual("South East");
+      expect($form.find('.select2-choices li:nth-child(3) .js-area-name').text()).toEqual("Scotland");
     });
   });
 
   describe('checking the english areas checkbox', function() {
-    it('should add english areas to the target select2 element' , function() {
-      form.find('#english_regions').trigger('click');
-      expect(form.find('.select2-choices li').length).toBe(3);
-      expect(form.find('.select2-choices li:first-child .js-area-name').text()).toEqual("London");
-      expect(form.find('.select2-choices li:nth-child(2) .js-area-name').text()).toEqual("South East");
+    it('should add english areas to the target select2 element', function() {
+      $form.find('#english_regions').trigger('click');
+      expect($form.find('.select2-choices li').length).toBe(3);
+      expect($form.find('.select2-choices li:first-child .js-area-name').text()).toEqual("London");
+      expect($form.find('.select2-choices li:nth-child(2) .js-area-name').text()).toEqual("South East");
     });
   });
 
   describe('checking english areas when uk areas is checked', function() {
-    it('should deselect uk areas' , function() {
-      form.find('#all_regions').prop('checked', true);
-      form.find('#english_regions').trigger('click');
-      expect(form.find('#all_regions').prop('checked')).toBeFalsy();
+    it('should deselect uk areas', function() {
+      $form.find('#all_regions').prop('checked', true);
+      $form.find('#english_regions').trigger('click');
+      expect($form.find('#all_regions').prop('checked')).toBeFalsy();
     });
   });
 
   describe('checking uk areas when english areas is checked', function() {
-    it('should deselect english areas' , function() {
-      form.find('#english_regions').prop('checked', true);
-      form.find('#all_regions').trigger('click');
-      expect(form.find('#english_regions').prop('checked')).toBeFalsy();
+    it('should deselect english areas', function() {
+      $form.find('#english_regions').prop('checked', true);
+      $form.find('#all_regions').trigger('click');
+      expect($form.find('#english_regions').prop('checked')).toBeFalsy();
     });
   });
 
   describe('removing an area when uk areas is checked', function() {
-    it('should deselect uk areas' , function() {
-      form.find('#all_regions').trigger('click');
-      expect(form.find('#all_regions').prop('checked')).toBeTruthy();
-      form.find('.select2-choices li:first-child .select2-search-choice-close').trigger('click');
-      expect(form.find('#all_regions').prop('checked')).toBeFalsy();
+    it('should deselect uk areas', function() {
+      $form.find('#all_regions').trigger('click');
+      expect($form.find('#all_regions').prop('checked')).toBeTruthy();
+      $form.find('.select2-choices li:first-child .select2-search-choice-close').trigger('click');
+      expect($form.find('#all_regions').prop('checked')).toBeFalsy();
     });
   });
 
   describe('removing an area when english areas is checked', function() {
-    it('should deselect english areas' , function() {
-      form.find('#english_regions').trigger('click');
-      expect(form.find('#english_regions').prop('checked')).toBeTruthy();
-      form.find('.select2-choices li:first-child .select2-search-choice-close').trigger('click');
-      expect(form.find('#english_regions').prop('checked')).toBeFalsy();
+    it('should deselect english areas', function() {
+      $form.find('#english_regions').trigger('click');
+      expect($form.find('#english_regions').prop('checked')).toBeTruthy();
+      $form.find('.select2-choices li:first-child .select2-search-choice-close').trigger('click');
+      expect($form.find('#english_regions').prop('checked')).toBeFalsy();
     });
   });
 });

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -215,6 +215,33 @@ class EditionsControllerTest < ActionController::TestCase
     assert_equal ["oil-and-gas/wells"], edition.additional_topics
   end
 
+  context "with Business Support areas" do
+    setup do
+      artefact = FactoryGirl.create(:artefact)
+
+      @business_support_edition = FactoryGirl.create(
+        :business_support_edition,
+        panopticon_id: artefact.id,
+      )
+
+      update_params = {
+        # select2 produces an array beginning with an empty string
+        "areas" => ["", "northern-ireland", "yorkshire-and-the-humber"],
+      }
+
+      post :update,
+        :id => @business_support_edition.id,
+        :edition => update_params
+
+      @business_support_edition.reload
+    end
+
+    should "update area slugs" do
+      assert_equal ["northern-ireland", "yorkshire-and-the-humber"],
+        @business_support_edition.areas
+    end
+  end
+
   test "destroy transaction" do
     assert @transaction.can_destroy?
     assert_difference('TransactionEdition.count', -1) do

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -226,7 +226,11 @@ class EditionsControllerTest < ActionController::TestCase
 
       update_params = {
         # select2 produces an array beginning with an empty string
-        "areas" => ["", "northern-ireland", "yorkshire-and-the-humber"],
+        "areas" => [
+          "",
+          "northern-ireland;N07000001",
+          "yorkshire-and-the-humber;E15000003",
+        ],
       }
 
       post :update,
@@ -239,6 +243,11 @@ class EditionsControllerTest < ActionController::TestCase
     should "update area slugs" do
       assert_equal ["northern-ireland", "yorkshire-and-the-humber"],
         @business_support_edition.areas
+    end
+
+    should "update area GSS codes" do
+      assert_equal ["N07000001", "E15000003"],
+        @business_support_edition.area_gss_codes
     end
   end
 

--- a/test/imminence_areas_test_helper.rb
+++ b/test/imminence_areas_test_helper.rb
@@ -19,12 +19,18 @@ module ImminenceAreasTestHelper
         name: "London",
         type: "EUR",
         country_name: "England",
+        codes: {
+          "gss" => "E15000007",
+        },
       },
       {
         slug: "scotland",
         name: "Scotland",
         type: "EUR",
         country_name: "Scotland",
+        codes: {
+          "gss" => "S15000001",
+        },
       },
     ]
   end
@@ -35,11 +41,17 @@ module ImminenceAreasTestHelper
         slug: "west-sussex-county-council",
         name: "West Sussex County Council",
         type: "CTY",
+        codes: {
+          "gss" => "E10000032",
+        },
       },
       {
         slug: "devon-county-council",
         name: "Devon County Council",
         type: "CTY",
+        codes: {
+          "gss" => "E10000008",
+        },
       },
     ]
   end
@@ -50,11 +62,17 @@ module ImminenceAreasTestHelper
         slug: "wycombe-district-council",
         name: "Wycombe District Council",
         type: "DIS",
+        codes: {
+          "gss" => "E07000007",
+        },
       },
       {
         slug: "south-bucks-district-council",
         name: "South Bucks District Council",
         type: "DIS",
+        codes: {
+          "gss" => "E07000006",
+        },
       },
     ]
   end
@@ -65,11 +83,17 @@ module ImminenceAreasTestHelper
         slug: "hackney-borough-council",
         name: "Hackney Borough Council",
         type: "LBO",
+        codes: {
+          "gss" => "E09000012",
+        },
       },
       {
         slug: "camden-borough-council",
         name: "Camden Borough Council",
         type: "LBO",
+        codes: {
+          "gss" => "E09000007",
+        },
       },
     ]
   end
@@ -80,11 +104,17 @@ module ImminenceAreasTestHelper
         slug: "derry-city-council",
         name: "Derry City Council",
         type: "LGD",
+        codes: {
+          "gss" => "N09000005",
+        },
       },
       {
         slug: "belfast-city-council",
         name: "Belfast City Council",
         type: "LGD",
+        codes: {
+          "gss" => "N09000003",
+        },
       },
     ]
   end
@@ -95,11 +125,17 @@ module ImminenceAreasTestHelper
         slug: "birmingham-city-council",
         name: "Birmingham City Council",
         type: "MTD",
+        codes: {
+          "gss" => "E08000025",
+        },
       },
       {
         slug: "leeds-city-council",
         name: "Leeds City Council",
         type: "MTD",
+        codes: {
+          "gss" => "E08000035",
+        },
       },
     ]
   end
@@ -110,11 +146,17 @@ module ImminenceAreasTestHelper
         slug: "glasgow-city-council",
         name: "Glasgow City Council",
         type: "UTA",
+        codes: {
+          "gss" => "S12000046",
+        },
       },
       {
         slug: "cardiff-council",
         name: "Cardiff Council",
         type: "UTA",
+        codes: {
+          "gss" => "W06000015",
+        },
       },
     ]
   end

--- a/test/imminence_areas_test_helper.rb
+++ b/test/imminence_areas_test_helper.rb
@@ -13,38 +13,110 @@ module ImminenceAreasTestHelper
   end
 
   def regions
-    [{slug: "london", name: "London", type: "EUR", country_name: "England"},
-     {slug: "scotland", name: "Scotland", type: "EUR", country_name: "Scotland"}]
+    [
+      {
+        slug: "london",
+        name: "London",
+        type: "EUR",
+        country_name: "England",
+      },
+      {
+        slug: "scotland",
+        name: "Scotland",
+        type: "EUR",
+        country_name: "Scotland",
+      },
+    ]
   end
 
   def counties
-    [{slug: "west-sussex-county-council", name: "West Sussex County Council", type: "CTY"},
-    {slug: "devon-county-council", name: "Devon County Council", type: "CTY"}]
+    [
+      {
+        slug: "west-sussex-county-council",
+        name: "West Sussex County Council",
+        type: "CTY",
+      },
+      {
+        slug: "devon-county-council",
+        name: "Devon County Council",
+        type: "CTY",
+      },
+    ]
   end
 
   def districts
-    [{slug: "wycombe-district-council", name: "Wycombe District Council", type: "DIS"},
-    {slug: "south-bucks-district-council", name: "South Bucks District Council", type: "DIS"}]
+    [
+      {
+        slug: "wycombe-district-council",
+        name: "Wycombe District Council",
+        type: "DIS",
+      },
+      {
+        slug: "south-bucks-district-council",
+        name: "South Bucks District Council",
+        type: "DIS",
+      },
+    ]
   end
 
   def london_boroughs
-    [{slug: "hackney-borough-council", name: "Hackney Borough Council", type: "LBO"},
-    {slug: "camden-borough-council", name: "Camden Borough Council", type: "LBO"}]
+    [
+      {
+        slug: "hackney-borough-council",
+        name: "Hackney Borough Council",
+        type: "LBO",
+      },
+      {
+        slug: "camden-borough-council",
+        name: "Camden Borough Council",
+        type: "LBO",
+      },
+    ]
   end
 
   def ni_councils
-    [{slug: "derry-city-council", name: "Derry City Council", type: "LGD"},
-    {slug: "belfast-city-council", name: "Belfast City Council", type: "LGD"}]
+    [
+      {
+        slug: "derry-city-council",
+        name: "Derry City Council",
+        type: "LGD",
+      },
+      {
+        slug: "belfast-city-council",
+        name: "Belfast City Council",
+        type: "LGD",
+      },
+    ]
   end
 
   def metropolitan_councils
-    [{slug: "birmingham-city-council", name: "Birmingham City Council", type: "MTD"},
-    {slug: "leeds-city-council", name: "Leeds City Council", type: "MTD"}]
+    [
+      {
+        slug: "birmingham-city-council",
+        name: "Birmingham City Council",
+        type: "MTD",
+      },
+      {
+        slug: "leeds-city-council",
+        name: "Leeds City Council",
+        type: "MTD",
+      },
+    ]
   end
 
   def unitary_authorities
-    [{slug: "glasgow-city-council", name: "Glasgow City Council", type: "UTA"},
-    {slug: "cardiff-council", name: "Cardiff Council", type: "UTA"}]
+    [
+      {
+        slug: "glasgow-city-council",
+        name: "Glasgow City Council",
+        type: "UTA",
+      },
+      {
+        slug: "cardiff-council",
+        name: "Cardiff Council",
+        type: "UTA",
+      },
+    ]
   end
 
   def stub_mapit_areas_requests(endpoint)
@@ -57,7 +129,7 @@ module ImminenceAreasTestHelper
     )
     stub_request(:get, %r{\A#{endpoint}/areas/DIS.json}).to_return(
       body: areas_response(districts)
-    ) 
+    )
     stub_request(:get, %r{\A#{endpoint}/areas/LBO.json}).to_return(
       body: areas_response(london_boroughs)
     )

--- a/test/integration/business_support_create_edit_test.rb
+++ b/test/integration/business_support_create_edit_test.rb
@@ -87,6 +87,7 @@ class BusinessSupportCreateEditTest < JavascriptIntegrationTest
           :start_date => @a_year_ago,
           :end_date => @a_year_since,
           :areas => ["london"],
+          :area_gss_codes => ["E15000007"],
           :business_sizes => ["up-to-249"],
           :business_types => ["charity"],
           :purposes => ["world-domination"],

--- a/test/integration/business_support_create_edit_test.rb
+++ b/test/integration/business_support_create_edit_test.rb
@@ -221,6 +221,7 @@ class BusinessSupportCreateEditTest < JavascriptIntegrationTest
 
         @bs.reload
         assert_equal ["london", "hackney-borough-council", "camden-borough-council"], @bs.areas
+        assert_equal ["E15000007", "E09000012", "E09000007"], @bs.area_gss_codes
       end
     end
   end

--- a/test/unit/area_test.rb
+++ b/test/unit/area_test.rb
@@ -30,12 +30,14 @@ class AreaTest < ActiveSupport::TestCase
   end
 
   def test_all
-    assert_equal regions + counties + districts + london_boroughs + ni_councils + 
+    assert_equal regions + counties + districts + london_boroughs + ni_councils +
       metropolitan_councils + unitary_authorities, Area.all.map(&:marshal_dump)
   end
 
   def test_areas_for_edition
-    edition = OpenStruct.new(areas: ["london", "hackney-borough-council"])
+    edition = OpenStruct.new(
+      areas: ["london", "hackney-borough-council"],
+    )
     assert_equal ["London", "Hackney Borough Council"], Area.areas_for_edition(edition).map(&:name)
   end
 

--- a/test/unit/area_test.rb
+++ b/test/unit/area_test.rb
@@ -37,6 +37,7 @@ class AreaTest < ActiveSupport::TestCase
   def test_areas_for_edition
     edition = OpenStruct.new(
       areas: ["london", "hackney-borough-council"],
+      area_gss_codes: ["E15000007", "E09000012"],
     )
     assert_equal ["London", "Hackney Borough Council"], Area.areas_for_edition(edition).map(&:name)
   end

--- a/test/unit/business_support_export_presenter_test.rb
+++ b/test/unit/business_support_export_presenter_test.rb
@@ -7,11 +7,22 @@ class BusinessSupportExportPresenterTest < ActiveSupport::TestCase
   end
 
   should "provide a CSV export of business support schemes" do
-    Area.stubs(:areas_for_edition).returns([
-      Area.new(id: 1234, name: "London"),
-      Area.new(id: 2345, name: "Hackney Borough Council"),
-      Area.new(id: 3456, name: "Camden Borough Council")
-    ])
+    Area.stubs(:areas_for_edition).returns(
+      [
+        Area.new(
+          id: 1234,
+          name: "London",
+        ),
+        Area.new(
+          id: 2345,
+          name: "Hackney Borough Council",
+        ),
+        Area.new(
+          id: 3456,
+          name: "Camden Borough Council",
+        ),
+      ]
+    )
 
     BusinessSupport::BusinessSize.stubs(:all).returns([OpenStruct.new(slug: "up-to-249", name: "Up to 249")])
     BusinessSupport::Location.stubs(:all).returns(

--- a/test/unit/business_support_export_presenter_test.rb
+++ b/test/unit/business_support_export_presenter_test.rb
@@ -12,14 +12,23 @@ class BusinessSupportExportPresenterTest < ActiveSupport::TestCase
         Area.new(
           id: 1234,
           name: "London",
+          codes: {
+            "gss" => "E15000007",
+          },
         ),
         Area.new(
           id: 2345,
           name: "Hackney Borough Council",
+          codes: {
+            "gss" => "E09000012",
+          },
         ),
         Area.new(
           id: 3456,
           name: "Camden Borough Council",
+          codes: {
+            "gss" => "E09000007",
+          },
         ),
       ]
     )

--- a/test/unit/helpers/areas_helper_test.rb
+++ b/test/unit/helpers/areas_helper_test.rb
@@ -11,11 +11,13 @@ class AreasHelperTest < ActionView::TestCase
 
     edition = OpenStruct.new(
       areas: ["london", "north-east"],
+      area_gss_codes: ["E15000007", "E15000001"],
     )
     assert_equal true, all_regions?(edition)
 
     edition = OpenStruct.new(
       areas: ["london", "north-east", "jersey"],
+      area_gss_codes: ["E15000007", "E15000001", "J99999999"],
     )
     assert_equal false, all_regions?(edition)
   end
@@ -28,11 +30,13 @@ class AreasHelperTest < ActionView::TestCase
 
     edition = OpenStruct.new(
       areas: ["yorkshire-and-the-humber"],
+      area_gss_codes: ["E15000003"],
     )
     assert_equal true, english_regions?(edition)
 
     edition = OpenStruct.new(
       areas: ["yorkshire-and-the-humber", "scotland"],
+      area_gss_codes: ["E15000003", "S15000001"],
     )
     assert_equal false, english_regions?(edition)
   end

--- a/test/unit/helpers/areas_helper_test.rb
+++ b/test/unit/helpers/areas_helper_test.rb
@@ -9,9 +9,14 @@ class AreasHelperTest < ActionView::TestCase
       Area.new(slug: "north-east", type: "EUR"),
     ])
 
-    edition = OpenStruct.new(areas: ["london","north-east"])
+    edition = OpenStruct.new(
+      areas: ["london", "north-east"],
+    )
     assert_equal true, all_regions?(edition)
-    edition = OpenStruct.new(areas: ["london","north-east", "jersey"])
+
+    edition = OpenStruct.new(
+      areas: ["london", "north-east", "jersey"],
+    )
     assert_equal false, all_regions?(edition)
   end
 
@@ -21,9 +26,14 @@ class AreasHelperTest < ActionView::TestCase
       Area.new(slug: "scotland", type: "EUR", country_name: "Scotland")
     ])
 
-    edition = OpenStruct.new(areas: ["yorkshire-and-the-humber"])
+    edition = OpenStruct.new(
+      areas: ["yorkshire-and-the-humber"],
+    )
     assert_equal true, english_regions?(edition)
-    edition = OpenStruct.new(areas: ["yorkshire-and-the-humber", "scotland"])
+
+    edition = OpenStruct.new(
+      areas: ["yorkshire-and-the-humber", "scotland"],
+    )
     assert_equal false, english_regions?(edition)
   end
 end

--- a/test/unit/helpers/areas_helper_test.rb
+++ b/test/unit/helpers/areas_helper_test.rb
@@ -4,10 +4,18 @@ class AreasHelperTest < ActionView::TestCase
   include AreasHelper
 
   def test_all_regions?
-    Area.stubs(:regions).returns([
-      Area.new(slug: "london", type: "EUR"),
-      Area.new(slug: "north-east", type: "EUR"),
-    ])
+    Area.stubs(:regions).returns(
+      [
+        Area.new(
+          slug: "london",
+          type: "EUR",
+        ),
+        Area.new(
+          slug: "north-east",
+          type: "EUR",
+        ),
+      ]
+    )
 
     edition = OpenStruct.new(
       areas: ["london", "north-east"],
@@ -23,10 +31,20 @@ class AreasHelperTest < ActionView::TestCase
   end
 
   def test_english_regions?
-    Area.stubs(:regions).returns([
-      Area.new(slug: "yorkshire-and-the-humber", type: "EUR", country_name: "England"),
-      Area.new(slug: "scotland", type: "EUR", country_name: "Scotland")
-    ])
+    Area.stubs(:regions).returns(
+      [
+        Area.new(
+          slug: "yorkshire-and-the-humber",
+          type: "EUR",
+          country_name: "England",
+        ),
+        Area.new(
+          slug: "scotland",
+          type: "EUR",
+          country_name: "Scotland",
+        ),
+      ]
+    )
 
     edition = OpenStruct.new(
       areas: ["yorkshire-and-the-humber"],

--- a/test/unit/helpers/areas_helper_test.rb
+++ b/test/unit/helpers/areas_helper_test.rb
@@ -9,10 +9,16 @@ class AreasHelperTest < ActionView::TestCase
         Area.new(
           slug: "london",
           type: "EUR",
+          codes: {
+            "gss" => "E15000007",
+          },
         ),
         Area.new(
           slug: "north-east",
           type: "EUR",
+          codes: {
+            "gss" => "E15000001",
+          },
         ),
       ]
     )
@@ -37,11 +43,17 @@ class AreasHelperTest < ActionView::TestCase
           slug: "yorkshire-and-the-humber",
           type: "EUR",
           country_name: "England",
+          codes: {
+            "gss" => "E15000003",
+          },
         ),
         Area.new(
           slug: "scotland",
           type: "EUR",
           country_name: "Scotland",
+          codes: {
+            "gss" => "S15000001",
+          },
         ),
       ]
     )

--- a/test/unit/lib/business_support_areas_importer_test.rb
+++ b/test/unit/lib/business_support_areas_importer_test.rb
@@ -40,6 +40,7 @@ EOT
         slug: "dont-update-me",
         state: "published",
         areas: ["london"],
+        area_gss_codes: ["E15000007"],
       )
 
       BusinessSupportEdition.where(slug: "archived-artefact").first.artefact.update_attribute(:state, "archived")

--- a/test/unit/lib/business_support_areas_importer_test.rb
+++ b/test/unit/lib/business_support_areas_importer_test.rb
@@ -22,10 +22,26 @@ investment-escalatorzz,London
 EOT
 
       %w(business-start-up-support international-economic-development-support archived-artefact investment-escalatorzz).each do |slug|
-        FactoryGirl.create(:business_support_edition, slug: slug, state: "published")
+        FactoryGirl.create(
+          :business_support_edition,
+          slug: slug,
+          state: "published",
+        )
       end
-      FactoryGirl.create(:business_support_edition, slug: "archived", state: "archived")
-      FactoryGirl.create(:business_support_edition, slug: "dont-update-me", state: "published", areas: ["london"])
+
+      FactoryGirl.create(
+        :business_support_edition,
+        slug: "archived",
+        state: "archived",
+      )
+
+      FactoryGirl.create(
+        :business_support_edition,
+        slug: "dont-update-me",
+        state: "published",
+        areas: ["london"],
+      )
+
       BusinessSupportEdition.where(slug: "archived-artefact").first.artefact.update_attribute(:state, "archived")
 
       results = OpenStruct.new(results: ["bolton-metropolitan-borough-council", "trafford-metropolitan-borough-council", "london",


### PR DESCRIPTION
We're working on removing BusinessSupportEdition's dependence on 'area slugs' in favour of referring to areas by their (more stable) GSS codes (http://www.ons.gov.uk/ons/guide-method/geography/products/names--codes-and-look-ups/standard-names-and-codes/index.html).

This is the latest in a string of attempts at adding GSS codes to these Editions.

The problems facing the previous attempt (https://github.com/alphagov/publisher/pull/420, reverted https://github.com/alphagov/publisher/pull/422) were mostly that our MapIt data didn't have a GSS code for Northern Ireland, which has now been fixed (https://github.gds/gds/puppet/pull/3545).

The only change between the contents of this and the previous pull request is the updated migration timestamp, since another migration has been introduced in the mean time.

Since the migration to GSS codes involves multiple applications and gems, we've decided to first add the GSS codes to the BusinessSupportEditions, then think about removing the current area slugs after.

I've explained the reasoning behind each change in their commit messages.

Changes of particular interest are in AreasHelper and the EditionsController. I'm not 100% happy with how using Area slugs and GSS codes side-by-side is being handled, but as a temporary measure, it works and is tested.

The story is https://trello.com/c/XsykRbHp/45-publisher-and-business-support-api-should-use-gss-codes.