### PR TITLE
Remove references to Business Support Locations

### DIFF
--- a/app/presenters/business_support_export_presenter.rb
+++ b/app/presenters/business_support_export_presenter.rb
@@ -8,7 +8,7 @@ class BusinessSupportExportPresenter < CSVPresenter
       "eligibility", "evaluation", "additional information", "contact details",
       "max employees", "min value", "max value",
       "continuation link", "will continue on", "start date", "end date",
-      "areas", "business sizes", "locations", "purposes", "sectors",
+      "areas", "business sizes", "purposes", "sectors",
       "stages","support types"
     ]
     scope.each do |scheme|
@@ -20,7 +20,6 @@ class BusinessSupportExportPresenter < CSVPresenter
         scheme.max_value, scheme.continuation_link, scheme.will_continue_on,
         scheme.start_date, scheme.end_date,area_names(scheme),
         facet_names("BusinessSize", scheme.business_sizes),
-        facet_names("Location", scheme.locations),
         facet_names("Purpose", scheme.purposes),
         facet_names("Sector", scheme.sectors),
         facet_names("Stage", scheme.stages),
@@ -34,7 +33,6 @@ class BusinessSupportExportPresenter < CSVPresenter
 
     facet_classes = [
       BusinessSupport::BusinessSize,
-      BusinessSupport::Location,
       BusinessSupport::Purpose,
       BusinessSupport::Sector,
       BusinessSupport::Stage,

--- a/db/seeds/business_support_facets.rb
+++ b/db/seeds/business_support_facets.rb
@@ -22,21 +22,6 @@ find_or_initialize_facets(BusinessSupport::BusinessSize,
                           "between-250-and-500"  => "Between 250 and 500",
                           "between-501-and-1000" => "Between 501 and 1000",
                           "over-1000"            => "Over 1000"})
-# BusinessSupportLocation
-find_or_initialize_facets(BusinessSupport::Location,
-                          { "northern-ireland" => "Northern Ireland",
-                            "england"          => "England",
-                            "london" => "London",
-                            "north-east" => "North East (England)",
-                            "north-west" => "North West (England)",
-                            "east-midlands" => "East Midlands (England)",
-                            "west-midlands" => "West Midlands (England)",
-                            "yorkshire-and-the-humber" => "Yorkshire and the Humber",
-                            "south-west" => "South West (England)",
-                            "east-of-england" => "East of England",
-                            "south-east" => "South East (England)",
-                            "wales"            => "Wales",
-                            "scotland"         => "Scotland"})
 
 # BusinessSupportSector
 find_or_initialize_facets(BusinessSupport::Sector,

--- a/test/unit/business_support_export_presenter_test.rb
+++ b/test/unit/business_support_export_presenter_test.rb
@@ -34,8 +34,6 @@ class BusinessSupportExportPresenterTest < ActiveSupport::TestCase
     )
 
     BusinessSupport::BusinessSize.stubs(:all).returns([OpenStruct.new(slug: "up-to-249", name: "Up to 249")])
-    BusinessSupport::Location.stubs(:all).returns(
-      ["London", "South East", "World"].map { |f| OpenStruct.new(slug: f.parameterize, name: f) })
     BusinessSupport::Purpose.stubs(:all).returns(
       ["Business growth and expansion", "Setting up your business", "World Domination"].map { |f| OpenStruct.new(slug: f.parameterize, name: f) })
     BusinessSupport::Sector.stubs(:all).returns([OpenStruct.new(slug: "manufacturing", name: "Manufacturing")])
@@ -58,7 +56,6 @@ class BusinessSupportExportPresenterTest < ActiveSupport::TestCase
                        :continuation_link => "http://www.capitalise.org/business_start.htm", :will_continue_on => "the Capitalise Business Support website",
                        :areas => ["1234","2345","3456"],
                        :business_sizes => ["up-to-249"],
-                       :locations => ["london", "south-east"],
                        :purposes => ["business-growth-and-expansion", "setting-up-your-business"],
                        :sectors => ["manufacturing"],
                        :stages => ["start-up", "grow-and-sustain"],
@@ -91,7 +88,6 @@ class BusinessSupportExportPresenterTest < ActiveSupport::TestCase
     assert_equal 1.year.since(Date.today).to_s, data[0]["end date"]
     assert_equal "London, Hackney Borough Council, Camden Borough Council", data[0]["areas"]
     assert_equal "Up to 249", data[0]["business sizes"]
-    assert_equal "London, South East", data[0]["locations"]
     assert_equal "Business growth and expansion, Setting up your business", data[0]["purposes"]
     assert_equal "Manufacturing", data[0]["sectors"]
     assert_equal "Start-up, Grow and sustain", data[0]["stages"]


### PR DESCRIPTION
The ability to edit a Business Support Scheme's `locations` seems to've been
removed in https://github.com/alphagov/publisher/pull/212, when it was replaced
with Imminence `areas`. (Since Imminence areas are more easily searchable by
postcode.)

The only place this was still being used was the
BusinessSupportExportPresenter, which is used to produce the Business Support
Schemes CSV report (served at https://publisher.publishing.service.gov.uk/reports/business_support_schemes_content).