### PR TITLE
Send the right routes to the publishing API

### DIFF
--- a/app/presenters/published_edition_presenter.rb
+++ b/app/presenters/published_edition_presenter.rb
@@ -15,9 +15,7 @@ class PublishedEditionPresenter
       public_updated_at: public_updated_at,
       publishing_app: "publisher",
       rendering_app: "frontend",
-      routes: [
-        {path: base_path, type: "exact"}
-      ],
+      routes: routes,
       redirects: [],
       update_type: update_type(options),
       details: {
@@ -39,8 +37,28 @@ private
     end
   end
 
+  def routes
+    [
+      { path: "#{base_path}", type: path_type },
+      { path: "#{json_path}", type: "exact" }
+    ]
+  end
+
   def base_path
     "/#{@edition.slug}"
+  end
+
+  def json_path
+    "#{base_path}.json"
+  end
+
+  def path_type
+    case @edition.class
+    when TransactionEdition, CampaignEdition, HelpPageEdition
+      "exact"
+    else
+      "prefix"
+    end
   end
 
   def update_type(options)

--- a/test/unit/published_edition_presenter_test.rb
+++ b/test/unit/published_edition_presenter_test.rb
@@ -33,7 +33,10 @@ class PublishedEditionPresenterTest < ActiveSupport::TestCase
         public_updated_at: @edition.public_updated_at,
         publishing_app: "publisher",
         rendering_app: "frontend",
-        routes: [ { path: "/#{@edition.slug}", type: "exact" }],
+        routes: [
+          { path: "/#{@edition.slug}", type: "prefix" },
+          { path: "/#{@edition.slug}.json", type: "exact" }
+        ],
         redirects: [],
         update_type: "major",
         details: {
@@ -80,7 +83,7 @@ class PublishedEditionPresenterTest < ActiveSupport::TestCase
       )
       updated_at = 1.minute.ago
       @edition = FactoryGirl.create(
-        :edition,
+        :transaction_edition,
         state: "draft",
         updated_at: updated_at,
         panopticon_id: artefact.id,
@@ -95,6 +98,15 @@ class PublishedEditionPresenterTest < ActiveSupport::TestCase
     should 'use updated_at value if public_updated_at is nil' do
       assert_nil @edition.public_updated_at
       assert_equal @edition.updated_at, @output[:public_updated_at]
+    end
+
+    should "have a exact route type for both path and json path" do
+      exact_routes = [
+        { path: "/#{@edition.slug}", type: "exact" },
+        { path: "/#{@edition.slug}.json", type: "exact" }
+      ]
+
+      assert_equal @output[:routes], exact_routes
     end
   end
 end


### PR DESCRIPTION
- Send the right routes to the publishing api.

[Trello card](https://trello.com/c/sZyeX2Ul/570-preparatory-work-fix-content-item-routes-for-publisher-formats-3)