### PR TITLE
Add answer to list of migrated formats

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,4 +47,5 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { :host => "example.com" }
 
+  config.jwt_auth_secret = '123'
 end

--- a/lib/enhancements/artefact.rb
+++ b/lib/enhancements/artefact.rb
@@ -10,7 +10,7 @@ class Artefact
   end
 
   def migrated_format?
-    %w(help_page).include?(kind)
+    %w(answer help_page).include?(kind)
   end
 
   def self.archived

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -72,7 +72,8 @@ class EditionTest < ActiveSupport::TestCase
 
     context "for a format that has not yet been migrated" do
       should "return nil" do
-        edition = FactoryGirl.create(:edition, state: 'fact_check_received', id: 123)
+        artefact = FactoryGirl.create(:artefact, kind: 'licence')
+        edition = FactoryGirl.create(:edition, state: 'fact_check_received', panopticon_id: artefact.id)
         assert_nil edition.fact_check_id
       end
     end


### PR DESCRIPTION
For preview purposes, the `Artefact.migrated_format?` method must include `answer`