### PR TITLE
Discard publishing api draft when artefact is destroyed...

### DIFF
--- a/lib/enhancements/artefact.rb
+++ b/lib/enhancements/artefact.rb
@@ -1,0 +1,11 @@
+require "artefact"
+
+class Artefact
+  before_destroy :discard_publishing_api_draft
+
+private
+
+  def discard_publishing_api_draft
+    Services.publishing_api.discard_draft(self.content_id)
+  end
+end

--- a/test/integration/delete_edition_test.rb
+++ b/test/integration/delete_edition_test.rb
@@ -1,0 +1,39 @@
+require 'integration_test_helper'
+
+class DeleteEditionTest < ActionDispatch::IntegrationTest
+
+  setup do
+    content_id = SecureRandom.uuid
+    @artefact = FactoryGirl.create(:artefact,
+      slug: "i-dont-want-this",
+      content_id: content_id,
+      kind: "guide",
+      name: "Foo bar",
+      owning_app: "publisher",
+    )
+
+    @edition = FactoryGirl.create(:guide_edition, panopticon_id: @artefact.id)
+
+    setup_users
+    stub_collections
+  end
+
+
+  teardown do
+    GDS::SSO.test_user = nil
+  end
+
+  test "deleting a draft edition discards the draft in the publishing api" do
+    visit "/editions/#{@edition.id}"
+
+    click_on "Admin"
+
+    Services.publishing_api.expects(:discard_draft).with(@artefact.content_id)
+
+    click_button "Delete this edition – #1"
+
+    within(".alert-success") do
+      assert page.has_content?("Guide destroyed")
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/5SKdEz0Q/609-publisher-discard-draft-for-unpublished-editions

In the event of an artefact being destroyed the publishing-api needs to
be notified to discard the draft content item as the artefact slug may
be used again, eg. to draft a different type of edition.
The artefact would have a different content_id from the publishing api as the draft is not currently removed.
The above scenario had happened in production and had to be remedied with a data fix so this PR attempts to ensure drafts are discarded in these cases in future.