### PR TITLE
Really use GdsApi.config.always_raise_for_not_found

### DIFF
--- a/config/initializers/gds_api.rb
+++ b/config/initializers/gds_api.rb
@@ -1,3 +1,6 @@
+# This file is overwritten on deploy (see alphagov-deployment), so be careful
+# about relying on this content
+
 require 'gds_api/base'
 require 'gds_api/asset_manager'
 require 'attachable'
@@ -16,5 +19,3 @@ PANOPTICON_API_CREDENTIALS = {
 Attachable.asset_api_client = GdsApi::AssetManager.new(Plek.current.find('asset-manager'), {
   bearer_token: ENV['PUBLISHER_ASSET_MANAGER_CLIENT_BEARER_TOKEN'] || 'also_set_at_deploy_time',
 })
-
-GdsApi.config.always_raise_for_not_found = true

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,0 +1,2 @@
+# This is a separate file from gds_api.rb to avoid being overwritten on deploy
+GdsApi.config.always_raise_for_not_found = true

--- a/lib/tagging/link_set.rb
+++ b/lib/tagging/link_set.rb
@@ -5,6 +5,8 @@ module Tagging
     def self.find(content_id)
       link_set = Services.publishing_api.get_links(content_id)
       new(link_set.to_h)
+    rescue GdsApi::HTTPNotFound
+      new({})
     end
 
     def initialize(data)

--- a/test/integration/tagging_test.rb
+++ b/test/integration/tagging_test.rb
@@ -148,6 +148,17 @@ class TaggingTest < JavascriptIntegrationTest
     end
   end
 
+  context "Getting links" do
+    should "handle 404s from publishing-api (e.g. straight after a new artefact is created)" do
+      stub_request(:get, "#{PUBLISHING_API_V2_ENDPOINT}/links/#{@content_id}")
+        .to_return(status: 404)
+
+      visit edition_path(@edition)
+
+      assert page.has_content?('Test guide')
+    end
+  end
+
   context "Tagging to external links" do
     should "add new external links when the item is not tagged" do
       visit edition_path(@edition)


### PR DESCRIPTION
The gds_api.rb initializer is overwritten on deploy by [files from alphagov-deployment](https://github.gds/gds/alphagov-deployment/blob/master/publisher/initializers_by_organisation/integration/gds_api.rb)

These files in alphagov-deployment don't have the `always_raise_for_not_found`
configuration set.  This means that it's only used in dev.  I recently tried
to create a new `Artefact` in Panopticon in dev (which worked), but I was
subsequently unable to edit the created `Edition` in Publisher as Publishing-api
returned a 404 for `Services.publishing_api.get_links` on it.

Production environments are currently unaffected, but if we fix the
alphagov-deployment files to also have this configuration before this fix is
merged we'll be unable to edit `Editions` on newly created `Artefacts`.

The production initializers also try to use environment variables, but this is
not backed up by Puppet or the deployment repo, so this is something that we'll
fix in the near future.

[Trello story](https://trello.com/c/v7pdphVZ/83-publisher-api-adapters-upgrade-is-incomplete)