### PR TITLE
Add possibility to tag organisations

### DIFF
--- a/app/views/shared/_tagging.html.erb
+++ b/app/views/shared/_tagging.html.erb
@@ -32,11 +32,10 @@
                          class: 'select2',
                          data: { module: "tagging", placeholder: 'Choose a breadcrumb…' } } %>
 
-         <br />
          <div class="alert mainstream alert-warning hidden">
+           <br />
            The breadcrumb does not match the browse pages.
          </div>
-
 
           <p class='help-block'>
             If the page has a breadcrumb, it will be this browse page. For example
@@ -62,6 +61,20 @@
             <a href="https://www.gov.uk/topic/business-tax/vat/email-signup">email alert to subscribers</a>.
             Formerly called <i>specialist sectors</i>.
           </p>
+        </div>
+
+        <div class="form-group" id="edition_organisations_input">
+          <%= f.label :organisations, "Organisations", class: 'control-label' %>
+          <%= f.select :organisations, @linkables.organisations,
+                       {},
+                       { multiple: true,
+                         class: 'select2',
+                         data: { placeholder: 'Choose Organisations…' } } %>
+
+           <p class="help-block">
+           Tagging a page to an organisation will make it show up in search.
+           Example: <a href="https://www.gov.uk/search?q=taxes&amp;filter_organisations%5B%5D=hm-revenue-customs">search for documents published by HMRC</a>.
+           </p>
         </div>
       </div>
     </div>

--- a/lib/tagging/tagging_update_form.rb
+++ b/lib/tagging/tagging_update_form.rb
@@ -2,7 +2,7 @@ module Tagging
   class TaggingUpdateForm
     include ActiveModel::Model
     attr_accessor :content_id, :previous_version
-    attr_accessor :topics, :mainstream_browse_pages, :parent
+    attr_accessor :topics, :organisations, :mainstream_browse_pages, :parent
 
     def self.build_from_publishing_api(content_id)
       link_set = LinkSet.find(content_id)
@@ -11,6 +11,7 @@ module Tagging
         content_id: content_id,
         previous_version: link_set.version,
         topics: link_set.links['topics'],
+        organisations: link_set.links['organisations'],
         mainstream_browse_pages: link_set.links['mainstream_browse_pages'],
         parent: link_set.links['parent'],
       )
@@ -27,6 +28,7 @@ module Tagging
     def links_payload
       {
         topics: clean_content_ids(topics),
+        organisations: clean_content_ids(organisations),
         mainstream_browse_pages: clean_content_ids(mainstream_browse_pages),
         parent: clean_content_ids(parent),
       }

--- a/test/integration/tagging_test.rb
+++ b/test/integration/tagging_test.rb
@@ -24,6 +24,7 @@ class TaggingTest < JavascriptIntegrationTest
         @content_id,
         links: {
           topics: [],
+          organisations: [],
           mainstream_browse_pages: ["CONTENT-ID-RTI", "CONTENT-ID-VAT"],
           parent: [],
         },
@@ -43,6 +44,26 @@ class TaggingTest < JavascriptIntegrationTest
         @content_id,
         links: {
           topics: ['CONTENT-ID-DISTILL', 'CONTENT-ID-FIELDS'],
+          organisations: [],
+          mainstream_browse_pages: [],
+          parent: [],
+        },
+        previous_version: 0
+      )
+    end
+
+    should "tag to organisations" do
+      visit edition_path(@edition)
+      switch_tab 'Tagging'
+
+      select 'Student Loans Company', from: 'Organisations'
+
+      save_tags_and_assert_success
+      assert_publishing_api_patch_links(
+        @content_id,
+        links: {
+          topics: [],
+          organisations: ["9a9111aa-1db8-4025-8dd2-e08ec3175e72"],
           mainstream_browse_pages: [],
           parent: [],
         },
@@ -61,6 +82,7 @@ class TaggingTest < JavascriptIntegrationTest
         @content_id,
         links: {
           topics: [],
+          organisations: [],
           mainstream_browse_pages: [],
           parent: ['CONTENT-ID-RTI'],
         },
@@ -93,6 +115,7 @@ class TaggingTest < JavascriptIntegrationTest
         @content_id,
         links: {
           topics: ['CONTENT-ID-FIELDS', 'CONTENT-ID-WELLS'],
+          organisations: [],
           mainstream_browse_pages: ['CONTENT-ID-RTI', 'CONTENT-ID-VAT'],
           parent: ['CONTENT-ID-CAPITAL'],
         },

--- a/test/support/tag_test_helpers.rb
+++ b/test/support/tag_test_helpers.rb
@@ -19,5 +19,18 @@ module TagTestHelpers
       { base_path: '/topic/oil-and-gas/fields', internal_name: 'Oil and Gas / Fields', publication_state: 'published', content_id: 'CONTENT-ID-FIELDS' },
       { base_path: '/topic/oil-and-gas/distillation', internal_name: 'Oil and Gas / Distillation', publication_state: 'draft', content_id: 'CONTENT-ID-DISTILL' },
     ], document_type: "topic")
+
+    publishing_api_has_linkables(
+      [
+        {
+          "public_updated_at" => "2014-10-15 14:35:22",
+          "title" => "Student Loans Company",
+          "content_id" => "9a9111aa-1db8-4025-8dd2-e08ec3175e72",
+          "publication_state" => "live",
+          "base_path" => "/government/organisations/student-loans-company",
+          "internal_name" => "Student Loans Company"
+        },
+      ],
+      document_type: "organisation")
   end
 end

--- a/test/unit/tagging/linkables_test.rb
+++ b/test/unit/tagging/linkables_test.rb
@@ -1,9 +1,11 @@
 require 'test_helper'
 
 class LinkablesTest < ActiveSupport::TestCase
-  test "returns sorted topics" do
+  setup do
     stub_linkables
+  end
 
+  test "returns sorted topics" do
     assert_equal({
       "Oil and Gas" => [
         ["Oil and Gas / Distillation (draft)", "CONTENT-ID-DISTILL"],
@@ -14,8 +16,6 @@ class LinkablesTest < ActiveSupport::TestCase
   end
 
   test "returns sorted browse pages" do
-    stub_linkables
-
     assert_equal({
       "Tax" => [
         ["Tax / Capital Gains Tax", "CONTENT-ID-CAPITAL"],
@@ -23,5 +23,12 @@ class LinkablesTest < ActiveSupport::TestCase
         ["Tax / VAT", "CONTENT-ID-VAT"]
       ]
     }, Tagging::Linkables.new.mainstream_browse_pages)
+  end
+
+  test "returns organisations" do
+    assert_equal(
+      [["Student Loans Company", "9a9111aa-1db8-4025-8dd2-e08ec3175e72"]],
+      Tagging::Linkables.new.organisations
+    )
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/tSuV5leL/192-add-publishing-organisation-to-mainstream-publisher

## Before
<img width="612" alt="screen shot 2016-09-27 at 14 24 55" src="https://cloud.githubusercontent.com/assets/136777/18875571/3b7107d0-84be-11e6-80c1-883575ad9546.png">

## After
<img width="612" alt="screen shot 2016-09-27 at 14 24 35" src="https://cloud.githubusercontent.com/assets/136777/18875575/3e0aae24-84be-11e6-8006-4257f5a84543.png">
