### PR TITLE
Local transaction schema

### DIFF
--- a/app/presenters/formats/local_transaction_presenter.rb
+++ b/app/presenters/formats/local_transaction_presenter.rb
@@ -1,0 +1,44 @@
+module Formats
+  class LocalTransactionPresenter < EditionFormatPresenter
+  private
+
+    def schema_name
+      'local_transaction'
+    end
+
+    def details
+      {
+        lgsl_code: edition.lgsl_code,
+        lgil_override: edition.lgil_override,
+        service_tiers: service_tiers,
+        introduction: [
+          {
+            content_type: "text/govspeak",
+            content: edition.introduction,
+          },
+        ],
+        more_information: [
+          {
+            content_type: "text/govspeak",
+            content: edition.more_information,
+          },
+        ],
+        need_to_know: [
+          {
+            content_type: "text/govspeak",
+            content: edition.need_to_know,
+          },
+        ],
+        external_related_links: external_related_links,
+      }
+    end
+
+    def registers_exact_route?
+      false
+    end
+
+    def service_tiers
+      edition.service.providing_tier if edition.service
+    end
+  end
+end

--- a/app/services/edition_presenter_factory.rb
+++ b/app/services/edition_presenter_factory.rb
@@ -6,10 +6,12 @@ class EditionPresenterFactory
 
     def presenter_class(edition_class)
       case edition_class
-      when "HelpPageEdition"
-        "Formats::HelpPagePresenter"
       when "AnswerEdition"
         "Formats::AnswerPresenter"
+      when "HelpPageEdition"
+        "Formats::HelpPagePresenter"
+      when "LocalTransactionEdition"
+        "Formats::LocalTransactionPresenter"
       else
         "Formats::GenericEditionPresenter"
       end

--- a/test/unit/presenters/formats/local_transaction_presenter_test.rb
+++ b/test/unit/presenters/formats/local_transaction_presenter_test.rb
@@ -1,0 +1,113 @@
+require 'test_helper'
+
+class LocalTransactionPresenterTest < ActiveSupport::TestCase
+  include GovukContentSchemaTestHelpers::TestUnit
+
+  setup do
+    LocalService.create(lgsl_code: 431, providing_tier: %w{county unitary})
+  end
+
+  def subject
+    Formats::LocalTransactionPresenter.new(edition)
+  end
+
+  def edition
+    @_edition ||= FactoryGirl.create(
+      :local_transaction_edition,
+      :published,
+      title: "Catch all rats",
+      slug: "pest-control",
+      panopticon_id: artefact.id,
+      lgsl_code: 431,
+      lgil_override: 8,
+      introduction: 'hello',
+      more_information: 'more info',
+      need_to_know: 'for your eyes only'
+    )
+  end
+
+  def artefact
+    @_artefact ||= FactoryGirl.create(:artefact, kind: "local_transaction")
+  end
+
+  def result
+    subject.render_for_publishing_api
+  end
+
+  should "be valid against schema" do
+    assert_valid_against_schema(result, 'local_transaction')
+  end
+
+  should "[:schema_name]" do
+    assert_equal 'local_transaction', result[:schema_name]
+  end
+
+  context "[:details]" do
+    should "[:lgsl_code]" do
+      expected = 431
+      assert_equal expected, result[:details][:lgsl_code]
+    end
+
+    should "[:lgil_override]" do
+      expected = 8
+      assert_equal expected, result[:details][:lgil_override]
+    end
+
+    should "[:service_tiers]" do
+      expected = %w{county unitary}
+      assert_equal expected, result[:details][:service_tiers]
+    end
+
+    should "[:introduction]" do
+      expected = [
+        {
+          content_type: "text/govspeak",
+          content: 'hello'
+        }
+      ]
+      assert_equal expected, result[:details][:introduction]
+    end
+
+    should "[:more_information]" do
+      expected = [
+        {
+          content_type: "text/govspeak",
+          content: 'more info'
+        }
+      ]
+      assert_equal expected, result[:details][:more_information]
+    end
+
+    should "[:need_to_know]" do
+      expected = [
+        {
+          content_type: "text/govspeak",
+          content: 'for your eyes only'
+        }
+      ]
+      assert_equal expected, result[:details][:need_to_know]
+    end
+
+    should "[:external_related_links]" do
+      link = { 'url' => 'www.foo.com', 'title' => 'foo' }
+      artefact.update_attribute(:external_links, [link])
+      expected = [
+        {
+          url: link['url'],
+          title: link['title']
+        }
+      ]
+
+      assert_equal expected, result[:details][:external_related_links]
+    end
+
+    should "[:routes]" do
+      edition.update_attribute(:slug, 'foo')
+      expected = [
+        { path: '/foo', type: 'prefix' },
+        { path: '/foo.json', type: 'exact' }
+      ]
+      assert_equal expected, result[:routes]
+    end
+  end
+end


### PR DESCRIPTION
Add presenter and sync checks for LocalTransaction format

CI won't pass until https://github.com/alphagov/govuk-content-schemas/pull/516 gets merged (and deployed)