### PR TITLE
Send documents to Rummager directly

### DIFF
--- a/app/presenters/search_payload_presenter.rb
+++ b/app/presenters/search_payload_presenter.rb
@@ -1,0 +1,33 @@
+class SearchPayloadPresenter
+  attr_reader :registerable_edition
+  delegate :slug,
+           :title,
+           :description,
+           :indexable_content,
+           :public_timestamp,
+           :artefact,
+           :format,
+           to: :registerable_edition
+
+  def initialize(registerable_edition)
+    @registerable_edition = registerable_edition
+  end
+
+  def self.present(registerable_edition)
+    new(registerable_edition).present
+  end
+
+  def present
+    {
+      content_id: artefact.content_id,
+      rendering_app: "publisher",
+      publishing_app: "publisher",
+      format: format.underscore,
+      title: title,
+      description: description,
+      indexable_content: indexable_content,
+      link: "/#{slug}",
+      public_timestamp: public_timestamp,
+    }
+  end
+end

--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -1,0 +1,30 @@
+class SearchIndexer
+  attr_reader :edition
+  delegate :slug, to: :edition
+
+  def initialize(edition)
+    @edition = edition
+  end
+
+  def self.call(edition)
+    new(edition).call
+  end
+
+  def call
+    Services.rummager.add_document(type, document_id, payload)
+  end
+
+private
+
+  def type
+    'edition'
+  end
+
+  def document_id
+    "/#{slug}"
+  end
+
+  def payload
+    SearchPayloadPresenter.present(edition)
+  end
+end

--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -1,4 +1,10 @@
 class SearchIndexer
+  FORMATS_NOT_TO_INDEX = %w(business_support completed_transaction)
+
+  # These are business support pages. They need to appear in search results as
+  # the content team expects that some users will search for them explicitly.
+  EXCEPTIONAL_SLUGS = %w(start-up-loans horizon-2020)
+
   attr_reader :edition
   delegate :slug, to: :edition
 
@@ -11,10 +17,20 @@ class SearchIndexer
   end
 
   def call
-    Services.rummager.add_document(type, document_id, payload)
+    if indexable?
+      Services.rummager.add_document(type, document_id, payload)
+    end
   end
 
 private
+
+  def kind
+    edition.artefact.kind
+  end
+
+  def indexable?
+    FORMATS_NOT_TO_INDEX.exclude?(kind) || EXCEPTIONAL_SLUGS.include?(slug)
+  end
 
   def type
     'edition'

--- a/lib/edition_slug_migrator.rb
+++ b/lib/edition_slug_migrator.rb
@@ -20,10 +20,12 @@ class EditionSlugMigrator
 
           # if there is a published edition, register the published edition
           # if there isn't a published edition, register the latest edition
-          if edition.published_edition.present?
-            edition.register_with_panopticon if edition == edition.published_edition
+          if edition.published_edition.present? && (edition == edition.published_edition)
+            edition.register_with_panopticon
+            edition.register_with_rummager
           elsif edition.latest_edition?
             edition.register_with_panopticon
+            edition.register_with_rummager
           end
 
           edition.actions.create!(

--- a/lib/mainstream_slug_updater.rb
+++ b/lib/mainstream_slug_updater.rb
@@ -9,7 +9,7 @@ class MainstreamSlugUpdater
   def update
     update_slug_on_all_editions
     update_artefact_slug
-    reregister_slug_with_panopticon
+    reregister_slug
   end
 
   def published_edition
@@ -49,8 +49,9 @@ private
     artefact.save_as(user, validate: false)
   end
 
-  def reregister_slug_with_panopticon
-    logger.info "Re-registering with panopticon to re-create in search"
+  def reregister_slug
+    logger.info "Re-registering with panopticon and rummager"
     published_edition.register_with_panopticon
+    published_edition.register_with_rummager
   end
 end

--- a/lib/registerable_edition.rb
+++ b/lib/registerable_edition.rb
@@ -1,7 +1,13 @@
 class RegisterableEdition
   extend Forwardable
 
-  def_delegators :@edition, :slug, :title, :indexable_content, :latest_change_note
+  def_delegators :@edition,
+    :slug,
+    :title,
+    :artefact,
+    :indexable_content,
+    :latest_change_note,
+    :format
 
   def initialize(edition)
     @edition = edition

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,4 +1,5 @@
 require "gds_api/publishing_api_v2"
+require "gds_api/rummager"
 
 module Services
   def self.publishing_api
@@ -6,5 +7,9 @@ module Services
       Plek.new.find('publishing-api'),
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
     )
+  end
+
+  def self.rummager
+    @rummager ||= GdsApi::Rummager.new(Plek.new.find("search"))
   end
 end

--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -5,7 +5,7 @@ namespace :panopticon do
   task reregister_all: [:environment] do
     task_logger.info "Re-registering all published editions..."
     slugs = Edition.published.map(&:slug)
-    PublishedSlugRegisterer.new(task_logger, slugs).run
+    PublishedSlugRegisterer.new(task_logger, slugs).do_panopticon
   end
 
   def task_logger

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,0 +1,14 @@
+require "published_slug_registerer"
+
+namespace :rummager do
+  desc "Indexes all editions in Rummager"
+  task index_all: :environment do
+    task_logger.info "Sending published editions to rummager..."
+    slugs = Edition.published.map(&:slug)
+    PublishedSlugRegisterer.new(task_logger, slugs).do_rummager
+  end
+
+  def task_logger
+    @_task_logger ||= GdsApi::Base.logger = Logger.new(STDERR).tap { |l| l.level = Logger::INFO }
+  end
+end

--- a/test/integration/edition_scheduled_publishing_test.rb
+++ b/test/integration/edition_scheduled_publishing_test.rb
@@ -52,7 +52,7 @@ class EditionScheduledPublishingTest < JavascriptIntegrationTest
 
   test "should allow a scheduled edition to be published now" do
     edition = FactoryGirl.create(:edition, :scheduled_for_publishing)
-    stub_artefact_registration(edition.slug)
+    stub_register_published_content
 
     visit_edition edition
     assert page.has_css?('.label', text: "Scheduled for publishing on #{edition.publish_at.strftime('%d/%m/%Y %H:%M')}")

--- a/test/integration/request_tracing_test.rb
+++ b/test/integration/request_tracing_test.rb
@@ -7,6 +7,7 @@ class RequestTracingTest < ActionDispatch::IntegrationTest
 
     stub_request(:any, /publishing-api/)
     stub_request(:put, /panopticon/)
+    stub_request(:post, /search/)
   end
 
   test "govuk_request_id is passed downstream across the worker boundary on publish" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -67,6 +67,7 @@ class ActiveSupport::TestCase
 
   def stub_register_published_content
     WebMock.stub_request(:put, %r{\A#{PANOPTICON_ENDPOINT}/artefacts/})
+    WebMock.stub_request(:post, %r{search.dev.gov.uk/documents})
   end
 
   teardown do

--- a/test/unit/edition_slug_migrator_test.rb
+++ b/test/unit/edition_slug_migrator_test.rb
@@ -19,6 +19,7 @@ class EditionSlugMigratorTest < ActiveSupport::TestCase
         "third-original-slug" => "third-new-slug"
       })
     GdsApi::Panopticon::Registerer.any_instance.stubs(:register)
+    SearchIndexer.stubs(:call)
 
     @it = EditionSlugMigrator.new( Logger.new("/dev/null") )
   end
@@ -31,10 +32,9 @@ class EditionSlugMigratorTest < ActiveSupport::TestCase
   end
 
   should "reregister the latest or published edition with Panopticon" do
-    GdsApi::Panopticon::Registerer.any_instance.unstub(:register)
-
     ["first-new-slug","second-new-slug","third-new-slug"].each do |slug|
       GdsApi::Panopticon::Registerer.any_instance.expects(:register).with(responds_with(:slug, slug)).returns(true)
+      SearchIndexer.expects(:call).with(responds_with(:slug, slug))
     end
 
     @it.run

--- a/test/unit/lib/mainstream_slug_updater_test.rb
+++ b/test/unit/lib/mainstream_slug_updater_test.rb
@@ -12,6 +12,7 @@ class MainstreamSlugUpdaterTest < ActiveSupport::TestCase
     @published_edition = FactoryGirl.create(:edition, slug: @old_slug, panopticon_id: @artefact.id, state: 'published', version_number: 2)
 
     AnswerEdition.any_instance.stubs(:register_with_panopticon)
+    AnswerEdition.any_instance.stubs(:register_with_rummager)
   end
 
   def test_slug_is_updated_on_relevent_editions
@@ -33,9 +34,10 @@ class MainstreamSlugUpdaterTest < ActiveSupport::TestCase
     assert_equal @published_edition, updater.published_edition
   end
 
-  def test_slug_is_registered_with_panopticon
+  def test_slug_is_reregistered
     updater = MainstreamSlugUpdater.new(@old_slug, @new_slug)
     updater.published_edition.expects(:register_with_panopticon)
+    updater.published_edition.expects(:register_with_rummager)
 
     updater.update
   end

--- a/test/unit/search_indexer_test.rb
+++ b/test/unit/search_indexer_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class SearchIndexerTest < ActiveSupport::TestCase
+  def test_indexing_to_rummager
+    artefact = FactoryGirl.create(
+      :artefact,
+      content_id: "content-id",
+    )
+    edition = FactoryGirl.create(
+      :answer_edition,
+      title: "A title",
+      overview: "An overview",
+      panopticon_id: artefact.id,
+      body: "Indexable content",
+    )
+    registerable_edition = RegisterableEdition.new(edition)
+
+    Services.rummager.expects(:add_document).with(
+      'edition',
+      "/#{edition.slug}",
+      content_id: "content-id",
+      rendering_app: "publisher",
+      publishing_app: "publisher",
+      format: "answer",
+      title: "A title",
+      description: "An overview",
+      indexable_content: "Indexable content",
+      link: "/#{edition.slug}",
+      public_timestamp: registerable_edition.public_timestamp,
+    )
+
+    SearchIndexer.call(registerable_edition)
+  end
+end


### PR DESCRIPTION
Previously this app would send documents to Panopticon in order to have
them added to the search index. This flow is now being simplified so
that all apps send documents to Rummager directly.

This commit adds:

- a presenter to form the payload required by Rummager. The payload now
  includes the following extra attributes: publishing_app, rendering_app
  and content_id.
- an indexer service object to handle the actual sending.
- updates across codebase and test suite wherever interaction with
  panopticon takes place.

search-admin result before:

![screen shot 2016-09-22 at 15 46 33](https://cloud.githubusercontent.com/assets/519250/18785639/3bb9403e-8191-11e6-9135-752d858c8d06.png)

search-admin result after:

![screen shot 2016-09-22 at 15 47 48](https://cloud.githubusercontent.com/assets/519250/18785643/41ab26ce-8191-11e6-8f9d-24632d7f0660.png)
