### PR TITLE
Remove segments from mulitpart redirects

### DIFF
--- a/lib/tasks/router_data.rake
+++ b/lib/tasks/router_data.rake
@@ -13,7 +13,7 @@ namespace :router_data do
 
     csv = "Source,Destination,Type\n"
     csv << artefacts
-      .map { |arr| "/#{arr[0]},#{arr[1]},prefix" }
+      .map { |arr| "/#{arr[0]},#{arr[1].gsub(/#.*/, '')},prefix" }
       .join("\n")
 
     File.write(filename, csv)


### PR DESCRIPTION
Publisher currently allows segment redirects within its' GUI. For our temporary task to export multipart redirects to router-data we will be removing all segment redirects and only redirect to the top of the page.

https://trello.com/c/4TxuwEgo/636-fix-publisher-multipart-csv-export-task