### PR TITLE
Improve CI when running as a downstream schema tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,8 +68,11 @@ node('mongodb-2.4') {
       govuk.bundleApp()
     }
 
-    stage("rubylinter") {
-      govuk.rubyLinter("app test lib")
+    // we don't need linting if this is a downstream schema test.
+    if (false == env.IS_SCHEMA_TEST) {
+      stage("rubylinter") {
+        govuk.rubyLinter("app test lib")
+      }
     }
 
     stage("Precompile assets") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,29 +43,15 @@ node('mongodb-2.4') {
       return
     }
 
-    stage("Checkout") {
+    stage("Setup") {
       checkout scm
-    }
-
-    stage("Clean up workspace") {
       govuk.cleanupGit()
-    }
-
-    stage("git merge") {
       govuk.mergeMasterBranch()
-    }
-
-    stage("Configure Rails environment") {
       govuk.setEnvar("RAILS_ENV", "test")
-    }
-
-    stage("Set up content schema dependency") {
       govuk.contentSchemaDependency(env.SCHEMA_BRANCH)
       govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
-    }
-
-    stage("bundle install") {
       govuk.bundleApp()
+      govuk.precompileAssets()
     }
 
     // we don't need linting if this is a downstream schema test.
@@ -73,10 +59,6 @@ node('mongodb-2.4') {
       stage("rubylinter") {
         govuk.rubyLinter("app test lib")
       }
-    }
-
-    stage("Precompile assets") {
-      govuk.precompileAssets()
     }
 
     stage("Run tests") {


### PR DESCRIPTION
There were CI failures against upstream govuk-content-schema branches
because of the configuration of the linter in this Jenkinsfile which was
running against the diff of deployed-to-production and origin/master.

There's really no need for the linter to run when we're testing schema
compatibility, so we skip it in this case.