### PR TITLE
Add the ability to create and edit Artefacts

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -1,0 +1,46 @@
+class ArtefactsController < ApplicationController
+  def new
+    @artefact = Artefact.new(content_id: SecureRandom.uuid)
+  end
+
+  def create
+    @artefact = Artefact.new
+    if @artefact.update_attributes_as(current_user, creatable_params)
+      redirect_to publication_path(@artefact)
+    else
+      render "new"
+    end
+  end
+
+  def update
+    artefact = Artefact.find(updatable_params[:id])
+    if artefact.update_attributes_as(current_user, updatable_params)
+      PublishingAPIUpdater.perform_async(artefact.latest_edition_id)
+      flash[:notice] = "Metadata updated"
+    else
+      flash[:danger] = artefact.errors.full_messages.join("\n")
+    end
+    redirect_to metadata_artefact_path(artefact)
+  end
+
+  helper_method :formats
+
+private
+
+  def formats
+    Artefact::FORMATS_BY_DEFAULT_OWNING_APP['publisher']
+  end
+
+  def metadata_artefact_path(artefact)
+    edition = Edition.where(panopticon_id: artefact.id).order_by(version_number: :desc).first
+    metadata_edition_path(edition)
+  end
+
+  def creatable_params
+    params.require(:artefact).permit(:content_id, :name, :slug, :kind, :owning_app, :language)
+  end
+
+  def updatable_params
+    params.require(:artefact).permit(:id, :slug)
+  end
+end

--- a/app/views/artefacts/new.html.erb
+++ b/app/views/artefacts/new.html.erb
@@ -1,0 +1,32 @@
+<%= content_for :page_title, "New artefact" %>
+<div class="page-header">
+  <h1><%= yield :page_title %></h1>
+</div>
+
+<% if @artefact.errors.count > 0 %>
+  <div class="alert alert-danger">
+    <ul>
+      <% @artefact.errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<%= semantic_bootstrap_nested_form_for(@artefact, :html => { :class => 'artefact', :id => 'edit_artefact'}) do |f| %>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="well">
+        <%= f.input :content_id, as: :hidden, input_html: {value: @artefact.content_id } %>
+        <%= f.input :name, :input_html => { :class => "input-md-6" } %>
+        <%= f.input :slug, :input_html => { :class => "input-md-6" } %>
+        <%= f.input :kind, :collection => formats.map { |s| [s.humanize, s]}, :as => :select, :prompt => "Select a kind", :input_html => { :class => "input-md-4" } %>
+        <%= f.input :owning_app, :as => :hidden, :input_html => {:value => 'publisher' } %>
+        <%= f.input :language, :collection => {"English" => "en", "Welsh" => "cy"}, :as => :select, :input_html => { :class => "input-md-4" }, :include_blank => false %>
+      </div>
+      <div class="form-actions">
+        <%= f.submit :value => "Save and go to item", :class => "add-left-margin btn btn-default" %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/artefacts/new.html.erb
+++ b/app/views/artefacts/new.html.erb
@@ -13,19 +13,19 @@
   </div>
 <% end %>
 
-<%= semantic_bootstrap_nested_form_for(@artefact, :html => { :class => 'artefact', :id => 'edit_artefact'}) do |f| %>
+<%= semantic_bootstrap_nested_form_for(@artefact, html: { class: 'artefact', id: 'edit_artefact' }) do |f| %>
   <div class="row">
     <div class="col-md-12">
       <div class="well">
-        <%= f.input :content_id, as: :hidden, input_html: {value: @artefact.content_id } %>
-        <%= f.input :name, :input_html => { :class => "input-md-6" } %>
-        <%= f.input :slug, :input_html => { :class => "input-md-6" } %>
-        <%= f.input :kind, :collection => formats.map { |s| [s.humanize, s]}, :as => :select, :prompt => "Select a kind", :input_html => { :class => "input-md-4" } %>
-        <%= f.input :owning_app, :as => :hidden, :input_html => {:value => 'publisher' } %>
-        <%= f.input :language, :collection => {"English" => "en", "Welsh" => "cy"}, :as => :select, :input_html => { :class => "input-md-4" }, :include_blank => false %>
+        <%= f.input :content_id, as: :hidden, input_html: { value: @artefact.content_id } %>
+        <%= f.input :name, label: 'Title', input_html: { class: "input-md-6" } %>
+        <%= f.input :slug, input_html: { class: "input-md-6" }, hint: 'For example: lower-case-hyphen-separated' %>
+        <%= f.input :kind, label: 'Format', collection: formats.map { |s| [s.humanize, s]}, as: :select, prompt: "Select a format", input_html: { class: "input-md-4" } %>
+        <%= f.input :owning_app, as: :hidden, input_html: { value: 'publisher' } %>
+        <%= f.input :language, collection: { "English" => "en", "Welsh" => "cy" }, as: :select, input_html: { class: "input-md-4" }, include_blank: false %>
       </div>
       <div class="form-actions">
-        <%= f.submit :value => "Save and go to item", :class => "add-left-margin btn btn-default" %>
+        <%= f.submit value: "Save and go to item", class: "add-left-margin btn btn-default" %>
       </div>
     </div>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
 
 <% content_for :navbar_items do %>
   <%= nav_link 'Publications', root_path %>
+  <%= nav_link 'Add artefact', new_artefact_path %>
   <%= nav_link 'Downtime', downtimes_path %>
   <%= nav_link 'Reports', reports_path %>
   <%= nav_link 'Search by user', user_search_path %>

--- a/app/views/shared/_edition_header.html.erb
+++ b/app/views/shared/_edition_header.html.erb
@@ -14,7 +14,7 @@
   <div class="callout callout-danger add-bottom-margin">
     <h2 class="callout-title">You can’t edit this publication</h2>
     <div class="callout-body">
-      This publication’s artefact file has been archived in Panopticon.<br />
+      This publication’s artefact file has been archived.<br />
       It’s unpublished from the website but you can still see the latest edition here.
     </div>
   </div>

--- a/app/views/shared/_metadata.html.erb
+++ b/app/views/shared/_metadata.html.erb
@@ -1,14 +1,24 @@
-<div class="row">
-  <div class="col-md-7">
-    <% publication.attributes.slice('slug', 'kind').each do |key, value| %>
-      <%= content_tag :label, key.humanize, for: key %>
-      <%= text_field_tag key, value, class: "form-control add-bottom-margin", disabled: 'disabled' %>
-    <% end %>
+<% if publication.draft? %>
+  <%= semantic_bootstrap_nested_form_for(@artefact, :html => { :class => 'artefact', :id => 'edit_artefact'}) do |f| %>
+    <div class="row">
+      <div class="col-md-12">
+        <%= f.input :id, as: :hidden, input_html: { value: @artefact.id } %>
+        <%= f.input :slug, :input_html => { :class => "input-md-6" } %>
+      </div>
+    </div>
+    <%= f.submit 'Update metadata', class: "btn btn-success btn-large" %>
+    <%= link_to "Add user need", panopticon_edit_url(publication), class: "btn btn-primary" %>
+    <%= link_to "Add or edit related GOV.UK links", content_tagger_url(publication), class: "btn btn-primary" %>
+  <% end %>
+<% else %>
+  <div class="row">
+    <div class="col-md-7">
+      <% @artefact.attributes.slice('slug', 'language').each do |key, value| %>
+        <%= content_tag :label, key.humanize, for: key %>
+        <%= text_field_tag key, value, class: "form-control add-bottom-margin", disabled: 'disabled' %>
+      <% end %>
+    </div>
   </div>
-</div>
-
-<ul class="list-unstyled">
-  <li><%= link_to "Add or edit related GOV.UK links", content_tagger_url(publication)%></li>
-  <li><%= link_to "Add user need or mark Welsh content", panopticon_edit_url(publication)%></li>
-  <li><%= link_to "Withdraw and redirect content", panopticon_withdraw_url(publication)%></li>
-</ul>
+  <%= link_to "Add or edit related GOV.UK links", content_tagger_url(publication), class: "btn btn-primary"%>
+  <%= link_to "Add user need", panopticon_edit_url(publication), class: "btn btn-primary"%>
+<% end %>

--- a/app/views/shared/_unpublish.html.erb
+++ b/app/views/shared/_unpublish.html.erb
@@ -11,8 +11,10 @@
   <%= form_tag("/editions/#{@resource.id}/process_unpublish", method: "post") do %>
     <h3 class="remove-top-margin add-bottom-margin">Unpublish</h3>
       <div class="form-group">
-        <label> Redirect to <span class="normal">(optional)<br />
-          For example: <code>/government/organisations/hm-revenue-customs</code></span> </label>
+        <label>Redirect to</label>
+        <span class="normal">
+          For example: <code>https://www.gov.uk/redirect-to-replacement-page</code>
+        </span>
         <%= text_field_tag 'redirect_url', '', class: "form-control input-md-12" %>
       </div>
       <%= button_tag 'Unpublish',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
 
   get 'downtimes' => 'downtimes#index'
 
+  resources :artefacts, only: [:new, :create, :update]
+
   resources :editions do
     member do
       get 'diff'

--- a/lib/enhancements/artefact.rb
+++ b/lib/enhancements/artefact.rb
@@ -3,6 +3,15 @@ require "artefact"
 class Artefact
   before_destroy :discard_publishing_api_draft
 
+  def latest_edition_id
+    Edition
+      .where(panopticon_id: id)
+      .order(version_number: :desc)
+      .first
+      .id
+      .to_s
+  end
+
 private
 
   def discard_publishing_api_draft

--- a/test/integration/add_artefact_test.rb
+++ b/test/integration/add_artefact_test.rb
@@ -1,0 +1,31 @@
+require "integration_test_helper"
+
+class AddArtefactTest < ActionDispatch::IntegrationTest
+  setup do
+    setup_users
+    stub_linkables
+  end
+
+  should "create a new artefact" do
+    visit root_path
+    click_link "Add artefact"
+
+    fill_in "Name", with: "Thingy McThingface"
+    fill_in "Slug", with: "thingy-mc-thingface"
+    select "Help page", from: "Kind"
+
+    click_button "Save and go to item"
+
+    assert page.has_content?("Help page slugs must have a help/ prefix")
+
+    fill_in "Slug", with: "help/thingy"
+
+    click_button "Save and go to item"
+
+    assert %r{^\/editions\/[a-f0-9]*$} =~ page.current_path
+
+    edition = HelpPageEdition.last
+    assert edition.artefact.name == "Thingy McThingface"
+    assert edition.artefact.slug == "help/thingy"
+  end
+end

--- a/test/integration/add_artefact_test.rb
+++ b/test/integration/add_artefact_test.rb
@@ -10,9 +10,9 @@ class AddArtefactTest < ActionDispatch::IntegrationTest
     visit root_path
     click_link "Add artefact"
 
-    fill_in "Name", with: "Thingy McThingface"
+    fill_in "Title", with: "Thingy McThingface"
     fill_in "Slug", with: "thingy-mc-thingface"
-    select "Help page", from: "Kind"
+    select "Help page", from: "Format"
 
     click_button "Save and go to item"
 

--- a/test/integration/edit_artefact_test.rb
+++ b/test/integration/edit_artefact_test.rb
@@ -1,0 +1,34 @@
+require "integration_test_helper"
+
+class EditArtefactTest < ActionDispatch::IntegrationTest
+  setup do
+    setup_users
+    stub_linkables
+  end
+
+  should "edit a draft artefact" do
+    edition = FactoryGirl.create(:edition)
+    visit metadata_edition_path(edition)
+
+    fill_in "Slug", with: ""
+    click_button "Update metadata"
+
+    assert page.has_content?("Slug can't be blank")
+
+    fill_in "Slug", with: "thingy-mc-thingface"
+
+    PublishingAPIUpdater.expects(:perform_async).with(edition.id.to_s)
+    click_button "Update metadata"
+    edition.reload
+
+    assert page.has_content?("Metadata updated")
+    assert edition.artefact.slug == "thingy-mc-thingface"
+  end
+
+  should "not be able to edit metadata for a published edition" do
+    edition = FactoryGirl.create(:edition, :published)
+    visit metadata_edition_path(edition)
+
+    assert !page.has_button?("Update metadata")
+  end
+end


### PR DESCRIPTION
This is functionality that is being deprecated from Panopticon.

It adds a new task to the main menu 'Add Artefact', as well as providing
a view to edit (draft) artefact parameters.

<img width="872" alt="screen shot 2017-01-19 at 14 48 35" src="https://cloud.githubusercontent.com/assets/608867/22111202/66f0b620-de56-11e6-85cf-d8b90e3b2ec2.png">

<img width="862" alt="screen shot 2017-01-13 at 15 46 42" src="https://cloud.githubusercontent.com/assets/608867/21936018/97260e16-d9a7-11e6-8db8-7c9946b0509c.png">

<img width="865" alt="screen shot 2017-01-13 at 15 46 53" src="https://cloud.githubusercontent.com/assets/608867/21936021/9a475000-d9a7-11e6-9d26-dde8fd2a8929.png">



