### PR TITLE
Update gds-api-adapters to 36.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 30.2.0'
+  gem 'gds-api-adapters', '~> 36.4.0'
 end
 
 gem 'erubis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       safe_yaml (~> 1.0.0)
     database_cleaner (1.5.1)
     diffy (3.0.6)
-    domain_name (0.5.20160310)
+    domain_name (0.5.20160826)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
@@ -101,13 +101,13 @@ GEM
       actionpack (>= 3.0)
     formtastic-bootstrap (3.0.0)
       formtastic (>= 2.2)
-    gds-api-adapters (30.2.1)
+    gds-api-adapters (36.4.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek (>= 1.9.0)
       rack-cache
-      rest-client (~> 1.8.0)
+      rest-client (~> 2.0)
     gds-sso (11.2.1)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
@@ -198,7 +198,9 @@ GEM
       mime-types (>= 1.16, < 4)
     metaclass (0.0.4)
     method_source (0.8.2)
-    mime-types (2.99.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
     minitest-reporters (1.1.7)
@@ -313,10 +315,10 @@ GEM
       redis (~> 3.0, >= 3.0.4)
     responders (2.1.1)
       railties (>= 4.2.0, < 5.1)
-    rest-client (1.8.0)
+    rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     retriable (2.1.0)
     reverse_markdown (0.3.0)
       nokogiri
@@ -435,7 +437,7 @@ DEPENDENCIES
   factory_girl_rails
   formtastic (= 2.3.0)
   formtastic-bootstrap (= 3.0.0)
-  gds-api-adapters (~> 30.2.0)
+  gds-api-adapters (~> 36.4.0)
   gds-sso (~> 11.2)
   govspeak (~> 3.4.0)
   govuk-content-schema-test-helpers (~> 1.4)
@@ -484,4 +486,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.12.5
+   1.13.1

--- a/config/initializers/gds_api.rb
+++ b/config/initializers/gds_api.rb
@@ -16,3 +16,5 @@ PANOPTICON_API_CREDENTIALS = {
 Attachable.asset_api_client = GdsApi::AssetManager.new(Plek.current.find('asset-manager'), {
   bearer_token: ENV['PUBLISHER_ASSET_MANAGER_CLIENT_BEARER_TOKEN'] || 'also_set_at_deploy_time',
 })
+
+GdsApi.config.always_raise_for_not_found = true


### PR DESCRIPTION
Update to the latest version, particularly as we've updated the
Panopticon adapter to stop handling search-related attributes (see
alphagov/gds-api-adapters#592).