### PR TITLE
Add LGSL 107 as first step of replacing 230

### DIFF
--- a/data/local_services.csv
+++ b/data/local_services.csv
@@ -23,6 +23,7 @@ LGSL,Description,Providing Tier
 90,Find out about appealing against  a rehousing decision,district/unitary
 92,Find out about applying for a council home,district/unitary
 101,Find out about squatters and unauthorised occupants in council property,district/unitary
+107,Find out about sheltered and supported housing,all
 112,Find out about advice for homeless people,district/unitary
 115,Find out about renting a council garage,district/unitary
 124,Find out about making insurance claims against the council,district/unitary


### PR DESCRIPTION
We currently use LGSL 230 to refer to sheltered housing, however this is from the Scottish list and is not supported in England and Wales.  107 seems like a better bet for us, also because it refers to sheltered housing more generally, as opposed to just for older people.

As a first step, we'll add 107 as an enabled service.

There is other work that needs to be done as part of this, and this is coordinated via [this Trello card](https://trello.com/c/Zb42F6Jq/417-switch-local-transaction-for-apply-for-sheltered-housing-from-one-lgsl-to-another-3).  Once that work is done, we can retire 230.