### PR TITLE
Migrate Completed Transaction to rendered

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'gds-sso', '~> 11.2'
 gem 'gds-api-adapters', '~> 40.1.0'
 gem 'govspeak', '~> 3.4.0'
 gem 'govuk_admin_template', '4.2.0'
-gem "govuk_content_models", "~> 42.0.1"
+gem "govuk_content_models", "~> 43.0.0"
 gem 'govuk_sidekiq', '0.0.4'
 gem 'has_scope'
 gem 'inherited_resources'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (42.0.1)
+    govuk_content_models (43.0.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (~> 11.2)
@@ -458,7 +458,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint (~> 0.7)
   govuk_admin_template (= 4.2.0)
-  govuk_content_models (~> 42.0.1)
+  govuk_content_models (~> 43.0.0)
   govuk_sidekiq (= 0.0.4)
   has_scope
   inherited_resources

--- a/app/presenters/formats/completed_transaction_presenter.rb
+++ b/app/presenters/formats/completed_transaction_presenter.rb
@@ -1,0 +1,39 @@
+module Formats
+  class CompletedTransactionPresenter < EditionFormatPresenter
+  private
+
+    PROMOTIONS = %w(organ_donor register_to_vote)
+
+    def schema_name
+      'completed_transaction'
+    end
+
+    def document_type
+      'completed_transaction'
+    end
+
+    def details
+      return optional_details.merge(required_details) if PROMOTIONS.include?(promotion_choice["choice"])
+      required_details
+    end
+
+    def required_details
+      {
+        external_related_links: external_related_links
+      }
+    end
+
+    def optional_details
+      {
+        promotion: {
+          category: promotion_choice.fetch("choice"),
+          url: promotion_choice.fetch("url", '')
+        }
+      }
+    end
+
+    def promotion_choice
+      edition.presentation_toggles["promotion_choice"]
+    end
+  end
+end

--- a/app/presenters/formats/local_transaction_presenter.rb
+++ b/app/presenters/formats/local_transaction_presenter.rb
@@ -16,8 +16,6 @@ module Formats
       .merge(external_related_links: external_related_links)
     end
 
-  private
-
     def required_details
       {
         lgsl_code: edition.lgsl_code,

--- a/app/services/edition_presenter_factory.rb
+++ b/app/services/edition_presenter_factory.rb
@@ -8,6 +8,8 @@ class EditionPresenterFactory
       case edition_class
       when "AnswerEdition"
         "Formats::AnswerPresenter"
+      when "CompletedTransactionEdition"
+        "Formats::CompletedTransactionPresenter"
       when "GuideEdition"
         "Formats::GuidePresenter"
       when "HelpPageEdition"

--- a/lib/enhancements/edition.rb
+++ b/lib/enhancements/edition.rb
@@ -27,6 +27,7 @@ class Edition
 
   MIGRATED_EDITION_CLASSES = [
     AnswerEdition,
+    CompletedTransactionEdition,
     GuideEdition,
     HelpPageEdition,
     LocalTransactionEdition,

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -83,6 +83,11 @@ class EditionTest < ActiveSupport::TestCase
       assert edition.migrated?
     end
 
+    should "return true for a CompletedTransactionEdition" do
+      edition = FactoryGirl.build(:completed_transaction_edition)
+      assert edition.migrated?
+    end
+
     should "return true for an LocalTransactionEdition" do
       edition = FactoryGirl.build(:local_transaction_edition)
       assert edition.migrated?

--- a/test/unit/presenters/formats/completed_transaction_presenter_test.rb
+++ b/test/unit/presenters/formats/completed_transaction_presenter_test.rb
@@ -1,0 +1,82 @@
+require 'test_helper'
+
+class CompletedTransactionPresenterTest < ActiveSupport::TestCase
+  include GovukContentSchemaTestHelpers::TestUnit
+
+  def subject
+    Formats::CompletedTransactionPresenter.new(edition)
+  end
+
+  def edition
+    @_edition ||= FactoryGirl.create(
+      :completed_transaction_edition,
+      :published,
+      title: "Whacked all moles",
+      slug: "done/good",
+      panopticon_id: artefact.id,
+    )
+  end
+
+  def artefact
+    @_artefact ||= FactoryGirl.create(:artefact, kind: "completed_transaction")
+  end
+
+  def result
+    subject.render_for_publishing_api
+  end
+
+  should "be valid against schema" do
+    assert_valid_against_schema(result, 'completed_transaction')
+  end
+
+  should "[:schema_name]" do
+    assert_equal 'completed_transaction', result[:schema_name]
+  end
+
+  context "[:details]" do
+    should "[:promotion]" do
+      edition.presentation_toggles["promotion_choice"] = {
+        'choice' => 'organ_donor',
+        'url' => 'http://www.foo.com'
+      }
+
+      expected = {
+        category: 'organ_donor',
+        url: 'http://www.foo.com'
+      }
+
+      assert_equal expected, result[:details][:promotion]
+    end
+
+    should "no [:promotion]" do
+      edition.presentation_toggles["promotion_choice"] = {
+        'choice' => 'none',
+        'url' => ''
+      }
+
+      assert_nil result[:details][:promotion]
+    end
+
+    should "[:external_related_links]" do
+      link = { 'url' => 'www.foo.com', 'title' => 'foo' }
+      artefact.update_attribute(:external_links, [link])
+      expected = [
+        {
+          url: link['url'],
+          title: link['title']
+        }
+      ]
+
+      assert_equal expected, result[:details][:external_related_links]
+    end
+  end
+
+  should "[:routes]" do
+    edition.update_attribute(:slug, 'foo')
+    expected = [
+      { path: '/foo', type: 'prefix' },
+      { path: '/foo.json', type: 'exact' }
+    ]
+    assert_equal expected, result[:routes]
+  end
+end

--- a/test/unit/services/edition_presenter_factory_test.rb
+++ b/test/unit/services/edition_presenter_factory_test.rb
@@ -20,6 +20,11 @@ class EditionPresenterFactoryTest < ActiveSupport::TestCase#
       assert result == "Formats::AnswerPresenter"
     end
 
+    should "return a presenter for Completed Transactions" do
+      result = EditionPresenterFactory.presenter_class("CompletedTransactionEdition")
+      assert result == "Formats::CompletedTransactionPresenter"
+    end
+
     should "return a presenter for Help pages" do
       result = EditionPresenterFactory.presenter_class("HelpPageEdition")
       assert result == "Formats::HelpPagePresenter"


### PR DESCRIPTION
Migrate the Completed Transaction format

https://trello.com/c/unTNbCHi/658-migrate-completed-transaction-format-to-rendered

Note: tests will not pass until https://github.com/alphagov/govuk-content-schemas/pull/538 is merged.

Mobbed with @emmabeynon @whoojemaflip @binaryberry 