### PR TITLE
Change default govuk-content-schemas branch

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -11,7 +11,7 @@ bundle exec rake stats
 
 # Clone govuk-content-schemas depedency for tests
 rm -rf tmp/govuk-content-schemas
-git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+git clone --branch deployed-to-production git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
 
 # Lint changes introduced in this branch, but not for master
 if [[ ${GIT_BRANCH} != "origin/master" ]]; then


### PR DESCRIPTION
Change the branch from master to deployed-to-production. This will help
prevent changes being merged in to the Publisher app that don't
work with the currently deployed govuk-content-schemas (this changes
comes from GOV.UK RFC 59).