### PR TITLE
Send locale when unpublishing

### DIFF
--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -38,6 +38,7 @@ class UnpublishService
     def unpublish_with_redirect(artefact, redirect_url)
       Services.publishing_api.unpublish(
         artefact.content_id,
+        locale: artefact.language,
         type: 'redirect',
         alternative_path: redirect_url,
         discard_drafts: true
@@ -47,6 +48,7 @@ class UnpublishService
     def unpublish_without_redirect(artefact)
       Services.publishing_api.unpublish(
         artefact.content_id,
+        locale: artefact.language,
         type: 'gone',
         discard_drafts: true
       )

--- a/test/unit/services/unpublish_service_test.rb
+++ b/test/unit/services/unpublish_service_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class UnpublishServiceTest < ActiveSupport::TestCase
   setup do
     @content_id = 'foo'
-    @artefact = stub(update_attributes_as: true, content_id: @content_id, slug: "foo", state: "live")
+    @artefact = stub(update_attributes_as: true, content_id: @content_id, slug: "foo", state: "live", language: "en")
     @user = stub
     @publishing_api = stub(unpublish: true)
     @rummager = stub(:delete_content)
@@ -52,7 +52,10 @@ class UnpublishServiceTest < ActiveSupport::TestCase
 
     should "tell the publishing API about the change" do
       @publishing_api.expects(:unpublish)
-        .with(@content_id, type: 'gone', discard_drafts: true)
+        .with(@content_id,
+              locale: "en",
+              type: 'gone',
+              discard_drafts: true)
         .returns(true)
 
       UnpublishService.call(@artefact, @user)
@@ -73,7 +76,11 @@ class UnpublishServiceTest < ActiveSupport::TestCase
 
     should "tell the publishing API about the change" do
       @publishing_api.expects(:unpublish)
-        .with(@content_id, type: 'redirect', alternative_path: '/bar', discard_drafts: true)
+        .with(@content_id,
+              locale: "en",
+              type: 'redirect',
+              alternative_path: '/bar',
+              discard_drafts: true)
         .returns(true)
 
       UnpublishService.call(@artefact, @user, '/bar')


### PR DESCRIPTION
Previously we were not sending the locale when unpublishing, which meant that Welsh content would not be unpublished properly against the publishing api.

For https://trello.com/c/WfsT2KM6/634-fix-unpublishing-welsh-content-bug-in-publisher