### PR TITLE
Allow filtering by format in the edition list index

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -30,13 +30,22 @@ class RootController < ApplicationController
 
 private
 
+  def format_filter
+    Artefact::FORMATS_BY_DEFAULT_OWNING_APP["publisher"].include?(params[:format_filter]) ? params[:format_filter] : 'edition'
+  end
+
+  def filtered_editions
+    return Edition if format_filter == 'edition'
+    Edition.where(_type: format_filter.camelcase + 'Edition')
+  end
+
   def list_parameter_from_state(state)
     STATE_NAME_LISTS[state] || state
   end
 
   def build_presenter(user_filter, current_page = nil)
     user_filter, user = process_user_filter(user_filter)
-    editions = Edition.order_by([sort_column, sort_direction])
+    editions = filtered_editions.order_by([sort_column, sort_direction])
     editions = editions.page(current_page).per(ITEMS_PER_PAGE)
     return PrimaryListingPresenter.new(editions, user), user_filter
   end

--- a/app/helpers/base_helper.rb
+++ b/app/helpers/base_helper.rb
@@ -49,7 +49,7 @@ module BaseHelper
 
 private
   def scope_path_options(scope)
-    opts = { :user_filter => params[:user_filter], :string_filter => params[:string_filter], :list => scope }
+    opts = { user_filter: params[:user_filter], string_filter: params[:string_filter], format_filter: params[:format_filter], list: scope }
     opts.merge!(in_review_url_defaults) if scope == :in_review
     opts
   end

--- a/app/helpers/editions_helper.rb
+++ b/app/helpers/editions_helper.rb
@@ -24,4 +24,9 @@ module EditionsHelper
     possible_target_formats = Edition.convertible_formats - [edition.artefact.kind]
     possible_target_formats.map{|format_name| [format_name.humanize, format_name]}
   end
+
+  def format_filter_selection_options
+    [%w(All edition)] +
+      Artefact::FORMATS_BY_DEFAULT_OWNING_APP["publisher"].map { |format_name| [format_name.humanize, format_name] }
+  end
 end

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -33,6 +33,12 @@
             %>
             <label for="string_filter" class="add-top-margin nav-header">Keyword</label>
             <%= text_field_tag "string_filter", params[:string_filter], class: 'form-control', type: "search" %>
+
+            <label for="format_filter" class="add-top-margin nav-header">Format</label>
+            <%= select_tag("format_filter", options_for_select(
+              format_filter_selection_options,
+              params[:format_filter]
+            ), class: 'form-control') %>
             <input class="add-top-margin btn btn-default" type="submit" value="Filter publications">
           </form>
         </div>

--- a/app/views/user_search/index.html.erb
+++ b/app/views/user_search/index.html.erb
@@ -6,14 +6,20 @@
       <div class="col-md-2">
         <div class="well sidebar-nav">
         <form method="GET" action="" class="user-filter-form nav nav-list">
-          <label for="user_filter" class="nav-header">Filter by user</label>
+          <label for="user_filter" class="nav-header">User</label>
           <%=
             select_tag("user_filter", options_for_select(
               User.enabled.alphabetized.map{ |u| [u.name, u.uid] }, @user_filter
             ), :class => "form-control")
           %>
-          <label for="string_filter" class="add-top-margin nav-header">Filter by keyword</label>
+          <label for="string_filter" class="add-top-margin nav-header">Keyword</label>
           <%= text_field_tag "string_filter", params[:string_filter], class: "form-control", type: "search" %>
+
+          <label for="format_filter" class="add-top-margin nav-header">Format</label>
+          <%= select_tag("format_filter", options_for_select(
+            format_filter_selection_options,
+            params[:format_filter]
+          ), class: 'form-control') %>
           <input class="add-top-margin btn btn-default" type="submit" value="Filter publications">
         </form>
         </div>

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -48,6 +48,13 @@ class ActionDispatch::IntegrationTest
     end
   end
 
+  def filter_by_format(format)
+    within ".user-filter-form" do
+      select format, from: "Format"
+      click_on "Filter publications"
+    end
+  end
+
   def using_javascript?
     Capybara.current_driver == Capybara.javascript_driver
   end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -33,12 +33,11 @@ class ActionDispatch::IntegrationTest
            "Can't find #{expected} within field #{field}. Field contains: #{found_field.value}")
   end
 
-  def filter_by_user(option)
+  def filter_by_user(option, from: 'Assignee')
     within ".user-filter-form" do
-      select option, from: "Assignee"
+      select option, from: from
       click_on "Filter publications"
     end
-    click_on "Drafts"
   end
 
   def filter_by_content(substring)


### PR DESCRIPTION
While doing discovery on migrating publisher formats to the new
world of publishing-api it became clear it'd be nice to filter the
index to show only one specific format.  Mostly for when we want
to find an example of a format.  This might be useful for others.

Only poked this a bit on dev, not sure if it needs to be more robust in the face of other controllers that share this functionality.