### PR TITLE
Fix ISO 8601 timezone format in downstream documents

### DIFF
--- a/app/presenters/formats/edition_format_presenter.rb
+++ b/app/presenters/formats/edition_format_presenter.rb
@@ -31,7 +31,7 @@ module Formats
         schema_name: schema_name,
         document_type: artefact.kind,
         need_ids: [],
-        public_updated_at: public_updated_at,
+        public_updated_at: public_updated_at.to_datetime.rfc3339(3),
         publishing_app: "publisher",
         rendering_app: "frontend",
         routes: routes,

--- a/test/unit/presenters/formats/generic_edition_presenter_test.rb
+++ b/test/unit/presenters/formats/generic_edition_presenter_test.rb
@@ -15,7 +15,7 @@ class GenericEditionPresenterTest < ActiveSupport::TestCase
 
       @edition = FactoryGirl.create(:edition, :published,
         major_change: true,
-        updated_at: 1.minute.ago,
+        updated_at: DateTime.new(2017, 2, 06, 17, 36, 58).in_time_zone,
         change_note: 'Test',
         version_number: 2,
         panopticon_id: artefact.id,
@@ -30,7 +30,7 @@ class GenericEditionPresenterTest < ActiveSupport::TestCase
         schema_name: "generic_with_external_related_links",
         document_type: artefact.kind,
         need_ids: [],
-        public_updated_at: @edition.public_updated_at,
+        public_updated_at: '2017-02-06T17:36:58.000+00:00',
         publishing_app: "publisher",
         rendering_app: "frontend",
         routes: [
@@ -76,11 +76,12 @@ class GenericEditionPresenterTest < ActiveSupport::TestCase
 
   context ".render_for_publishing_api with a draft document" do
     setup do
-      artefact = FactoryGirl.create(:artefact,
+      artefact = FactoryGirl.create(
+        :artefact,
         content_id: SecureRandom.uuid,
         language: 'cy',
-                                   )
-      updated_at = 1.minute.ago
+      )
+      updated_at = DateTime.new(2017, 2, 06, 17, 36, 58).in_time_zone
       @edition = FactoryGirl.create(
         :transaction_edition,
         state: "draft",

--- a/test/unit/presenters/formats/help_page_presenter_test.rb
+++ b/test/unit/presenters/formats/help_page_presenter_test.rb
@@ -17,7 +17,7 @@ class HelpPagePresenterTest < ActiveSupport::TestCase
         :help_page_edition,
         :published,
         major_change: true,
-        updated_at: 1.minute.ago,
+        updated_at: DateTime.new(2017, 2, 06, 17, 36, 58).in_time_zone,
         change_note: 'Test',
         version_number: 2,
         panopticon_id: artefact.id,
@@ -33,7 +33,7 @@ class HelpPagePresenterTest < ActiveSupport::TestCase
         schema_name: "help_page",
         document_type: artefact.kind,
         need_ids: [],
-        public_updated_at: @edition.public_updated_at,
+        public_updated_at: '2017-02-06T17:36:58.000+00:00',
         publishing_app: "publisher",
         rendering_app: "frontend",
         routes: [
@@ -97,7 +97,9 @@ class HelpPagePresenterTest < ActiveSupport::TestCase
         kind: 'help_page',
         slug: 'help/i_need_somebody'
       )
-      updated_at = 1.minute.ago
+
+      updated_at = DateTime.new(2017, 2, 06, 17, 36, 58).in_time_zone
+
       @edition = FactoryGirl.create(
         :help_page_edition,
         state: "fact_check",


### PR DESCRIPTION
Documents returned from the content-store have inconsistant date formats. Some use the trailing modifier `Z` to signify UTC, whereas others are represented using the `+00:00` time zone offset.

For consistency, and because the publishing-platform has standardised on the latter, this changes datetime strings in rendered JSON to use the `rfc3339` standard.

<img width="454" alt="screen shot 2017-02-06 at 18 34 39" src="https://cloud.githubusercontent.com/assets/608867/22660857/fa14d5f6-ec9a-11e6-84be-c3176d76d050.png">

