### PR TITLE
Exclude local transaction import "ghost" csvs from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ test/reports
 data/local_interactions.csv
 config/initializers/dev_*.rb
 reports/*
+
+# Local transactions import reports
+removed_ghosts*.csv
+ghosts*.csv


### PR DESCRIPTION
The following rake tasks generate CSV reports which git doesn't need to know
 about:
 - rake check_for_ghosts:remove
 - rake check_for_ghosts:run
 - rake local_transactions:fetch_and_clean