### PR TITLE
Add Unpublish tab to the edition editor

### DIFF
--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -3,7 +3,7 @@ module TabsHelper
     return @active_tab if @active_tab
 
     visited_tab = request.path.split("/").last
-    tab_name = [visited_tab] & %w(metadata tagging history admin related_external_links)
+    tab_name = [visited_tab] & %w(metadata tagging history admin related_external_links unpublish)
     @active_tab = tab_name.blank? ? Edition::Tab['edit'] : Edition::Tab[tab_name.first]
   end
 
@@ -22,7 +22,7 @@ module TabsHelper
   module Edition
     class Tab < Struct.new(:name)
 
-      TABS = %w(edit tagging metadata history admin related_external_links)
+      TABS = %w(edit tagging metadata history admin related_external_links unpublish)
 
       def self.all
         @@all ||= TABS.map { |name| Tab.new(name) }

--- a/app/models/routable_artefact.rb
+++ b/app/models/routable_artefact.rb
@@ -1,0 +1,87 @@
+require 'plek'
+require 'gds_api/router'
+
+class RoutableArtefact
+  attr_reader :artefact
+
+  def initialize(artefact)
+    @artefact = artefact
+  end
+
+  def logger
+    Rails.logger
+  end
+
+  def router_api
+    @router_api ||= GdsApi::Router.new(Plek.current.find('router-api'))
+  end
+
+  def submit(options = {})
+    if artefact.live?
+      register
+    elsif artefact.archived? && artefact.redirect_url.present?
+      redirect(artefact.redirect_url)
+    elsif artefact.archived?
+      delete
+    else
+      return
+    end
+
+    if options[:skip_commit] || prefixes.empty? && paths.empty?
+      return
+    end
+
+    commit
+  end
+
+  def register
+    prefixes.each do |path|
+      logger.debug("Registering route #{path} (prefix) => #{rendering_app}")
+      router_api.add_route(path, "prefix", rendering_app)
+    end
+    paths.each do |path|
+      logger.debug("Registering route #{path} (exact) => #{rendering_app}")
+      router_api.add_route(path, "exact", rendering_app)
+    end
+  end
+
+  def delete
+    prefixes.each do |path|
+      logger.debug "Removing route #{path}"
+      router_api.add_gone_route(path, "prefix")
+    end
+    paths.each do |path|
+      logger.debug "Removing route #{path}"
+      router_api.add_gone_route(path, "exact")
+    end
+  end
+
+  def redirect(destination)
+    prefixes.each do |path|
+      logger.debug "Redirecting route #{path}"
+      router_api.add_redirect_route(path, "prefix", destination, "permanent", segments_mode: "ignore")
+    end
+    paths.each do |path|
+      logger.debug "Redirecting route #{path}"
+      router_api.add_redirect_route(path, "exact", destination)
+    end
+  end
+
+  def commit
+    router_api.commit_routes
+  end
+
+private
+
+  def rendering_app
+    @rendering_app ||= [artefact.rendering_app, artefact.owning_app].reject(&:blank?).first
+  end
+
+  def paths
+    artefact.paths || []
+  end
+
+  def prefixes
+    artefact.prefixes || []
+  end
+end

--- a/app/services/remove_from_search.rb
+++ b/app/services/remove_from_search.rb
@@ -1,0 +1,33 @@
+class RemoveFromSearch
+  attr_reader :base_path
+
+  def self.call(slug)
+    new(slug).call
+  end
+
+  def initialize(slug)
+    @base_path = "/#{slug}"
+  end
+
+  def call
+    with_error_handling do
+      Services.rummager.delete_content!(base_path)
+    end
+  end
+
+  def with_error_handling(&_block)
+    begin
+      tries ||= 2
+      yield
+    rescue => exception
+      if (tries -= 1).zero?
+        Airbrake.notify_or_ignore(
+          exception,
+          parameters: { failed_base_path: base_path }
+        )
+      else
+        retry
+      end
+    end
+  end
+end

--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -1,0 +1,60 @@
+class UnpublishService
+  class << self
+    def call(artefact, user, redirect_url = "")
+      return false if archived?(artefact)
+
+      if update_artefact_in_shared_db(artefact, user, redirect_url)
+        remove_from_rummager_search artefact
+        add_gone_route_in_router_api artefact
+        unpublish_in_publishing_api artefact, redirect_url
+      end
+    end
+
+  private
+
+    def archived?(artefact)
+      artefact.state == 'archived'
+    end
+
+    def update_artefact_in_shared_db(artefact, user, redirect_url)
+      artefact.update_attributes_as(
+        user,
+        state: "archived",
+        redirect_url: redirect_url
+      )
+    end
+
+    def remove_from_rummager_search(artefact)
+      RemoveFromSearch.call(artefact.slug)
+    end
+
+    def add_gone_route_in_router_api(artefact)
+      RoutableArtefact.new(artefact).submit
+    end
+
+    def unpublish_in_publishing_api(artefact, redirect_url)
+      if redirect_url.present?
+        unpublish_with_redirect(artefact, redirect_url)
+      else
+        unpublish_without_redirect(artefact)
+      end
+    end
+
+    def unpublish_with_redirect(artefact, redirect_url)
+      Services.publishing_api.unpublish(
+        artefact.content_id,
+        type: 'redirect',
+        alternative_path: redirect_url,
+        discard_drafts: true
+      )
+    end
+
+    def unpublish_without_redirect(artefact)
+      Services.publishing_api.unpublish(
+        artefact.content_id,
+        type: 'gone',
+        discard_drafts: true
+      )
+    end
+  end
+end

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -9,6 +9,10 @@
       </h1>
     </div>
 
+    <% if flash[:notice] %>
+      <%= flash[:notice] %>
+    <% end %>
+
     <div class="row">
 
       <div class="col-md-2">

--- a/app/views/shared/_unpublish.html.erb
+++ b/app/views/shared/_unpublish.html.erb
@@ -1,0 +1,24 @@
+<div class="callout callout-warning add-bottom-margin">
+  <div class="callout-title">
+    Warning
+  </div>
+  <div class="callout-body">
+    Unpublish a page from GOV.UK. This can’t be undone.
+  </div>
+</div>
+
+<div class="well">
+  <%= form_tag("/editions/#{@resource.id}/process_unpublish", method: "post") do %>
+    <h3 class="remove-top-margin add-bottom-margin">Unpublish</h3>
+      <div class="form-group">
+        <label> Redirect to <span class="normal">(optional)<br />
+          For example: <code>/government/organisations/hm-revenue-customs</code></span> </label>
+        <%= text_field_tag 'redirect_url', '', class: "form-control input-md-12" %>
+      </div>
+      <%= button_tag 'Unpublish',
+      "data-module" => 'confirm',
+      "data-message" => "This will remove ‘#{@artefact.name}’ from the website.\n\n Are you sure?",
+      :class => "btn btn-danger" %>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,8 +15,10 @@ Rails.application.routes.draw do
       get 'admin'
       get 'tagging', to: "editions#linking"
       get 'related_external_links' , to: "editions#linking"
+      get 'unpublish'
       post 'duplicate'
       post 'update_tagging'
+      post 'process_unpublish'
       patch 'update_related_external_links'
       post 'progress'
       put 'review'

--- a/test/integration/unpublish_test.rb
+++ b/test/integration/unpublish_test.rb
@@ -1,0 +1,76 @@
+require "integration_test_helper"
+
+class UnpublishTest < ActionDispatch::IntegrationTest
+  setup do
+    @artefact = FactoryGirl.create(:artefact,
+       slug: "bertie-botts-every-flavour-beans",
+       kind: "video",
+       name: "Bertie Bott's Every Flavour Beans",
+       owning_app: "publisher")
+
+    @edition = FactoryGirl.create(:video_edition,
+                                   panopticon_id: @artefact.id,
+                                   title: "Bertie Bott's Every Flavour Beans",
+                                   video_url: "http://www.youtube.com/watch?v=qySFp3qnVmM",
+                                   video_summary: "All about Bertie Bott's Every Flavour Beans",
+                                   body: "They're quite gross.")
+    setup_users
+    stub_linkables
+  end
+
+  should "unpublishing an artefact archives all editions" do
+    visit "/editions/#{@edition.id}"
+
+    select_tab "Unpublish"
+
+    UnpublishService.expects(:call).with(@artefact, User.first, '').returns(true)
+
+    click_button "Unpublish"
+
+    assert current_url, root_path
+
+    within(".alert-success") do
+      assert page.has_content?("Content unpublished")
+    end
+
+    @artefact.update(state: 'archived')
+
+    visit "/editions/#{@edition.id}"
+
+    within(".callout-danger") do
+      assert page.has_content?("You can’t edit this publication")
+      assert page.has_content?("This publication’s artefact file has been archived")
+    end
+  end
+
+  context "when redirecting a piece of content" do
+    should "display a confirmation message when redirected successfully" do
+      visit "editions/#{@edition.id}"
+
+      select_tab "Unpublish"
+
+      fill_in 'redirect_url', with: 'https://gov.uk/beans'
+
+      UnpublishService.expects(:call).with(@artefact, User.first, '/beans').returns(true)
+
+      click_button "Unpublish"
+
+      assert current_url, root_path
+
+      within(".alert-success") do
+        assert page.has_content?("Content unpublished and redirected")
+      end
+    end
+
+    should "show an error when using an external redirect" do
+      visit "editions/#{@edition.id}/unpublish"
+
+      fill_in "redirect_url", with: "https://www.example.com/bar"
+
+      click_button "Unpublish"
+
+      assert_selector ".alert-danger"
+      assert page.has_content?("Redirect URL is not a valid redirect target")
+    end
+  end
+end

--- a/test/support/tab_test_helpers.rb
+++ b/test/support/tab_test_helpers.rb
@@ -1,0 +1,7 @@
+module TabTestHelpers
+  def select_tab(tab_name)
+    within "div.tabbable" do
+      click_link tab_name
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,7 @@ require 'gds_api/test_helpers/panopticon'
 require 'gds_api/test_helpers/publishing_api_v2'
 require 'govuk_content_models/test_helpers/factories'
 require 'support/tag_test_helpers'
+require 'support/tab_test_helpers'
 require 'govuk_content_models/test_helpers/action_processor_helpers'
 require 'govuk-content-schema-test-helpers'
 require 'govuk-content-schema-test-helpers/test_unit'
@@ -83,4 +84,5 @@ class ActiveSupport::TestCase
   include GdsApi::TestHelpers::Panopticon
   include GdsApi::TestHelpers::PublishingApiV2
   include TagTestHelpers
+  include TabTestHelpers
 end

--- a/test/unit/remove_from_search_test.rb
+++ b/test/unit/remove_from_search_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class RemoveFromSearchTest < ActiveSupport::TestCase
+  def test_it_asks_rummager_to_remove_an_artefact_from_search
+    Services.rummager.expects(:delete_content!).with("/some-content")
+
+    RemoveFromSearch.call("some-content")
+  end
+
+  def test_it_handles_errors
+    Services.rummager.expects(:delete_content!)
+      .with("/some-content")
+      .twice
+      .raises(ArgumentError)
+    Airbrake.expects(:notify_or_ignore).with(
+      instance_of(ArgumentError),
+      parameters: { failed_base_path: "/some-content" }
+    ).once
+
+    RemoveFromSearch.call("some-content")
+  end
+end

--- a/test/unit/routable_artefact_test.rb
+++ b/test/unit/routable_artefact_test.rb
@@ -1,0 +1,232 @@
+require 'test_helper'
+require 'gds_api/test_helpers/router'
+
+class RoutableArtefactTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::Router
+
+  context "submitting a live artefact" do
+    context "for a artefact owned by a whitelisted application" do
+      setup do
+        @artefact = FactoryGirl.create(:live_artefact,
+                                       owning_app: "publisher",
+                                       paths: ["/foo"])
+        @routable = RoutableArtefact.new(@artefact)
+      end
+
+      should "register the route" do
+        @routable.expects(:register)
+        @routable.expects(:commit)
+
+        @routable.submit
+      end
+
+      should "set an archived route as Gone" do
+        @routable.expects(:delete)
+        @routable.expects(:commit)
+
+        @artefact.state = "archived"
+
+        @routable.submit
+      end
+
+      should "add a redirect if requested" do
+        @routable.expects(:redirect).with("/bar")
+        @routable.expects(:commit)
+
+        @artefact.state = "archived"
+        @artefact.redirect_url = "/bar"
+
+        @routable.submit
+      end
+    end
+  end
+
+  context "registering routes for an artefact" do
+    setup do
+      @artefact = FactoryGirl.create(:artefact, owning_app: "publisher")
+      @routable = RoutableArtefact.new(@artefact)
+      stub_all_router_registration
+    end
+
+    should "add all defined prefix routes" do
+      requests = [
+        stub_route_registration("/foo", "prefix", "publisher"),
+        stub_route_registration("/bar", "prefix", "publisher"),
+        stub_route_registration("/baz", "prefix", "publisher")
+      ]
+
+      @artefact.prefixes = ["/foo", "/bar", "/baz"]
+      @routable.register
+
+      requests.each do |route_request, _commit_request|
+        assert_requested route_request
+      end
+    end
+
+    should "add all defined exact routes" do
+      requests = [
+        stub_route_registration("/foo.json", "exact", "publisher"),
+        stub_route_registration("/bar", "exact", "publisher")
+      ]
+
+      @artefact.paths = ["/foo.json", "/bar"]
+      @routable.register
+
+      requests.each do |route_request, _commit_request|
+        assert_requested route_request
+      end
+    end
+
+    should "not blow up if prefixes or paths is nil" do
+      @artefact.prefixes = nil
+      @artefact.paths = nil
+      assert_nothing_raised do
+        @routable.register
+      end
+    end
+  end
+
+  context "deleting routes for an artefact" do
+    setup do
+      @artefact = FactoryGirl.create(:artefact, owning_app: "publisher")
+      @routable = RoutableArtefact.new(@artefact)
+    end
+
+    should "delete all defined prefix routes" do
+      requests = [
+        stub_gone_route_registration("/foo", "prefix"),
+        stub_gone_route_registration("/bar", "prefix"),
+        stub_gone_route_registration("/baz", "prefix")
+      ]
+
+      @artefact.prefixes = ["/foo", "/bar", "/baz"]
+      @routable.delete
+
+      requests.each do |route_request, _commit_request|
+        assert_requested route_request
+      end
+    end
+
+    should "delete all defined exact routes" do
+      requests = [
+        stub_gone_route_registration("/foo.json", "exact"),
+        stub_gone_route_registration("/bar", "exact")
+      ]
+
+      @artefact.paths = ["/foo.json", "/bar"]
+      @routable.delete
+
+      requests.each do |route_request, _commit_request|
+        assert_requested route_request
+      end
+    end
+
+    should "not blow up if prefixes or paths is nil" do
+      @artefact.prefixes = nil
+      @artefact.paths = nil
+      assert_nothing_raised do
+        @routable.delete
+      end
+    end
+
+    context "when router-api returns 404 for a delete request" do
+      should "not blow up" do
+        gone_request, _commit_request = stub_gone_route_registration(
+          "/foo", "prefix")
+
+        gone_request.to_return(status: 404)
+
+        @artefact.prefixes = ["/foo"]
+        assert_nothing_raised do
+          @routable.delete
+        end
+      end
+
+      should "continue to delete other routes" do
+        missing_gone_request, _commit_request = stub_gone_route_registration(
+          "/foo", "prefix")
+        missing_gone_request.to_return(status: 404)
+
+        gone_request, _commit_request = stub_gone_route_registration(
+          "/bar", "prefix")
+
+        @artefact.prefixes = ["/foo", "/bar"]
+        @routable.delete
+
+        assert_requested gone_request
+      end
+    end
+  end
+
+  context "redirecting routes for an artefact" do
+    setup do
+      @artefact = FactoryGirl.create(:artefact, owning_app: "publisher")
+      @routable = RoutableArtefact.new(@artefact)
+    end
+
+    should "redirect all defined prefix routes" do
+      requests = [
+        stub_redirect_registration("/foo", "prefix", "/new", "permanent", "ignore"),
+        stub_redirect_registration("/bar", "prefix", "/new", "permanent", "ignore"),
+        stub_redirect_registration("/baz", "prefix", "/new", "permanent", "ignore")
+      ]
+
+      @artefact.prefixes = ["/foo", "/bar", "/baz"]
+      @routable.redirect("/new")
+
+      requests.each do |redirect_request, _commit_request|
+        assert_requested redirect_request
+      end
+    end
+
+    should "redirect all defined exact routes" do
+      requests = [
+        stub_redirect_registration("/foo.json", "exact", "/new", "permanent"),
+        stub_redirect_registration("/bar", "exact", "/new", "permanent")
+      ]
+
+      @artefact.paths = ["/foo.json", "/bar"]
+      @routable.redirect("/new")
+
+      requests.each do |redirect_request, _commit_request|
+        assert_requested redirect_request
+      end
+    end
+
+    should "not blow up if prefixes or paths is nil" do
+      @artefact.prefixes = nil
+      @artefact.paths = nil
+      assert_nothing_raised do
+        @routable.redirect("/new")
+      end
+    end
+
+    context "when router-api returns 404 for a delete request" do
+      should "not blow up" do
+        gone_request, _commit_request = stub_redirect_registration(
+          "/foo", "prefix", "/new", "permanent", "ignore")
+
+        gone_request.to_return(status: 404)
+
+        @artefact.prefixes = ["/foo"]
+        assert_nothing_raised do
+          @routable.redirect("/new")
+        end
+      end
+
+      should "continue to redirect other routes" do
+        missing_redirect_request, _commit_request = stub_redirect_registration(
+          "/foo", "prefix", "/new", "permanent", "ignore")
+        missing_redirect_request.to_return(status: 404)
+
+        redirect_request, _commit_request = stub_redirect_registration(
+          "/bar", "prefix", "/new", "permanent", "ignore")
+
+        @artefact.prefixes = ["/foo", "/bar"]
+        @routable.redirect("/new")
+
+        assert_requested redirect_request
+      end
+    end
+  end
+end

--- a/test/unit/services/unpublish_service_test.rb
+++ b/test/unit/services/unpublish_service_test.rb
@@ -1,0 +1,128 @@
+require 'test_helper'
+
+class UnpublishServiceTest < ActiveSupport::TestCase
+  setup do
+    @content_id = 'foo'
+    @artefact = stub(update_attributes_as: true, content_id: @content_id, slug: "foo", state: "live")
+    @user = stub
+    @publishing_api = stub(unpublish: true)
+    @router_api = stub(:submit)
+
+    RemoveFromSearch.stubs(:call)
+    RoutableArtefact.stubs(:new).returns(@router_api)
+    Services.stubs(:publishing_api).returns(@publishing_api)
+  end
+
+  context "when an invalid redirect URL is provided" do
+    should "Rummager is not called" do
+      @artefact.expects(:update_attributes_as).returns(false)
+      RemoveFromSearch.expects(:call).never
+
+      UnpublishService.call(@artefact, @user)
+    end
+
+    should "Router API is not called" do
+      @artefact.expects(:update_attributes_as).returns(false)
+      @router_api.expects(:submit).never
+
+      UnpublishService.call(@artefact, @user)
+    end
+
+    should "Publishing API is not called" do
+      @artefact.expects(:update_attributes_as).returns(false)
+      @publishing_api.expects(:unpublish).never
+
+      UnpublishService.call(@artefact, @user)
+    end
+
+    should "return nil" do
+      @artefact.expects(:update_attributes_as).returns(false)
+
+      result = UnpublishService.call(@artefact, @user)
+      assert result == nil
+    end
+  end
+
+  context "when no redirect URL is provided" do
+    should "archive the artefact" do
+      @artefact.expects(:update_attributes_as)
+        .with(@user, state: 'archived', redirect_url: "")
+        .returns(true)
+
+      UnpublishService.call(@artefact, @user)
+    end
+
+    should "remove the artefact from Rummager search" do
+      RemoveFromSearch.expects(:call).with(@artefact.slug)
+      UnpublishService.call(@artefact, @user)
+    end
+
+    should "add gone route to router_api" do
+      @router_api.expects(:submit)
+
+      UnpublishService.call(@artefact, @user)
+    end
+
+    should "tell the publishing API about the change" do
+      @publishing_api.expects(:unpublish)
+        .with(@content_id, type: 'gone', discard_drafts: true)
+        .returns(true)
+
+      UnpublishService.call(@artefact, @user)
+    end
+
+    should "return true" do
+      @artefact.expects(:update_attributes_as).returns(true)
+
+      assert UnpublishService.call(@artefact, @user)
+    end
+  end
+
+  context "when a valid redirect URL is provided" do
+    should "remove the artefact from Rummager search" do
+      RemoveFromSearch.expects(:call).with(@artefact.slug)
+      UnpublishService.call(@artefact, @user)
+    end
+
+    should "tell the publishing API about the change" do
+      @publishing_api.expects(:unpublish)
+        .with(@content_id, type: 'redirect', alternative_path: '/bar', discard_drafts: true)
+        .returns(true)
+
+      UnpublishService.call(@artefact, @user, '/bar')
+    end
+
+    should "allow a redirect_url to be passed in" do
+      @artefact.expects(:update_attributes_as)
+        .with(@user, state: 'archived', redirect_url: '/bar')
+        .returns(true)
+
+      UnpublishService.call(@artefact, @user, "/bar")
+    end
+
+    should "add gone route to router_api" do
+      @router_api.expects(:submit)
+
+      UnpublishService.call(@artefact, @user, '/bar')
+    end
+
+    should "return true" do
+      @artefact.expects(:update_attributes_as).returns(true)
+
+      assert UnpublishService.call(@artefact, @user, '/bar')
+    end
+  end
+
+  context "when an artefact is already archived" do
+    should "return false early" do
+      @artefact.expects(:state).returns("archived")
+      @artefact.expects(:update_attributes_as).never
+      RemoveFromSearch.expects(:call).never
+      @router_api.expects(:submit).never
+      @publishing_api.expects(:unpublish).never
+
+      result = UnpublishService.call(@artefact, @user)
+      assert result == false
+    end
+  end
+end

--- a/test/unit/tabs_helper_test.rb
+++ b/test/unit/tabs_helper_test.rb
@@ -5,16 +5,16 @@ class TabsHelperTest < ActionView::TestCase
 
   context 'Tab' do
     should 'return all tabs in order' do
-      assert_equal 6, tabs.count
-      assert_equal %w(edit tagging metadata history admin related_external_links), tabs.map(&:name)
+      assert_equal 7, tabs.count
+      assert_equal %w(edit tagging metadata history admin related_external_links unpublish), tabs.map(&:name)
     end
 
     should 'return tabs with expected titles' do
-      assert_equal ["Edit", "Tagging", "Metadata", "History and notes", "Admin", "Related external links"], tabs.map(&:title)
+      assert_equal ["Edit", "Tagging", "Metadata", "History and notes", "Admin", "Related external links", "Unpublish"], tabs.map(&:title)
     end
 
     should 'return tabs with expected paths' do
-      assert_equal %w(path path/tagging path/metadata path/history path/admin path/related_external_links), tabs.map { |t| t.path('path') }
+      assert_equal %w(path path/tagging path/metadata path/history path/admin path/related_external_links path/unpublish), tabs.map { |t| t.path('path') }
     end
 
     should 'return a single tab by name' do


### PR DESCRIPTION
This adds unpublish (fomerly know as 'withdraw') functionality to Publisher.  This functionality is copied from Panopticon, where it is soon to be deleted.

It's 'old world' publishing platform, in that it expects to be managing routes and
Rummager content itself, rather than letting the publishing-api manage them.

When we move the mainstream formats to a new Schema (soon!) we will need to revisit
this to stop it from speaking to the router-api and rummager directly.

Trello: https://trello.com/c/xM4HRRYt/574-preparatory-work-moving-withdrawing-functionality-into-publisher-5

![image](https://cloud.githubusercontent.com/assets/13434452/21898544/0d8411ac-d8e5-11e6-9741-6566470d7c32.png)

Paired with @whoojemaflip