### PR TITLE
Rename index_all task to index

### DIFF
--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -2,7 +2,7 @@ require "published_slug_registerer"
 
 namespace :rummager do
   desc "Indexes all editions in Rummager"
-  task index_all: :environment do
+  task index: :environment do
     task_logger.info "Sending published editions to rummager..."
     slugs = Edition.published.map(&:slug)
     PublishedSlugRegisterer.new(task_logger, slugs).do_rummager


### PR DESCRIPTION
All other repos that perform document indexing directly via Rummager have rake
tasks called `rummager:index`. The intent of this change is to keep things
consistent.