### PR TITLE
Move publishing api calls to controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,4 +32,7 @@ class ApplicationController < ActionController::Base
     params
   end
 
+  def notify_update_publishing_api(edition)
+    PublishingAPIUpdater.perform_async(edition.id.to_s)
+  end
 end

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -3,6 +3,7 @@ class PublicationsController < InheritedResources::Base
     edition = Edition.find_or_create_from_panopticon_data(params[:id], current_user)
 
     if edition.persisted?
+      notify_update_publishing_api(edition)
       redirect_with_return_to(edition) and return
     else
       render_new_form(edition) and return

--- a/lib/enhancements/edition.rb
+++ b/lib/enhancements/edition.rb
@@ -48,8 +48,6 @@ class Edition
     all_of(for_user(user).selector, internal_search(term).selector)
   }
 
-  after_save :notify_update_publishing_api
-
   def publish_anonymously!
     if can_publish?
       publish!
@@ -105,11 +103,4 @@ class Edition
   def self.convertible_formats
     Artefact::FORMATS_BY_DEFAULT_OWNING_APP["publisher"] - ["local_transaction"]
   end
-
-  private
-
-  def notify_update_publishing_api
-    PublishingAPIUpdater.perform_async(self.id.to_s)
-  end
-
 end

--- a/test/functional/publications_controller_test.rb
+++ b/test/functional/publications_controller_test.rb
@@ -3,39 +3,64 @@ require 'test_helper'
 class PublicationsControllerTest < ActionController::TestCase
   setup do
     login_as_stub_user
-
-
   end
 
-  test "requesting a panopticon_id should redirect to the latest edition" do
-    artefact = FactoryGirl.create(:artefact,
-        slug: "hedgehog-topiary",
-        kind: "guide",
-        name: "Foo bar",
-        owning_app: "publisher",
-    )
+  context "#show" do
+    context "with existing edition" do
+      should "redirect to the latest edition when requesting a panopticon_id" do
+        artefact = FactoryGirl.create(:artefact,
+          slug: "hedgehog-topiary",
+          kind: "guide",
+          name: "Foo bar",
+          owning_app: "publisher",
+                                     )
 
+        FactoryGirl.create(:edition, panopticon_id: artefact.id, state: 'archived', version_number: 1)
+        FactoryGirl.create(:edition, panopticon_id: artefact.id, state: 'published', version_number: 2)
+        latest_edition = FactoryGirl.create(:edition, panopticon_id: artefact.id, state: 'draft', version_number: 3)
 
-    FactoryGirl.create(:edition, :panopticon_id => artefact.id, :state => 'archived', :version_number => 1)
-    FactoryGirl.create(:edition, :panopticon_id => artefact.id, :state => 'published', :version_number => 2)
-    latest_edition = FactoryGirl.create(:edition, :panopticon_id => artefact.id, :state => 'draft', :version_number => 3)
+        get :show, id: artefact.id
 
-    get :show, :id => artefact.id
+        assert_redirected_to(controller: 'editions', action: 'show', id: latest_edition.id)
+      end
+    end
 
-    assert_redirected_to(:controller => 'editions', :action => 'show', :id => latest_edition.id)
-  end
+    context "without existing edition" do
+      setup do
+        @artefact = FactoryGirl.create(:artefact,
+            slug: "hedgehog-topiary",
+            kind: "guide",
+            name: "Foo bar",
+            owning_app: "publisher",
+                                      )
+      end
 
-  test "when saving publication fails we show a page" do
-    artefact = FactoryGirl.create(:artefact,
-        slug: "hedgehog-topiary",
-        kind: "local_transaction",
-        name: "Foo bar",
-        owning_app: "publisher",
-    )
-    assert Edition.where(panopticon_id: artefact.id).first.nil?
+      should "redirect to new edition when requesting a panopticon_id" do
+        get :show, id: @artefact.id
 
-    get :show, :id => artefact.id
-    assert Edition.where(panopticon_id: artefact.id).first.nil?
-    assert_response :success
+        latest_edition = GuideEdition.find_by(slug: "hedgehog-topiary")
+        assert_redirected_to(controller: 'editions', action: 'show', id: latest_edition.id)
+      end
+
+      should "send updated content to the PublishingAPI" do
+        PublishingAPIUpdater.expects(:perform_async)
+
+        get :show, id: @artefact.id
+      end
+    end
+
+    should "show a page when saving publication fails" do
+      artefact = FactoryGirl.create(:artefact,
+          slug: "hedgehog-topiary",
+          kind: "local_transaction",
+          name: "Foo bar",
+          owning_app: "publisher",
+                                   )
+      assert Edition.where(panopticon_id: artefact.id).first.nil?
+
+      get :show, id: artefact.id
+      assert Edition.where(panopticon_id: artefact.id).first.nil?
+      assert_response :success
+    end
   end
 end

--- a/test/integration/request_tracing_test.rb
+++ b/test/integration/request_tracing_test.rb
@@ -69,7 +69,7 @@ class RequestTracingTest < ActionDispatch::IntegrationTest
       onward_headers = { "GOVUK-Request-Id" => "12345-67890" }
       content_id = artefact.content_id
 
-      assert_requested(:put, %r|publishing-api.*content/#{content_id}|, times: 7, headers: onward_headers)
+      assert_requested(:put, %r|publishing-api.*content/#{content_id}|, times: 1, headers: onward_headers)
       assert_requested(:post, %r|publishing-api.*content/#{content_id}/publish|, headers: onward_headers)
       assert_requested(:put, /panopticon/, headers: onward_headers)
     end

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -77,16 +77,6 @@ class EditionTest < ActiveSupport::TestCase
     publish(user, edition)
   end
 
-  should "notify the content store when updated" do
-    edition = FactoryGirl.create(:guide_edition, state: "ready")
-    PublishingAPIUpdater.expects(:perform_async).with(edition.id.to_s)
-    GdsApi::Panopticon::Registerer.any_instance.stubs(:register)
-
-    user = FactoryGirl.create(:user)
-    edition.title = "Test guide 3"
-    edition.save
-  end
-
   should "raise an exception when publish_anonymously! fails to publish" do
     edition = FactoryGirl.create(:guide_edition_with_two_parts, state: "ready")
     # simulate validation error causing failure to publish anonymously


### PR DESCRIPTION
This commit aims to solve the following problems:
- Publisher creating a draft content item in PublishingAPI after making a 'publish' request to PublishingAPI
- Publisher sending the wrong content to PublishingAPI before a 'publish' request
- Publisher sending multiple redundant 'put_content' requests as part of its Edition-related workflow

Before this commit, the Edition model had an after_save hook that would make a 'put_content' request to PublishingAPI each time an Edition was saved. This would happen multiple times per state change for an edition (see workflow.rb) due to the state machine and extra calls to record users (see denormalize users). Since in the PublishingAPI we do not yet model the Publisher workflow, doing a put_content for these state changes is redundant, however it is possible to change edition content while also changing state (e.g when requesting 2i without clicking save directly ) so we cannot remove all the calls.

Also when an edition is published, each previous edition for that artefact would be set to 'archived', thereby triggering the save method and put_content calls to PublishingAPI. This led to the wrong content being in the PublishingAPI when 'publish' was finally called. Also, after the publish, the published edition in Publisher would be saved again, causing another put_content which would create a new draft content_item in the PublishingAPI.

To fix the issues described above, we remove the after_save hook from the Edition Model and call the put_content commands from the relevant controller methods instead. This makes it more obvious at which point Publisher communicates with the PublishingAPI and resolves the issues described above.

We refactor the functional tests for EditionController and PublicationsController to make add tests for calls to the PublishingAPI simpler.