### PR TITLE
View published editions on origin production, not draft

### DIFF
--- a/app/helpers/edition_activity_buttons_helper.rb
+++ b/app/helpers/edition_activity_buttons_helper.rb
@@ -52,7 +52,11 @@ module EditionActivityButtonsHelper
   end
 
   def preview_button(edition)
-    link_to('Preview', preview_edition_path(edition), class: 'btn btn-primary btn-large')
+    if edition.published?
+      link_to('View this on the GOV.UK website', "#{Plek.new.website_root}/#{edition.slug}", class: 'btn btn-primary btn-large')
+    else
+      link_to('Preview', preview_edition_path(edition), class: 'btn btn-primary btn-large')
+    end
   end
 
   def skip_review?

--- a/app/views/root/_publication.html.erb
+++ b/app/views/root/_publication.html.erb
@@ -10,7 +10,9 @@
       <% end %>
     </h4>
 
-    <% if publication.safe_to_preview? %>
+    <% if publication.published? %>
+      <%= link_to "#{Plek.new.website_root}/#{publication.slug}", class: 'link-muted' %>
+    <% elsif publication.safe_to_preview? %>
       <%= link_to "/#{publication.slug}", preview_edition_path(publication), class: 'link-muted' %>
     <% else %>
       <span class="text-muted"><%= publication.slug %></span>

--- a/app/views/shared/_history.html.erb
+++ b/app/views/shared/_history.html.erb
@@ -62,7 +62,9 @@
   </div>
 
   <p class="add-bottom-margin">
-    <% if resource.safe_to_preview? %>
+    <% if resource.published? %>
+      View this on the GOV.UK website <%= link_to "#{Plek.new.website_root}/#{resource.slug}" %>.<br />
+    <% elsif resource.safe_to_preview? %>
       Preview edition at <%= link_to preview_edition_path(resource), preview_edition_path(resource) %>.<br />
     <% else %>
       This edition can’t be previewed yet.<br />

--- a/test/integration/edition_history_test.rb
+++ b/test/integration/edition_history_test.rb
@@ -27,6 +27,13 @@ class EditionHistoryTest < JavascriptIntegrationTest
       assert_equal ["fourth", "fifth", "sixth", "link http://www.some-link.com"], @guide.actions.map(&:comment)
     end
 
+    should "direct the user to view a published edition on GOV.UK directly, not draft" do
+      visit "/editions/#{@answer.id}"
+      click_on "History and notes"
+
+      assert page.has_css?('#edition-history p.add-bottom-margin', text: "View this on the GOV.UK website")
+    end
+
     should "have the first history actions visible" do
       visit "/editions/#{@guide.id}"
       click_on "History and notes"

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -226,6 +226,20 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     assert page.has_content? "New edition created"
   end
 
+  test "can preview a draft article on draft-origin" do
+    guide.update_attribute(:state, 'draft')
+
+    visit_edition guide
+    assert page.has_text?('Preview')
+  end
+
+  test "can view a published article on the live site" do
+    guide.update_attribute(:state, 'published')
+
+    visit_edition guide
+    assert page.has_text?('View this on the GOV.UK website')
+  end
+
   test "should link to a newer sibling" do
     artefact = FactoryGirl.create(:artefact)
     old_edition = FactoryGirl.create(


### PR DESCRIPTION
- It makes no sense for users to be directed to draft-origin to view
  already published editions, so link them to "View this on the GOV.UK
  website" corresponding to the environment they're in.

Trello: https://trello.com/c/5d86KxiY/685-make-ui-changes-in-publisher-for-previewing-published-and-archived-editions-2

Before:
<img width="1680" alt="screenshot 2017-03-15 13 18 50" src="https://cloud.githubusercontent.com/assets/355033/23950865/513a8c76-0984-11e7-941e-695f870f3398.png">

<img width="1680" alt="screenshot 2017-03-15 12 46 49" src="https://cloud.githubusercontent.com/assets/355033/23950893/644dd174-0984-11e7-831a-546950530176.png">

After:

<img width="1680" alt="screenshot 2017-03-15 13 40 31" src="https://cloud.githubusercontent.com/assets/355033/23951122/2724c2ac-0985-11e7-910b-c6acfcbed8fe.png">


<img width="1680" alt="screenshot 2017-03-15 13 49 02" src="https://cloud.githubusercontent.com/assets/355033/23951538/40634c88-0986-11e7-8001-1720cdd51777.png">
