### PR TITLE
Exclude areas without GSS codes

### DIFF
--- a/app/helpers/areas_helper.rb
+++ b/app/helpers/areas_helper.rb
@@ -20,12 +20,12 @@ module AreasHelper
   def all_regions?(edition)
     Area.regions.map { |area|
       area.codes["gss"]
-    }.sort.compact == edition.area_gss_codes.sort
+    }.sort == edition.area_gss_codes.sort
   end
 
   def english_regions?(edition)
     Area.english_regions.map { |area|
       area.codes["gss"]
-    }.sort.compact == edition.area_gss_codes.sort
+    }.sort == edition.area_gss_codes.sort
   end
 end

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -28,7 +28,7 @@ class Area < OpenStruct
   private
 
     def self.areas
-      @areas ||= all_areas
+      @areas ||= areas_with_gss_codes
     end
 
     def self.all_areas
@@ -39,5 +39,9 @@ class Area < OpenStruct
         end
       end
       areas.flatten
+    end
+
+    def self.areas_with_gss_codes
+      self.all_areas.select { |a| a.codes["gss"].present? }
     end
 end

--- a/test/imminence_areas_test_helper.rb
+++ b/test/imminence_areas_test_helper.rb
@@ -12,7 +12,7 @@ module ImminenceAreasTestHelper
     }.to_json
   end
 
-  def regions
+  def regions_with_gss_codes
     [
       {
         slug: "london",
@@ -33,6 +33,18 @@ module ImminenceAreasTestHelper
         },
       },
     ]
+  end
+
+  def region_without_gss_code
+    {
+      slug: "england",
+      name: "England",
+      type: "EUR",
+      country_name: "England",
+      codes: {
+        "gss" => nil,
+      }
+    }
   end
 
   def counties
@@ -164,7 +176,7 @@ module ImminenceAreasTestHelper
   def stub_mapit_areas_requests(endpoint)
 
     stub_request(:get, %r{\A#{endpoint}/areas/EUR.json}).to_return(
-      body: areas_response(regions)
+      body: areas_response(regions_with_gss_codes.unshift(region_without_gss_code))
     )
     stub_request(:get, %r{\A#{endpoint}/areas/CTY.json}).to_return(
       body: areas_response(counties)

--- a/test/unit/area_test.rb
+++ b/test/unit/area_test.rb
@@ -29,14 +29,16 @@ class AreaTest < ActiveSupport::TestCase
     assert_equal ['EUR','CTY','DIS','LBO', 'LGD', 'MTD', 'UTA'], Area::AREA_TYPES
   end
 
-  def test_all
-    assert_equal (regions_with_gss_codes + counties + districts + london_boroughs +
-        ni_councils + metropolitan_councils + unitary_authorities),
-      Area.all.map(&:marshal_dump)
-  end
+  context ".all" do
+    should "return areas of all types" do
+      assert_equal (regions_with_gss_codes + counties + districts + london_boroughs +
+          ni_councils + metropolitan_councils + unitary_authorities),
+        Area.all.map(&:marshal_dump)
+    end
 
-  def test_all_excludes_areas_without_gss_code
-    assert Area.all.map(&:marshal_dump).exclude?(region_without_gss_code)
+    should "exclude areas without GSS codes" do
+      assert Area.all.map(&:marshal_dump).exclude?(region_without_gss_code)
+    end
   end
 
   context ".areas_for_edition" do

--- a/test/unit/area_test.rb
+++ b/test/unit/area_test.rb
@@ -30,8 +30,13 @@ class AreaTest < ActiveSupport::TestCase
   end
 
   def test_all
-    assert_equal regions + counties + districts + london_boroughs + ni_councils +
-      metropolitan_councils + unitary_authorities, Area.all.map(&:marshal_dump)
+    assert_equal (regions_with_gss_codes + counties + districts + london_boroughs +
+        ni_councils + metropolitan_councils + unitary_authorities),
+      Area.all.map(&:marshal_dump)
+  end
+
+  def test_all_excludes_areas_without_gss_code
+    assert Area.all.map(&:marshal_dump).exclude?(region_without_gss_code)
   end
 
   context ".areas_for_edition" do


### PR DESCRIPTION
At the moment on master visiting the edit page for any business support edition [errors with `ArgumentError: comparison of NilClass with String failed`](https://errbit.preview.alphagov.co.uk/apps/5304e0470da1152df9000004/problems/563b6a1d65786306a12e0500), which is caused by trying to sort an array of GSS codes which contains a `nil` as well as strings. This was introduced by https://github.com/alphagov/publisher/commit/86b5a5ee2a82a71bbe4c4d253c28987fb219b8ec.

The `nil` is for a [fake `England` region](https://github.com/alphagov/imminence/blob/1295ff3c5b6caeb2a16f24d34165c369b237ef03/lib/mapit_api.rb#L48-L50) which Imminence adds to the regions returned by MapIt, and no GSS code is included in that region's data. That region already doesn't work as intended (it isn't in MapIt so it's never returned to the business support API for a postcode lookup, so is never used to find schemes via the content API even if some were tagged with it) so we should remove it. In the meantime we should handle it safely here.

This PR supercedes https://github.com/alphagov/publisher/pull/430 and follows suggestions from @benilovj and @jamiecobbett.