### PR TITLE
Add help page sync checker rake task

### DIFF
--- a/lib/sync_checker.rb
+++ b/lib/sync_checker.rb
@@ -1,0 +1,122 @@
+require 'gds_api/content_store'
+
+class SyncChecker
+  class Success
+    attr_reader :base_path
+
+    def initialize(base_path:, content_store:)
+      @base_path = base_path
+      @content_store = content_store
+    end
+
+    def to_s
+      "✅  #{@base_path} in #{@content_store}"
+    end
+  end
+
+  class NotFoundFailure
+    attr_reader :base_path, :content_store
+
+    def initialize(base_path:, content_store:)
+      @base_path = base_path
+      @content_store = content_store
+    end
+
+    def to_s
+      "❌  Failed path: #{base_path} in #{content_store}, failed expectations: Not found\n\n"
+    end
+  end
+
+  class Failure
+    attr_reader :edition, :content_item, :base_path, :failed_expectations, :content_store
+
+    def initialize(edition:, content_item:, base_path:, failed_expectations:, content_store:)
+      @edition = edition
+      @content_item = content_item
+      @base_path = base_path
+      @failed_expectations = failed_expectations
+      @content_store = content_store
+    end
+
+    def to_s
+      str = "😡  Failed path: #{base_path} in #{content_store}, failed expectations: #{failed_expectations.join(', ')}"
+      str << "\nExpected: #{filter_attributes(presented_edition)}"
+      str << "\nActual: #{filter_attributes(content_item)}" if content_item
+      str << "\n\n"
+      str
+    end
+
+  private
+
+    def filter_attributes(attrs)
+      attrs.symbolize_keys.select { |a| meaningful_attributes.include?(a) }
+    end
+
+    def meaningful_attributes
+      %i(schema_name document_format title public_updated_at)
+    end
+
+    def presented_edition
+      presenter = EditionPresenterFactory.get_presenter(edition)
+      presenter.render_for_publishing_api
+    end
+  end
+
+
+  def initialize(scope, store_string)
+    @scope = scope
+    @store_string = store_string
+    @expectations = []
+  end
+
+  attr_reader :store_string, :expectations
+
+  def add_expectation(description, &block)
+    expectations << { description: description, block: block }
+  end
+
+  def call
+    @scope.each do |edition|
+      result = check(edition)
+      puts result.to_s
+    end
+  end
+
+private
+
+  def check(edition)
+    base_path = "/#{edition.slug}"
+    response = content_store.content_item(base_path)
+
+    content_item = response.to_h
+    compare_content(content_item, edition, base_path)
+  rescue
+    NotFoundFailure.new(
+      base_path: base_path,
+      content_store: store_string
+    )
+  end
+
+  def compare_content(content_item, edition, base_path)
+    failed_expectations = expectations.reject do |expectation|
+      expectation[:block].call(content_item, edition)
+    end
+
+    if failed_expectations.empty?
+      Success.new(base_path: base_path, content_store: store_string)
+    else
+      failed_expectation_descriptions = failed_expectations.map { |expectation| expectation[:description] }
+      Failure.new(
+        edition: edition,
+        content_item: content_item,
+        base_path: base_path,
+        failed_expectations: failed_expectation_descriptions,
+        content_store: store_string
+      )
+    end
+  end
+
+  def content_store
+    GdsApi::ContentStore.new(Plek.find(store_string))
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -20,6 +20,7 @@ namespace :publishing_api do
       print "."
     end
 
+    puts
     puts "Scheduling finished"
   end
 
@@ -32,6 +33,7 @@ namespace :publishing_api do
       print "."
     end
 
+    puts
     puts "Scheduling finished"
   end
 end

--- a/lib/tasks/sync_checks.rake
+++ b/lib/tasks/sync_checks.rake
@@ -1,0 +1,44 @@
+require 'sync_checker'
+
+namespace :sync_checks do
+  desc "Check editions against their content item in the content store"
+  task check_help_page: [:environment] do
+    check_published
+    check_draft
+  end
+
+  def check_published
+    puts "Checking live content"
+    check_content(['published'], 'content-store')
+  end
+
+  def check_draft
+    puts "Checking draft content"
+    check_content(Edition::PUBLISHING_API_DRAFT_STATES, 'draft-content-store')
+  end
+
+  def check_content(states, store)
+    editions = HelpPageEdition.where(state: { '$in' => states })
+    checker = SyncChecker.new(editions, store)
+    puts "#{editions.count} Help Pages from #{store}"
+
+    checker.add_expectation("schema_name") do |content_item, _|
+      content_item["schema_name"] == "help_page"
+    end
+
+    checker.add_expectation("document_type") do |content_item, _|
+      content_item["document_type"] == "help_page"
+    end
+
+    checker.add_expectation("title") do |content_item, edition|
+      content_item["title"] == edition.title
+    end
+
+    checker.add_expectation("public_updated_at") do |content_item, edition|
+      content_item_date = DateTime.parse(content_item['public_updated_at'])
+      content_item_date == edition.public_updated_at.to_s
+    end
+
+    checker.call
+  end
+end

--- a/test/unit/lib/sync_checker_test.rb
+++ b/test/unit/lib/sync_checker_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+require 'gds_api/test_helpers/content_store'
+
+class SyncCheckerTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::ContentStore
+
+  context "#call" do
+    setup do
+      edition = stub(
+        slug: "help/cookies",
+        schema_name: "help_page",
+      )
+      @scope = [edition]
+      @sync_checker = SyncChecker.new(@scope, "content-store")
+    end
+
+    context "for content present in content store" do
+      setup do
+        content_store_has_item("/help/cookies", schema_name: "help_page")
+      end
+
+      should 'succeed for matching expectation' do
+        SyncChecker::Success.stubs(new: stub(to_s: "yay"))
+        SyncChecker::Success.expects(:new).once
+
+        @sync_checker.add_expectation("schema_name") do |content_item, _|
+          content_item["schema_name"] == "help_page"
+        end
+
+        @sync_checker.call
+      end
+
+      should 'fail for non-matching expectation' do
+        SyncChecker::Failure.stubs(new: stub(to_s: "boo"))
+        SyncChecker::Failure.expects(:new).once
+
+        @sync_checker.add_expectation("schema_name") do |content_item, _|
+          content_item["schema_name"] == "other_format"
+        end
+
+        @sync_checker.call
+      end
+    end
+
+    context "for content missing in content store" do
+      setup do
+        content_store_does_not_have_item("/help/cookies")
+      end
+
+      should 'fail' do
+        SyncChecker::NotFoundFailure.stubs(new: stub(to_s: "not found"))
+        SyncChecker::NotFoundFailure.expects(:new).once
+
+        @sync_checker.call
+      end
+    end
+  end
+end

--- a/test/unit/tasks/local_transactions_rake_test.rb
+++ b/test/unit/tasks/local_transactions_rake_test.rb
@@ -1,19 +1,11 @@
-require_relative '../../test_helper'
+require 'test_helper'
 require 'rake'
 
 class LocalTransactionsRakeTest < ActiveSupport::TestCase
-
-  setup do
-    @rake = Rake::Application.new
-    Rake.application = @rake
-    Rake.application.rake_require("lib/tasks/local_transactions", [Rails.root.to_s], [])
-    Rake::Task.define_task(:environment)
-  end
-
   context "local_transactions:update_services" do
     should "call LocalServiceImporter.update" do
       LocalServiceImporter.expects(:update)
-      @rake['local_transactions:update_services'].invoke
+      Rake::Task['local_transactions:update_services'].invoke
     end
   end
 end

--- a/test/unit/tasks/republish_content_test.rb
+++ b/test/unit/tasks/republish_content_test.rb
@@ -1,5 +1,5 @@
 require "test_helper"
-require "securerandom"
+require "rake"
 
 class RepublishContentTest < ActiveSupport::TestCase
   setup do
@@ -13,6 +13,7 @@ class RepublishContentTest < ActiveSupport::TestCase
       PublishingAPIRepublisher.expects(:perform_async).with(@published_edition.id.to_s)
       PublishingAPIUpdater.expects(:perform_async).with(@draft_edition.id.to_s)
 
+      # This is to prevent the rake task ouputting to the console
       silence_stream(STDOUT) do
         silence_stream(STDERR) do
           Rake::Task['publishing_api:republish_content'].invoke
@@ -25,6 +26,7 @@ class RepublishContentTest < ActiveSupport::TestCase
     should "only republish items of that format" do
       PublishingAPIUpdater.expects(:perform_async).with(@draft_edition.id.to_s)
 
+      # This is to prevent the rake task ouputting to the console
       silence_stream(STDOUT) do
         silence_stream(STDERR) do
           Rake::Task['publishing_api:republish_by_format'].invoke('help_page')


### PR DESCRIPTION
In order to check that we have migrated the help pages correctly this rake task will check certain fields have not changed after the format has been republished using the new schema.

https://trello.com/c/1zlDYRH8/625-migrate-help-page-format-to-rendered-1-3-3