### PR TITLE
Add a test:schemas rake task

### DIFF
--- a/lib/tasks/schema_tests.rake
+++ b/lib/tasks/schema_tests.rake
@@ -1,0 +1,8 @@
+namespace :test do
+  Rake::TestTask.new(:schemas => "test:prepare") do |t|
+    t.libs << 'test'
+    t.test_files = `grep -rlE "schema" test`.lines.map(&:chomp)
+  end
+
+  Rake::Task['test:schemas'].comment = "Test Publishing API presenters against schemas"
+end


### PR DESCRIPTION
This rake task only runs tests that have the word "schema" in them. We can run this task instead of the full test (which takes 8 minutes) when testing as a downstream build from govuk-content-schemas.

Having "schema" in the test file is obviously going to cause false positives, but hopefully no false negatives - which would be worse.

This test run takes 10s to complete.