### PR TITLE
Reduce local services to only those in use

### DIFF
--- a/data/local_services.csv
+++ b/data/local_services.csv
@@ -4,165 +4,83 @@ LGSL,Description,Providing Tier
 3,Find out about home to school travel support,county/unitary
 4,Find out about free school meals,county/unitary
 9,Find out about an assessment of special educational needs,county/unitary
-11,Find out about disabled students allowance,county/unitary
 12,Find out about nursery school places,county/unitary
 13,Find out about primary school places,county/unitary
 14,Find out about secondary school places,county/unitary
 18,Find out about school holiday schemes,all
 19,Find out about after/before school childcare,county/unitary
-25,Find out more about student loans,county/unitary
-29,Find out about school governors,county/unitary
-34,Find out about pupil exclusions from school,county/unitary
 35,Find out about school truancy,county/unitary
 36,Find out school term dates,county/unitary
-37,Find out more about school meals,county/unitary
 40,Find out abut school transport for a child with special educational needs,county/unitary
-47,Find out about local organisations for students,county/unitary
 48,Find out about performance/stage licences for school age children,county/unitary
-51,Find out about instrumental tuition in schools,county/unitary
 55,Find out about business rates relief,district/unitary
-56,Business rates account enquiries,district/unitary
 57,Find out more about  council tax,district/unitary
-58,Find out about your council tax account,district/unitary
 59,Find out about discounts on council tax,district/unitary
-60,Find out about exemptions from council tax,district/unitary
-61,Find out about council tax band reductions,district/unitary
-62,Find out about backdating of council tax benefit claims,district/unitary
 63,Find out about council tax benefit,district/unitary
-64,Find out about changes in circumstances which affect council tax benefit claims,district/unitary
-65,Find out about appeals relating to council tax benefit decisions,district/unitary
-68,Find out about backdating of housing benefit claims,district/unitary
 69,Find out about housing benefit,district/unitary
-70,Find out about changes in circumstances which affect housing benefit claims,district/unitary
 72,Find out about appeals relating to housing benefit decisions,district/unitary
-85,Find out about 'Hard to Let' council properties,district/unitary
-87,Find out about Housing Association homes,district/unitary
 88,Find out about mutual council home exchange,district/unitary
 90,Find out about appealing against  a rehousing decision,district/unitary
 92,Find out about applying for a council home,district/unitary
-97,Find out about support for council tenants who are victims of crime,district/unitary
-98,Find out about support for council tenants who are victims of nuisance,district/unitary
-99,Find out about community safety on council estates,district/unitary
 101,Find out about squatters and unauthorised occupants in council property,district/unitary
-108,Find out about help from the council for private tenants,district/unitary
-109,Find out about advice for council tenants,district/unitary
 112,Find out about advice for homeless people,district/unitary
-114,Find out about parking on council estates,district/unitary
 115,Find out about renting a council garage,district/unitary
-116,Find out about rent arrears on a council tenancy,district/unitary
-117,Find out about eviction from council housing,district/unitary
-120,Find out about council housing rents,district/unitary
-122,Find out about communal heating charges for council properties,district/unitary
-123,Find out about home insurance for council tenants,district/unitary
 124,Find out about making insurance claims against the council,district/unitary
-129,Find out about the modernisation of council properties,district/unitary
-130,Find out about adaptions to council properties for people with mobility problems,district/unitary
-135,Find out about home improvement renovation grants,district/unitary
 137,Find out about the Disability Facility Grant,district/unitary
-139,Find out about emergency out of hours repairs to council homes,district/unitary
-140,Find out about repairs to communal areas of council properties,district/unitary
 141,Find out about repairs to council properties,district/unitary
-143,Find out about decoration and disturbance allowances for council tenants,district/unitary
-146,Find out about council home repairs,district/unitary
 147,Find out about garden maintenance for elderly or disabled council tenants,district/unitary
-149,Find out about council rent inspections of shared accommodation,district/unitary
-150,Find out about council safety inspections of homes in multiple occupation,district/unitary
 151,Find out about the right to buy scheme,district/unitary
-156,Find out about council repairs of communal areas (for leaseholders),district/unitary
 159,Find out about fostering a child,county/unitary
 160,Find out about adopting a child,county/unitary
 169,Find out about the council's interpreting and translation service,all
-175,Find out about parenting orders,county/unitary
 178,Find out about equipment and adaptions to the home for disabled people,county/unitary
-204,Find out about rehabilitation  to help recovery following illness or injury,county/unitary
 209,Find out about a needs assessment by social services,county/unitary
-225,Find out about advice and support for adult carers,county/unitary
-227,Find out about short term breaks for carers,county/unitary
 230,Find out about sheltered and supported housing,all
-242,Find out about care in your own home,county/unitary
 260,Find out about short term breaks for carers of children,county/unitary
-263,Find out about residential care for children,county/unitary
 266,Find your local authority's child protection team,county/unitary
-269,Find out about the keeping warm in winter service,county/unitary
 272,Find out about community transport schemes,district/unitary
 273,Find out about older person's bus pass,county/unitary
 274,Find out about parking bays for registered disabled drivers,county/unitary
 279,Find out about Blue Badge parking permits,county/unitary
 280,Find out about the disabled person's bus pass,county/unitary
 287,Find out about direct payments,county/unitary
-292,Find out more about residential care,county/unitary
 296,Find out about day centres,county/unitary
 297,Find out about local support groups and organisations,all
-298,Find out about local carer support groups and organisations,all
-300,Find out about advice and support for young carers,county/unitary
 313,Find out about community alarm services,district/unitary
 315,Find out about mobile meals service,county/unitary
-317,Find out about civil marriage ceremonies,county/unitary
-319,Find out about registering a birth,county/unitary
-322,Find out about registering a still birth,county/unitary
-323,Find out about searching for a birth certificate,county/unitary
-324,Find out about searching for a death certificate,county/unitary
 328,Find out about the bereavement service,district/unitary
-329,Find out about a community funeral service,district/unitary
-330,Find out about cremation,district/unitary
-331,Find out about funeral expenses,district/unitary
-333,Find out about buying a grave plot,district/unitary
-335,Find out about burial and grave details,district/unitary
-337,Find out about jobs at your local council,all
 353,Find out about complaints procedure,all
-354,"Search council minutes, agendas and reports",all
-355,Find out about councillors declaration of interest,all
-357,Find out about councillor advice surgeries,all
 358,Find out about your local councillors,all
-359,Find out local council news,all
 361,Find out about proxy votes,district/unitary
-362,Find out about elections,district/unitary
 364,Find out more about the electoral register,district/unitary
 372,Find out about abandoned vehicles,district/unitary
-382,Scaffolding and hoarding licence,county/unitary
-399,Find out about illegal street trading,district/unitary
 412,Find out about noise nuisance,district/unitary
-413,Find out about local air  pollution,district/unitary
 415,Find out about asbestos removal,district/unitary
-418,Find out about contaminated land,district/unitary
 428,Find out about removal and disposal of syringes,district/unitary
 431,Find out about pest control,district/unitary
 432,Find out about the dog warden service,district/unitary
-433,Find out about renovation grants,district/unitary
-435,Find out about infectious diseases,district/unitary
 437,Find out about library services,county/unitary
 438,Find out about joining a library,county/unitary
 439,Search the library catalogue,county/unitary
 440,Find out about library loans,county/unitary
 442,Find out about internet access in a library,county/unitary
-443,Find out about library fines,county/unitary
 444,Find out about mobile libraries,county/unitary
-445,Find out about the historical search service in a library,county/unitary
 448,Find out about archives,county/unitary
-456,Find out about leisure passes,district/unitary
 461,Find out about local parks,all
 471,Find out about parking fines,all
 474,Find out about parking permits,all
 477,Find out how to apply for a dropped kerb,county/unitary
-478,Find out about council car parks,district/unitary
-485,Find out about planning permission,district/unitary
 493,Find out about local transport policy,county/unitary
-497,Find out about crime prevention in town centres,district/unitary
 499,Find out about building regulations,district/unitary
 508,Find out about tree preservation orders,district/unitary
 510,Find out about allotments,district/unitary
 512,Find out about carrying out works on a property in a conservation area,district/unitary
-513,Find out about street naming and numbering,district/unitary
-514,Find out about listed buildings,district/unitary
 516,Search the register of planning decisions,district/unitary
 521,Find out about skip permits,county/unitary
 524,Find out which day the refuse is collected,district/unitary
-526,Find out about domestic bins,district/unitary
 528,Find out about special collections for large items,district/unitary
 530,Find out about disposing of garden waste,district/unitary
 533,Find out more about recycling collections,district/unitary
-534,Find your nearest recycling centre,all
-536,Find out more about blocked pavements,county/unitary
 537,Find out more about pavement problems,county/unitary
 541,Find out about street name plates,district/unitary
 546,Find out more about safe routes to school,county/unitary
@@ -177,7 +95,6 @@ LGSL,Description,Providing Tier
 567,Find out about traffic lights,county/unitary
 568,Find out about pedestrian crossings,county/unitary
 569,Find out about road works in your area,county/unitary
-570,Find out about road closures and diversions,county/unitary
 571,Find out about speed limits,county/unitary
 576,Find out about dead animal removal,district/unitary
 577,Find out about dog fouling,district/unitary
@@ -189,81 +106,27 @@ LGSL,Description,Providing Tier
 591,Find out about spillages on the roads,all
 600,Find out about dangerous buildings and structures,district/unitary
 603,Find out about nuisance caused by demolition work,district/unitary
-610,Find out about personal searches of local land charges,district/unitary
 615,Find out about grants to local voluntary organisations,all
-623,Find a tourist information centre,district/unitary
-629,Find out about volunteering for young people,county/unitary
 630,Find out how to complain about a school,county/unitary
 631,Find out about the chaperone service,county/unitary
-640,Find out about leisure activities for older people,district/unitary
-641,Find out about sports clubs,all
-642,Find out about youth clubs,all
-643,Find out about activities for young people,all
-644,Find out about sports facilities,district/unitary
-649,Find out about common land and village greens,all
-650,Find out about properties which are not fit to live in,district/unitary
-651,Find out about debt counselling,all
-652,Find out about advice for tenants and landlords in the private sector,district/unitary
-654,Find out about improving a council property,district/unitary
-655,Find out about gypsy and traveller sites,all
-657,Find out about alley gating,all
-663,Find out about copy certificates,county/unitary
 664,Find out about blocked drains,district/unitary
-665,Find out about supported tenancies,district/unitary
-670,Find out about play facilities in the community,district/unitary
-671,Find out about a council funeral,district/unitary
 684,Find out about open and derelict properties,district/unitary
-695,Skip operator licence,county/unitary
-698,Find out about historical searches on marriages,county/unitary
-700,Find advice for young people,county/unitary
-701,Find out about road adoption by the council,county/unitary
 703,Find out about emergency planning for a major incident,all
 705,Find out about the schools admissions appeals process,county/unitary
-711,Find out about changing a council tenancy,district/unitary
-719,Find out about local council meetings,all
-721,Find out about election results,all
-722,Find out about freedom of information requests,all
-734,Find out about holiday accommodation,district/unitary
-742,Street cafe licence,county/unitary
-744,Highway projection licence,county/unitary
-750,Find out about countryside volunteering,all
-780,Find out about the use and mooring of houseboats,district/unitary
-787,Find advice to consumers,county/unitary
-788,Find out about animal health and welfare,county/unitary
-802,Find out about fire safety,county/unitary
-810,Petroleum storage licence,county/unitary
-828,Find out about council contracts and tenders over £500,all
 831,"Find out about local support groups for children, young people and families",all
-838,Find out about local arts events,all
-840,Find out about support for looked after children,county/unitary
-843,Weighbridge operator certificate,county/unitary
 850,Find out about hazardous waste collection,district/unitary
-851,Find out about recycling,all
 852,Find out about citizenship ceremonies,county/unitary
-856,Find out about Local Development Frameworks,district/unitary
 859,Find out about collection of clinical waste,district/unitary
 860,Find out about liquor licences,district/unitary
 867,Find out about local consultations,all
 870,Find out about community safety,all
-873,Find out about naming ceremonies,county/unitary
-874,Find out about marriage renewal ceremonies,county/unitary
-876,Find out about civil partnerships,county/unitary
-1077,Performing animals licence,county/unitary
 1116,Find out about Youth Opportunity Funding,county/unitary
 1135,Find out about transport for 16-19 year olds in education,county/unitary
 1140,Find out about emergency school closures,county/unitary
 1145,Find your local 14-19 prospectus,county/unitary
-1150,Find out about your Local Area Network (LINk),county/unitary
-1287,Get local information about swine flu,all
-1296,Civil marriage and civil partnership venue licence,county/unitary
 1307,Get information on services disrupted by severe weather,all
-1354,"Licence for bridges, buildings, beams and cables over or along the highway",county/unitary
-1465,Find out about details of council expenditure,all
-1573,Find out about senior salary details at your council,all
-1574,Find out about councillor allowances and expenses at your council,all
 1579,Find out about family information services,county/unitary
 1580,Find out how to hold a street party,all
-1584,Find out when you can check the accounts at your council,all
 1741,Find out about free early education,county/unitary
 1742,Find the location of weighbridges,county/unitary
 1743,Find out about the Care Act 2014,county/unitary

--- a/db/migrate/20160621120231_fix_incorrect_lgsl_code_in_archived_local_transaction_edition.rb
+++ b/db/migrate/20160621120231_fix_incorrect_lgsl_code_in_archived_local_transaction_edition.rb
@@ -1,0 +1,16 @@
+class FixIncorrectLgslCodeInArchivedLocalTransactionEdition < Mongoid::Migration
+  def self.up
+    # "Editing of an edition with an Archived artefact is not allowed".
+    Edition.skip_callback(:save, :before, :check_for_archived_artefact)
+
+    # LGSL Code 1743 entered incorrectly as 1473 (see: https://github.com/alphagov/publisher/commit/5411e984203fe57149089f06961ca76fe201db46)
+    care_act_editions = LocalTransactionEdition.where(lgsl_code: 1473)
+    care_act_editions.each do |edition|
+      edition.lgsl_code = 1743
+      edition.save!(validate: false)
+    end
+  end
+
+  def self.down
+  end
+end

--- a/lib/local_service_cleaner.rb
+++ b/lib/local_service_cleaner.rb
@@ -1,0 +1,46 @@
+require 'set'
+
+class LocalServiceCleaner
+  def initialize(input_data = LocalServiceImporter.fetch_data)
+    @input_data = input_data
+  end
+
+  def run
+    LocalService.all.each do |local_service|
+      print "Looking at #{local_service.lgsl_code} -"
+      if in_csv? local_service
+        puts " in csv"
+      elsif in_local_transaction? local_service
+        puts " in local transaction"
+      else
+        puts " removed"
+        local_service.destroy!
+      end
+    end
+  end
+
+  def lgsls_from_csv
+    @_lgsls_from_csv ||= fetch_lgsls_from_csv
+  end
+
+private
+
+  def in_csv?(local_service)
+    lgsls_from_csv.include? local_service.lgsl_code
+  end
+
+  def in_local_transaction?(local_service)
+    LocalTransactionEdition.where(lgsl_code: local_service.lgsl_code).any?
+  end
+
+  def fetch_lgsls_from_csv
+    output = Set.new
+    CSV.new(@input_data, headers: true).
+      each.with_object(output) do |row, lgsls|
+        lgsls.add row['LGSL'].to_i
+      end
+    output
+  ensure
+    @input_data.close unless @input_data.nil? || @input_data.closed?
+  end
+end

--- a/lib/tasks/local_transactions.rake
+++ b/lib/tasks/local_transactions.rake
@@ -9,6 +9,7 @@ namespace :local_transactions do
   task :fetch_and_clean => :environment do
     Rake::Task["local_transactions:fetch"].invoke
     Rake::Task["check_for_ghosts:remove"].invoke
+    Rake::Task["local_transactions:remove_old_services"].invoke
   end
 
   desc "Dowload the latest contact list CSV from Local Directgov and import"
@@ -24,5 +25,10 @@ namespace :local_transactions do
   desc "Import services from the service list CSV"
   task :update_services => :environment do
     LocalServiceImporter.update
+  end
+
+  desc "Removes services that do not appear in the service list CSV"
+  task remove_old_services: :environment do
+    LocalServiceCleaner.new.run
   end
 end

--- a/test/unit/lib/local_service_cleaner_test.rb
+++ b/test/unit/lib/local_service_cleaner_test.rb
@@ -1,0 +1,47 @@
+require_relative '../../test_helper'
+
+class LocalServiceCleanerTest < ActiveSupport::TestCase
+  context "removing services we don't need anymore" do
+    setup do
+      data = "LGSL,Description,Providing Tier\n"
+      data += "1234,Finding Joy,all\n"
+      data += "5678,Escaping Sadness,county/unitary\n"
+      @input = StringIO.new(data)
+    end
+
+    context 'when lgsl of service present in input' do
+      setup do
+        @service = LocalService.create(lgsl_code: 1234, description: 'Escaping Joy', providing_tier: %w{district unitary county})
+      end
+
+      should 'not destroy service' do
+        LocalServiceCleaner.new(@input).run
+        assert LocalService.where(id: @service.id).any?
+      end
+    end
+
+    context 'when lgsl of service not present in input' do
+      setup do
+        @service = LocalService.create(lgsl_code: 9012, description: 'Whatever', providing_tier: %w{district unitary county})
+      end
+
+      context 'and lgsl not used by local transaction edition' do
+        should 'destroy service' do
+          LocalServiceCleaner.new(@input).run
+          refute LocalService.where(id: @service.id).any?
+        end
+      end
+
+      context 'but lgsl used by local transaction edition' do
+        setup do
+          @edition = FactoryGirl.create(:local_transaction_edition, lgsl_code: 9012)
+        end
+
+        should 'not destroy service' do
+          LocalServiceCleaner.new(@input).run
+          assert LocalService.where(id: @service.id).any?
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
For: https://trello.com/c/bXJG1RU8/401-investigate-and-fix-data-discrepancies-3

We want to use the local_services.csv as an indicator of which LGSL codes are actually used by GOV.UK documents.  To this end we remove all rows from it that are not currently used by a local transaction and provide rake tasks to clean up the now "orphaned" instances that would be left in the DB.

There's also a db migration which should be run before the rake task to fix the LGSL code used in an archived edition.

See the individual commits for a more verbose description of why we're doing this.