### PR TITLE
Skip review button should be available permitted authors of content

### DIFF
--- a/app/helpers/edition_activity_buttons_helper.rb
+++ b/app/helpers/edition_activity_buttons_helper.rb
@@ -11,7 +11,6 @@ module EditionActivityButtonsHelper
   def review_buttons(edition)
     buttons = []
     buttons << build_review_button(edition, "request_amendments", "Needs more work")
-    buttons << build_review_button(edition, "skip_review", "Skip review") if skip_review?
     buttons << build_review_button(edition, "approve_review", "OK for publication")
     buttons.join("\n").html_safe
   end

--- a/app/views/shared/_review.html.erb
+++ b/app/views/shared/_review.html.erb
@@ -3,6 +3,9 @@
     <p><%= @resource.latest_status_action(Action::REQUEST_REVIEW).requester.name %> has requested this edition be reviewed.</p>
     <% if @resource.latest_status_action.requester == current_user %>
       <p>That&rsquo;s you! You'll get an email when it has been reviewed.</p>
+      <% if skip_review? %>
+        <p><%= build_review_button(@resource, "skip_review", "Skip review").html_safe %></p>
+      <% end %>
     <% else %>
       <div class="workflow-buttons">
         <%= review_buttons(@resource)%>

--- a/test/integration/skip_review_test.rb
+++ b/test/integration/skip_review_test.rb
@@ -3,6 +3,12 @@ require 'integration_test_helper'
 
 class SkipReviewTest < JavascriptIntegrationTest
   setup do
+    @permitted_user = FactoryGirl.create(:user,
+                                         name: "Vincent Panache",
+                                         email: "test@example.com",
+                                         permissions: ["skip_review"])
+
+
     stub_linkables
 
     @artefact = FactoryGirl.create(:artefact,
@@ -18,6 +24,8 @@ class SkipReviewTest < JavascriptIntegrationTest
                                review_requested_at: 1.hour.ago)
     @guide.parts.build(title: "Placeholder", body: "placeholder", slug: 'placeholder', order: 1)
     @guide.save!
+
+    @guide.new_action(@permitted_user, Action::REQUEST_REVIEW)
   end
 
   teardown do
@@ -25,17 +33,12 @@ class SkipReviewTest < JavascriptIntegrationTest
   end
 
   should "allow a user with the correct permissions to force publish" do
-    permitted_user = FactoryGirl.create(:user,
-                                        name: "Vincent Panache",
-                                        email: "test@example.com",
-                                        permissions: ["skip_review"])
 
-
-    login_as permitted_user
+    login_as @permitted_user
 
     visit "/publications/#{@artefact.id}"
 
-    within(".alert .workflow-buttons") do
+    within(".alert-info") do
       assert page.has_content? "Skip review"
       click_on "Skip review"
     end
@@ -63,7 +66,7 @@ class SkipReviewTest < JavascriptIntegrationTest
 
     visit "/publications/#{@artefact.id}"
 
-    within(".alert .workflow-buttons") do
+    within(".alert-info") do
       assert page.has_no_content? "Skip review"
     end
 


### PR DESCRIPTION
https://trello.com/c/r7YfHVzG/282-add-force-publish-to-mainstream-medium
The original story for this feature mentioned placing the button within
the review buttons visible when viewing another editor's work when in
review. The skip review feature should mean that an author with the correct
permissions can skip the review stage of their own work which means the
relevant button needs to appear when the user is viewing their own work.

![screenshot from 2016-10-20 12 10 51](https://cloud.githubusercontent.com/assets/93511/19557604/786bcd16-96be-11e6-977a-f6ea16385cfb.png)

![screenshot from 2016-10-20 12 11 47](https://cloud.githubusercontent.com/assets/93511/19557615/8495e7c0-96be-11e6-8ffe-e39036007a13.png)
