### PR TITLE
Force text fields to be strings

### DIFF
--- a/app/presenters/formats/local_transaction_presenter.rb
+++ b/app/presenters/formats/local_transaction_presenter.rb
@@ -14,19 +14,19 @@ module Formats
         introduction: [
           {
             content_type: "text/govspeak",
-            content: edition.introduction,
+            content: edition.introduction.to_s,
           },
         ],
         more_information: [
           {
             content_type: "text/govspeak",
-            content: edition.more_information,
+            content: edition.more_information.to_s,
           },
         ],
         need_to_know: [
           {
             content_type: "text/govspeak",
-            content: edition.need_to_know,
+            content: edition.need_to_know.to_s,
           },
         ],
         external_related_links: external_related_links,

--- a/test/unit/presenters/formats/local_transaction_presenter_test.rb
+++ b/test/unit/presenters/formats/local_transaction_presenter_test.rb
@@ -58,34 +58,74 @@ class LocalTransactionPresenterTest < ActiveSupport::TestCase
       assert_equal expected, result[:details][:service_tiers]
     end
 
-    should "[:introduction]" do
-      expected = [
-        {
-          content_type: "text/govspeak",
-          content: 'hello'
-        }
-      ]
-      assert_equal expected, result[:details][:introduction]
+    context "[:introduction]" do
+      should "convert text input" do
+        expected = [
+          {
+            content_type: "text/govspeak",
+            content: 'hello'
+          }
+        ]
+        assert_equal expected, result[:details][:introduction]
+      end
+
+      should "handle nil values" do
+        edition.update(introduction: nil)
+        expected = [
+          {
+            content_type: "text/govspeak",
+            content: ""
+          }
+        ]
+        assert_equal expected, result[:details][:introduction]
+      end
     end
 
-    should "[:more_information]" do
-      expected = [
-        {
-          content_type: "text/govspeak",
-          content: 'more info'
-        }
-      ]
-      assert_equal expected, result[:details][:more_information]
+    context "[:more_information]" do
+      should "convert text input" do
+        expected = [
+          {
+            content_type: "text/govspeak",
+            content: 'more info'
+          }
+        ]
+        assert_equal expected, result[:details][:more_information]
+      end
+
+      should "handle nil values" do
+        edition.update(more_information: nil)
+        expected = [
+
+          {
+            content_type: "text/govspeak",
+            content: ""
+          }
+        ]
+        assert_equal expected, result[:details][:more_information]
+      end
     end
 
-    should "[:need_to_know]" do
-      expected = [
-        {
-          content_type: "text/govspeak",
-          content: 'for your eyes only'
-        }
-      ]
-      assert_equal expected, result[:details][:need_to_know]
+    context "[:need_to_know]" do
+      should "convert text input" do
+        expected = [
+          {
+            content_type: "text/govspeak",
+            content: 'for your eyes only'
+          }
+        ]
+        assert_equal expected, result[:details][:need_to_know]
+      end
+
+      should "handle nil values" do
+        edition.update(need_to_know: nil)
+        expected = [
+          {
+            content_type: "text/govspeak",
+            content: ""
+          }
+        ]
+        assert_equal expected, result[:details][:need_to_know]
+      end
     end
 
     should "[:external_related_links]" do


### PR DESCRIPTION
In the case of any of these fields being nil, they will fail against the published schemas, so we force them to be empty strings.