### PR TITLE
Make 20160805145635_remove_local_interactions.rb runnable

### DIFF
--- a/db/migrate/20160805145635_remove_local_interactions.rb
+++ b/db/migrate/20160805145635_remove_local_interactions.rb
@@ -1,6 +1,8 @@
 class RemoveLocalInteractions < Mongoid::Migration
   def self.up
-    LocalAuthority.all.each { |la| la.unset(:local_interactions) }
+    # The next migration removes this collection entirely, and the model at
+    # this point is gone, so this line fails.
+    # LocalAuthority.all.each { |la| la.unset(:local_interactions) }
   end
 
   def self.down


### PR DESCRIPTION
The commits after this migration removed the LocalAuthority model
entirely so this migration can no longer run successfully.  The next
migration also removes the local_authorities collection so the work
this migration does is superceded by that migration.  Commenting out
the broken reference to LocalAuthority seems like the best approach
to making it runnable.