### PR TITLE
Use Rails form helper for conversion form

### DIFF
--- a/app/helpers/editions_helper.rb
+++ b/app/helpers/editions_helper.rb
@@ -36,6 +36,11 @@ module EditionsHelper
     end
   end
 
+  def conversion_classes_for_select(edition)
+    conversion_classes = Edition.conversion_classes - [edition.class.to_s.gsub("Edition", " Edition")]
+    conversion_classes.map{|class_name| [class_name, class_name.gsub(" ", "")]}
+  end
+
   def ordered_pages(unordered)
     options = browse_options_for_select(unordered)
     prioritise_data_container(options, @resource.browse_pages)

--- a/app/views/shared/_admin.html.erb
+++ b/app/views/shared/_admin.html.erb
@@ -17,7 +17,7 @@
     locals: {
       edition: @edition,
       edition_class: @edition.class,
-      to_classes: Edition.edition_types
+      to_classes: Edition.conversion_classes
     }
 %>
 

--- a/app/views/shared/_clone_buttons.html.erb
+++ b/app/views/shared/_clone_buttons.html.erb
@@ -5,13 +5,12 @@
     <p>All parts of Guide Editions and Programme Editions will be copied across. If the format you are converting to doesn't have parts, the content of all the parts will be copied into the body, with the part title displayed as a top-level sub-heading. </p>
   <% end %>
   </div>
-  <form method="post" action="<%= duplicate_edition_path(@resource, from: edition_class.to_s)%>" >
-    <div class="form-group">
-    <%= label_tag :to, "Create as new" %>
-    <%= select_tag :to, options_for_select(to_classes.map { |c| [c.model_name.titleize, c.to_s] }.sort!), class: "form-control input-md-3"%>
-    </div>
-    <input type="submit" value="Change format" class="btn btn-default">
-    <br>
-    <br>
-  </form>
+
+  <%= form_for @resource, url: duplicate_edition_path(@resource, from: edition_class.to_s), method: "post" do |f| %>
+    <%= f.label :to, "Create as new" %>
+    <%= select_tag :to, options_for_select(conversion_classes_for_select(@resource)), class: "form-control input-md-3 add-bottom-margin"%>
+    <%= f.submit "Change format", class: "btn btn-default" %>
+  <% end %>
+
 <% end %>
+

--- a/lib/enhancements/edition.rb
+++ b/lib/enhancements/edition.rb
@@ -88,7 +88,9 @@ class Edition
     PublishingAPINotifier.perform_async(self.id.to_s)
   end
 
-  def self.edition_types
-    subclasses - [LocalTransactionEdition]
+  def self.conversion_classes
+    classes = Artefact::FORMATS_BY_DEFAULT_OWNING_APP["publisher"] - ["local_transaction"]
+    classes.map{|c| (c + "_edition").titleize }
   end
+
 end

--- a/test/integration/change_edition_type_test.rb
+++ b/test/integration/change_edition_type_test.rb
@@ -2,7 +2,6 @@ require 'integration_test_helper'
 require 'imminence_areas_test_helper'
 
 class ChangeEditionTypeTest < JavascriptIntegrationTest
-  include ActiveSupport::Inflector
   include ImminenceAreasTestHelper
 
   setup do
@@ -18,10 +17,6 @@ class ChangeEditionTypeTest < JavascriptIntegrationTest
     GDS::SSO.test_user = nil
   end
 
-  def self.class_to_symbol(class_name)
-    ActiveSupport::Inflector::underscore(class_name)
-  end
-
   def select_target_edition(format)
     select(format.to_s.gsub("_", " ").titleize.gsub(/Edition.*/, 'Edition'), from: 'to')
   end
@@ -30,7 +25,7 @@ class ChangeEditionTypeTest < JavascriptIntegrationTest
     Set.new(edition.parts.map { |part| part.attributes.slice("title", "body", "slug") })
   end
 
-  edition_types = Edition.edition_types.map{ |edition_type| class_to_symbol(edition_type).to_sym}
+  edition_types = Edition.conversion_classes.map{ |edition_type| edition_type.parameterize('_').to_sym}
 
   sample_parts = Set.new([
     {


### PR DESCRIPTION
This will allow the authentication token to be passed through and
therefore fix the form.

Instead of Edition.subclasses, I am now using the list of formats provided in govuk_content_models, so that all formats are available and loaded when needed by the select tag in the view.

cc @benilovj 

[Trello](https://trello.com/c/7fEwgEVS/144-un-withdraw-guidance-document-small)