### PR TITLE
Fix settings after Rails upgrade.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,7 +31,7 @@ Publisher::Application.configure do
 
   # Disable Rails's static asset server
   # In production, Apache or nginx will already do this
-  config.serve_static_assets = false
+  config.serve_static_files = false
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -26,12 +26,6 @@ test:
 production:
   clients:
     default:
-      hosts:
-        - <%= ENV['MONGOID_HOST'] %>
-      port: <%= ENV['MONGOID_PORT'] %>
-      database: <%= ENV['MONGOID_DATABASE'] %>
-      options:
-        user: <%= ENV['MONGOID_USERNAME'] %>
-        password: <%= ENV['MONGOID_PASSWORD'] %>
+      uri: <%= ENV['MONGODB_URI'] %>
   options:
     use_activesupport_time_zone: true


### PR DESCRIPTION
Use a single MONGODB_URI env var, and fix a deprecated setting in the production environment file.