### PR TITLE
Set locale correctly in content item

### DIFF
--- a/app/presenters/published_edition_presenter.rb
+++ b/app/presenters/published_edition_presenter.rb
@@ -24,7 +24,7 @@ class PublishedEditionPresenter
         change_note: @edition.latest_change_note,
         external_related_links: external_related_links,
       },
-      locale: 'en',
+      locale: @artefact.language,
     }
   end
 

--- a/test/unit/published_edition_presenter_test.rb
+++ b/test/unit/published_edition_presenter_test.rb
@@ -77,6 +77,7 @@ class PublishedEditionPresenterTest < ActiveSupport::TestCase
     setup do
       artefact = FactoryGirl.create(:artefact,
         content_id: SecureRandom.uuid,
+        language: 'cy',
       )
       updated_at = 1.minute.ago
       @edition = FactoryGirl.create(
@@ -95,6 +96,10 @@ class PublishedEditionPresenterTest < ActiveSupport::TestCase
     should 'use updated_at value if public_updated_at is nil' do
       assert_nil @edition.public_updated_at
       assert_equal @edition.updated_at, @output[:public_updated_at]
+    end
+
+    should 'choose locale based on the artefact language' do
+      assert_equal 'cy', @output[:locale]
     end
   end
 end


### PR DESCRIPTION
Language is set on the artefact by Panopticon, and we should use it for
the content item instead of saying everything is English.

https://trello.com/c/KoJ833G9/591-fix-locale-welsh-publisher-content-in-publishing-api