### PR TITLE
Content Summary and Workflow History report

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -22,6 +22,10 @@ class ReportsController < ApplicationController
     send_report "edition_churn"
   end
 
+  def content_workflow
+    send_report "content_workflow"
+  end
+
   private
 
   def report_last_updated(report)

--- a/app/presenters/content_workflow_presenter.rb
+++ b/app/presenters/content_workflow_presenter.rb
@@ -1,0 +1,35 @@
+class ContentWorkflowPresenter < CSVPresenter
+  def initialize(scope = Edition.published)
+    super(scope)
+    self.column_headings = [
+      :content_title,
+      :content_slug,
+      :content_url,
+      :current_status,
+      :stage,
+      :format,
+      :current_assignee,
+      :created_at,
+    ]
+  end
+
+private
+
+  def build_csv(csv)
+    csv << column_headings.collect { |ch| ch.to_s.humanize }
+    scope.each do |item|
+      item.actions.each do |action|
+        csv << [
+          item.title,
+          item.slug,
+          "#{Plek.current.website_root}/#{item.slug}",
+          item.state,
+          action.request_type,
+          item.format,
+          item.assignee,
+          action.created_at.to_s(:db),
+        ]
+      end
+    end
+  end
+end

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -19,5 +19,9 @@
   <strong><%= link_to 'Published business support editions', business_support_report_path(format: :csv) %></strong><br />
   <%= report_last_updated("business_support_export")%>
 </p>
+<p>
+  <strong><%= link_to 'Content summary and workflow history', content_workflow_report_path(format: :csv) %></strong><br />
+  <%= report_last_updated("content_workflow")%>
+</p>
 
 <% content_for :page_title, "Reports" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,8 @@ Publisher::Application.routes.draw do
   get 'reports/business_support_schemes_content' => 'reports#business_support_schemes_content', :as => :business_support_report
   get 'reports/organisation-content' => 'reports#organisation_content', :as => :organisation_content_report
   get 'reports/edition-churn' => 'reports#edition_churn', as: "edition_churn_report"
-
+  get 'reports/content_workflow' => 'reports#content_workflow', as: "content_workflow_report"
+  
   get 'user_search' => 'user_search#index'
 
   resources :publications

--- a/lib/csv_report_generator.rb
+++ b/lib/csv_report_generator.rb
@@ -32,6 +32,8 @@ class CsvReportGenerator
 
       EditionChurnPresenter.new(
         Edition.not_in(state: ["archived"]).order(created_at: 1)),
+
+      ContentWorkflowPresenter.new(Edition.published.order(created_at: :desc)),
     ]
   end
 

--- a/test/unit/content_workflow_presenter_test.rb
+++ b/test/unit/content_workflow_presenter_test.rb
@@ -1,0 +1,71 @@
+# encoding: utf-8
+require 'test_helper'
+
+class ContentWorkflowPresenterTest < ActiveSupport::TestCase
+  should "provide a CSV export of content workflow" do
+    action_1 = Action.new(
+      request_type: "create",
+      created_at: "2016-01-07 17:41:57"
+    )
+
+    action_2 = Action.new(
+      request_type: "request_review",
+      created_at: "2016-01-11 10:21:00"
+    )
+
+    action_3 = Action.new(
+      request_type: "send_fact_check",
+      created_at: "2016-01-17 12:11:33"
+    )
+
+    action_4 = Action.new(
+      request_type: "request_amendments",
+      created_at: "2016-01-20 17:41:28"
+    )
+
+    action_5 = Action.new(
+      request_type: "send_fact_check",
+      created_at: "2016-03-07 17:31:44"
+    )
+
+    transaction_edition = TransactionEdition.new(
+      title: "Register to vote (armed forces)",
+      slug: "register-to-vote-armed-forces",
+      state: "published",
+      assignee: "Ray Khan",
+      actions: [action_1, action_2, action_3, action_4, action_5]
+    )
+
+    guide_edition = GuideEdition.new(
+      title: "The Queen's Awards for Enterprise",
+      slug: "queens-awards-for-enterprise",
+      state: "published",
+      assignee: "Constance Cerf",
+      actions: [action_1, action_2, action_3, action_4, action_5]
+    )
+
+    Edition.stubs(:published).returns([transaction_edition, guide_edition])
+
+    csv = ContentWorkflowPresenter.new(Edition.published).to_csv
+    data = CSV.parse(csv, headers: true)
+
+    assert_equal 10, data.length
+    assert_equal "Register to vote (armed forces)", data.first["Content title"]
+    assert_equal "register-to-vote-armed-forces", data.first["Content slug"]
+    assert_equal "#{Plek.current.website_root}/register-to-vote-armed-forces", data.first["Content URL"]
+    assert_equal "published", data.first["Current status"]
+    assert_equal "create", data.first["Stage"]
+    assert_equal "Transaction", data.first["Format"]
+    assert_equal "Ray Khan", data.first["Current assignee"]
+    assert_equal "2016-01-07 17:41:57", data.first["Created at"]
+
+    assert_equal "The Queen's Awards for Enterprise", data[7]["Content title"]
+    assert_equal "queens-awards-for-enterprise", data[7]["Content slug"]
+    assert_equal "#{Plek.current.website_root}/queens-awards-for-enterprise", data[7]["Content URL"]
+    assert_equal "published", data[7]["Current status"]
+    assert_equal "send_fact_check", data[7]["Stage"]
+    assert_equal "Guide", data[7]["Format"]
+    assert_equal "Constance Cerf", data[7]["Current assignee"]
+    assert_equal "2016-01-17 12:11:33", data[7]["Created at"]
+  end
+end


### PR DESCRIPTION
This PR is aimed at producing a Content Summary and Workflow history report that will offer Content Delivery Managers  better insights into the flow of work through Publisher, 

This report will be listed and accessed via this [url](https://publisher.publishing.service.gov.uk/reports)

This CSV report comprises of the following columns:

- Content title
- Content slug
- Content URL
- Current status
- Format
- Current assignee
- *** Timestamps for each request type during the workflow ***