### PR TITLE
Fix link to Govspeak Guide

### DIFF
--- a/app/views/shared/_govspeak_help.html.erb
+++ b/app/views/shared/_govspeak_help.html.erb
@@ -1,6 +1,6 @@
 <section class="govspeak_help">
 
-<p>For full examples see: <a href="https://sites.google.com/a/digital.cabinet-office.gov.uk/wiki/projects-and-processes/processes/editorial/govspeak" target="_blank" rel="external">the Govspeak Wiki</a>.</p>
+<p>For full examples see: <a href="http://govspeak-guide.herokuapp.com/" target="_blank" rel="external">the Govspeak Guide</a>.</p>
 
 <h4>Headers</h4>
 <p class="help-block">Note that the page already has a top heading from the article name.</p>


### PR DESCRIPTION
The current URL links to our old wiki:

https://sites.google.com/a/digital.cabinet-office.gov.uk/wiki/projects-and-processes/processes/editorial/govspeak

Which links to the Wiki on alphagov/govspeak:

https://github.com/alphagov/govspeak/wiki/Using-govspeak-on-GOV.UK

Which recommends a link to the new Govspeak Guide:

http://govspeak-guide.herokuapp.com/

This updates the URL to save the user two clicks.