### PR TITLE
Add router-data compatible export tool for archived multipart content

### DIFF
--- a/lib/enhancements/artefact.rb
+++ b/lib/enhancements/artefact.rb
@@ -3,6 +3,8 @@ require "artefact"
 class Artefact
   before_destroy :discard_publishing_api_draft
 
+  MULTIPART_FORMATS = %w(guide local_transaction licence programme simple_smart_answer)
+
   def self.published_edition_ids_for_format(format)
     artefact_ids = Artefact.where(kind: format).pluck(:id).map(&:to_s)
 
@@ -11,6 +13,18 @@ class Artefact
       .where(state: 'published')
       .map(&:id)
       .map(&:to_s)
+  end
+
+  def self.multipart_formats
+    where(kind: { '$in' => MULTIPART_FORMATS })
+  end
+
+  def self.archived
+    where(state: 'archived')
+  end
+
+  def self.with_redirect
+    where(:redirect_url.nin => [nil, ""])
   end
 
   def latest_edition

--- a/lib/tasks/router_data.rake
+++ b/lib/tasks/router_data.rake
@@ -1,0 +1,24 @@
+namespace :router_data do
+  task export_multipart_redirects: [:environment] do
+    artefacts = Artefact
+      .multipart_formats
+      .archived
+      .with_redirect
+      .order(slug: :ASC)
+      .pluck(:slug, :redirect_url)
+
+    filename = "/tmp/publisher_router_data_export.csv"
+
+    puts "Writing file with #{artefacts.count} redirects"
+
+    csv = "Source,Destination,Type\n"
+    csv << artefacts
+      .map { |arr| "/#{arr[0]},#{arr[1]},prefix" }
+      .join("\n")
+
+    File.write(filename, csv)
+
+    puts "#{filename}"
+    puts "Complete."
+  end
+end


### PR DESCRIPTION
There's a bug in the publishing platform that means all multi-part documents are incorrectly redirected upon archival.

As a short-term workaround, here we have a tool to create a router-data compatible CSV file with the redirects of all archived multi-part content. 

The resultant CSV will need to be integrated into router-data, independently.

Trello:
https://trello.com/c/jWVgYcxQ/618-investigate-unpublishing-parted-formats-with-redirects