### PR TITLE
Continue to unpublish if Rummager 404s

### DIFF
--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -25,6 +25,8 @@ class UnpublishService
 
     def remove_from_rummager_search(artefact)
       Services.rummager.delete_content("/#{artefact.slug}")
+    rescue GdsApi::HTTPNotFound
+      return
     end
 
     def unpublish_in_publishing_api(artefact, redirect_url)

--- a/test/unit/services/unpublish_service_test.rb
+++ b/test/unit/services/unpublish_service_test.rb
@@ -113,4 +113,21 @@ class UnpublishServiceTest < ActiveSupport::TestCase
       assert result == false
     end
   end
+
+  context "when an artefact is not in Rummager" do
+    should "continue to unpublish" do
+      @rummager.expects(:delete_content)
+        .with('/foo')
+        .raises(GdsApi::HTTPNotFound.new(404))
+
+      @publishing_api.expects(:unpublish)
+        .with(@content_id,
+              locale: "en",
+              type: 'gone',
+              discard_drafts: true)
+        .returns(true)
+
+      UnpublishService.call(@artefact, @user)
+    end
+  end
 end


### PR DESCRIPTION
Some artefacts don’t exist in Rummager, causing an `HTTPNotFound`
error. This stops the unpublishing process from reaching Publishing
API. Instead we should swallow the exception.