### PR TITLE
Update campaign edit tests to refect GDS API Adapters response

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ end
 if ENV['CONTENT_MODELS_DEV']
   gem "govuk_content_models", :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", "~> 42.0.0"
+  gem "govuk_content_models", "~> 42.0.1"
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (42.0.0)
+    govuk_content_models (42.0.1)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (~> 11.2)
@@ -443,7 +443,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint (~> 0.7)
   govuk_admin_template (= 4.2.0)
-  govuk_content_models (~> 42.0.0)
+  govuk_content_models (~> 42.0.1)
   govuk_sidekiq (= 0.0.4)
   has_scope
   inherited_resources

--- a/test/integration/campaign_edit_test.rb
+++ b/test/integration/campaign_edit_test.rb
@@ -71,9 +71,9 @@ class CampaignEditTest < JavascriptIntegrationTest
       medium_image = File.open(Rails.root.join("test","fixtures","uploads","campaign_medium.jpg"))
       large_image = File.open(Rails.root.join("test","fixtures","uploads","campaign_large.jpg"))
 
-      asset_one = OpenStruct.new(:id => 'http://asset-manager.dev.gov.uk/assets/asset_one', :file_url => 'http://path/to/campaign_small.jpg')
-      asset_two = OpenStruct.new(:id => 'http://asset-manager.dev.gov.uk/assets/asset_two', :file_url => 'http://path/to/campaign_medium.jpg')
-      asset_three = OpenStruct.new(:id => 'http://asset-manager.dev.gov.uk/assets/asset_three', :file_url => 'http://path/to/campaign_large.jpg')
+      asset_one = { "id" => 'http://asset-manager.dev.gov.uk/assets/asset_one', "file_url" => 'http://path/to/campaign_small.jpg' }
+      asset_two = { "id" => 'http://asset-manager.dev.gov.uk/assets/asset_two', "file_url" => 'http://path/to/campaign_medium.jpg' }
+      asset_three = { "id" => 'http://asset-manager.dev.gov.uk/assets/asset_three', "file_url" => 'http://path/to/campaign_large.jpg' }
 
       # This matches against the original_filename attribute on ActionDispatch::Http::UploadedFile
       GdsApi::AssetManager.any_instance.stubs(:create_asset).with(has_entry(:file => responds_with(:original_filename, "campaign_small.jpg"))).returns(asset_one)


### PR DESCRIPTION
GDS API Adapters now returns a hash response.  This updates the campaign edit tests to reflect this.
We also bump govuk_content_models to the latest version.