### PR TITLE
Retire LGSL 230 (sheltered housing) in favour of LGSL 107

### DIFF
--- a/data/local_services.csv
+++ b/data/local_services.csv
@@ -35,7 +35,6 @@ LGSL,Description,Providing Tier
 160,Find out about adopting a child,county/unitary
 178,Find out about equipment and adaptions to the home for disabled people,county/unitary
 209,Find out about a needs assessment by social services,county/unitary
-230,Find out about sheltered and supported housing,all
 260,Find out about short term breaks for carers of children,county/unitary
 272,Find out about community transport schemes,district/unitary
 273,Find out about older person's bus pass,county/unitary

--- a/db/migrate/20160719141858_change_lgsl_230_to_107_on_local_transaction.rb
+++ b/db/migrate/20160719141858_change_lgsl_230_to_107_on_local_transaction.rb
@@ -1,0 +1,15 @@
+class ChangeLgsl230To107OnLocalTransaction < Mongoid::Migration
+  def self.up
+    # "Editing of an edition with an Archived artefact is not allowed".
+    Edition.skip_callback(:save, :before, :check_for_archived_artefact)
+
+    sheltered_housing_editions = LocalTransactionEdition.where(lgsl_code: 230)
+    sheltered_housing_editions.each do |edition|
+      edition.lgsl_code = 107
+      edition.save!(validate: false)
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
LGSL 230 is being retired in favour of LGSL 107 which was added in a previous commit.

We're waiting until we've done the rest of the shuffling steps in https://trello.com/c/Zb42F6Jq/417-switch-local-transaction-for-apply-for-sheltered-housing-from-one-lgsl-to-another-3 before removing 230 from the CSV.  This means that we will no longer import URLs for LGSL 230 from Local Direct Gov. 

We'll then run the migration to change the LGSL code on the LocalTransactions from 230 to 107 (which we are still importing)

We'll then run the `local_transactions:remove_old_services` task to clean up