### PR TITLE
Fix schema type clash in upstream project CI

### DIFF
--- a/test/unit/presenters/formats/generic_edition_presenter_test.rb
+++ b/test/unit/presenters/formats/generic_edition_presenter_test.rb
@@ -5,7 +5,7 @@ class GenericEditionPresenterTest < ActiveSupport::TestCase
 
   context ".render_for_publishing_api with a published document" do
     setup do
-      artefact = FactoryGirl.create(:artefact)
+      artefact = FactoryGirl.create(:artefact, kind: :video)
 
       expected_external_related_links = [
         { title: "GOVUK", url: "https://www.gov.uk" },


### PR DESCRIPTION
Content-Schemas is failing CI because of a default Artefact `kind` being set in the content-models factory. This override should ensure we don't run into this problem again during migration.