### PR TITLE
Allow Isles of Scilly in tags

### DIFF
--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -5,9 +5,11 @@ class Area < OpenStruct
   extend GdsApi::Helpers
 
   # This list should stay in sync with Business Support API's
-  # WHITELISTED_AREA_CODES list:
-  # (https://github.com/alphagov/business-support-api/blob/master/app/models/scheme.rb#L8-L10).
-  AREA_TYPES = ["EUR", "CTY", "DIS", "LBO", "LGD", "MTD", "UTA"]
+  # Scheme::WHITELISTED_AREA_CODES list:
+  # https://github.com/alphagov/business-support-api/blob/master/app/models/scheme.rb#L16-L18
+  # and Imminence's areas route constraint:
+  # https://github.com/alphagov/imminence/blob/master/config/routes.rb#L13-L17
+  AREA_TYPES = ["EUR", "CTY", "DIS", "LBO", "LGD", "MTD", "UTA", "COI"]
 
   def self.all
     areas

--- a/test/imminence_areas_test_helper.rb
+++ b/test/imminence_areas_test_helper.rb
@@ -173,6 +173,19 @@ module ImminenceAreasTestHelper
     ]
   end
 
+  def isles_of_scilly
+    [
+      {
+        slug: "isles-of-scilly",
+        name: "Isles of Scilly",
+        type: "COI",
+        codes: {
+          "gss" => "E06000053",
+        },
+      },
+    ]
+  end
+
   def stub_mapit_areas_requests(endpoint)
 
     stub_request(:get, %r{\A#{endpoint}/areas/EUR.json}).to_return(
@@ -195,6 +208,9 @@ module ImminenceAreasTestHelper
     )
     stub_request(:get, %r{\A#{endpoint}/areas/UTA.json}).to_return(
       body: areas_response(unitary_authorities)
+    )
+    stub_request(:get, %r{\A#{endpoint}/areas/COI.json}).to_return(
+      body: areas_response(isles_of_scilly)
     )
   end
 end

--- a/test/unit/area_test.rb
+++ b/test/unit/area_test.rb
@@ -23,16 +23,17 @@ class AreaTest < ActiveSupport::TestCase
     assert_requested :get, %r{\A#{IMMINENCE_API_ENDPOINT}/areas/LGD.json}, times: 1
     assert_requested :get, %r{\A#{IMMINENCE_API_ENDPOINT}/areas/MTD.json}, times: 1
     assert_requested :get, %r{\A#{IMMINENCE_API_ENDPOINT}/areas/UTA.json}, times: 1
+    assert_requested :get, %r{\A#{IMMINENCE_API_ENDPOINT}/areas/COI.json}, times: 1
   end
 
   def test_area_types
-    assert_equal ['EUR','CTY','DIS','LBO', 'LGD', 'MTD', 'UTA'], Area::AREA_TYPES
+    assert_equal ['EUR','CTY','DIS','LBO', 'LGD', 'MTD', 'UTA', 'COI'], Area::AREA_TYPES
   end
 
   context ".all" do
     should "return areas of all types" do
       assert_equal (regions_with_gss_codes + counties + districts + london_boroughs +
-          ni_councils + metropolitan_councils + unitary_authorities),
+          ni_councils + metropolitan_councils + unitary_authorities + isles_of_scilly),
         Area.all.map(&:marshal_dump)
     end
 


### PR DESCRIPTION
They have their own special area type in mapit (COI) so we have to add
it to the list.  Also we update the comment pointing out the other
places that this list needs to be synchronized with.

For: https://trello.com/c/BI5QN49V/308-add-isles-of-scilly-council-to-the-related-areas-tag-available-in-publisher-imminence-3

This doesn't live on it's own, it will not work unless we also merge / deploy: 

* https://github.com/alphagov/imminence/pull/126
* https://github.com/alphagov/business-support-api/pull/34
