### PR TITLE
Fix image upload view to handle GDS API Adapters response

### DIFF
--- a/app/views/campaigns/_image_upload.html.erb
+++ b/app/views/campaigns/_image_upload.html.erb
@@ -5,12 +5,12 @@
   </th>
   <td>
     <% if @edition.send("#{format}_image") %>
-      <% if @edition.send("#{format}_image").state == "unscanned" %>
-        <p class="alert alert-info"><%= @edition.send("#{format}_image").name %> is being scanned for viruses</p>
+      <% if @edition.send("#{format}_image")["state"] == "unscanned" %>
+        <p class="alert alert-info"><%= @edition.send("#{format}_image")["name"] %> is being scanned for viruses</p>
       <% else %>
         <p>
-          <%= link_to @edition.send("#{format}_image").file_url do %>
-            <%= image_tag @edition.send("#{format}_image").file_url, :height => "200px" %>
+          <%= link_to @edition.send("#{format}_image")["file_url"] do %>
+            <%= image_tag @edition.send("#{format}_image")["file_url"], :height => "200px" %>
           <% end %>
         </p>
       <% end %>


### PR DESCRIPTION
GDS API Adapters returns a hash response, however the image upload view accessed this as if it were an OpenStruct, and so editing campaigns would break. This fixes the view.
Trello: https://trello.com/c/dhivh7TF/593-fix-campaigns-in-publisher