### PR TITLE
Remove unused collections in shared database

### DIFF
--- a/db/migrate/20160901083027_remove_unused_collections.rb
+++ b/db/migrate/20160901083027_remove_unused_collections.rb
@@ -1,0 +1,10 @@
+class RemoveUnusedCollections < Mongoid::Migration
+  def self.up
+    Mongoid.default_client['authorities'].drop
+    Mongoid.default_client['local_transactions_source_lgsls'].drop
+    Mongoid.default_client['local_transactions_sources'].drop
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
These collections are old and redundant so we'll clean them up.

They last had documents added in Feb 2012 at the latest and we can't find any reference of them being used now.

[Trello card](https://trello.com/c/2NFVxE0F/472-clean-up-old-unused-collections-in-shared-database-3-2)