### PR TITLE
Clarify when external related links are published

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -126,7 +126,7 @@ class EditionsController < InheritedResources::Base
       artefact.external_links_attributes = external_links["external_links_attributes"]
 
       if artefact.save
-        flash[:success] = "External links have been saved."
+        flash[:success] = "External links have been saved. They will be visible the next time this publication is published."
       else
         flash[:danger] = artefact.errors.full_messages.join("\n")
       end

--- a/app/views/shared/_related_external_links.html.erb
+++ b/app/views/shared/_related_external_links.html.erb
@@ -1,4 +1,9 @@
 <%= semantic_bootstrap_nested_form_for @artefact, url: update_related_external_links_edition_path(@resource) do |f| %>
+  <div class='alert alert-info'>
+    Once saved, related external links will be visible on the site the next time
+    this publication is published.
+  </div>
+
   <div class="related-external-links fieldset-section">
     <label class="section-label">Related external links</label><br />
     <%= f.fields_for :external_links do |link| %>
@@ -21,5 +26,6 @@
   </div>
 
   <br/>
+
   <%= f.submit 'Save links', class: "btn btn-success btn-large" %>
 <% end %>


### PR DESCRIPTION
When the related external links were first moved from panopticon into this application, the sidebars on the site were populated from the content-api. This has been changed to the content store.

This means that the "save" action on the related external links tab will no longer have an immediate effect. Instead, the user has to republish the edition to make it visible on the site.

This adds two notes to the UI to make this clear.

https://trello.com/c/71hfUPZA