### PR TITLE
Fix sorting of GSS codes for regions for business support editions

### DIFF
--- a/app/helpers/areas_helper.rb
+++ b/app/helpers/areas_helper.rb
@@ -20,12 +20,12 @@ module AreasHelper
   def all_regions?(edition)
     Area.regions.map { |area|
       area.codes["gss"]
-    }.sort.compact == edition.area_gss_codes.sort
+    }.compact.sort == edition.area_gss_codes.sort
   end
 
   def english_regions?(edition)
     Area.english_regions.map { |area|
       area.codes["gss"]
-    }.sort.compact == edition.area_gss_codes.sort
+    }.compact.sort == edition.area_gss_codes.sort
   end
 end


### PR DESCRIPTION
Imminence still returns a [fake 'England' region](https://github.com/alphagov/imminence/blob/1295ff3c5b6caeb2a16f24d34165c369b237ef03/lib/mapit_api.rb#L48-L50), which doesn't have a GSS
code. That means that there will be a `nil` in an array of GSS codes for all
areas returned from Imminence, which needs to be removed by `compact` before
the array can be sorted; otherwise we get `ArgumentError: comparison of
NilClass with String failed`.