### PR TITLE
Change the schema of Help Pages so the routes are managed by Publishing-API

### DIFF
--- a/app/presenters/published_edition_presenter.rb
+++ b/app/presenters/published_edition_presenter.rb
@@ -5,6 +5,38 @@ class PublishedEditionPresenter
   end
 
   def render_for_publishing_api(options={})
+    if @artefact.generic_schema?
+      render_for_generic_schema(options)
+    else
+      render_for_placeholder_content(options)
+    end
+  end
+
+private
+
+  def render_for_generic_schema(options)
+    {
+      title: @edition.title,
+      base_path: base_path,
+      description: @edition.overview || "",
+      schema_name: "generic_with_external_related_links",
+      document_type: @artefact.kind,
+      need_ids: [],
+      public_updated_at: public_updated_at,
+      publishing_app: "publisher",
+      rendering_app: "frontend",
+      routes: routes,
+      redirects: [],
+      update_type: update_type(options),
+      change_note: @edition.latest_change_note,
+      details: {
+        external_related_links: external_related_links,
+      },
+      locale: @artefact.language,
+    }
+  end
+
+  def render_for_placeholder_content(options)
     {
       title: @edition.title,
       base_path: base_path,
@@ -25,8 +57,6 @@ class PublishedEditionPresenter
       locale: @artefact.language,
     }
   end
-
-private
 
   def external_related_links
     @edition.artefact.external_links.map do |link|

--- a/lib/enhancements/edition.rb
+++ b/lib/enhancements/edition.rb
@@ -66,9 +66,13 @@ class Edition
   end
 
   def notify_publishing_platform_services
-    register_with_router_api
+    register_with_router_api unless routes_managed_by_publishing_api?
     register_with_rummager
     notify_publishing_api
+  end
+
+  def routes_managed_by_publishing_api?
+    artefact.generic_schema?
   end
 
   def fact_check_skipped?

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -6,4 +6,17 @@ namespace :publishing_api do
 
     puts "Scheduling finished"
   end
+
+  task :republish_by_format, [:format] => :environment do |_, args|
+    editions = Artefact.published_edition_ids_for_format(args[:format])
+
+    puts "Scheduling republishing of #{editions.count} #{args[:format]}s."
+
+    editions.each do |edition_id|
+      PublishingAPIRepublisher.perform_async(edition_id)
+      print "."
+    end
+
+    puts "\nScheduling finished"
+  end
 end

--- a/test/unit/published_edition_presenter_test.rb
+++ b/test/unit/published_edition_presenter_test.rb
@@ -114,4 +114,28 @@ class PublishedEditionPresenterTest < ActiveSupport::TestCase
       assert_equal @output[:routes], exact_routes
     end
   end
+
+  context ".render_for_publishing_api with a new format schema" do
+    setup do
+      artefact = FactoryGirl.create(
+        :artefact,
+        content_id: SecureRandom.uuid,
+        language: 'cy',
+        kind: 'help_page',
+        slug: 'help/me-im-trapped-in-an-artefact-factory'
+      )
+      updated_at = 1.minute.ago
+      @edition = FactoryGirl.create(
+        :help_page_edition,
+        state: "draft",
+        updated_at: updated_at,
+        panopticon_id: artefact.id,
+      )
+      @output = PublishedEditionPresenter.new(@edition).render_for_publishing_api
+    end
+
+    should "set the schema to generic_with_external_related_links" do
+      assert @output[:schema_name] == "generic_with_external_related_links"
+    end
+  end
 end


### PR DESCRIPTION
The first of the Publisher owned formats to have their routes managed by
content-store. This changes the published schema of the help pages from
'placeholder' to 'generic_with_external_related_links'.

In addition, we make it so that Publisher does not attempt to manage
routes or rummager for this content.