### PR TITLE
Revert "Set locale correctly in content item"

### DIFF
--- a/app/presenters/published_edition_presenter.rb
+++ b/app/presenters/published_edition_presenter.rb
@@ -24,7 +24,7 @@ class PublishedEditionPresenter
         change_note: @edition.latest_change_note,
         external_related_links: external_related_links,
       },
-      locale: @artefact.language,
+      locale: 'en',
     }
   end
 

--- a/test/unit/published_edition_presenter_test.rb
+++ b/test/unit/published_edition_presenter_test.rb
@@ -77,7 +77,6 @@ class PublishedEditionPresenterTest < ActiveSupport::TestCase
     setup do
       artefact = FactoryGirl.create(:artefact,
         content_id: SecureRandom.uuid,
-        language: 'cy',
       )
       updated_at = 1.minute.ago
       @edition = FactoryGirl.create(
@@ -96,10 +95,6 @@ class PublishedEditionPresenterTest < ActiveSupport::TestCase
     should 'use updated_at value if public_updated_at is nil' do
       assert_nil @edition.public_updated_at
       assert_equal @edition.updated_at, @output[:public_updated_at]
-    end
-
-    should 'choose locale based on the artefact language' do
-      assert_equal 'cy', @output[:locale]
     end
   end
 end


### PR DESCRIPTION
Reverts alphagov/publisher#521

Unfortunately the way that Publisher currently saves items causes Publishing API to be unable to republish items as it sees them in a 'draft' state. Further work needs to be done to rectify this.