### PR TITLE
Fix a bug with setting the transaction done page promos

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -236,7 +236,13 @@ protected
         :video_summary,
         :caption_file,
       ]
-    else # answer_edition, completed_transaction_edition, help_page_edition
+    when :completed_transaction_edition
+      [
+        :body,
+        :promote_organ_donor_registration,
+        :organ_donor_registration_url,
+      ]
+    else # answer_edition, help_page_edition
       [
         :body,
       ]

--- a/test/integration/completed_transactions_create_edit_test.rb
+++ b/test/integration/completed_transactions_create_edit_test.rb
@@ -77,6 +77,7 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
     fill_in "Organ donor registration URL", with: organ_donor_registration_promotion_url
     save_edition_and_assert_success
 
+    visit current_path # Refresh the page to check that the boxes are still ticked.
     assert page.has_checked_field? "Promote organ donor registration"
     assert page.has_field? 'Organ donor registration URL', with: organ_donor_registration_promotion_url
   end


### PR DESCRIPTION
- It was reported that new done pages failed to save when adding the
  organ donation promo to them.