### PR TITLE
Simplify the task to send documents to Panopticon

### DIFF
--- a/db/migrate/20160527152831_unset_local_authority_contact_details.rb
+++ b/db/migrate/20160527152831_unset_local_authority_contact_details.rb
@@ -1,0 +1,17 @@
+class UnsetLocalAuthorityContactDetails < Mongoid::Migration
+  def self.up
+    LocalAuthority.all.each do |authority|
+      authority.unset(:contact_address)
+      authority.unset(:contact_phone)
+      authority.unset(:contact_url)
+      authority.unset(:contact_email)
+      puts "unset contact details for #{authority.name}"
+    end
+  end
+
+  def self.down
+    # This is a destructive migration so the data can't be recovered from here.
+    # Revert the associated changes to the LocalContactImporter and run that to
+    # re-import the contact details instead.
+  end
+end

--- a/lib/local_contact_importer.rb
+++ b/lib/local_contact_importer.rb
@@ -15,16 +15,8 @@ class LocalContactImporter < LocalAuthorityDataImporter
       return
     end
     authority.name = decode_broken_entities( row['Name'] )
-    authority.contact_address = parse_address(row)
-    authority.contact_phone = decode_broken_entities( row['Telephone Number 1'] )
-    authority.contact_url = parse_url( row['Contact page URL'] )
-    authority.contact_email = row['Main Contact Email']
     authority.homepage_url = parse_url( row['Home page URL'] )
     authority.save!
-  end
-
-  def parse_address(row)
-    [row['Address Line 1'], row['Address Line 2'], row['Town'], row['City'], row['County'], row['Postcode']].reject(&:blank?)
   end
 
   def parse_url(url)

--- a/lib/published_slug_registerer.rb
+++ b/lib/published_slug_registerer.rb
@@ -1,11 +1,8 @@
-require "gds_api/publishing_api"
 require 'gds_api/panopticon'
 
-# Registers slugs for published editions with other apps
-# Currently, this is content store and panopticon (and panopticon in turn
-# updates search).
+# Registers slugs for published editions with Panopticon (which in turn updates
+# rummager/search).
 class PublishedSlugRegisterer
-
   attr_reader :logger
 
   def initialize(logger, slugs)
@@ -64,7 +61,7 @@ private
     logger.info "Registering #{slug} [#{@count}/#{@slugs.count}]"
     edition = published_edition(slug)
     if edition
-      if register_with_panopticon(edition) && register_with_publishing_api(edition)
+      if register_with_panopticon(edition)
         @success_slugs << slug
       else
         @errored_slugs << slug
@@ -73,19 +70,6 @@ private
       @not_found_slugs << slug
       logger.error "No published edition found with slug #{slug}"
     end
-  end
-
-  def register_with_publishing_api(edition)
-    presenter = PublishedEditionPresenter.new(edition)
-    document_for_publishing_api = presenter.render_for_publishing_api(republish: true)
-    base_path = document_for_publishing_api[:base_path]
-
-    publishing_api.put_content_item(base_path, document_for_publishing_api)
-    true
-  end
-
-  def publishing_api
-    @publishing_api ||= GdsApi::PublishingApi.new(Plek.find("publishing-api"))
   end
 
   def register_with_panopticon(edition)

--- a/lib/tasks/register.rake
+++ b/lib/tasks/register.rake
@@ -2,53 +2,10 @@ require "published_slug_registerer"
 
 namespace :reregister do
 
-  desc "Re-register all published editions"
+  desc "Send all published editions to Panopticon"
   task :all => :environment do
     task_logger.info "Re-registering all published editions..."
     slugs = Edition.published.map(&:slug)
-    PublishedSlugRegisterer.new(task_logger, slugs).run
-  end
-
-  desc "Re-register published editions for slugs from stdin"
-  task :slugs_from_stdin => :environment do
-    task_logger.info "Re-registering published editions for slugs from stdin..."
-    slugs = []
-    while line = STDIN.gets
-      slugs << line.chomp
-    end
-    PublishedSlugRegisterer.new(task_logger, slugs).run
-  end
-
-  desc "Re-register published editions tagged to a topic, read from the TOPIC environment variable"
-  task :by_topic => :environment do
-    topic = ENV.fetch('TOPIC')
-    task_logger.info "Re-registering all published editions tagged to topic #{topic}..."
-    slugs = Artefact.where(
-      tags: {"tag_id" => topic, "tag_type" => "specialist_sector"},
-      owning_app: "publisher",
-    ).map(&:slug)
-    PublishedSlugRegisterer.new(task_logger, slugs).run
-  end
-
-  desc "Re-register published editions tagged to a browse page, read from the BROWSE_PAGE environment variable"
-  task :by_mainstream_browse => :environment do
-    browse_page = ENV.fetch('BROWSE_PAGE')
-    task_logger.info "Re-registering all published editions tagged to mainstream browse page #{browse_page}..."
-    slugs = Artefact.where(
-      tags: {"tag_id" => browse_page, "tag_type" => "section"},
-      owning_app: "publisher",
-    ).map(&:slug)
-    PublishedSlugRegisterer.new(task_logger, slugs).run
-  end
-
-  desc "Re-register published editions tagged to an organisation, read from the ORGANISATION environment variable"
-  task :by_organisation => :environment do
-    organisation = ENV.fetch('ORGANISATION')
-    task_logger.info "Re-registering all published editions tagged to organisation #{organisation}..."
-    slugs = Artefact.where(
-      tags: {"tag_id" => organisation, "tag_type" => "organisation"},
-      owning_app: "publisher",
-    ).map(&:slug)
     PublishedSlugRegisterer.new(task_logger, slugs).run
   end
 

--- a/test/unit/lib/published_slug_registerer_test.rb
+++ b/test/unit/lib/published_slug_registerer_test.rb
@@ -25,7 +25,6 @@ class PublishedSlugRegistererTest < ActiveSupport::TestCase
       make_edition("archived", "slug3", 1),
     ]
 
-    @publishing_api = stub(:publishing_api)
     @panopticon_registerer = stub(:panopticon_registerer)
     GdsApi::Panopticon::Registerer.stubs(:new).returns(@panopticon_registerer)
   end
@@ -42,20 +41,12 @@ class PublishedSlugRegistererTest < ActiveSupport::TestCase
     @panopticon_registerer.expects(:register).with(responds_with(:slug, slug))
   end
 
-  def stub_publishing(slug)
-    @publishing_api.expects(:put_content_item).with("/#{slug}", has_entries(
-      base_path: "/#{slug}",
-      update_type: "republish",
-    ))
-  end
-
   def completion_message(success, not_found, errored)
     "\nRegistration complete: processed #{success} slugs successfully, #{not_found} slugs not found, #{errored} slugs had errors"
   end
 
   def test_registers_published_editions
     @registerer = PublishedSlugRegisterer.new(@logger, @slugs)
-    @registerer.stubs(:publishing_api).returns(@publishing_api)
 
     @logger.expects(:info).at_least_once
     @logger.expects(:info).with(completion_message(2, 1, 0))
@@ -71,7 +62,6 @@ class PublishedSlugRegistererTest < ActiveSupport::TestCase
 
   def test_handles_panopticon_timeout
     @registerer = PublishedSlugRegisterer.new(@logger, @slugs)
-    @registerer.stubs(:publishing_api).returns(@publishing_api)
 
     @logger.expects(:info).at_least_once
     @logger.expects(:info).with(completion_message(2, 1, 0))
@@ -91,7 +81,6 @@ class PublishedSlugRegistererTest < ActiveSupport::TestCase
 
   def test_handles_panopticon_repeated_timeout
     @registerer = PublishedSlugRegisterer.new(@logger, @slugs)
-    @registerer.stubs(:publishing_api).returns(@publishing_api)
 
     @logger.expects(:info).at_least_once
     @logger.expects(:info).with(completion_message(0, 1, 2))


### PR DESCRIPTION
This app "registers" its documents with panopticon.

This commit removes the publishing-api interaction from the class, so that `PublishedSlugRegisterer` does only one thing (you can use `rake publishing_api:republish_content` to republish to the publishing-api more efficiently). The publishing-api sending had stopped working, because the client uses the V1 endpoint and does not use a bearer token.

Also removes a bunch of rake tasks that are seldom/never used to remove cognitive overload.