### PR TITLE
Worker request tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ test/reports
 data/local_interactions.csv
 config/initializers/dev_*.rb
 reports/*
+.byebug_history
 
 # Local transactions import reports
 removed_ghosts*.csv

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 29.6'
+  gem 'gds-api-adapters', '~> 30.2.0'
 end
 
 gem 'erubis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       actionpack (>= 3.0)
     formtastic-bootstrap (3.0.0)
       formtastic (>= 2.2)
-    gds-api-adapters (29.6.0)
+    gds-api-adapters (30.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -445,7 +445,7 @@ DEPENDENCIES
   factory_girl_rails
   formtastic (= 2.3.0)
   formtastic-bootstrap (= 3.0.0)
-  gds-api-adapters (~> 29.6)
+  gds-api-adapters (~> 30.2.0)
   gds-sso (~> 11.2)
   govspeak (~> 3.4.0)
   govuk-content-schema-test-helpers (~> 1.4)

--- a/app/workers/panopticon_reregisterer.rb
+++ b/app/workers/panopticon_reregisterer.rb
@@ -1,7 +1,5 @@
-class PanopticonReregisterer
-  include Sidekiq::Worker
-
-  def perform(edition_id)
+class PanopticonReregisterer < WorkerBase
+  def call(edition_id)
     edition = Edition.find(edition_id)
     edition.register_with_panopticon
   end

--- a/app/workers/publishing_api_publisher.rb
+++ b/app/workers/publishing_api_publisher.rb
@@ -1,9 +1,7 @@
 require 'services'
 
-class PublishingAPIPublisher
-  include Sidekiq::Worker
-
-  def perform(edition_id, update_type = "minor")
+class PublishingAPIPublisher < WorkerBase
+  def call(edition_id, update_type = "minor")
     edition = Edition.find(edition_id)
     content_id = edition.artefact.content_id
 

--- a/app/workers/publishing_api_republisher.rb
+++ b/app/workers/publishing_api_republisher.rb
@@ -2,7 +2,7 @@ class PublishingAPIRepublisher
   include Sidekiq::Worker
 
   def perform(*args)
-    PublishingAPIUpdater.new.perform(*args)
-    PublishingAPIPublisher.new.perform(*args)
+    PublishingAPIUpdater.new.call(*args)
+    PublishingAPIPublisher.new.call(*args)
   end
 end

--- a/app/workers/publishing_api_updater.rb
+++ b/app/workers/publishing_api_updater.rb
@@ -1,9 +1,7 @@
 require 'services'
 
-class PublishingAPIUpdater
-  include Sidekiq::Worker
-
-  def perform(edition_id, update_type = "minor")
+class PublishingAPIUpdater < WorkerBase
+  def call(edition_id, update_type = "minor")
     edition = Edition.find(edition_id)
     presenter = PublishedEditionPresenter.new(edition)
     payload = presenter.render_for_publishing_api(republish: update_type == "republish")

--- a/app/workers/worker_base.rb
+++ b/app/workers/worker_base.rb
@@ -1,0 +1,30 @@
+class WorkerBase
+  include Sidekiq::Worker
+
+  def self.perform_async(*args)
+    args << request_id_argument
+    super(*args)
+  end
+
+  def self.perform_at(*args)
+    args << request_id_argument
+    super(*args)
+  end
+
+  def self.request_id_argument
+    { request_id: GdsApi::GovukHeaders.headers[:govuk_request_id] }
+  end
+  private_class_method :request_id_argument
+
+  def perform(*args)
+    last_arg = args.last
+
+    if last_arg.is_a?(Hash) && last_arg.keys == ["request_id"]
+      args.pop
+      request_id = last_arg["request_id"]
+      GdsApi::GovukHeaders.set_header(:govuk_request_id, request_id)
+    end
+
+    call(*args)
+  end
+end

--- a/test/integration/request_tracing_test.rb
+++ b/test/integration/request_tracing_test.rb
@@ -1,0 +1,78 @@
+require 'integration_test_helper'
+
+class RequestTracingTest < ActionDispatch::IntegrationTest
+  setup do
+    WebMock.reset!
+    setup_users
+
+    stub_request(:any, /publishing-api/)
+    stub_request(:put, /panopticon/)
+  end
+
+  test "govuk_request_id is passed downstream across the worker boundary on publish" do
+    Sidekiq::Testing.fake! do
+      inbound_headers = { "HTTP_GOVUK_REQUEST_ID" => "12345-67890" }
+      artefact = FactoryGirl.create(:artefact)
+
+      # Create an edition.
+      post "/editions", {
+        edition: {
+          panopticon_id: artefact.id,
+          kind: "answer",
+          title: "a title"
+        }
+      }, inbound_headers
+      assert_equal 302, response.status
+      edition = Edition.last
+
+      # Transition the edition to 'in_review'
+      post "/editions/#{edition.id}/progress", {
+        edition: {
+          activity: {
+            request_type: :request_review
+          }
+        }
+      }, inbound_headers
+      assert_equal 302, response.status
+
+      login_as(@reviewer)
+
+      # Transition the edition to 'ready'
+      post "/editions/#{edition.id}/progress", {
+        edition: {
+          activity: {
+            request_type: :approve_review
+          }
+        }
+      }, inbound_headers
+      assert_equal 302, response.status
+
+      # Transition the edition to 'published'
+      post "/editions/#{edition.id}/progress", {
+        edition: {
+          activity: {
+            request_type: :publish
+          }
+        }
+      }, inbound_headers
+      assert_equal 302, response.status
+
+      worker_classes = Sidekiq::Worker.jobs.map(&:first).uniq
+      worker_classes.each do |worker_class|
+        while worker_class.jobs.any?
+          GdsApi::GovukHeaders.clear_headers
+          worker_class.perform_one
+          GdsApi::GovukHeaders.clear_headers
+        end
+      end
+
+      onward_headers = { "GOVUK-Request-Id" => "12345-67890" }
+      content_id = artefact.content_id
+
+      assert_requested(:put, %r|publishing-api.*content/#{content_id}|, times: 7, headers: onward_headers)
+      assert_requested(:patch, %r|publishing-api.*links/#{content_id}|, headers: onward_headers)
+      assert_requested(:post, %r|publishing-api.*content/#{content_id}/publish|, headers: onward_headers)
+      assert_requested(:put, /panopticon/, headers: onward_headers)
+    end
+  end
+end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -6,6 +6,7 @@ require 'capybara/poltergeist'
 
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
+  include Warden::Test::Helpers
 
   teardown do
     Capybara.reset_sessions!    # Forget the (simulated) browser state
@@ -19,6 +20,11 @@ class ActionDispatch::IntegrationTest
     # tests that cover the oauth interaction properly
     @author   = FactoryGirl.create(:user, :name=>"Author",   :email=>"test@example.com")
     @reviewer = FactoryGirl.create(:user, :name=>"Reviewer", :email=>"test@example.com")
+  end
+
+  def login_as(user)
+    GDS::SSO.test_user = user
+    super(user)
   end
 
   def assert_field_contains(expected, field)


### PR DESCRIPTION
https://trello.com/c/Eddv2AiS/688-for-migrated-formats-update-for-request-tracing

This change makes it so that a `request_id` is passed into Sidekiq jobs so that we can send this as a header downstream, via `GdsApi::GovukHeaders`. Currently, this header is lost when the Sidekiq jobs run because they run in a separate process to the one in which the request was processed.

This is based on this pull request: https://github.com/alphagov/whitehall/pull/2567