### PR TITLE
Switch back to released version of content_models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'rails', '4.2.5.1'
+gem 'sass-rails', '5.0.4'
+gem 'uglifier', '2.7.2'
 
 if ENV['BUNDLE_DEV']
   gem 'gds-sso', path: '../gds-sso'
@@ -65,11 +67,6 @@ gem 'unicorn', '4.3.1'
 gem 'airbrake', '3.1.15'
 gem 'sidekiq', '2.17.2'
 gem 'sidekiq-statsd', '0.1.2'
-
-group :assets do
-  gem 'sass-rails', '5.0.4'
-  gem 'uglifier', '2.7.2'
-end
 
 group :test do
   gem 'minitest'

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", :github => 'alphagov/govuk_content_models', :branch => 'rails-mongoid-upgrade'
+  gem "govuk_content_models", '35.0.0'
 
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,4 @@
 GIT
-  remote: git://github.com/alphagov/govuk_content_models.git
-  revision: abc8edec36967cc3cd52a6196c2d54afda3d8777
-  branch: rails-mongoid-upgrade
-  specs:
-    govuk_content_models (33.0.0)
-      bson_ext
-      gds-api-adapters (>= 10.9.0)
-      gds-sso (~> 11.2)
-      govspeak (~> 3.1)
-      mongoid (~> 5.1)
-      plek
-      state_machines (~> 0.4)
-      state_machines-mongoid (~> 0.1)
-
-GIT
   remote: https://github.com/alphagov/nested_form.git
   revision: ac43d8fe0cd3805b7309169ca8fbdd6a1527d9b5
   branch: add-wrapper-class
@@ -165,6 +150,15 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
+    govuk_content_models (35.0.0)
+      bson_ext
+      gds-api-adapters (>= 10.9.0)
+      gds-sso (~> 11.2)
+      govspeak (~> 3.1)
+      mongoid (~> 5.1)
+      plek
+      state_machines (~> 0.4)
+      state_machines-mongoid (~> 0.1)
     has_scope (0.6.0)
       actionpack (>= 3.2, < 5)
       activesupport (>= 3.2, < 5)
@@ -451,7 +445,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint (~> 0.7)
   govuk_admin_template (= 4.2.0)
-  govuk_content_models!
+  govuk_content_models (= 35.0.0)
   has_scope
   inherited_resources
   jasmine (= 2.1.0)

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,6 @@ require 'ci/reporter/rake/minitest' if Rails.env.test?
 
 Rake.application.options.trace = true
 
-Publisher::Application.load_tasks
+Rails.application.load_tasks
 
 task :default => [:test, :check_for_bad_time_handling, 'jasmine:ci']

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+load Gem.bin_path('bundler', 'bundle')

--- a/bin/rails
+++ b/bin/rails
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+APP_PATH = File.expand_path('../../config/application', __FILE__)
+require_relative '../config/boot'
+require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+require_relative '../config/boot'
+require 'rake'
+Rake.application.run

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment',  __FILE__)
-run Publisher::Application
+require ::File.expand_path('../config/environment', __FILE__)
+run Rails.application

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,12 +7,9 @@ require "action_mailer/railtie"
 require "rails/test_unit/railtie"
 require "sprockets/railtie"
 
-if defined?(Bundler)
-  # If you precompile assets before deploying to production, use this line
-  Bundler.require(*Rails.groups(:assets => %w(development test)))
-  # If you want your assets lazily compiled in production, use this line
-  # Bundler.require(:default, :assets, Rails.env)
-end
+# Require the gems listed in Gemfile, including any gems
+# you've limited to :test, :development, or :production.
+Bundler.require(*Rails.groups)
 
 module Publisher
   class Application < Rails::Application
@@ -48,13 +45,6 @@ module Publisher
     end
 
     config.action_dispatch.rack_cache = nil
-
-    # Only load the plugins named here, in the order given (default is alphabetical).
-    # :all can be used as a placeholder for all plugins not explicitly named.
-    # config.plugins = [ :exception_notification, :ssl_requirement, :all ]
-
-    # Activate observers that should always be running.
-    # config.active_record.observers = :cacher, :garbage_collector, :forum_observer
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -2,4 +2,4 @@
 require File.expand_path('../application', __FILE__)
 
 # Initialize the rails application
-Publisher::Application.initialize!
+Rails.application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,4 @@
-Publisher::Application.configure do
+Rails.application.configure do
   # Settings specified here will take precedence over those in config/environment.rb
 
   # In the development environment your application's code is reloaded on
@@ -24,9 +24,17 @@ Publisher::Application.configure do
 
   config.action_mailer.default_url_options = { :host => "www.dev.gov.uk" }
 
-  # Do not compress assets
-  config.assets.compress = false
-
-  # Expands the lines which load the assets
+  # Debug mode disables concatenation and preprocessing of assets.
+  # This option may cause significant delays in view rendering with a large
+  # number of complex assets.
   config.assets.debug = true
+
+  # Asset digests allow you to set far-future HTTP expiration dates on all assets,
+  # yet still be able to expire them through the digest params.
+  config.assets.digest = true
+
+  # Adds additional error checking when serving assets at runtime.
+  # Checks for improperly declared sprockets dependencies.
+  # Raises helpful error messages.
+  config.assets.raise_runtime_errors = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,4 @@
-Publisher::Application.configure do
+Rails.application.configure do
   # Settings specified here will take precedence over those in config/environment.rb
 
   # The production environment is meant for finished, "live" apps.
@@ -60,6 +60,9 @@ Publisher::Application.configure do
 
   # Generate digests for assets URLs.
   config.assets.digest = true
+
+  # Do not dump schema after migrations.
+  config.active_record.dump_schema_after_migration = false
 
   # Enable JSON-style logging
   config.logstasher.enabled = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,4 @@
-Publisher::Application.configure do
+Rails.application.configure do
   # Settings specified here will take precedence over those in config/environment.rb
 
   # The test environment is used exclusively to run your application's
@@ -12,6 +12,10 @@ Publisher::Application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = false
 
+  # Configure static file server for tests with Cache-Control for performance.
+  config.serve_static_files   = true
+  config.static_cache_control = 'public, max-age=3600'
+
   # Log error messages when you accidentally call methods on nil.
   config.whiny_nils = true
 
@@ -23,12 +27,15 @@ Publisher::Application.configure do
   config.action_dispatch.show_exceptions = false
 
   # Disable request forgery protection in test environment
-  config.action_controller.allow_forgery_protection    = false
+  config.action_controller.allow_forgery_protection = false
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+
+  # Randomize the order test cases are executed.
+  config.active_support.test_order = :random
 
   # Use SQL instead of Active Record's schema dumper when creating the test database.
   # This is necessary if your schema can't be completely dumped by the schema dumper,
@@ -40,5 +47,4 @@ Publisher::Application.configure do
 
   config.action_mailer.default_url_options = { :host => "example.com" }
 
-  config.active_support.test_order = :sorted
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-Publisher::Application.routes.draw do
+Rails.application.routes.draw do
   get '/healthcheck' => 'healthcheck#check'
 
   namespace :api do


### PR DESCRIPTION
The rails-upgrade branch has been merged back to master and released, so switching back to that.

Also bring Rails ancillary files up to date after upgrade.