### PR TITLE
Send need_ids as content_ids to the Publishing API in the links hash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 36.4.0'
+  gem 'gds-api-adapters', '~> 38.0.0'
 end
 
 gem 'erubis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
       actionpack (>= 3.0)
     formtastic-bootstrap (3.0.0)
       formtastic (>= 2.2)
-    gds-api-adapters (36.4.0)
+    gds-api-adapters (38.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -437,7 +437,7 @@ DEPENDENCIES
   factory_girl_rails
   formtastic (= 2.3.0)
   formtastic-bootstrap (= 3.0.0)
-  gds-api-adapters (~> 36.4.0)
+  gds-api-adapters (~> 38.0.0)
   gds-sso (~> 11.2)
   govspeak (~> 3.4.0)
   govuk-content-schema-test-helpers (~> 1.4)

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,2 +1,0 @@
-# This is a separate file from gds_api.rb to avoid being overwritten on deploy
-GdsApi.config.always_raise_for_not_found = true

--- a/lib/tasks/send_content_ids_for_needs_to_publishingapi.rake
+++ b/lib/tasks/send_content_ids_for_needs_to_publishingapi.rake
@@ -1,0 +1,35 @@
+require 'gds_api/need_api'
+require 'gds_api/publishing_api_v2'
+
+namespace :needs do
+  desc "Send links to the Publishing API specifying which needs a piece of content is associated with"
+  task send_content_ids_for_needs_to_publishingapi: :environment do
+    @need_api = GdsApi::NeedApi.new(Plek.current.find('need-api'), bearer_token: ENV['NEED_API_BEARER_TOKEN'])
+    @publishing_api = GdsApi::PublishingApiV2.new(Plek.current.find('publishing-api'), timeout: 30)
+
+    Artefact.where(owning_app: 'publisher').each do |a|
+      if a.need_ids.present?
+        puts "#{a.content_id}, #{a.slug}:\n"
+
+        need_content_ids = a.need_ids.map do |need|
+          begin
+            @need_api.content_id(need)
+          rescue GdsApi::HTTPNotFound
+            # For when the provided need_id doesn't exist in the Need API.
+            nil
+          end
+        end
+
+        puts "Patching links..."
+        payload = {
+          links: {
+            meets_user_needs: need_content_ids.compact
+          }
+        }
+        @publishing_api.patch_links(a.content_id, payload)
+
+        puts "\n"
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Bump GDS API Adapters to v38.0.0 to use the new Need API adapter to
  return content_ids for needs. It complained at the lack of
  `GdsApi.config`, because the config option has been removed because
  now the behaviour it was referring to is the default, so remove the
  file.

Trello: https://trello.com/c/jywEoQ1M/8-import-existing-need-information-from-publisher-into-publishing-api