### PR TITLE
Import Home page URL from local contact csv

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", '~> 32.1'
+  gem "govuk_content_models", '~> 32.2'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
       bootstrap-sass (= 3.3.5)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (32.1.0)
+    govuk_content_models (32.2.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (~> 11.2)
@@ -377,7 +377,7 @@ DEPENDENCIES
   govspeak (~> 3.4.0)
   govuk-content-schema-test-helpers (= 1.3.0)
   govuk_admin_template (= 4.0.1)
-  govuk_content_models (~> 32.1)
+  govuk_content_models (~> 32.2)
   has_scope
   inherited_resources
   jasmine (= 2.1.0)

--- a/lib/local_contact_importer.rb
+++ b/lib/local_contact_importer.rb
@@ -17,18 +17,24 @@ class LocalContactImporter < LocalAuthorityDataImporter
     authority.name = decode_broken_entities( row['Name'] )
     authority.contact_address = parse_address(row)
     authority.contact_phone = decode_broken_entities( row['Telephone Number 1'] )
-    url = row['Contact page URL']
-    unless url.blank? || url.start_with?("http://") || url.start_with?("https://")
-      url = "http://" + url
-    end
-    authority.contact_url = url
+    authority.contact_url = parse_url( row['Contact page URL'] )
     authority.contact_email = row['Main Contact Email']
+    authority.homepage_url = parse_url( row['Home page URL'] )
     authority.save!
   end
 
   def parse_address(row)
     [row['Address Line 1'], row['Address Line 2'], row['Town'], row['City'], row['County'], row['Postcode']].reject(&:blank?)
   end
+
+  def parse_url(url)
+    if url.blank? || url.start_with?("http://") || url.start_with?("https://")
+      url
+    else
+      "http://" + url
+    end
+  end
+
 
   # The CSV contains some broken HTML entities (e.g. &#40) note the missing ;
   # This will decode any printable ascii characters, and leave any others unchanged.


### PR DESCRIPTION
This is part two of https://trello.com/c/td7NzjPG/261-use-local-authority-home-page-url-when-we-don-t-have-a-matching-transaction

There is a PR on frontend that uses this newly imported attribute in the "we matched your postcode to an LA but don't have a service endpoint for it" case (see: https://github.com/alphagov/frontend/pull/914).