### PR TITLE
Add capability to change start button text on Simple Smart Answer page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", '39.0.0'
+  gem "govuk_content_models", '41.0.0'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (39.0.0)
+    govuk_content_models (41.0.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (~> 11.2)
@@ -441,7 +441,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint (~> 0.7)
   govuk_admin_template (= 4.2.0)
-  govuk_content_models (= 39.0.0)
+  govuk_content_models (= 41.0.0)
   govuk_sidekiq (= 0.0.4)
   has_scope
   inherited_resources

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -236,6 +236,7 @@ protected
     when :simple_smart_answer_edition
       [
         :body,
+        :start_button_text,
         nodes_attributes: [
           :slug, :title, :body, :order, :kind, :id, :_destroy,
           options_attributes: [:label, :next_node, :id, :_destroy]

--- a/app/views/simple_smart_answers/_fields.html.erb
+++ b/app/views/simple_smart_answers/_fields.html.erb
@@ -8,6 +8,12 @@
 <% end %>
 
 <div class="builder-container">
+  <div class="row">
+    <div class="col-md-8">
+      <label for="edition_start_button_text" class="control-label">Start button text</label>
+      <%= f.select :start_button_text, ["Start now", "Continue", "Next"], {}, { :class => "form-control input-md-3", :disabled => @resource.locked_for_edits?, "data-module" => 'assignee-select'} %>
+    </div>
+  </div>
   <div class="nodes" id="nodes">
     <%# We need to output questions followed by outcomes but the potential for unsaved (invalid) nodes rules out the user of database ordering. So we must instead sort the collection by node order ascending (a.order <=> b.order) within node kind descending (b.kind <=> a.kind). %>
     <%= f.semantic_fields_for :nodes, @resource.nodes.sort {|a,b| [b.kind, a.order] <=> [a.kind, b.order] }, :wrapper_class => lambda {|n| return "row node #{n.kind}" } do |node| %>

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -30,6 +30,9 @@ class SimpleSmartAnswersTest < JavascriptIntegrationTest
       assert page.has_no_css?(".nodes .outcome")
 
       within ".builder-container" do
+        assert page.has_content? "Start button text"
+        assert page.has_selector?("select#edition_start_button_text")
+
         assert page.has_content? "Question 1"
 
         assert page.has_link? "Add question"


### PR DESCRIPTION
As requested in this [Trello card](https://trello.com/c/CUe4odRB/45-make-start-now-editable-in-simple-smart-answers), the need to add the capability to change the text of the start button for simple smart answers.

Here, I have added a new form attribute "start_button_text"

Also included are integration tests that ensure that this start button text is rendered on the SimpleSmartAnswerEdition form page.

This PR is related and/or dependent on the changes made to the following:

* [Content Models](https://github.com/alphagov/govuk_content_models/pull/383)
* [Content API](https://github.com/alphagov/govuk_content_api/pull/242)
* [Frontend](https://github.com/alphagov/frontend/pull/950)

SEE Trello ticket

![screen shot 2016-05-03 at 16 41 13](https://cloud.githubusercontent.com/assets/84896/14989058/f3de416e-114d-11e6-81c3-4608510997df.png)