### PR TITLE
Remove rake task to republish all tags

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -6,36 +6,4 @@ namespace :publishing_api do
 
     puts "Scheduling finished"
   end
-
-  desc "Send publishable item links to Publishing API."
-  task publish_all_links: [:environment] do
-    def patch_links(item)
-      retries = 0
-      begin
-        payload = EditionLinksPresenter.new(item).payload
-
-        unless payload[:links][:mainstream_browse_pages].empty? && payload[:links][:topics].empty?
-          Services.publishing_api.patch_links(item.artefact.content_id, payload)
-        end
-      rescue GdsApi::TimedOutException, Timeout::Error
-        retries = 1
-        if retries <= 3
-          $stderr.puts "Class #{item.class} id: #{item.id} Timeout: retry #{retries}"
-          sleep 0.5
-          retry
-        end
-        raise
-      end
-    rescue => err
-      $stderr.puts "Class: #{item.class}; id: #{item.id}; Error: #{err.message}"
-    end
-
-    edition_count = Edition.published.count
-    Edition.published.each_with_index do |edition, i|
-      patch_links(edition)
-      $stdout.puts "Processed #{i}/#{edition_count} published editions" if i % 100 == 0
-    end
-
-    $stdout.puts "Finished sending items to Publishing API"
-  end
 end


### PR DESCRIPTION
We introduced this task to migrate the tags to the publishing-api.

However, the [rake task in panopticon](https://github.com/alphagov/panopticon/blob/ae5426fcebe457ad7d6fa6f9eb74666c1762ab94/lib/tasks/migrate_taggings.rake) is actually more suited for this task because it also sends the `organisation` taggings. Panopticon and Publisher share a database, so we can use the task. 

cc @MatMoore 