### PR TITLE
Fix Isles of Scilly for district-based local transactions

### DIFF
--- a/lib/local_interaction_importer.rb
+++ b/lib/local_interaction_importer.rb
@@ -24,7 +24,7 @@ class LocalInteractionImporter < LocalAuthorityDataImporter
 
     existing_interactions = authority.interactions_for(row['LGSL'], row['LGIL'])
     if existing_interactions.count == 0
-      # The source data sometimes has an 'X' in the URL field.  We don't want to create 
+      # The source data sometimes has an 'X' in the URL field.  We don't want to create
       # entries for these lines
       unless row['Service URL'].strip.upcase == 'X'
         authority.local_interactions.create!(

--- a/lib/local_interaction_importer.rb
+++ b/lib/local_interaction_importer.rb
@@ -88,7 +88,7 @@ class LocalInteractionImporter < LocalAuthorityDataImporter
     case mapit_type
     when 'DIS' then 'district'
     when 'CTY' then 'county'
-    when 'LBO','MTD','UTA', 'COI' then 'unitary'
+    when 'LBO', 'MTD', 'UTA', 'COI' then 'unitary'
     else
       'county'
     end

--- a/lib/local_interaction_importer.rb
+++ b/lib/local_interaction_importer.rb
@@ -88,7 +88,7 @@ class LocalInteractionImporter < LocalAuthorityDataImporter
     case mapit_type
     when 'DIS' then 'district'
     when 'CTY' then 'county'
-    when 'LBO','MTD','UTA' then 'unitary'
+    when 'LBO','MTD','UTA', 'COI' then 'unitary'
     else
       'county'
     end


### PR DESCRIPTION
The Isles of Scilly have a [unique area type in MapIt, `COI`](http://mapit.mysociety.org/areas/COI.html). It's an [unusual
local authority](https://en.wikipedia.org/wiki/Isles_of_Scilly#Local_government) but is most similar to a unitary authority - [Cornwall doesn't
cover it](http://mapit.mysociety.org/area/2250.html) so this is the [only local authority which covers the islands](http://mapit.mysociety.org/postcode/TR210LB.html).

Frontend [already treats COI as unitary](https://github.com/alphagov/frontend/blob/3b12a066f0787f9a926912becf04a8b440792f12/lib/location_identifier.rb#L11), so users get redirected to the right
page for local transactions, but the [results page for district-level local
transactions](https://www.gov.uk/pay-council-tax/isles-of-scilly) is incorrectly rendered at the moment. This is because Publisher
has been treating the LA as a county on import, so when content API gets a
request for a district-level local transaction with the SNAC for this LA, it
can't find a district or unitary authority with that SNAC in its database so
returns the artefact with no LA details. Frontend then interprets that as
indicating that it's rendering the front page rather than an LA-specific page,
so shows the postcode form again instead of a link (or a message saying we
don't have a link). [County-based ones work fine already](https://www.gov.uk/school-term-holiday-dates/isles-of-scilly).

Adding COI to the list of area types to treat as unitary fixes this, so that
all local transactions should work for the Isles of Scilly.