### PR TITLE
Update govuk_content_models to 4.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", '41.1.0'
+  gem "govuk_content_models", '41.1.1'
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (41.1.0)
+    govuk_content_models (41.1.1)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (~> 11.2)
@@ -443,7 +443,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint (~> 0.7)
   govuk_admin_template (= 4.2.0)
-  govuk_content_models (= 41.1.0)
+  govuk_content_models (= 41.1.1)
   govuk_sidekiq (= 0.0.4)
   has_scope
   inherited_resources


### PR DESCRIPTION
https://github.com/alphagov/govuk_content_models/pull/400 fixes an issue that prevented the worker process from starting up in development mode.  

This updates to the new content models patch version that contains the fix.