### PR TITLE
Fix update type when publishing content

### DIFF
--- a/app/workers/publishing_api_publisher.rb
+++ b/app/workers/publishing_api_publisher.rb
@@ -3,7 +3,7 @@ require 'services'
 class PublishingAPIPublisher
   include Sidekiq::Worker
 
-  def perform(edition_id, update_type = "minor")
+  def perform(edition_id, update_type = nil)
     edition = Edition.find(edition_id)
     content_id = edition.artefact.content_id
 

--- a/test/unit/publishing_api_publisher_test.rb
+++ b/test/unit/publishing_api_publisher_test.rb
@@ -9,13 +9,20 @@ class PublishingAPIPublisherTest < ActiveSupport::TestCase
       @edition = FactoryGirl.create(:edition)
       @artefact = @edition.artefact
       @artefact.update_attributes(content_id: "vat-charities-id")
-
-      stub_publishing_api_publish("vat-charities-id", "update_type" => "minor", "locale" => "en")
     end
 
-    should "notify the publishing API of the published document and links" do
+    should "publish content with the update_type set to nil" do
+      stub_publishing_api_publish("vat-charities-id", "update_type" => nil, "locale" => "en")
       PublishingAPIPublisher.new.perform(@edition.id)
-      assert_publishing_api_publish("vat-charities-id", "update_type" => "minor", "locale" => "en")
+
+      assert_publishing_api_publish("vat-charities-id", "update_type" => nil, "locale" => "en")
+    end
+
+    should "publish content with a specified update_type" do
+      stub_publishing_api_publish("vat-charities-id", "update_type" => "republish", "locale" => "en")
+      PublishingAPIPublisher.new.perform(@edition.id, "republish")
+
+      assert_publishing_api_publish("vat-charities-id", "update_type" => "republish", "locale" => "en")
     end
   end
 end


### PR DESCRIPTION
Previously in Publisher we were sending the update_type as "minor" for
every publish. This resulted in the publishing-api never knowing about
"major" updates.

We now send nil as the default update_type as we can allow
publishing-api to make the decision to use the editions update type as
seen here:

https://docs.publishing.service.gov.uk/apis/publishing-api/api.html#post-v2-content-content-id-publish