### PR TITLE
Add fact check token to preview link for preludial states

### DIFF
--- a/app/helpers/paths_helper.rb
+++ b/app/helpers/paths_helper.rb
@@ -3,21 +3,16 @@ module PathsHelper
     "#{preview_url(edition)}/#{edition.slug}"
   end
 
-  def fact_check_edition_path(edition)
-    if edition.fact_check_id
-      token = jwt_token(sub: edition.fact_check_id)
-      url = preview_edition_path(edition)
-      url << "&token=#{token}"
-      url
-    else
-      preview_edition_path(edition)
-    end
-  end
-
   def preview_edition_path(edition, cache_bust = Time.zone.now.to_i)
     path = edition_front_end_path(edition) + "?"
     path << "edition=#{edition.version_number}&" unless edition.migrated?
     path << "cache=#{cache_bust}"
+
+    if edition.migrated? && edition.state != "published" && edition.fact_check_id
+      token = jwt_token(sub: edition.fact_check_id)
+      path << "&token=#{token}"
+    end
+
     path
   end
 

--- a/app/views/noisy_workflow/request_fact_check.text.erb
+++ b/app/views/noisy_workflow/request_fact_check.text.erb
@@ -3,7 +3,7 @@ Hello.
 The following piece of GOV.UK content needs to be fact checked because
 
 Title: <%= @edition.title %>
-<%= fact_check_edition_path(@edition) %>
+<%= preview_edition_path(@edition) %>
 
 <% unless @edition.migrated? %>
 You'll need your GOV.UK user name and password to view the content. Email factcheck-help@digital.cabinet-office.gov.uk if you've forgotten your username and password.

--- a/lib/enhancements/edition.rb
+++ b/lib/enhancements/edition.rb
@@ -129,7 +129,7 @@ class Edition
   end
 
   def fact_check_id
-    if %w(fact_check fact_check_received ready).include?(state) && migrated?
+    if migrated?
       ary = Digest::SHA256.digest(id.to_s).unpack('NnnnnN')
       ary[2] = (ary[2] & 0x0fff) | 0x4000
       ary[3] = (ary[3] & 0x3fff) | 0x8000

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -62,12 +62,6 @@ class EditionTest < ActiveSupport::TestCase
         edition.artefact.update_attribute(:kind, 'help_page')
         assert_equal edition.fact_check_id, "a665a459-2042-4f9d-817e-4867efdc4fb8"
       end
-
-      should "return nil if edition is in in any other state" do
-        edition = FactoryGirl.create(:edition, state: 'draft')
-        edition.artefact.update_attribute(:kind, 'help_page')
-        assert_nil edition.fact_check_id
-      end
     end
 
     context "for a format that has not yet been migrated" do

--- a/test/unit/helpers/admin/paths_helper_test.rb
+++ b/test/unit/helpers/admin/paths_helper_test.rb
@@ -2,24 +2,6 @@ require 'test_helper'
 
 class PathsHelperTest < ActionView::TestCase
   context "#preview_edition_path" do
-    context "for migrated formats" do
-      should "return path for draft stack" do
-        edition = stub(version_number: 1, migrated?: true, id: 999, slug: "for-funzies")
-        expected_path = "#{draft_origin}/for-funzies?cache=1234"
-        assert_equal expected_path, preview_edition_path(edition, 1234)
-      end
-    end
-
-    context "for non-migrated formats" do
-      should "return path for private frontend" do
-        edition = stub(version_number: 1, migrated?: false, id: 999, slug: "for-funzies")
-        expected_path = "#{private_frontend}/for-funzies?edition=1&cache=9876"
-        assert_equal expected_path, preview_edition_path(edition, 9876)
-      end
-    end
-  end
-
-  context "#fact_check_edition_path" do
     setup do
       Rails.stubs(:application).returns(
         stub(
@@ -30,10 +12,18 @@ class PathsHelperTest < ActionView::TestCase
       )
     end
 
+    context "for non-migrated formats" do
+      should "return path for private frontend" do
+        edition = stub(version_number: 1, migrated?: false, id: 999, slug: "for-funzies")
+        expected_path = "#{private_frontend}/for-funzies?edition=1&cache=9876"
+        assert_equal expected_path, preview_edition_path(edition, 9876)
+      end
+    end
+
     context "when the edition returns a fact_check_id" do
       should "append a valid JWT token to the preview path" do
-        edition = stub(fact_check_id: '123', migrated?: true, slug: 'foo')
-        result = fact_check_edition_path(edition)
+        edition = stub(fact_check_id: '123', migrated?: true, state: 'draft', slug: 'foo')
+        result = preview_edition_path(edition)
 
         path = result.gsub(/^(.*)\?cache=.*&token=.*$/, '\1')
         assert_equal "#{draft_origin}/foo", path
@@ -44,10 +34,10 @@ class PathsHelperTest < ActionView::TestCase
       end
     end
 
-    context "when the edition doesn't return a fact_check_id" do
+    context "when the edition is published" do
       should "not append the JWT token" do
-        edition = stub(fact_check_id: nil, migrated?: true, slug: 'foo')
-        result = fact_check_edition_path(edition)
+        edition = stub(migrated?: true, state: 'published', slug: 'foo')
+        result = preview_edition_path(edition)
         assert_no_match %r(&token=), result
       end
     end

--- a/test/unit/presenters/formats/generic_edition_presenter_test.rb
+++ b/test/unit/presenters/formats/generic_edition_presenter_test.rb
@@ -13,7 +13,7 @@ class GenericEditionPresenterTest < ActiveSupport::TestCase
       ]
       artefact.external_links = expected_external_related_links
 
-      @edition = FactoryGirl.create(:edition, :published,
+      @edition = FactoryGirl.create(:video_edition, :published,
         major_change: true,
         updated_at: DateTime.new(2017, 2, 06, 17, 36, 58).in_time_zone,
         change_note: 'Test',


### PR DESCRIPTION
Users of Publisher want to provide access to the draft content, even
when its not in the fact check state. Therefore, add the fact check
token to the Preview button link.

As the preview link now includes the token, remove the
fact_check_edition_path function and changes uses of it to use
preview_edition_path.

Alter the model to allow for the generation of the fact check id
regardless of the state.

Note that the Publishing API currently strips the access limited
information when sending published content to the draft content
store. This means that the token won't have any effect, therefore to
avoid confusion, don't include the token if this is the case.

https://trello.com/c/LTxUDSbU/661-enable-preview-links-for-external-users-for-draft-content