### PR TITLE
Add 'skip review' workflow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", '41.0.0'
+  gem "govuk_content_models", '41.1.0'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (41.0.0)
+    govuk_content_models (41.1.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (~> 11.2)
@@ -443,7 +443,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint (~> 0.7)
   govuk_admin_template (= 4.2.0)
-  govuk_content_models (= 41.0.0)
+  govuk_content_models (= 41.1.0)
   govuk_sidekiq (= 0.0.4)
   has_scope
   inherited_resources

--- a/app/helpers/edition_activity_buttons_helper.rb
+++ b/app/helpers/edition_activity_buttons_helper.rb
@@ -9,12 +9,11 @@ module EditionActivityButtonsHelper
   end
 
   def review_buttons(edition)
-    [
-      ["Needs more work", "request_amendments"],
-      ["OK for publication", "approve_review"]
-    ].map{ |title, activity|
-      build_review_button(edition, activity, title)
-    }.join("\n").html_safe
+    buttons = []
+    buttons << build_review_button(edition, "request_amendments", "Needs more work")
+    buttons << build_review_button(edition, "skip_review", "Skip review") if skip_review?
+    buttons << build_review_button(edition, "approve_review", "OK for publication")
+    buttons.join("\n").html_safe
   end
 
   def fact_check_buttons(edition)
@@ -57,4 +56,7 @@ module EditionActivityButtonsHelper
     link_to('Preview', preview_edition_path(edition), class: 'btn btn-primary btn-large')
   end
 
+  def skip_review?
+    current_user.permissions.include?("skip_review")
+  end
 end

--- a/app/views/noisy_workflow/_skip_review.text.erb
+++ b/app/views/noisy_workflow/_skip_review.text.erb
@@ -1,0 +1,5 @@
+<%= @action.requester.name %> skipped reviewing "<%= @action.edition.title %>" (<%= @action.edition.format %>) at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
+
+Comment: <%= @action.comment %>
+
+<%= "#{Plek.current.find("private-frontend")}/#{@action.edition.slug}?edition=#{@action.edition.version_number}" %>

--- a/app/views/shared/_workflow_buttons.html.erb
+++ b/app/views/shared/_workflow_buttons.html.erb
@@ -9,7 +9,7 @@
             <%= link_to 'Create new edition', duplicate_edition_path(@resource), class: 'btn btn-primary btn-large', method: :post %>
           <% end %>
           <% if @resource.in_progress_sibling.present? %>
-            <%= link_to 'Edit existing newer edition', edition_path(@resource.in_progress_sibling), html_options = { "class" => "btn btn-primary btn-large"} %>
+            <%= link_to 'Edit existing newer edition', edition_path(@resource.in_progress_sibling), html_options: { "class" => "btn btn-primary btn-large"} %>
           <% end %>
           <%= progress_buttons(@resource, skip_disabled_buttons: true) %>
         <% else %>

--- a/lib/enhancements/edition.rb
+++ b/lib/enhancements/edition.rb
@@ -15,7 +15,8 @@ class Edition
     publish: "Send to publish",
     approve_review: "OK for publication",
     request_amendments: "Request amendments",
-    approve_fact_check: "Approve fact check"
+    approve_fact_check: "Approve fact check",
+    skip_review: "Skip review",
   }
   REVIEW_ACTIONS = ACTIONS.slice(:request_amendments, :approve_review)
   FACT_CHECK_ACTIONS = ACTIONS.slice(:request_amendments, :approve_fact_check)

--- a/test/integration/skip_review_test.rb
+++ b/test/integration/skip_review_test.rb
@@ -1,0 +1,74 @@
+#encoding: utf-8
+require 'integration_test_helper'
+
+class SkipReviewTest < JavascriptIntegrationTest
+  setup do
+    stub_linkables
+
+    @artefact = FactoryGirl.create(:artefact,
+                                    slug: "hedgehog-topiary",
+                                    kind: "guide",
+                                    name: "Foo bar",
+                                    owning_app: "publisher")
+
+    @guide = FactoryGirl.build(:guide_edition,
+                               panopticon_id: @artefact.id,
+                               title: "Foo bar",
+                               state: "in_review",
+                               review_requested_at: 1.hour.ago)
+    @guide.parts.build(title: "Placeholder", body: "placeholder", slug: 'placeholder', order: 1)
+    @guide.save!
+  end
+
+  teardown do
+    GDS::SSO.test_user = nil
+  end
+
+  should "allow a user with the correct permissions to force publish" do
+    permitted_user = FactoryGirl.create(:user,
+                                        name: "Vincent Panache",
+                                        email: "test@example.com",
+                                        permissions: ["skip_review"])
+
+
+    login_as permitted_user
+
+    visit "/publications/#{@artefact.id}"
+
+    within(".alert .workflow-buttons") do
+      assert page.has_content? "Skip review"
+      click_on "Skip review"
+    end
+
+    # Fill out review modal
+    fill_in "Comment", with: "Vincent Panache can skip reviews"
+    click_button "Skip review"
+
+    within(".page-title .label-info") do
+      assert page.has_content? "Ready"
+    end
+
+    within(".workflow-buttons.navbar-btn") do
+      assert page.has_css?(".btn-primary", text: "Publish")
+    end
+  end
+
+  should "not allow a user without permissions to force publish" do
+    editor = FactoryGirl.create(:user,
+                                name: "Editor",
+                                email: "thingy@example.com",
+                                permissions: ["editor"])
+
+    login_as editor
+
+    visit "/publications/#{@artefact.id}"
+
+    within(".alert .workflow-buttons") do
+      assert page.has_no_content? "Skip review"
+    end
+
+    within(".workflow-buttons.navbar-btn") do
+      assert page.has_css?(".btn-primary.disabled", text: "Publish")
+    end
+  end
+end


### PR DESCRIPTION
Part of https://trello.com/c/r7YfHVzG/282-add-force-publish-to-mainstream-medium

Mainstream content in review can be transitioned to ready by users with the correct signon permissions for the purposes of publishing an urgent update to content where normal 2i workflow is not practical or expedient.
This effectively allows a permitted user to publish their own content without review.

Skip review button presented to permitted users:
![screenshot from 2016-10-13 09 17 54](https://cloud.githubusercontent.com/assets/93511/19341639/1ce5b292-9126-11e6-9fea-d09a99dc2aa2.png)

Skip review comment dialogue:
![screenshot from 2016-10-13 09 18 13](https://cloud.githubusercontent.com/assets/93511/19341651/2b703d14-9126-11e6-87d7-deed7703b985.png)
