### PR TITLE
Update govuk_content_models & gds-api-adapters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", :github => 'alphagov/govuk_content_models', :ref => 'd7fae3a0f3bbbfccbe94e9c13f15e58a58422526'
+  gem "govuk_content_models", :github => 'alphagov/govuk_content_models', :branch => 'rails-mongoid-upgrade'
 
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '27.2.0'
+  gem 'gds-api-adapters', '~> 29.6'
 end
 
 gem 'erubis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: git://github.com/alphagov/govuk_content_models.git
-  revision: d7fae3a0f3bbbfccbe94e9c13f15e58a58422526
-  ref: d7fae3a0f3bbbfccbe94e9c13f15e58a58422526
+  revision: 3f1f07ecf8ea096102997534eaaeb82c85d628c7
+  branch: rails-mongoid-upgrade
   specs:
-    govuk_content_models (32.2.0)
+    govuk_content_models (33.0.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (~> 11.2)
@@ -77,7 +77,7 @@ GEM
     bootstrap-sass (3.3.5)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.2.19)
-    bson (4.0.1)
+    bson (4.0.4)
     bson_ext (1.5.1)
     builder (3.2.2)
     byebug (8.2.2)
@@ -113,13 +113,13 @@ GEM
       minitest (~> 5.0)
     cliver (0.3.2)
     coderay (1.1.0)
-    concurrent-ruby (1.0.0)
+    concurrent-ruby (1.0.1)
     connection_pool (2.2.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     database_cleaner (1.5.1)
     diffy (3.0.6)
-    domain_name (0.5.20160128)
+    domain_name (0.5.20160309)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
@@ -195,7 +195,7 @@ GEM
     json (1.8.3)
     json-schema (2.5.2)
       addressable (~> 2.3.8)
-    jwt (1.5.2)
+    jwt (1.5.1)
     kaminari (0.13.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -216,7 +216,7 @@ GEM
       mime-types (>= 1.16, < 3)
     metaclass (0.0.4)
     method_source (0.8.2)
-    mime-types (2.99)
+    mime-types (2.99.1)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
     minitest-reporters (1.1.7)
@@ -230,9 +230,9 @@ GEM
       metaclass (~> 0.0.1)
     momentjs-rails (2.8.3)
       railties (>= 3.1)
-    mongo (2.2.2)
+    mongo (2.2.4)
       bson (~> 4.0)
-    mongoid (5.1.0)
+    mongoid (5.1.1)
       activemodel (~> 4.0)
       mongo (~> 2.1)
       origin (~> 2.2)
@@ -385,7 +385,7 @@ GEM
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.0.1)
+    sprockets-rails (3.0.4)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
       actionpack (>= 3.0)
     formtastic-bootstrap (3.0.0)
       formtastic (>= 2.2)
-    gds-api-adapters (27.2.0)
+    gds-api-adapters (29.6.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -446,7 +446,7 @@ DEPENDENCIES
   factory_girl_rails
   formtastic (= 2.3.0)
   formtastic-bootstrap (= 3.0.0)
-  gds-api-adapters (= 27.2.0)
+  gds-api-adapters (~> 29.6)
   gds-sso (~> 11.2)
   govspeak (~> 3.4.0)
   govuk-content-schema-test-helpers (~> 1.4)


### PR DESCRIPTION
We are going to need the most recent versions of these gems in upcoming pull requests.

cc @MatMoore @jackscotti 