### PR TITLE
Use Rails form helper for conversion form

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -44,11 +44,12 @@ class EditionsController < InheritedResources::Base
 
   def duplicate
     command = EditionDuplicator.new(resource, current_user)
+    target_edition_class_name = (params[:to] + "_edition").classify if params[:to]
 
     if !resource.can_create_new_edition?
       flash[:warning] = 'Another person has created a newer edition'
       redirect_to edition_path(resource)
-    elsif command.duplicate(params[:to], new_assignee)
+    elsif command.duplicate(target_edition_class_name, new_assignee)
       return_to = params[:return_to] || edition_path(command.new_edition)
       flash[:success] = 'New edition created'
       redirect_to return_to

--- a/app/helpers/editions_helper.rb
+++ b/app/helpers/editions_helper.rb
@@ -36,6 +36,11 @@ module EditionsHelper
     end
   end
 
+  def format_conversion_select_options(edition)
+    possible_target_formats = Edition.convertible_formats - [edition.artefact.kind]
+    possible_target_formats.map{|format_name| [format_name.humanize, format_name]}
+  end
+
   def ordered_pages(unordered)
     options = browse_options_for_select(unordered)
     prioritise_data_container(options, @resource.browse_pages)

--- a/app/views/shared/_admin.html.erb
+++ b/app/views/shared/_admin.html.erb
@@ -17,7 +17,6 @@
     locals: {
       edition: @edition,
       edition_class: @edition.class,
-      to_classes: Edition.edition_types
     }
 %>
 

--- a/app/views/shared/_clone_buttons.html.erb
+++ b/app/views/shared/_clone_buttons.html.erb
@@ -5,13 +5,12 @@
     <p>All parts of Guide Editions and Programme Editions will be copied across. If the format you are converting to doesn't have parts, the content of all the parts will be copied into the body, with the part title displayed as a top-level sub-heading. </p>
   <% end %>
   </div>
-  <form method="post" action="<%= duplicate_edition_path(@resource, from: edition_class.to_s)%>" >
-    <div class="form-group">
-    <%= label_tag :to, "Create as new" %>
-    <%= select_tag :to, options_for_select(to_classes.map { |c| [c.model_name.titleize, c.to_s] }.sort!), class: "form-control input-md-3"%>
-    </div>
-    <input type="submit" value="Change format" class="btn btn-default">
-    <br>
-    <br>
-  </form>
+
+  <%= form_for @resource, url: duplicate_edition_path(@resource, from: edition_class.to_s), method: "post" do |f| %>
+    <%= f.label :to, "Create as new" %>
+    <%= select_tag :to, options_for_select(format_conversion_select_options(@resource)), class: "form-control input-md-3 add-bottom-margin"%>
+    <%= f.submit "Change format", class: "btn btn-default" %>
+  <% end %>
+
 <% end %>
+

--- a/lib/enhancements/edition.rb
+++ b/lib/enhancements/edition.rb
@@ -88,7 +88,8 @@ class Edition
     PublishingAPINotifier.perform_async(self.id.to_s)
   end
 
-  def self.edition_types
-    subclasses - [LocalTransactionEdition]
+  def self.convertible_formats
+    Artefact::FORMATS_BY_DEFAULT_OWNING_APP["publisher"] - ["local_transaction"]
   end
+
 end


### PR DESCRIPTION
This will allow the authentication token to be passed through and
therefore fix the form.

Instead of Edition.subclasses, I am now using the list of formats provided in govuk_content_models, so that all formats are available and loaded when needed by the select tag in the view.

cc @benilovj

[Trello](https://trello.com/c/p7wzEHo0/79-self-serve-changing-a-format-to-any-format-in-mainstream-publisher-medium)