### PR TITLE
[DISCUSS] - Add segments column to multipart redirects export task

### DIFF
--- a/lib/tasks/router_data.rake
+++ b/lib/tasks/router_data.rake
@@ -11,14 +11,18 @@ namespace :router_data do
 
     puts "Writing file with #{artefacts.count} redirects"
 
-    csv = "Source,Destination,Type\n"
+    csv = "Source,Destination,Type,Segments\n"
     csv << artefacts
-      .map { |arr| "/#{arr[0]},#{arr[1].gsub(/#.*/, '')},prefix" }
+      .map { |arr| "/#{arr[0]},#{arr[1]},prefix#{segment(arr[1])}" }
       .join("\n")
 
     File.write(filename, csv)
 
     puts "#{filename}"
     puts "Complete."
+  end
+
+  def segment(redirect_url)
+    redirect_url.include?('#') ? ',ignore' : ''
   end
 end


### PR DESCRIPTION
[This PR](https://github.com/alphagov/publisher/pull/552) changed the export of the multipart redirects to remove linking to a page fragment identifier. This was felt to not be robust as content changes regularly and these identifiers may not exist in the future.

An alternative to this is to add the `Segments` column to the exported csv. Router-API would then [take care](https://github.com/alphagov/router-api/blob/8828caf69a69533023a1f6fe68bc7276ccc42b6f/app/models/route.rb#L77) of whether or not to preserve or ignore the segment redirect. Broken page fragment identifiers would simply send the user to the top of the page.