### PR TITLE
Filter out Linkables with nil titles (eg. redirects)

### DIFF
--- a/lib/tagging/linkables.rb
+++ b/lib/tagging/linkables.rb
@@ -61,7 +61,8 @@ module Tagging
     end
 
     def get_tags_of_type(document_type)
-      Services.publishing_api.get_linkables(format: document_type)
+      items = Services.publishing_api.get_linkables(format: document_type)
+      items.select { |item| item['internal_name'] }
     end
   end
 end

--- a/test/support/tag_test_helpers.rb
+++ b/test/support/tag_test_helpers.rb
@@ -11,6 +11,7 @@ module TagTestHelpers
       { base_path: '/browse/tax/vat', internal_name: 'Tax / VAT', publication_state: 'published', content_id: 'CONTENT-ID-VAT' },
       { base_path: '/browse/tax/capital-gains', internal_name: 'Tax / Capital Gains Tax', publication_state: 'published', content_id: 'CONTENT-ID-CAPITAL' },
       { base_path: '/browse/tax/rti', internal_name: 'Tax / RTI', publication_state: 'draft', content_id: 'CONTENT-ID-RTI' },
+      { base_path: '/browse/tax/nil', internal_name: nil, publication_state: 'draft', content_id: 'CONTENT-ID-NIL' },
     ], document_type: "mainstream_browse_page")
 
     publishing_api_has_linkables([


### PR DESCRIPTION
https://errbit.publishing.service.gov.uk/apps/5304e0520da11511b0000011/problems/57d7ed6c6578636cf0a40100

Publisher is erroring due to a redirected browse page which now has a nil title. So filter out items with nil titles.