### PR TITLE
Fix document types for content store & rummager

### DIFF
--- a/app/presenters/formats/answer_presenter.rb
+++ b/app/presenters/formats/answer_presenter.rb
@@ -6,6 +6,10 @@ module Formats
       'answer'
     end
 
+    def document_type
+      'answer'
+    end
+
     def details
       {
         body: [

--- a/app/presenters/formats/edition_format_presenter.rb
+++ b/app/presenters/formats/edition_format_presenter.rb
@@ -29,7 +29,7 @@ module Formats
         base_path: base_path,
         description: edition.overview || "",
         schema_name: schema_name,
-        document_type: schema_name,
+        document_type: document_type,
         need_ids: [],
         public_updated_at: public_updated_at.to_datetime.rfc3339(3),
         publishing_app: "publisher",
@@ -46,6 +46,10 @@ module Formats
   private
 
     def schema_name
+      "override me"
+    end
+
+    def document_type
       "override me"
     end
 

--- a/app/presenters/formats/generic_edition_presenter.rb
+++ b/app/presenters/formats/generic_edition_presenter.rb
@@ -6,6 +6,10 @@ module Formats
       "generic_with_external_related_links"
     end
 
+    def document_type
+      @artefact.kind
+    end
+
     def path_type
       case @edition.class
       when TransactionEdition, CampaignEdition

--- a/app/presenters/formats/guide_presenter.rb
+++ b/app/presenters/formats/guide_presenter.rb
@@ -6,6 +6,10 @@ module Formats
       'guide'
     end
 
+    def document_type
+      'guide'
+    end
+
     def details
       {
         parts: parts,

--- a/app/presenters/formats/help_page_presenter.rb
+++ b/app/presenters/formats/help_page_presenter.rb
@@ -6,6 +6,10 @@ module Formats
       'help_page'
     end
 
+    def document_type
+      'help_page'
+    end
+
     def details
       {
         body: [

--- a/app/presenters/formats/local_transaction_presenter.rb
+++ b/app/presenters/formats/local_transaction_presenter.rb
@@ -6,6 +6,10 @@ module Formats
       'local_transaction'
     end
 
+    def document_type
+      'local_transaction'
+    end
+
     def details
       required_details
       .merge(optional_details)

--- a/app/presenters/formats/simple_smart_answer_presenter.rb
+++ b/app/presenters/formats/simple_smart_answer_presenter.rb
@@ -6,6 +6,10 @@ module Formats
       'simple_smart_answer'
     end
 
+    def document_type
+      'simple_smart_answer'
+    end
+
     def details
       required_details
         .merge(optional_details)

--- a/app/presenters/search_payload_presenter.rb
+++ b/app/presenters/search_payload_presenter.rb
@@ -20,15 +20,22 @@ class SearchPayloadPresenter
   def present
     {
       content_id: artefact.content_id,
-      rendering_app: "publisher",
-      publishing_app: "publisher",
+      rendering_app: publishing_api_payload.fetch(:rendering_app),
+      publishing_app: publishing_api_payload.fetch(:publishing_app),
       format: format.underscore,
       title: title,
       description: description,
       indexable_content: indexable_content,
       link: "/#{slug}",
       public_timestamp: public_timestamp,
-      content_store_document_type: artefact.kind,
+      content_store_document_type: publishing_api_payload.fetch(:document_type),
     }
+  end
+
+  def publishing_api_payload
+    @publishing_api_payload ||= begin
+      presenter = EditionPresenterFactory.get_presenter(registerable_edition)
+      presenter.render_for_publishing_api
+    end
   end
 end

--- a/test/unit/presenters/formats/generic_edition_presenter_test.rb
+++ b/test/unit/presenters/formats/generic_edition_presenter_test.rb
@@ -28,7 +28,7 @@ class GenericEditionPresenterTest < ActiveSupport::TestCase
         base_path: "/#{@edition.slug}",
         description: "",
         schema_name: "generic_with_external_related_links",
-        document_type: "generic_with_external_related_links",
+        document_type: "answer",
         need_ids: [],
         public_updated_at: '2017-02-06T17:36:58.000+00:00',
         publishing_app: "publisher",

--- a/test/unit/services/search_indexer_test.rb
+++ b/test/unit/services/search_indexer_test.rb
@@ -20,7 +20,7 @@ class SearchIndexerTest < ActiveSupport::TestCase
       'edition',
       "/#{edition.slug}",
       content_id: "content-id",
-      rendering_app: "publisher",
+      rendering_app: "frontend",
       publishing_app: "publisher",
       format: "answer",
       title: "A title",


### PR DESCRIPTION
- Use the artefact "kind" as document type. For non-migrated editions we're currently sending the schema name (`generic_with_external_related_links`) to the content store as document type. This is affecting the analytics gathering, which uses document type.

  This separates the two concepts by having a separate method for the type. This will make sure we won't confuse the two anymore.

  As noted in #566, `@artefact.kind` isn't always the correct type (the kind doesn't change
if the format changes). This will be solved by migrating all the documents. In the meantime, the `kind` is preferable to `generic_with_external_related_links`.

- Send the same data to rummager as content-store. This makes sure that the rendering_app, publishing_app and content_store_document_type are the same in rummager and content store. Currently we're sending "publisher" as rendering app wrongly. We're also sending the "kind" as document type, which is not always true.

cc @davidbasalla 
