### PR TITLE
Use Plek to find Mapit

### DIFF
--- a/config/initializers/mapit.rb
+++ b/config/initializers/mapit.rb
@@ -1,1 +1,1 @@
-MAPIT_BASE_URL = 'http://mapit.preview.alphagov.co.uk/'
+MAPIT_BASE_URL = "#{Plek.current.find('mapit')}/"


### PR DESCRIPTION
This will make the app use the environment specific Mapit meaning that we don't have to override this file in alphagov-deployment.

It will also change Publisher so that it uses Mapit over HTTPS rather than HTTP.