### PR TITLE
Set locale when publishing with PublishingAPI

### DIFF
--- a/app/workers/publishing_api_publisher.rb
+++ b/app/workers/publishing_api_publisher.rb
@@ -7,6 +7,10 @@ class PublishingAPIPublisher
     edition = Edition.find(edition_id)
     content_id = edition.artefact.content_id
 
-    Services.publishing_api.publish(content_id, update_type)
+    Services.publishing_api.publish(
+      content_id,
+      update_type,
+      locale: edition.artefact.language
+    )
   end
 end

--- a/test/unit/publishing_api_publisher_test.rb
+++ b/test/unit/publishing_api_publisher_test.rb
@@ -10,12 +10,12 @@ class PublishingAPIPublisherTest < ActiveSupport::TestCase
       @artefact = @edition.artefact
       @artefact.update_attributes(content_id: "vat-charities-id")
 
-      stub_publishing_api_publish("vat-charities-id", {"update_type" => "minor"})
+      stub_publishing_api_publish("vat-charities-id", "update_type" => "minor", "locale" => "en")
     end
 
     should "notify the publishing API of the published document and links" do
       PublishingAPIPublisher.new.perform(@edition.id)
-      assert_publishing_api_publish("vat-charities-id", {"update_type" => "minor"})
+      assert_publishing_api_publish("vat-charities-id", "update_type" => "minor", "locale" => "en")
     end
   end
 end


### PR DESCRIPTION
This is necessary when publishing Welsh content (ie with locale 'cy') via the PublishingAPI. The publish command defaults to using the 'en' locale so we set it here explicitely

Tested successfully on Integration with Welsh and English content