### PR TITLE
Fix GSS codes for some councils in existing Business Support editions

### DIFF
--- a/db/migrate/20160505130158_fix_gss_codes_for_some_councils_in_existing_support_schemes.rb
+++ b/db/migrate/20160505130158_fix_gss_codes_for_some_councils_in_existing_support_schemes.rb
@@ -1,0 +1,37 @@
+class FixGssCodesForSomeCouncilsInExistingSupportSchemes < Mongoid::Migration
+  def self.up
+    # "Editing of an edition with an Archived artefact is not allowed".
+    Edition.skip_callback(:save, :before, :check_for_archived_artefact)
+
+    northumberland_schemes = BusinessSupportEdition.where(area_gss_codes: "E06000048")
+    northumberland_schemes.each do |ns|
+      ns.area_gss_codes.delete("E06000048")
+      ns.area_gss_codes.push("E06000057")
+      ns.save!(validate: false)
+    end
+
+    gateshead_schemes = BusinessSupportEdition.where(area_gss_codes: "E08000020")
+    gateshead_schemes.each do |gs|
+      gs.area_gss_codes.delete("E08000020")
+      gs.area_gss_codes.push("E08000037")
+      gs.save!(validate: false)
+    end
+
+    east_hertfordshire_schemes = BusinessSupportEdition.where(area_gss_codes: "E07000097")
+    east_hertfordshire_schemes.each do |ehs|
+      ehs.area_gss_codes.delete("E07000097")
+      ehs.area_gss_codes.push("E07000242")
+      ehs.save!(validate: false)
+    end
+
+    stevenage_schemes = BusinessSupportEdition.where(area_gss_codes: "E07000101")
+    stevenage_schemes.each do |ss|
+      ss.area_gss_codes.delete("E07000101")
+      ss.area_gss_codes.push("E07000243")
+      ss.save!(validate: false)
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
- Following on from frontend PR 948, we had to edit existing Business
  Support Editions so that they would refer to the correct GSS codes
  from the new data in MapIt, not the old ones that no longer worked.
  This migration does just that, replacing the old GSS codes in the
  edition's `area_gss_codes` array with the new ones. The councils
  edited are: Northumberland, Gateshead, East Hertfordshire and
  Stevenage.
- We had to skip callbacks that checked for archived Artefacts in
  Panopticon, and skip validations that said that already published
  editions couldn't be edited.