### PR TITLE
Fix multi page redirect bug on unpublish

### DIFF
--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -4,6 +4,7 @@ class UnpublishService
       return false if archived?(artefact)
 
       if update_artefact_in_shared_db(artefact, user, redirect_url)
+        artefact.reload
         remove_from_rummager_search artefact
         add_gone_route_in_router_api artefact
         unpublish_in_publishing_api artefact, redirect_url
@@ -33,6 +34,9 @@ class UnpublishService
     end
 
     def unpublish_in_publishing_api(artefact, redirect_url)
+      # workaround for <link to bug in trello>
+      return if artefact.multipart_format?
+
       if redirect_url.present?
         unpublish_with_redirect(artefact, redirect_url)
       else

--- a/lib/enhancements/artefact.rb
+++ b/lib/enhancements/artefact.rb
@@ -4,9 +4,14 @@ class Artefact
   before_destroy :discard_publishing_api_draft
 
   GENERIC_SCHEMA_FORMATS = %w(help_page)
+  MULTIPART_FORMATS = %w(guide local_transaction licence programme simple_smart_answer)
 
   def generic_schema?
-    GENERIC_SCHEMA_FORMATS.include?(kind)
+    !multipart_format? && GENERIC_SCHEMA_FORMATS.include?(kind)
+  end
+
+  def multipart_format?
+    MULTIPART_FORMATS.include?(kind)
   end
 
   def self.published_edition_ids_for_format(format)


### PR DESCRIPTION
Previously when unpublishing multi page content the publishing api was
receving an exact route for the first page and not redirecting any of
the parts.