### PR TITLE
Send document_type based on edition type

### DIFF
--- a/app/presenters/formats/edition_format_presenter.rb
+++ b/app/presenters/formats/edition_format_presenter.rb
@@ -29,7 +29,7 @@ module Formats
         base_path: base_path,
         description: edition.overview || "",
         schema_name: schema_name,
-        document_type: artefact.kind,
+        document_type: schema_name,
         need_ids: [],
         public_updated_at: public_updated_at.to_datetime.rfc3339(3),
         publishing_app: "publisher",

--- a/lib/tasks/sync_checks.rake
+++ b/lib/tasks/sync_checks.rake
@@ -28,7 +28,7 @@ namespace :sync_checks do
     end
 
     checker.add_expectation("document_type") do |content_item, edition|
-      content_item["document_type"] == edition.artefact.kind
+      content_item["document_type"] == format
     end
 
     checker.add_expectation("title") do |content_item, edition|

--- a/test/unit/presenters/formats/edition_format_presenter_test.rb
+++ b/test/unit/presenters/formats/edition_format_presenter_test.rb
@@ -29,7 +29,6 @@ class EditionFormatPresenterTest < ActiveSupport::TestCase
       edition.stubs :latest_change_note
       edition.stubs :fact_check_id
 
-      artefact.stubs :kind
       artefact.stubs :language
     end
 
@@ -59,8 +58,7 @@ class EditionFormatPresenterTest < ActiveSupport::TestCase
     end
 
     should "[:document_type]" do
-      artefact.expects(:kind).returns('foo')
-      assert_equal 'foo', result[:document_type]
+      assert_equal "override me", result[:document_type]
     end
 
     should "[:need_ids]" do

--- a/test/unit/presenters/formats/generic_edition_presenter_test.rb
+++ b/test/unit/presenters/formats/generic_edition_presenter_test.rb
@@ -5,7 +5,7 @@ class GenericEditionPresenterTest < ActiveSupport::TestCase
 
   context ".render_for_publishing_api with a published document" do
     setup do
-      artefact = FactoryGirl.create(:artefact, kind: :video)
+      artefact = FactoryGirl.create(:artefact)
 
       expected_external_related_links = [
         { title: "GOVUK", url: "https://www.gov.uk" },
@@ -28,7 +28,7 @@ class GenericEditionPresenterTest < ActiveSupport::TestCase
         base_path: "/#{@edition.slug}",
         description: "",
         schema_name: "generic_with_external_related_links",
-        document_type: artefact.kind,
+        document_type: "generic_with_external_related_links",
         need_ids: [],
         public_updated_at: '2017-02-06T17:36:58.000+00:00',
         publishing_app: "publisher",


### PR DESCRIPTION
Previously this was determined by the 'kind' attribute on the edition's artefact. However when an edition was converted into another type (eg from Answer to Guide), the artefact's 'kind' would not updated. When sending this information to the publishing api, it could end up being misleading to have differening schema_name and document_type (to my knowledge, the two different attributes can be used define specialisations), so we prefer to send the document type as directly determined by the edition.