### PR TITLE
Draft stack auth bypass for fact-checkers

### DIFF
--- a/app/helpers/paths_helper.rb
+++ b/app/helpers/paths_helper.rb
@@ -49,7 +49,7 @@ protected
 
   def preview_url(edition)
     if edition.migrated?
-      Plek.current.find("draft-frontend")
+      Plek.current.find("draft-origin")
     else
       Plek.current.find("private-frontend")
     end

--- a/app/helpers/paths_helper.rb
+++ b/app/helpers/paths_helper.rb
@@ -3,6 +3,17 @@ module PathsHelper
     "#{preview_url(edition)}/#{edition.slug}"
   end
 
+  def fact_check_edition_path(edition)
+    if edition.fact_check_id
+      token = jwt_token(sub: edition.fact_check_id)
+      url = preview_edition_path(edition)
+      url << "&token=#{token}"
+      url
+    else
+      preview_edition_path(edition)
+    end
+  end
+
   def preview_edition_path(edition, cache_bust = Time.zone.now.to_i)
     path = edition_front_end_path(edition) + "?"
     path << "edition=#{edition.version_number}&" unless edition.migrated?
@@ -23,6 +34,15 @@ module PathsHelper
   end
 
 protected
+
+  def jwt_token(sub:)
+    JWT.encode({ 'sub' => sub }, jwt_auth_secret, 'HS256')
+  end
+
+  def jwt_auth_secret
+    Rails.application.config.jwt_auth_secret
+  end
+
   def path_from_edition_class(edition)
     edition.format.underscore.pluralize
   end

--- a/app/presenters/formats/edition_format_presenter.rb
+++ b/app/presenters/formats/edition_format_presenter.rb
@@ -6,12 +6,30 @@ module Formats
     end
 
     def render_for_publishing_api(republish: false)
+      required_fields(republish).merge optional_fields
+    end
+
+  private
+
+    attr_reader :edition, :artefact
+
+    def optional_fields
+      fields = {}
+
+      if edition.fact_check_id
+        fields[:access_limited] = { fact_check_ids: [edition.fact_check_id] }
+      end
+
+      fields
+    end
+
+    def required_fields(republish)
       {
-        title: @edition.title,
+        title: edition.title,
         base_path: base_path,
-        description: @edition.overview || "",
+        description: edition.overview || "",
         schema_name: schema_name,
-        document_type: @artefact.kind,
+        document_type: artefact.kind,
         need_ids: [],
         public_updated_at: public_updated_at,
         publishing_app: "publisher",
@@ -19,16 +37,14 @@ module Formats
         routes: routes,
         redirects: [],
         update_type: update_type(republish),
-        change_note: @edition.latest_change_note,
+        change_note: edition.latest_change_note,
         details: details,
-        locale: @artefact.language,
+        locale: artefact.language,
       }
     end
 
-  private
-
     def external_related_links
-      @edition.artefact.external_links.map do |link|
+      edition.artefact.external_links.map do |link|
         {
           url: link["url"],
           title: link["title"]
@@ -44,7 +60,7 @@ module Formats
     end
 
     def base_path
-      "/#{@edition.slug}"
+      "/#{edition.slug}"
     end
 
     def json_path
@@ -73,11 +89,11 @@ module Formats
     end
 
     def major_change?
-      @edition.major_change || @edition.version_number == 1
+      edition.major_change || edition.version_number == 1
     end
 
     def public_updated_at
-      @edition.public_updated_at || @edition.updated_at
+      edition.public_updated_at || edition.updated_at
     end
   end
 end

--- a/app/views/noisy_workflow/request_fact_check.text.erb
+++ b/app/views/noisy_workflow/request_fact_check.text.erb
@@ -3,10 +3,12 @@ Hello.
 The following piece of GOV.UK content needs to be fact checked because
 
 Title: <%= @edition.title %>
-<%= "#{Plek.current.find("private-frontend")}/#{@edition.slug}?edition=#{@edition.version_number}" %>
+<%= fact_check_edition_path(@edition) %>
 
+<% unless @edition.migrated? %>
 You'll need your GOV.UK user name and password to view the content. Email factcheck-help@digital.cabinet-office.gov.uk if you've forgotten your username and password.
 
+<% end %>
 Please reply to this email and either:
 
 - confirm that the content is correct

--- a/config/application.rb
+++ b/config/application.rb
@@ -66,6 +66,8 @@ module Publisher
 
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]
+
+    config.jwt_auth_secret = ENV['JWT_AUTH_SECRET']
   end
 end
 

--- a/lib/enhancements/edition.rb
+++ b/lib/enhancements/edition.rb
@@ -1,6 +1,6 @@
 require "edition"
 require "registerable_edition"
-require 'gds_api/panopticon'
+require 'digest'
 
 class Edition
   include BaseHelper
@@ -139,5 +139,14 @@ class Edition
 
   def self.convertible_formats
     Artefact::FORMATS_BY_DEFAULT_OWNING_APP["publisher"] - ["local_transaction"]
+  end
+
+  def fact_check_id
+    if %w(fact_check fact_check_received ready).include?(state) && migrated?
+      ary = Digest::SHA256.digest(id.to_s).unpack('NnnnnN')
+      ary[2] = (ary[2] & 0x0fff) | 0x4000
+      ary[3] = (ary[3] & 0x3fff) | 0x8000
+      "%08x-%04x-%04x-%04x-%04x%08x" % ary
+    end
   end
 end

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -74,4 +74,39 @@ class EditionTest < ActiveSupport::TestCase
     assert_match "Cannot transition state via :publish from :ready (Reason(s): Parts", exception.message
     assert_match "Internal links must start with a forward slash", exception.message
   end
+
+  context "#fact_check_id" do
+    context "for a migrated format" do
+      should "return a deterministic hex id if edition is in fact-check state" do
+        edition = FactoryGirl.create(:edition, state: 'fact_check', id: 123)
+        edition.artefact.update_attribute(:kind, 'help_page')
+        assert_equal edition.fact_check_id, "a665a459-2042-4f9d-817e-4867efdc4fb8"
+      end
+
+      should "return a deterministic hex id if edition is in fact-check-received state" do
+        edition = FactoryGirl.create(:edition, state: 'fact_check_received', id: 123)
+        edition.artefact.update_attribute(:kind, 'help_page')
+        assert_equal edition.fact_check_id, "a665a459-2042-4f9d-817e-4867efdc4fb8"
+      end
+
+      should "return a deterministic hex id if edition is in ready state" do
+        edition = FactoryGirl.create(:edition, state: 'ready', id: 123)
+        edition.artefact.update_attribute(:kind, 'help_page')
+        assert_equal edition.fact_check_id, "a665a459-2042-4f9d-817e-4867efdc4fb8"
+      end
+
+      should "return nil if edition is in in any other state" do
+        edition = FactoryGirl.create(:edition, state: 'draft')
+        edition.artefact.update_attribute(:kind, 'help_page')
+        assert_nil edition.fact_check_id
+      end
+    end
+
+    context "for a format that has not yet been migrated" do
+      should "return nil" do
+        edition = FactoryGirl.create(:edition, state: 'fact_check_received', id: 123)
+        assert_nil edition.fact_check_id
+      end
+    end
+  end
 end

--- a/test/unit/helpers/admin/paths_helper_test.rb
+++ b/test/unit/helpers/admin/paths_helper_test.rb
@@ -5,10 +5,7 @@ class PathsHelperTest < ActionView::TestCase
     context "for migrated formats" do
       should "return path for draft stack" do
         edition = stub(version_number: 1, migrated?: true, id: 999, slug: "for-funzies")
-
-        expected_base_path = Plek.current.find("draft-frontend")
-        expected_path = "#{expected_base_path}/for-funzies?cache=1234"
-
+        expected_path = "#{draft_origin}/for-funzies?cache=1234"
         assert_equal expected_path, preview_edition_path(edition, 1234)
       end
     end
@@ -16,12 +13,51 @@ class PathsHelperTest < ActionView::TestCase
     context "for non-migrated formats" do
       should "return path for private frontend" do
         edition = stub(version_number: 1, migrated?: false, id: 999, slug: "for-funzies")
-
-        expected_base_path = Plek.current.find("private-frontend")
-        expected_path = "#{expected_base_path}/for-funzies?edition=1&cache=9876"
-
+        expected_path = "#{private_frontend}/for-funzies?edition=1&cache=9876"
         assert_equal expected_path, preview_edition_path(edition, 9876)
       end
     end
+  end
+
+  context "#fact_check_edition_path" do
+    setup do
+      Rails.stubs(:application).returns(
+        stub(
+          config: stub(
+            jwt_auth_secret: '111'
+          )
+        )
+      )
+    end
+
+    context "when the edition returns a fact_check_id" do
+      should "append a valid JWT token to the preview path" do
+        edition = stub(fact_check_id: '123', migrated?: true, slug: 'foo')
+        result = fact_check_edition_path(edition)
+
+        path = result.gsub(/^(.*)\?cache=.*&token=.*$/, '\1')
+        assert_equal "#{draft_origin}/foo", path
+
+        token = result.gsub(/.*token=(.*)$/, '\1')
+        jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.qev-lRek9IUTvoMW1Hx2KUDUmmbnAVXzoFJL1Gvm0pg"
+        assert_equal jwt, token
+      end
+    end
+
+    context "when the edition doesn't return a fact_check_id" do
+      should "not append the JWT token" do
+        edition = stub(fact_check_id: nil, migrated?: true, slug: 'foo')
+        result = fact_check_edition_path(edition)
+        assert_no_match %r(&token=), result
+      end
+    end
+  end
+
+  def draft_origin
+    Plek.current.find("draft-origin")
+  end
+
+  def private_frontend
+    Plek.current.find("private-frontend")
   end
 end

--- a/test/unit/presenters/formats/help_page_presenter_test.rb
+++ b/test/unit/presenters/formats/help_page_presenter_test.rb
@@ -13,14 +13,16 @@ class HelpPagePresenterTest < ActiveSupport::TestCase
       ]
       artefact.external_links = expected_external_related_links
 
-      @edition = FactoryGirl.create(:help_page_edition, :published,
+      @edition = FactoryGirl.create(
+        :help_page_edition,
+        :published,
         major_change: true,
         updated_at: 1.minute.ago,
         change_note: 'Test',
         version_number: 2,
         panopticon_id: artefact.id,
         body: 'some content'
-                                   )
+      )
 
       @presenter = Formats::HelpPagePresenter.new(@edition)
 
@@ -79,18 +81,26 @@ class HelpPagePresenterTest < ActiveSupport::TestCase
       output = presenter.render_for_publishing_api(republish: false)
       assert_equal 'major', output[:update_type]
     end
+
+    should 'not have an access_limited property' do
+      output = @presenter.render_for_publishing_api(republish: false)
+      assert_nil output[:access_limited]
+    end
   end
 
   context ".render_for_publishing_api with a draft document" do
     setup do
-      artefact = FactoryGirl.create(:artefact,
+      artefact = FactoryGirl.create(
+        :artefact,
         content_id: SecureRandom.uuid,
         language: 'cy',
-                                   )
+        kind: 'help_page',
+        slug: 'help/i_need_somebody'
+      )
       updated_at = 1.minute.ago
       @edition = FactoryGirl.create(
         :help_page_edition,
-        state: "draft",
+        state: "fact_check",
         updated_at: updated_at,
         panopticon_id: artefact.id,
       )
@@ -117,6 +127,11 @@ class HelpPagePresenterTest < ActiveSupport::TestCase
       ]
 
       assert_equal @output[:routes], exact_routes
+    end
+
+    should "have a fact_check_id" do
+      assert_not_nil @output[:access_limited]
+      assert_not_nil @output[:access_limited][:fact_check_ids]
     end
   end
 end


### PR DESCRIPTION
Using [JWT](https://trello.com/c/rROSYwYF/95-allow-token-based-access-to-preview-for-fact-checking-3) we can allow unauthenticated users to view specific pages in the draft
stack.

This change adds the JWT token to the generated URL in the fact-check
invitation emails. It will allow anyone with that URL to access the
specific draft edition it refers to. The URL will cease to work once
the edition has been published, and won't work for future editions.

https://trello.com/c/510Jc9Cl/628-migrate-help-page-fact-check-without-signon-account-3-3-8