### PR TITLE
Send parent mainstream browse to publishing api

### DIFF
--- a/test/unit/edition_links_presenter_test.rb
+++ b/test/unit/edition_links_presenter_test.rb
@@ -45,6 +45,11 @@ class EditionLinksPresenterTest < ActiveSupport::TestCase
         ]
       )
 
+      assert_equal(
+        payload[:links][:parent],
+        [content_ids_by_path["/browse/tax/vat"]]
+      )
+
       assert_valid_against_links_schema(payload, 'placeholder')
     end
 
@@ -62,14 +67,8 @@ class EditionLinksPresenterTest < ActiveSupport::TestCase
 
       payload = EditionLinksPresenter.new(edition).payload
 
-      assert_equal(
-        payload[:links][:mainstream_browse_pages],
-        []
-      )
-
-      assert_equal(
-        payload[:links][:topics],
-        []
+      assert(
+        payload[:links].values.all?(&:empty?),
       )
 
       assert_valid_against_links_schema(payload, 'placeholder')


### PR DESCRIPTION
When we started sending links to the publishing api, we missed
the parent link. This is used for the breadcrumb in mainstream browse and is
always the first tagged browse page.

https://trello.com/c/B8J0eOkm/561-send-parent-mainstream-browse-page-from-publisher