### PR TITLE
Created new rake task to import local transactions and remove ghosts

### DIFF
--- a/lib/tasks/check-for-ghosts.rake
+++ b/lib/tasks/check-for-ghosts.rake
@@ -68,11 +68,13 @@ namespace :check_for_ghosts do
     if statuses_to_remove.empty?
       puts "Usage: `rake check_for_ghosts:remove` or `rake check_for_ghosts:remove[statuses_to_remove]`"
       puts "  If statuses_to_remove is omitted only interaction_not_in_input ghosts will be removed."
-      puts "  If statuses_to_remove is provideded statuses not in #{possible_statuses.inspect} will be ignored."
+      puts "  If statuses_to_remove is provided statuses not in #{possible_statuses.inspect} will be ignored."
+      abort "There are no statuses to remove. Check that the arguments passed to this task are appropriate."
     else
       if detector.directgov_interactions_count < interaction_limit
-        puts "WARNING! Less than #{interaction_limit} interactions in directgov data (found #{detector.directgov_interactions_count}) - halting run!"
-        puts "Specify a different limit via environment variable INTERACTION_LIMIT if you want to run anyway."
+        exit_text = "WARNING! Less than #{interaction_limit} interactions in directgov data (found #{detector.directgov_interactions_count}) - halting run!\n"
+        exit_text += "Specify a different limit via environment variable INTERACTION_LIMIT if you want to run anyway."
+        abort exit_text
       else
         puts "More than #{interaction_limit} interactions in directgov data (found #{detector.directgov_interactions_count}) - proceeeding."
         puts "Removing ghost interactions with statuses: #{statuses_to_remove.inspect}"

--- a/lib/tasks/local_transactions.rake
+++ b/lib/tasks/local_transactions.rake
@@ -5,6 +5,12 @@ namespace :local_transactions do
     LocalAuthorityDataImporter.update_all
   end
 
+  desc "Download and import services, interactions and contacts, and subsequently remove 'ghost' interactions"
+  task :fetch_and_clean => :environment do
+    Rake::Task["local_transactions:fetch"].invoke
+    Rake::Task["check_for_ghosts:remove"].invoke
+  end
+
   desc "Dowload the latest contact list CSV from Local Directgov and import"
   task :update_contacts => :environment do
     LocalContactImporter.update


### PR DESCRIPTION
The current process to import local transactions from [http://local.direct.gov.uk/Data/](http://local.direct.gov.uk/Data/local_authority_service_details.csv) does not check to see if existing entries in our database have been removed from the CSV.  This has resulted in a number of "ghost" entries which could still be visible in GOV.UK.

I have added the `local_transactions:fetch_and_clean` task to perform the import as before, but then
subsequently run the `check_for_ghosts:remove` task to do the clean up.

The `check_for_ghosts:remove` task also now aborts if it fails checks.  This is to ensure that a run failure results in a non-zero return code that will be picked up in the monitoring software.

@jennyd has changed `schedule.rb` in deployment to call the new rake task.

https://trello.com/c/bIG472Xz/233-automate-removal-of-ghost-local-interactions