### PR TITLE
Bugfix: do not crash when trying to save an unmodified item

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -121,15 +121,20 @@ class EditionsController < InheritedResources::Base
 
   def update_related_external_links
     artefact = resource.artefact
-    external_links = params.require(:artefact).permit(external_links_attributes: [:title, :url, :id, :_destroy])
 
-    artefact.external_links_attributes = external_links["external_links_attributes"]
+    if params.has_key?("artefact")
+      external_links = params.require(:artefact).permit(external_links_attributes: [:title, :url, :id, :_destroy])
+      artefact.external_links_attributes = external_links["external_links_attributes"]
 
-    if artefact.save
-      flash[:success] = "External links have been saved."
+      if artefact.save
+        flash[:success] = "External links have been saved."
+      else
+        flash[:danger] = artefact.errors.full_messages.join("\n")
+      end
     else
-      flash[:danger] = artefact.errors.full_messages.join("\n")
+      flash[:danger] = "There aren't any external related links yet"
     end
+
     redirect_to :back
   end
 

--- a/app/views/shared/_related_external_links.html.erb
+++ b/app/views/shared/_related_external_links.html.erb
@@ -21,5 +21,5 @@
   </div>
 
   <br/>
-  <%= f.submit 'Update related external links', class: "btn btn-success btn-large" %>
+  <%= f.submit 'Save links', class: "btn btn-success btn-large" %>
 <% end %>

--- a/test/integration/tagging_test.rb
+++ b/test/integration/tagging_test.rb
@@ -161,7 +161,7 @@ class TaggingTest < JavascriptIntegrationTest
         fill_in "URL", with: "https://www.gov.uk"
       end
 
-      click_on "Update related external links"
+      click_on "Save links"
       @artefact.reload
 
       assert_equal 1, @artefact.external_links.length
@@ -181,10 +181,18 @@ class TaggingTest < JavascriptIntegrationTest
         fill_in "URL", with: "https://www.gov.uk", match: :first
       end
 
-      click_on "Update related external links"
+      click_on "Save links"
       @artefact.reload
 
       assert_equal 1, @artefact.external_links.length
+    end
+
+    should "not save when no links are added" do # check both title and url
+      visit edition_path(@edition)
+      switch_tab 'Related external links'
+      click_on "Save links"
+
+      assert page.has_content?("There aren't any external related links yet")
     end
 
     should "delete links" do
@@ -194,7 +202,7 @@ class TaggingTest < JavascriptIntegrationTest
       visit edition_path(@edition)
       switch_tab "Related external links"
       click_on "Remove this URL"
-      click_on "Update related external links"
+      click_on "Save links"
       @artefact.reload
 
       assert_equal 0, @artefact.external_links.length
@@ -210,7 +218,7 @@ class TaggingTest < JavascriptIntegrationTest
         fill_in "URL", with: "an invalid url"
       end
 
-      click_on "Update related external links"
+      click_on "Save links"
       @artefact.reload
 
       assert_equal 0, @artefact.external_links.length


### PR DESCRIPTION
This makes impossible to save without having added new external related links. 

Different approach the one proposed that was hiding/showing the save button based on the addition of external links (with JS).

![screen shot 2016-10-05 at 16 32 11](https://cloud.githubusercontent.com/assets/5038475/19119963/50eb6b08-8b19-11e6-84b2-c7ad0dacf2c7.png)

This works updates the copy of the buttons too. Wasn't very clear. 