### PR TITLE
Send external related links to publishing api

### DIFF
--- a/app/presenters/published_edition_presenter.rb
+++ b/app/presenters/published_edition_presenter.rb
@@ -28,12 +28,22 @@ class PublishedEditionPresenter
           additional_topics: @edition.additional_topics,
           topics: (primary_topic + @edition.additional_topics)
         },
+        external_related_links: external_related_links,
       },
       locale: 'en',
     }
   end
 
 private
+
+  def external_related_links
+    @edition.artefact.external_links.map do |link|
+      {
+        "url": link["url"],
+        "title": link["title"]
+      }
+    end
+  end
 
   def base_path
     "/#{@edition.slug}"

--- a/test/unit/published_edition_presenter_test.rb
+++ b/test/unit/published_edition_presenter_test.rb
@@ -7,6 +7,12 @@ class PublishedEditionPresenterTest < ActiveSupport::TestCase
     setup do
       artefact = FactoryGirl.create(:artefact)
 
+      expected_external_related_links = [
+        { title: "GOVUK", url: "https://www.gov.uk" },
+        { title: "GOVUK", url: "https://www.gov.uk" },
+      ]
+      artefact.external_links = expected_external_related_links
+
       @edition = FactoryGirl.create(:edition, :published,
         browse_pages: ["tax/vat", "tax/capital-gains"],
         primary_topic: "oil-and-gas/wells",
@@ -40,7 +46,8 @@ class PublishedEditionPresenterTest < ActiveSupport::TestCase
             primary_topic: ["oil-and-gas/wells"],
             additional_topics: ["oil-and-gas/fields", "oil-and-gas/distillation"],
             topics: ["oil-and-gas/wells", "oil-and-gas/fields", "oil-and-gas/distillation"],
-          }
+          },
+          external_related_links: expected_external_related_links,
         },
         locale: 'en',
       }


### PR DESCRIPTION
The final objective is storing and retrieving them from the content-store.

This PR needs to be merged first: https://github.com/alphagov/govuk-content-schemas/pull/392

Ticket: https://trello.com/c/rDKC4sLm/133-send-related-external-links-to-pub-api-from-publisher
Part of: https://trello.com/c/mOeDK914/107-epic-related-links-and-panopticon
