### PR TITLE
Add 'kind' column to generated report

### DIFF
--- a/app/presenters/organisation_content_presenter.rb
+++ b/app/presenters/organisation_content_presenter.rb
@@ -4,6 +4,7 @@ class OrganisationContentPresenter < CSVPresenter
     self.column_headings = [
       :id,
       :name,
+      :format,
       :slug,
       :state,
       :browse_pages,
@@ -36,6 +37,8 @@ private
       artefact.organisations.map(&:title).join(", ")
     when :need_ids
       artefact.need_ids.join(',')
+    when :format
+      artefact.kind
     else
       super
     end

--- a/test/unit/organisation_content_presenter_test.rb
+++ b/test/unit/organisation_content_presenter_test.rb
@@ -11,6 +11,7 @@ class OrganisationContentPresenterTest < ActiveSupport::TestCase
     document = FactoryGirl.create(:artefact,
       name: "Important document",
       organisations: [hmrc.tag_id],
+      kind: "answer",
       need_ids: ["123456","123321","654321"]
     )
     FactoryGirl.create(:edition,
@@ -30,6 +31,7 @@ class OrganisationContentPresenterTest < ActiveSupport::TestCase
     assert_equal "business-tax/vat", data[0]["Primary topic"]
     assert_equal "oil-and-gas/licensing,environmental-management/boating", data[0]["Additional topics"]
     assert_equal "HMRC", data[0]["Organisations"]
+    assert_equal "answer", data[0]["Format"]
     assert_equal "123456,123321,654321", data[0]["Need ids"]
   end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/MFIzBBFZ/23-add-new-fields-to-publisher-export)

Titled as 'format' because that's what's shown in panopticon. We want to make this information available in the publisher reports so that it's still available when panopticon is retired.

TODO:

- [x] Deploy this branch to integration and run the rake task to generate these reports. I haven't been able to do this locally due to the hilarious number of app dependencies involved.