### PR TITLE
Improve UI for edition metadata

### DIFF
--- a/app/helpers/publications_helper.rb
+++ b/app/helpers/publications_helper.rb
@@ -9,9 +9,22 @@ module PublicationsHelper
     %{<time datetime="#{ time.strftime("%Y-%m-%dT%H:%M:%SZ") }">#{ time.strftime("%d/%m/%Y %H:%M") }</time>}.html_safe
   end
 
+  def panopticon_url(edition)
+    id = edition.panopticon_id || edition.slug
+    Plek.current.find("panopticon") + "/artefacts/#{id}"
+  end
+
+  def panopticon_withdraw_url(edition)
+    panopticon_url(edition) + '/withdraw'
+  end
+
   def panopticon_edit_url(edition)
-  	id = edition.panopticon_id || edition.slug
-  	Plek.current.find("panopticon") + "/artefacts/#{id}/edit"
+    panopticon_url(edition) + '/edit'
+  end
+
+  def content_tagger_url(edition)
+    content_id = edition.artefact.content_id
+    Plek.current.find("content-tagger") + "/content/#{content_id}"
   end
 
   def enabled_users_select_options(empty_value=true)

--- a/app/views/shared/_metadata.html.erb
+++ b/app/views/shared/_metadata.html.erb
@@ -6,4 +6,9 @@
     <% end %>
   </div>
 </div>
-<%= link_to "Edit in Panopticon", panopticon_edit_url(publication), :class => "btn btn-primary" %>
+
+<ul class="list-unstyled">
+  <li><%= link_to "Add or edit related GOV.UK links", content_tagger_url(publication)%></li>
+  <li><%= link_to "Add user need or mark Welsh content", panopticon_edit_url(publication)%></li>
+  <li><%= link_to "Withdraw and redirect content", panopticon_withdraw_url(publication)%></li>
+</ul>


### PR DESCRIPTION
The current user journey to add or edit related links was sending users
through Panopticon and then they would see the functionality had moved
to Content Tagger.

This commit aims to be easier for users to identify where they need to
go and send them directly to the place they need.

## How it looks
![screen shot 2017-01-13 at 15 28 35](https://cloud.githubusercontent.com/assets/136777/21935337/0efcb834-d9a5-11e6-81bf-7dad1dcbbe54.png)


Trello: https://trello.com/c/1PBuV84e/418-link-to-content-tagger-from-mainstream-publisher