### PR TITLE
Add rake task for detecting "ghost" interactions

### DIFF
--- a/lib/local_authority_interaction_ghost_detector.rb
+++ b/lib/local_authority_interaction_ghost_detector.rb
@@ -8,7 +8,7 @@ class LocalAuthorityInteractionGhostDetector
 
   def detect_ghosts
     local_authorities.each do |la|
-      la.local_interactions.each do |lai|
+      la.local_interactions.to_a.each do |lai|
         yield la, lai, ghost_status(la, lai)
       end
     end

--- a/lib/local_authority_interaction_ghost_detector.rb
+++ b/lib/local_authority_interaction_ghost_detector.rb
@@ -1,0 +1,56 @@
+class LocalAuthorityInteractionGhostDetector
+
+  attr_reader :input_data
+
+  def initialize(input_data)
+    @input_data = input_data
+  end
+
+  def detect_ghosts
+    local_authorities.each do |la|
+      la.local_interactions.each do |lai|
+        yield la, lai, ghost_status(la, lai)
+      end
+    end
+  end
+
+private
+  def ghost_status(authority, interaction)
+    if directgov_interactions.key? authority.snac.to_s
+      interactions = directgov_interactions[authority.snac.to_s]
+      interaction_key = [interaction.lgsl_code.to_s, interaction.lgil_code.to_s]
+      if interactions.key? interaction_key
+        if interactions[interaction_key].upcase == 'X'
+          :interaction_in_input_to_be_deleted
+        else
+          :interaction_in_input
+        end
+      else
+        :interaction_not_in_input
+      end
+    else
+      :authority_not_in_input
+    end
+  end
+
+  def local_authorities
+    @_local_authorities ||= LocalAuthority.all.to_a
+  end
+
+  def directgov_interactions
+    @_directgov_interactions ||= prepare_directgov_interactions
+  end
+
+  def prepare_directgov_interactions
+    # CSV Headers: "Authority Name,SNAC,LAid,Service Name,LGSL,LGIL,Service URL,Last Updated"
+    CSV.new(input_data, headers: true).
+      reject { |row| row['SNAC'].nil? || row['SNAC'].strip.blank? }.
+      each.
+      with_object({}) do |row, result|
+        snac = row['SNAC'].to_s
+        result[snac] ||= {}
+        interaction_key = [row['LGSL'].to_s, row['LGIL'].to_s]
+        result[snac][interaction_key] = row['Service URL'].to_s.strip
+      end
+  end
+end

--- a/lib/local_authority_interaction_ghost_detector.rb
+++ b/lib/local_authority_interaction_ghost_detector.rb
@@ -4,6 +4,7 @@ class LocalAuthorityInteractionGhostDetector
 
   def initialize(input_data)
     @input_data = input_data
+    @interaction_count = 0
   end
 
   def detect_ghosts
@@ -12,6 +13,18 @@ class LocalAuthorityInteractionGhostDetector
         yield la, lai, ghost_status(la, lai)
       end
     end
+  end
+
+  def directgov_interactions_count
+    @_directgov_interactions_count ||= calculate_directgov_interaction_count
+  end
+
+  def local_authorities
+    @_local_authorities ||= LocalAuthority.all.to_a
+  end
+
+  def directgov_interactions
+    @_directgov_interactions ||= prepare_directgov_interactions
   end
 
 private
@@ -33,12 +46,8 @@ private
     end
   end
 
-  def local_authorities
-    @_local_authorities ||= LocalAuthority.all.to_a
-  end
-
-  def directgov_interactions
-    @_directgov_interactions ||= prepare_directgov_interactions
+  def calculate_directgov_interaction_count
+    directgov_interactions.inject(0) { |sum, (_snac, interactions)| sum + interactions.size }
   end
 
   def prepare_directgov_interactions

--- a/lib/tasks/check-for-ghosts.rake
+++ b/lib/tasks/check-for-ghosts.rake
@@ -1,0 +1,37 @@
+require 'local_authority_interaction_ghost_detector'
+
+namespace :check_for_ghosts do
+  desc "Compare local authority interactions in our DB against the local.directgov CSV export to detect \"ghosts\"."
+  task :run => :environment do
+    File.open(Rails.root.join('local_authority_service_details.csv'), 'r:windows-1252:UTF-8') do |input|
+      detector = LocalAuthorityInteractionGhostDetector.new(input)
+
+      output_filename = Rails.root.join("ghosts_in_local_authority_interactions_#{Time.zone.today.iso8601}.csv")
+      CSV.open(output_filename, 'w') do |output|
+        output.puts ['LA Name', 'LA SNAC', 'LGSL', 'LGIL', 'URL']
+
+        current_la = nil
+        total_count = ghosts_count = current_ghost_count = 0
+
+        detector.detect_ghosts do |la, lai, ghost_status|
+          if current_la != la
+            if current_la.present?
+              puts " - #{current_ghost_count} ghosts"
+            end
+            print "#{la.name} (#{la.snac}): #{la.local_interactions.count} interactions"
+            current_la = la
+            current_ghost_count = 0
+          end
+          total_count += 1
+          if ghost_status != :interaction_in_input
+            output.puts [la.name, la.snac, lai.lgsl_code, lai.lgil_code, lai.url]
+            ghosts_count += 1
+            current_ghost_count += 1
+          end
+        end
+        puts " - #{current_ghost_count} ghosts"
+        puts "Total Interactions: #{total_count}, Total Ghosts: #{ghosts_count}"
+      end
+    end
+  end
+end

--- a/lib/tasks/check-for-ghosts.rake
+++ b/lib/tasks/check-for-ghosts.rake
@@ -69,18 +69,23 @@ namespace :check_for_ghosts do
       total_count = destroyed_count = ghosts_count = 0
       output_filename = with_output_file 'removed_ghosts_in_local_authority_interactions' do |output|
         to_keep = []
+        to_remove = []
         iterate_over_interactions(
           on_new_authority: ->(current_la, new_la) do
             if current_la.present?
               current_la.local_interactions.substitute(to_keep)
+              to_remove.each do |(lai, ghost_status)|
+                output.puts [current_la.name, current_la.snac, lai.lgsl_code, lai.lgil_code, lai.url, ghost_status]
+              end
             end
             to_keep = []
+            to_remove = []
           end
         ) do |la, lai, ghost_status|
           total_count += 1
           ghosts_count +=1 if ghost_status != :interaction_in_input
           if statuses_to_remove.include? ghost_status
-            output.puts [la.name, la.snac, lai.lgsl_code, lai.lgil_code, lai.url, ghost_status]
+            to_remove << [lai, ghost_status]
             destroyed_count += 1
           else
             to_keep << lai

--- a/lib/tasks/check-for-ghosts.rake
+++ b/lib/tasks/check-for-ghosts.rake
@@ -50,8 +50,8 @@ namespace :check_for_ghosts do
     puts "Total Interactions: #{total_count}, Total Ghosts: #{ghosts_count}, Data: #{output_filename}"
   end
 
-  desc "Destroy any local authority interactions that appear in our DB but not in the local.directgov CSV export."
-  task :destroy, [] => :environment do |_task, args|
+  desc "Remove any local authority interactions that appear in our DB but not in the local.directgov CSV export."
+  task :remove, [] => :environment do |_task, args|
     interaction_limit =
       if ENV['INTERACTION_LIMIT']
         Integer(ENV['INTERACTION_LIMIT'])
@@ -66,7 +66,7 @@ namespace :check_for_ghosts do
         [:interaction_not_in_input]
       end
     if statuses_to_remove.empty?
-      puts "Usage: `rake check_for_ghosts:destroy` or `rake check_for_ghosts:destroy[statues_to_remove]`"
+      puts "Usage: `rake check_for_ghosts:remove` or `rake check_for_ghosts:remove[statuses_to_remove]`"
       puts "  If statuses_to_remove is omitted only interaction_not_in_input ghosts will be removed."
       puts "  If statuses_to_remove is provideded statuses not in #{possible_statuses.inspect} will be ignored."
     else
@@ -76,7 +76,7 @@ namespace :check_for_ghosts do
       else
         puts "More than #{interaction_limit} interactions in directgov data (found #{detector.directgov_interactions_count}) - proceeeding."
         puts "Removing ghost interactions with statuses: #{statuses_to_remove.inspect}"
-        total_count = destroyed_count = ghosts_count = 0
+        total_count = removed_count = ghosts_count = 0
         output_filename = with_output_file 'removed_ghosts_in_local_authority_interactions' do |output|
           to_keep = []
           to_remove = []
@@ -96,14 +96,14 @@ namespace :check_for_ghosts do
             ghosts_count +=1 if ghost_status != :interaction_in_input
             if statuses_to_remove.include? ghost_status
               to_remove << [lai, ghost_status]
-              destroyed_count += 1
+              removed_count += 1
             else
               to_keep << lai
             end
-            print "\rT: #{total_count} / G: #{ghosts_count} / D: #{destroyed_count}"
+            print "\rT: #{total_count} / G: #{ghosts_count} / R: #{removed_count}"
           end
         end
-        puts "\rTotal Interactions: #{total_count}, Total Ghosts: #{ghosts_count}, Total Destroyed: #{destroyed_count}, Data: #{output_filename}"
+        puts "\rTotal Interactions: #{total_count}, Total Ghosts: #{ghosts_count}, Total Removed: #{removed_count}, Data: #{output_filename}"
       end
     end
   end

--- a/lib/tasks/check-for-ghosts.rake
+++ b/lib/tasks/check-for-ghosts.rake
@@ -1,37 +1,38 @@
+require 'local_authority_data_importer'
+require 'local_interaction_importer'
 require 'local_authority_interaction_ghost_detector'
 
 namespace :check_for_ghosts do
   desc "Compare local authority interactions in our DB against the local.directgov CSV export to detect \"ghosts\"."
   task :run => :environment do
-    File.open(Rails.root.join('local_authority_service_details.csv'), 'r:windows-1252:UTF-8') do |input|
-      detector = LocalAuthorityInteractionGhostDetector.new(input)
+    input = LocalInteractionImporter.fetch_data()
+    detector = LocalAuthorityInteractionGhostDetector.new(input)
 
-      output_filename = Rails.root.join("ghosts_in_local_authority_interactions_#{Time.zone.today.iso8601}.csv")
-      CSV.open(output_filename, 'w') do |output|
-        output.puts ['LA Name', 'LA SNAC', 'LGSL', 'LGIL', 'URL']
+    output_filename = Rails.root.join("ghosts_in_local_authority_interactions_#{Time.zone.today.iso8601}.csv")
+    CSV.open(output_filename, 'w') do |output|
+      output.puts ['LA Name', 'LA SNAC', 'LGSL', 'LGIL', 'URL', 'status']
 
-        current_la = nil
-        total_count = ghosts_count = current_ghost_count = 0
+      current_la = nil
+      total_count = ghosts_count = current_ghost_count = 0
 
-        detector.detect_ghosts do |la, lai, ghost_status|
-          if current_la != la
-            if current_la.present?
-              puts " - #{current_ghost_count} ghosts"
-            end
-            print "#{la.name} (#{la.snac}): #{la.local_interactions.count} interactions"
-            current_la = la
-            current_ghost_count = 0
+      detector.detect_ghosts do |la, lai, ghost_status|
+        if current_la != la
+          if current_la.present?
+            puts " - #{current_ghost_count} ghosts"
           end
-          total_count += 1
-          if ghost_status != :interaction_in_input
-            output.puts [la.name, la.snac, lai.lgsl_code, lai.lgil_code, lai.url]
-            ghosts_count += 1
-            current_ghost_count += 1
-          end
+          print "#{la.name} (#{la.snac}): #{la.local_interactions.count} interactions"
+          current_la = la
+          current_ghost_count = 0
         end
-        puts " - #{current_ghost_count} ghosts"
-        puts "Total Interactions: #{total_count}, Total Ghosts: #{ghosts_count}"
+        total_count += 1
+        if ghost_status != :interaction_in_input
+          output.puts [la.name, la.snac, lai.lgsl_code, lai.lgil_code, lai.url, ghost_status]
+          ghosts_count += 1
+          current_ghost_count += 1
+        end
       end
+      puts " - #{current_ghost_count} ghosts"
+      puts "Total Interactions: #{total_count}, Total Ghosts: #{ghosts_count}, Data: #{output_filename}"
     end
   end
 end

--- a/lib/tasks/check-for-ghosts.rake
+++ b/lib/tasks/check-for-ghosts.rake
@@ -8,24 +8,38 @@ namespace :check_for_ghosts do
     LocalAuthorityInteractionGhostDetector.new(input)
   end
 
-  desc "Compare local authority interactions in our DB against the local.directgov CSV export to detect \"ghosts\"."
-  task :run => :environment do
-    output_filename = Rails.root.join("ghosts_in_local_authority_interactions_#{Time.zone.today.iso8601}.csv")
+  def with_output_file(name)
+    output_filename = Rails.root.join("#{name}_#{Time.zone.today.iso8601}.csv")
     CSV.open(output_filename, 'w') do |output|
       output.puts ['LA Name', 'LA SNAC', 'LGSL', 'LGIL', 'URL', 'status']
+      yield output
+    end
+    output_filename
+  end
 
-      current_la = nil
-      total_count = ghosts_count = current_ghost_count = 0
+  def iterate_over_interactions(on_new_authority: nil, &interaction_block)
+    current_la = nil
+    detector.detect_ghosts do |la, lai, ghost_status|
+      if current_la != la
+        on_new_authority.call(current_la, la) unless on_new_authority.nil?
+        current_la = la
+      end
+      interaction_block.call(la, lai, ghost_status)
+    end
+    on_new_authority.call(current_la, nil) unless on_new_authority.nil?
+  end
 
-      detector.detect_ghosts do |la, lai, ghost_status|
-        if current_la != la
-          if current_la.present?
-            puts " - #{current_ghost_count} ghosts"
-          end
-          print "#{la.name} (#{la.snac}): #{la.local_interactions.count} interactions"
-          current_la = la
+  desc "Compare local authority interactions in our DB against the local.directgov CSV export to detect \"ghosts\"."
+  task :run => :environment do
+    total_count = ghosts_count = current_ghost_count = 0
+    output_filename = with_output_file 'ghosts_in_local_authority_interactions' do |output|
+      iterate_over_interactions(
+        on_new_authority: ->(current_la, new_la) do
+          puts " - #{current_ghost_count} ghosts" if current_la.present?
+          print "#{new_la.name} (#{new_la.snac}): #{new_la.local_interactions.count} interactions" if new_la.present?
           current_ghost_count = 0
         end
+      ) do |la, lai, ghost_status|
         total_count += 1
         if ghost_status != :interaction_in_input
           output.puts [la.name, la.snac, lai.lgsl_code, lai.lgil_code, lai.url, ghost_status]
@@ -33,9 +47,8 @@ namespace :check_for_ghosts do
           current_ghost_count += 1
         end
       end
-      puts " - #{current_ghost_count} ghosts"
-      puts "Total Interactions: #{total_count}, Total Ghosts: #{ghosts_count}, Data: #{output_filename}"
     end
+    puts "Total Interactions: #{total_count}, Total Ghosts: #{ghosts_count}, Data: #{output_filename}"
   end
 
   desc "Destroy any local authority interactions that appear in our DB but not in the local.directgov CSV export."
@@ -53,39 +66,29 @@ namespace :check_for_ghosts do
       puts "  If statuses_to_remove is provideded statuses not in #{possible_statuses.inspect} will be ignored."
     else
       puts "Removing ghost interactions with statuses: #{statuses_to_remove.inspect}"
-      output_filename = Rails.root.join("removed_ghosts_in_local_authority_interactions_#{Time.zone.today.iso8601}.csv")
-      CSV.open(output_filename, 'w') do |output|
-        output.puts ['LA Name', 'LA SNAC', 'LGSL', 'LGIL', 'URL', 'status']
-        total_count = destroyed_count = ghosts_count = 0
-        current_la = nil
+      total_count = destroyed_count = ghosts_count = 0
+      output_filename = with_output_file 'removed_ghosts_in_local_authority_interactions' do |output|
         to_keep = []
-        detector.detect_ghosts do |la, lai, ghost_status|
-          if la != current_la
+        iterate_over_interactions(
+          on_new_authority: ->(current_la, new_la) do
             if current_la.present?
               current_la.local_interactions.substitute(to_keep)
             end
             to_keep = []
-            current_la = la
           end
+        ) do |la, lai, ghost_status|
           total_count += 1
-          if ghost_status != :interaction_in_input
-            ghosts_count +=1
-            if statuses_to_remove.include? ghost_status
-              output.puts [la.name,la.snac,lai.lgsl_code,lai.lgil_code,lai.url, ghost_status]
-              destroyed_count += 1
-            else
-              to_keep << lai
-            end
+          ghosts_count +=1 if ghost_status != :interaction_in_input
+          if statuses_to_remove.include? ghost_status
+            output.puts [la.name, la.snac, lai.lgsl_code, lai.lgil_code, lai.url, ghost_status]
+            destroyed_count += 1
           else
             to_keep << lai
           end
           print "\rT: #{total_count} / G: #{ghosts_count} / D: #{destroyed_count}"
         end
-        puts "\rTotal Interactions: #{total_count}, Total Ghosts: #{ghosts_count}, Total Destroyed: #{destroyed_count}, Data: #{output_filename}"
-        if current_la.present?
-          current_la.local_interactions.substitute(to_keep)
-        end
       end
+      puts "\rTotal Interactions: #{total_count}, Total Ghosts: #{ghosts_count}, Total Destroyed: #{destroyed_count}, Data: #{output_filename}"
     end
   end
 end

--- a/lib/tasks/check-for-ghosts.rake
+++ b/lib/tasks/check-for-ghosts.rake
@@ -3,11 +3,13 @@ require 'local_interaction_importer'
 require 'local_authority_interaction_ghost_detector'
 
 namespace :check_for_ghosts do
+  def detector
+    input = LocalInteractionImporter.fetch_data()
+    LocalAuthorityInteractionGhostDetector.new(input)
+  end
+
   desc "Compare local authority interactions in our DB against the local.directgov CSV export to detect \"ghosts\"."
   task :run => :environment do
-    input = LocalInteractionImporter.fetch_data()
-    detector = LocalAuthorityInteractionGhostDetector.new(input)
-
     output_filename = Rails.root.join("ghosts_in_local_authority_interactions_#{Time.zone.today.iso8601}.csv")
     CSV.open(output_filename, 'w') do |output|
       output.puts ['LA Name', 'LA SNAC', 'LGSL', 'LGIL', 'URL', 'status']
@@ -33,6 +35,42 @@ namespace :check_for_ghosts do
       end
       puts " - #{current_ghost_count} ghosts"
       puts "Total Interactions: #{total_count}, Total Ghosts: #{ghosts_count}, Data: #{output_filename}"
+    end
+  end
+
+  desc "Destroy any local authority interactions that appear in our DB but not in the local.directgov CSV export."
+  task :destroy, [] => :environment do |_task, args|
+    possible_statuses = [:interaction_in_input_to_be_deleted, :interaction_not_in_input, :authority_not_in_input]
+    statuses_to_remove =
+      if args.extras.any?
+        args.extras.map { |x| x.to_sym }.select { |x| possible_statuses.include? x }
+      else
+        [:interaction_not_in_input]
+      end
+    if statuses_to_remove.empty?
+      puts "Usage: `rake check_for_ghosts:destroy` or `rake check_for_ghosts:destroy[statues_to_remove]`"
+      puts "  If statuses_to_remove is omitted only interaction_not_in_input ghosts will be removed."
+      puts "  If statuses_to_remove is provideded statuses not in #{possible_statuses.inspect} will be ignored."
+    else
+      puts "Removing ghost interactions with statuses: #{statuses_to_remove.inspect}"
+      output_filename = Rails.root.join("removed_ghosts_in_local_authority_interactions_#{Time.zone.today.iso8601}.csv")
+      CSV.open(output_filename, 'w') do |output|
+        output.puts ['LA Name', 'LA SNAC', 'LGSL', 'LGIL', 'URL', 'status']
+        total_count = destroyed_count = ghosts_count = 0
+        detector.detect_ghosts do |la, lai, ghost_status|
+          total_count += 1
+          if ghost_status != :interaction_in_input
+            ghosts_count +=1
+            if statuses_to_remove.include? ghost_status
+              lai.destroy
+              output.puts [la.name,la.snac,lai.lgsl_code,lai.lgil_code,lai.url, ghost_status]
+              destroyed_count += 1
+            end
+          end
+          print "\rT: #{total_count} / G: #{ghosts_count} / D: #{destroyed_count}"
+        end
+        puts "\rTotal Interactions: #{total_count}, Total Ghosts: #{ghosts_count}, Total Destroyed: #{destroyed_count}, Data: #{output_filename}"
+      end
     end
   end
 end

--- a/test/unit/lib/local_authority_interaction_ghost_detector_test.rb
+++ b/test/unit/lib/local_authority_interaction_ghost_detector_test.rb
@@ -1,0 +1,97 @@
+require_relative '../../test_helper'
+
+class LocalAuthorityInteractionGhostDetectorTest < ActiveSupport::TestCase
+
+  context "detecting ghosts" do
+    setup do
+      data = "Authority Name,SNAC,LAid,Service Name,LGSL,LGIL,Service URL,Last Updated\n"
+      data += "Happyland Council,1234,5678,Finding Joy,901,234,http://happyland-council.example.com/901/234,\n"
+      data += "Happyland Council,1234,5678,Finding Joy,901,235,X,\n"
+      @input = StringIO.new(data)
+    end
+
+    context 'snac not present in input' do
+      setup do
+        @la = LocalAuthority.create(snac: '2345', name: 'Sadland Council', local_directgov_id: '6790', tier: 'district')
+        @lai = @la.local_interactions.create(lgsl_code: '901', lgil_code: '234', url: 'http://example.com/hats')
+      end
+
+      should 'detect status as authority_not_in_input' do
+        collected = []
+        LocalAuthorityInteractionGhostDetector.new(@input).detect_ghosts do |la, lai, ghost_status|
+          collected << [la, lai, ghost_status]
+        end
+
+        assert_equal 1, collected.size
+        detected = collected.first
+        assert_equal @la, detected[0]
+        assert_equal @lai, detected[1]
+        assert_equal :authority_not_in_input, detected[2]
+      end
+    end
+
+    context 'snac present, but lsgl / lgil combination not present' do
+      setup do
+        @la = LocalAuthority.create(snac: '1234', name: 'Happyland Council', local_directgov_id: '5679', tier: 'district')
+        @lai = @la.local_interactions.create(lgsl_code: '902', lgil_code: '234', url: 'http://example.com/hats')
+      end
+
+      should 'detect a interaction as interaction_not_in_input if snac present, but lgsl/lgil combination not present in input' do
+        collected = []
+        LocalAuthorityInteractionGhostDetector.new(@input).detect_ghosts do |la, lai, ghost_status|
+          collected << [la, lai, ghost_status]
+        end
+
+        assert_equal 1, collected.size
+        detected = collected.first
+        assert_equal @la, detected[0]
+        assert_equal @lai, detected[1]
+        assert_equal :interaction_not_in_input, detected[2]
+      end
+    end
+
+    context 'snac / lsgl / lgil combination present' do
+      context 'with full url' do
+        setup do
+          @la = LocalAuthority.create(snac: '1234', name: 'Happyland Council', local_directgov_id: '5679', tier: 'district')
+          @lai = @la.local_interactions.create(lgsl_code: '901', lgil_code: '234', url: 'http://example.com/hats')
+        end
+
+        should 'detect a interaction as interaction_in_input' do
+          collected = []
+          LocalAuthorityInteractionGhostDetector.new(@input).detect_ghosts do |la, lai, ghost_status|
+            collected << [la, lai, ghost_status]
+          end
+
+          assert_equal 1, collected.size
+          detected = collected.first
+          assert_equal @la, detected[0]
+          assert_equal @lai, detected[1]
+          assert_equal :interaction_in_input, detected[2]
+        end
+      end
+
+      context 'with "X" url' do
+        setup do
+          @la = LocalAuthority.create(snac: '1234', name: 'Happyland Council', local_directgov_id: '5679', tier: 'district')
+          @lai = @la.local_interactions.create(lgsl_code: '901', lgil_code: '235', url: 'http://example.com/hats')
+        end
+
+        should 'detect a interaction as interaction_in_input' do
+          collected = []
+
+          LocalAuthorityInteractionGhostDetector.new(@input).detect_ghosts do |la, lai, ghost_status|
+            collected << [la, lai, ghost_status]
+          end
+
+          assert_equal 1, collected.size
+          detected = collected.first
+          assert_equal @la, detected[0]
+          assert_equal @lai, detected[1]
+          assert_equal :interaction_in_input_to_be_deleted, detected[2]
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
The CSV of interactions from local.directgov includes a complete list of all interactions in their database.  Those that have been deleted are marked with an "X" instead of a URL.  Our importer handles this to add/remove/update our DB so it mirrors this file.  However, we've noticed lots of "ghost" interactions where we have a record of an interaction that does not appear in the CSV file.  This shouldn't happen, but it does.  While we get to the root of the problem this rake task allows us to generate a CSV of all interactions that are in our DB but not in the CSV.

We iterate over all the local interactions stored against all the local authorities in our DB and so-doing we can detect 3 types of ghost:

 * interaction_in_input_to_be_deleted - any interaction that still lives in our DB but is listed as an "X" in the CSV.  Assumption here is that we simply haven't run the importer yet and it will be cleared on next import.
 * interaction_not_in_input - an interaction in our DB where the authority exists in the CSV but the interaction does not
 * authority_not_in_input - an interaction in our DB where the authority does not exist in the CSV