### PR TITLE
Save links to publishing-api on publish

### DIFF
--- a/app/presenters/edition_links_presenter.rb
+++ b/app/presenters/edition_links_presenter.rb
@@ -1,0 +1,39 @@
+class EditionLinksPresenter
+  def initialize(edition)
+    @edition = edition
+  end
+
+  def payload
+    all_paths = browse_pages + topics
+    if all_paths.empty?
+      content_ids_by_path = {}
+    else
+      content_ids_by_path = fetch_content_ids(all_paths)
+    end
+
+    {
+      links: {
+        mainstream_browse_pages: browse_pages.map { |base_path| content_ids_by_path.fetch(base_path) },
+        topics: topics.map { |base_path| content_ids_by_path.fetch(base_path) },
+      }
+    }
+  end
+
+private
+
+  def browse_pages
+    @edition.browse_pages.map { |slug| "/browse/#{slug}" }
+  end
+
+  def topics
+    (primary_topic + @edition.additional_topics).map { |slug| "/topic/#{slug}" }
+  end
+
+  def primary_topic
+    [@edition.primary_topic].select(&:present?)
+  end
+
+  def fetch_content_ids(base_paths)
+    Services.publishing_api.lookup_content_ids(base_paths: base_paths)
+  end
+end

--- a/app/workers/publishing_api_publisher.rb
+++ b/app/workers/publishing_api_publisher.rb
@@ -8,5 +8,8 @@ class PublishingAPIPublisher
     content_id = edition.artefact.content_id
 
     Services.publishing_api.publish(content_id, update_type)
+
+    presenter = EditionLinksPresenter.new(edition)
+    Services.publishing_api.patch_links(content_id, presenter.payload)
   end
 end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,9 +1,41 @@
 namespace :publishing_api do
-  task :republish_content => [:environment] do
+  task republish_content: [:environment] do
     puts "Scheduling republishing of #{Edition.published.count} editions"
 
     RepublishContent.schedule_republishing
 
     puts "Scheduling finished"
+  end
+
+  desc "Send publishable item links to Publishing API."
+  task publish_all_links: [:environment] do
+    def patch_links(item)
+      retries = 0
+      begin
+        payload = EditionLinksPresenter.new(item).payload
+
+        unless payload[:links][:mainstream_browse_pages].empty? && payload[:links][:topics].empty?
+          Services.publishing_api.patch_links(item.artefact.content_id, payload)
+        end
+      rescue GdsApi::TimedOutException, Timeout::Error
+        retries = 1
+        if retries <= 3
+          $stderr.puts "Class #{item.class} id: #{item.id} Timeout: retry #{retries}"
+          sleep 0.5
+          retry
+        end
+        raise
+      end
+    rescue => err
+      $stderr.puts "Class: #{item.class}; id: #{item.id}; Error: #{err.message}"
+    end
+
+    edition_count = Edition.published.count
+    Edition.published.each_with_index do |edition, i|
+      patch_links(edition)
+      $stdout.puts "Processed #{i}/#{edition_count} published editions" if i % 100 == 0
+    end
+
+    $stdout.puts "Finished sending items to Publishing API"
   end
 end

--- a/test/unit/edition_links_presenter_test.rb
+++ b/test/unit/edition_links_presenter_test.rb
@@ -1,0 +1,78 @@
+require "test_helper"
+
+class EditionLinksPresenterTest < ActiveSupport::TestCase
+  include GovukContentSchemaTestHelpers::TestUnit
+
+  context ".payload" do
+    should "prepare links payload for publishing with publishing-api" do
+      artefact = FactoryGirl.create(:artefact)
+
+      edition = FactoryGirl.create(
+        :edition,
+        :published,
+        browse_pages: ["tax/vat", "tax/capital-gains"],
+        primary_topic: "oil-and-gas/wells",
+        additional_topics: ["oil-and-gas/fields", "oil-and-gas/distillation"],
+        panopticon_id: artefact.id,
+      )
+
+      content_ids_by_path = {
+        "/browse/tax/vat" => SecureRandom.uuid,
+        "/browse/tax/capital-gains" => SecureRandom.uuid,
+        "/topic/oil-and-gas/wells" => SecureRandom.uuid,
+        "/topic/oil-and-gas/fields" => SecureRandom.uuid,
+        "/topic/oil-and-gas/distillation" => SecureRandom.uuid
+      }
+
+      publishing_api_has_lookups(content_ids_by_path)
+
+      payload = EditionLinksPresenter.new(edition).payload
+
+      assert_equal(
+        payload[:links][:mainstream_browse_pages],
+        [
+          content_ids_by_path["/browse/tax/vat"],
+          content_ids_by_path["/browse/tax/capital-gains"]
+        ]
+      )
+
+      assert_equal(
+        payload[:links][:topics],
+        [
+          content_ids_by_path["/topic/oil-and-gas/wells"],
+          content_ids_by_path["/topic/oil-and-gas/fields"],
+          content_ids_by_path["/topic/oil-and-gas/distillation"]
+        ]
+      )
+
+      assert_valid_against_links_schema(payload, 'placeholder')
+    end
+
+    should "create an empty payload if there are no links" do
+      artefact = FactoryGirl.create(:artefact)
+
+      edition = FactoryGirl.create(
+        :edition,
+        :published,
+        browse_pages: [],
+        primary_topic: nil,
+        additional_topics: [],
+        panopticon_id: artefact.id,
+      )
+
+      payload = EditionLinksPresenter.new(edition).payload
+
+      assert_equal(
+        payload[:links][:mainstream_browse_pages],
+        []
+      )
+
+      assert_equal(
+        payload[:links][:topics],
+        []
+      )
+
+      assert_valid_against_links_schema(payload, 'placeholder')
+    end
+  end
+end

--- a/test/unit/publishing_api_publisher_test.rb
+++ b/test/unit/publishing_api_publisher_test.rb
@@ -13,9 +13,10 @@ class PublishingAPIPublisherTest < ActiveSupport::TestCase
       stub_publishing_api_publish("vat-charities-id", {"update_type" => "minor"})
     end
 
-    should "notify the publishing API of the published document" do
+    should "notify the publishing API of the published document and links" do
       PublishingAPIPublisher.new.perform(@edition.id)
       assert_publishing_api_publish("vat-charities-id", {"update_type" => "minor"})
+      assert_publishing_api_patch_links("vat-charities-id")
     end
   end
 end

--- a/test/unit/republish_content_test.rb
+++ b/test/unit/republish_content_test.rb
@@ -36,13 +36,15 @@ class RepublishContentTest < ActiveSupport::TestCase
     end
   end
 
-  should "sends the content as a PUT and a POST for the publish" do
+  should "sends the content as PUT, POST, PATCH for the publish" do
     request_1 = stub_request(:put, "#{Plek.find('publishing-api')}/v2/content/#{@published_edition.artefact.content_id}")
     request_2 = stub_request(:post, "#{Plek.find('publishing-api')}/v2/content/#{@published_edition.artefact.content_id}/publish")
+    request_3 = stub_request(:patch, "#{Plek.find('publishing-api')}/v2/links/#{@published_edition.artefact.content_id}")
 
     RepublishContent.schedule_republishing
 
     assert_requested(request_1)
     assert_requested(request_2)
+    assert_requested(request_3)
   end
 end


### PR DESCRIPTION
Ticket: https://trello.com/c/Cx3K3y8I/544-publisher-migration-publisher-should-send-links-to-publishing-api-on-publish
Part of: https://trello.com/c/nGta782z/525-epic-migrate-publisher-to-the-new-tagging-infrastructure

Paired on this with @MatMoore.

cc: @tijmenb @mobaig @Davidslv @bishboria 