### PR TITLE
Fix Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ node('mongodb-2.4') {
     }
 
     stage("Set up content schema dependency") {
-      govuk.contentSchemaDependency()
+      govuk.contentSchemaDependency(env.SCHEMA_BRANCH)
       govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
     }
 

--- a/test/integration/root_overview_test.rb
+++ b/test/integration/root_overview_test.rb
@@ -172,7 +172,7 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
     click_on "In review"
 
     within("#publication-list-container tbody tr:first-child td:nth-child(6)") do
-      click_on "Claim 2i"
+      find_button("Claim 2i").click
     end
 
     assert edition_url(edition), current_url
@@ -199,7 +199,7 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
     edition.save!
 
     within("#publication-list-container tbody tr:first-child td:nth-child(6)") do
-      click_on "Claim 2i"
+      find_button("Claim 2i").click
     end
 
     assert edition_url(edition), current_url


### PR DESCRIPTION
Schema tests were building against the wrong `govuk-content-schemas` branch when being started from `govuk-content-schemas` branch CI. This updates the Jenkinsfile to use the specified schema.

Whilst trying to get this to build a couple of flakey tests popped up so I've tried to fix those too.