### PR TITLE
Change the done page promo checkbox to radio buttons, to add a new one

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -15,3 +15,8 @@
   padding: $default-vertical-margin/2;
   border-radius: $border-radius-base;
 }
+
+.promotion-choice-none:checked ~ .promotion-choice-url {
+  position: absolute;
+  left: -9999em;
+}

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -239,8 +239,8 @@ protected
     when :completed_transaction_edition
       [
         :body,
-        :promote_organ_donor_registration,
-        :organ_donor_registration_url,
+        :promotion_choice,
+        :promotion_choice_url,
       ]
     else # answer_edition, help_page_edition
       [

--- a/app/views/completed_transactions/_fields.html.erb
+++ b/app/views/completed_transactions/_fields.html.erb
@@ -10,23 +10,31 @@
 
 <hr />
 <div class="row">
-  <div class="col-md-8" data-module="checkbox-toggle">
-    <h3 class="remove-top-margin">Promote organ donor registration</h3>
+  <div class="col-md-8">
+    <h3 class="remove-top-margin">Promotions</h3>
     <p class="help-block add-bottom-margin">
       Display a promotion above the satisfaction survey
     </p>
 
     <div class="form-group">
-      <%= f.input :promote_organ_donor_registration,
-        as: :boolean,
-        input_html: { disabled: @resource.locked_for_edits?, 'data-target' => 'organ-donor-registration-url' },
-        wrapper_html: { class: "form-group input-md-8 emphasised-field" } %>
+      <%= f.radio_button :promotion_choice, 'none',
+        { checked: (f.object.promotion_choice == "none"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-none' } %>
+      <%= f.label :promotion_choice, "Don't promote anything on this page", value: 'none' %>
+      <br />
+      <%= f.radio_button :promotion_choice, 'organ_donor',
+        { checked: (f.object.promotion_choice == "organ_donor"), disabled: @resource.locked_for_edits? } %>
+      <%= f.label :promotion_choice, "Promote organ donation", value: 'organ_donor' %>
+      <br />
+      <%= f.radio_button :promotion_choice, 'register_to_vote',
+        { checked: (f.object.promotion_choice == "register_to_vote"), disabled: @resource.locked_for_edits? } %>
+      <%= f.label :promotion_choice, "Promote register to vote", value: 'register_to_vote' %>
 
-      <%= f.input :organ_donor_registration_url,
+      <%= f.input :promotion_choice_url,
           required: false,
           input_html: { disabled: @resource.locked_for_edits? },
-          wrapper_html: { class: "form-group input-md-8", id: 'organ-donor-registration-url' } %>
+          wrapper_html: { class: "form-group input-md-8 promotion-choice-url", id: 'promotion-choice-url' } %>
     </div>
+
   </div>
 </div>
 

--- a/test/integration/completed_transactions_create_edit_test.rb
+++ b/test/integration/completed_transactions_create_edit_test.rb
@@ -71,14 +71,31 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
     organ_donor_registration_promotion_url = "https://www.organdonation.nhs.uk/how_to_become_a_donor/registration/consent.asp?campaign=2244&v=7"
 
     visit "/editions/#{edition.to_param}"
-    assert page.has_unchecked_field? "Promote organ donor registration"
+    assert page.has_unchecked_field? "Promote organ donation"
 
-    check "Promote organ donor registration"
-    fill_in "Organ donor registration URL", with: organ_donor_registration_promotion_url
+    choose "Promote organ donation"
+    fill_in "Promotion choice URL", with: organ_donor_registration_promotion_url
     save_edition_and_assert_success
 
     visit current_path # Refresh the page to check that the boxes are still ticked.
-    assert page.has_checked_field? "Promote organ donor registration"
-    assert page.has_field? 'Organ donor registration URL', with: organ_donor_registration_promotion_url
+    assert page.has_checked_field? "Promote organ donation"
+    assert page.has_field? 'Promotion choice URL', with: organ_donor_registration_promotion_url
+  end
+
+  should "only allow one promotion to be displayed at once" do
+    edition = FactoryGirl.create(:completed_transaction_edition, panopticon_id: @artefact.id)
+    register_to_vote_promotion_url = "https://gov.uk/register-to-vote"
+
+    visit "/editions/#{edition.to_param}"
+
+    assert page.has_unchecked_field? "Promote register to vote"
+
+    choose "Promote register to vote"
+    fill_in "Promotion choice URL", with: register_to_vote_promotion_url
+    save_edition_and_assert_success
+
+    assert page.has_checked_field? "Promote register to vote"
+    assert page.has_field? "Promotion choice URL", with: register_to_vote_promotion_url
+    assert page.has_unchecked_field? "Promote organ donation"
   end
 end


### PR DESCRIPTION
- This allows us to have mutually exclusive EITHER "organ_donor" OR
  "register_to_vote" OR "none" built-in, as radio buttons only allow one
  selection at once.
- If "none" is selected, the URL field doesn't appear.

A PR on frontend to understand these changes is open as alphagov/frontend#942

## Screenshots

### Before

#### No promotion
![promo old none](https://cloud.githubusercontent.com/assets/608/14783154/b2f2f384-0ae5-11e6-8eeb-29ff8c0a5d9e.jpg)

#### With a promotion
![promo old something](https://cloud.githubusercontent.com/assets/608/14783155/b2f61ef6-0ae5-11e6-9b20-51e98e0f0ca7.jpg)

### After

#### No promotion
![promo none](https://cloud.githubusercontent.com/assets/608/14783153/b2f2f2bc-0ae5-11e6-8feb-67694571ef73.jpg)

#### With a promotion
![promo something](https://cloud.githubusercontent.com/assets/608/14783156/b2f71ce8-0ae5-11e6-92c6-3328d00e6378.jpg)
