### PR TITLE
Remove local authority contact details

### DIFF
--- a/db/migrate/20160527152831_unset_local_authority_contact_details.rb
+++ b/db/migrate/20160527152831_unset_local_authority_contact_details.rb
@@ -1,0 +1,17 @@
+class UnsetLocalAuthorityContactDetails < Mongoid::Migration
+  def self.up
+    LocalAuthority.all.each do |authority|
+      authority.unset(:contact_address)
+      authority.unset(:contact_phone)
+      authority.unset(:contact_url)
+      authority.unset(:contact_email)
+      puts "unset contact details for #{authority.name}"
+    end
+  end
+
+  def self.down
+    # This is a destructive migration so the data can't be recovered from here.
+    # Revert the associated changes to the LocalContactImporter and run that to
+    # re-import the contact details instead.
+  end
+end

--- a/lib/local_contact_importer.rb
+++ b/lib/local_contact_importer.rb
@@ -15,16 +15,8 @@ class LocalContactImporter < LocalAuthorityDataImporter
       return
     end
     authority.name = decode_broken_entities( row['Name'] )
-    authority.contact_address = parse_address(row)
-    authority.contact_phone = decode_broken_entities( row['Telephone Number 1'] )
-    authority.contact_url = parse_url( row['Contact page URL'] )
-    authority.contact_email = row['Main Contact Email']
     authority.homepage_url = parse_url( row['Home page URL'] )
     authority.save!
-  end
-
-  def parse_address(row)
-    [row['Address Line 1'], row['Address Line 2'], row['Town'], row['City'], row['County'], row['Postcode']].reject(&:blank?)
   end
 
   def parse_url(url)


### PR DESCRIPTION
Stop importing local authority contact details, and delete the existing contact details. We already don't use most of them and are stopping using the contact URL now. We're also [archiving the unused local authorities API](https://github.com/alphagov/govuk_content_api/pull/245) which exposes the contact details.

This is the third in a series of PRs to remove local authority contact details, and the first two should be merged and deployed before this one:

- https://github.com/alphagov/frontend/pull/962
- https://github.com/alphagov/govuk_content_api/pull/245

https://trello.com/c/asuAAsR6/399-delete-code-related-to-local-authority-contact-details