### PR TITLE
Do not present nil values for local transactions

### DIFF
--- a/app/presenters/formats/local_transaction_presenter.rb
+++ b/app/presenters/formats/local_transaction_presenter.rb
@@ -7,34 +7,74 @@ module Formats
     end
 
     def details
-      {
-        lgsl_code: edition.lgsl_code,
-        lgil_override: edition.lgil_override,
-        service_tiers: service_tiers,
-        introduction: [
-          {
-            content_type: "text/govspeak",
-            content: edition.introduction,
-          },
-        ],
-        more_information: [
-          {
-            content_type: "text/govspeak",
-            content: edition.more_information,
-          },
-        ],
-        need_to_know: [
-          {
-            content_type: "text/govspeak",
-            content: edition.need_to_know,
-          },
-        ],
-        external_related_links: external_related_links,
-      }
+      required_details
+      .merge(optional_details)
+      .merge(external_related_links: external_related_links)
     end
 
     def registers_exact_route?
       false
+    end
+
+  private
+
+    def required_details
+      {
+        lgsl_code: edition.lgsl_code,
+        service_tiers: service_tiers,
+      }
+    end
+
+    def optional_details
+      {}.merge(lgil_override)
+        .merge(introduction)
+        .merge(more_information)
+        .merge(need_to_know)
+    end
+
+    def lgil_override
+      return {} if edition.lgil_override.nil?
+
+      { lgil_override: edition.lgil_override }
+    end
+
+    def introduction
+      return {} if edition.introduction.nil?
+
+      {
+        introduction: [
+          {
+            content_type: "text/govspeak",
+            content: edition.introduction,
+          }
+        ]
+      }
+    end
+
+    def more_information
+      return {} if edition.more_information.nil?
+
+      {
+        more_information: [
+          {
+            content_type: "text/govspeak",
+            content: edition.more_information,
+          }
+        ]
+      }
+    end
+
+    def need_to_know
+      return {} if edition.need_to_know.nil?
+
+      {
+        need_to_know: [
+          {
+            content_type: "text/govspeak",
+            content: edition.need_to_know,
+          }
+        ]
+      }
     end
 
     def service_tiers

--- a/test/unit/presenters/formats/local_transaction_presenter_test.rb
+++ b/test/unit/presenters/formats/local_transaction_presenter_test.rb
@@ -43,49 +43,81 @@ class LocalTransactionPresenterTest < ActiveSupport::TestCase
   end
 
   context "[:details]" do
-    should "[:lgsl_code]" do
-      expected = 431
-      assert_equal expected, result[:details][:lgsl_code]
+    context "required details" do
+      should "[:lgsl_code]" do
+        expected = 431
+        assert_equal expected, result[:details][:lgsl_code]
+      end
+
+      should "[:service_tiers]" do
+        expected = %w{county unitary}
+        assert_equal expected, result[:details][:service_tiers]
+      end
     end
 
-    should "[:lgil_override]" do
-      expected = 8
-      assert_equal expected, result[:details][:lgil_override]
-    end
+    context "optional details" do
+      context "[:lgil_override]" do
+        should "present the data" do
+          expected = 8
+          assert_equal expected, result[:details][:lgil_override]
+        end
 
-    should "[:service_tiers]" do
-      expected = %w{county unitary}
-      assert_equal expected, result[:details][:service_tiers]
-    end
+        should "not present the data if nil" do
+          edition.update(lgil_override: nil)
+          refute_includes result[:details].keys, :lgil_override
+        end
+      end
 
-    should "[:introduction]" do
-      expected = [
-        {
-          content_type: "text/govspeak",
-          content: 'hello'
-        }
-      ]
-      assert_equal expected, result[:details][:introduction]
-    end
+      context "[:introduction]" do
+        should "present the data" do
+          expected = [
+            {
+              content_type: "text/govspeak",
+              content: 'hello'
+            }
+          ]
+          assert_equal expected, result[:details][:introduction]
+        end
 
-    should "[:more_information]" do
-      expected = [
-        {
-          content_type: "text/govspeak",
-          content: 'more info'
-        }
-      ]
-      assert_equal expected, result[:details][:more_information]
-    end
+        should "not present the data if nil" do
+          edition.update(introduction: nil)
+          refute_includes result[:details].keys, :introduction
+        end
+      end
 
-    should "[:need_to_know]" do
-      expected = [
-        {
-          content_type: "text/govspeak",
-          content: 'for your eyes only'
-        }
-      ]
-      assert_equal expected, result[:details][:need_to_know]
+      context "[:more_information]" do
+        should "present the data" do
+          expected = [
+            {
+              content_type: "text/govspeak",
+              content: 'more info'
+            }
+          ]
+          assert_equal expected, result[:details][:more_information]
+        end
+
+        should "not present the data if nil" do
+          edition.update(more_information: nil)
+          refute_includes result[:details].keys, :more_information
+        end
+      end
+
+      context "[:need_to_know]" do
+        should "present the data" do
+          expected = [
+            {
+              content_type: "text/govspeak",
+              content: 'for your eyes only'
+            }
+          ]
+          assert_equal expected, result[:details][:need_to_know]
+        end
+
+        should "not present the data if nil" do
+          edition.update(need_to_know: nil)
+          refute_includes result[:details].keys, :need_to_know
+        end
+      end
     end
 
     should "[:external_related_links]" do


### PR DESCRIPTION
The fields `introduction`, `more_information`, `need_to_know` and `lgil_override` are not required in the schema for local transactions. Therefore when these are nil, we don't send them at all (rather than sending nil which will fail schema validation or sending an empty string which is less explicit)