### PR TITLE
Update meaning of migrated

### DIFF
--- a/lib/enhancements/artefact.rb
+++ b/lib/enhancements/artefact.rb
@@ -9,10 +9,6 @@ class Artefact
     where(kind: { '$in' => MULTIPART_FORMATS })
   end
 
-  def migrated_format?
-    %w(answer help_page).include?(kind)
-  end
-
   def self.archived
     where(state: 'archived')
   end

--- a/lib/enhancements/edition.rb
+++ b/lib/enhancements/edition.rb
@@ -25,6 +25,8 @@ class Edition
   }
   PUBLISHING_API_DRAFT_STATES = %w(fact_check amends_needed fact_check_received draft ready in_review scheduled_for_publishing).freeze
 
+  MIGRATED_EDITION_CLASSES = [AnswerEdition, HelpPageEdition].freeze
+
   def self.state_names
     state_machine.states.map &:name
   end
@@ -50,7 +52,7 @@ class Edition
   }
 
   def migrated?
-    artefact.migrated_format?
+    MIGRATED_EDITION_CLASSES.include?(self.class)
   end
 
   def publish_anonymously!
@@ -62,9 +64,8 @@ class Edition
   end
 
   def self.by_format(format)
-    artefact_ids = Artefact.where(kind: format).pluck(:id).map(&:to_s)
-
-    Edition.where(panopticon_id: { '$in' => artefact_ids })
+    edition_class = "#{format}_edition".classify.constantize
+    edition_class.all
   end
 
   scope :published, -> { where(state: 'published') }

--- a/lib/sync_checker.rb
+++ b/lib/sync_checker.rb
@@ -49,7 +49,8 @@ class SyncChecker
   private
 
     def filter_attributes(attrs)
-      attrs.symbolize_keys.select { |a| meaningful_attributes.include?(a) }
+      hash = attrs.symbolize_keys.select { |a| meaningful_attributes.include?(a) }
+      Hash[hash.sort]
     end
 
     def meaningful_attributes

--- a/lib/tasks/sync_checks.rake
+++ b/lib/tasks/sync_checks.rake
@@ -18,7 +18,7 @@ namespace :sync_checks do
   end
 
   def check_content(format, states, store)
-    scope = "#{format.classify}Edition".constantize
+    scope = Edition.by_format(format)
     editions = scope.where(state: { '$in' => states })
     checker = SyncChecker.new(editions, store)
     puts "#{editions.count} #{format.titleize} from #{store}"

--- a/lib/tasks/sync_checks.rake
+++ b/lib/tasks/sync_checks.rake
@@ -27,8 +27,8 @@ namespace :sync_checks do
       content_item["schema_name"] == format
     end
 
-    checker.add_expectation("document_type") do |content_item, _|
-      content_item["document_type"] == format
+    checker.add_expectation("document_type") do |content_item, edition|
+      content_item["document_type"] == edition.artefact.kind
     end
 
     checker.add_expectation("title") do |content_item, edition|
@@ -37,7 +37,8 @@ namespace :sync_checks do
 
     checker.add_expectation("public_updated_at") do |content_item, edition|
       content_item_date = DateTime.parse(content_item['public_updated_at'])
-      content_item_date == edition.public_updated_at.to_s
+      content_item_date.change(usec: 0).utc ==
+        edition.public_updated_at.change(usec: 0).utc
     end
 
     checker.call

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -72,10 +72,26 @@ class EditionTest < ActiveSupport::TestCase
 
     context "for a format that has not yet been migrated" do
       should "return nil" do
-        artefact = FactoryGirl.create(:artefact, kind: 'licence')
-        edition = FactoryGirl.create(:edition, state: 'fact_check_received', panopticon_id: artefact.id)
+        edition = FactoryGirl.create(:licence_edition, state: 'fact_check_received')
         assert_nil edition.fact_check_id
       end
+    end
+  end
+
+  context "#migrated?" do
+    should "return true for a HelpPageEdition" do
+      edition = FactoryGirl.build(:help_page_edition)
+      assert edition.migrated?
+    end
+
+    should "return true for an AnswerEdition" do
+      edition = FactoryGirl.build(:answer_edition)
+      assert edition.migrated?
+    end
+
+    should "return false for an edition type that's not been migrated" do
+      edition = FactoryGirl.build(:licence_edition)
+      assert_not edition.migrated?
     end
   end
 end


### PR DESCRIPTION
We discovered an error when republishing Answer content. Namely,
our assumption that Artefact#kind will always equal the Edition type
was wrong. When an Edition changes format, the Artefact#kind doesn't
change with the edition.
