### PR TITLE
Don't let users preview archived editions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'gds-sso', '~> 11.2'
 gem 'gds-api-adapters', '~> 40.1.0'
 gem 'govspeak', '~> 3.4.0'
 gem 'govuk_admin_template', '4.2.0'
-gem "govuk_content_models", "~> 43.2.0"
+gem "govuk_content_models", '44.0.0'
 gem 'govuk_sidekiq', '0.0.4'
 gem 'has_scope'
 gem 'inherited_resources'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (43.2.0)
+    govuk_content_models (44.0.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (~> 11.2)
@@ -460,7 +460,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint (~> 0.7)
   govuk_admin_template (= 4.2.0)
-  govuk_content_models (~> 43.2.0)
+  govuk_content_models (= 44.0.0)
   govuk_sidekiq (= 0.0.4)
   has_scope
   inherited_resources

--- a/app/helpers/edition_activity_buttons_helper.rb
+++ b/app/helpers/edition_activity_buttons_helper.rb
@@ -54,6 +54,8 @@ module EditionActivityButtonsHelper
   def preview_button(edition)
     if edition.published?
       link_to('View this on the GOV.UK website', "#{Plek.new.website_root}/#{edition.slug}", class: 'btn btn-primary btn-large')
+    elsif edition.archived?
+      link_to('Preview', '#', class: 'btn btn-primary btn-large disabled')
     else
       link_to('Preview', preview_edition_path(edition), class: 'btn btn-primary btn-large')
     end

--- a/app/views/root/_publication.html.erb
+++ b/app/views/root/_publication.html.erb
@@ -14,8 +14,6 @@
       <%= link_to "/#{publication.slug}", "#{Plek.new.website_root}/#{publication.slug}", class: 'link-muted' %>
     <% elsif publication.safe_to_preview? %>
       <%= link_to "/#{publication.slug}", preview_edition_path(publication), class: 'link-muted' %>
-    <% else %>
-      <span class="text-muted"><%= publication.slug %></span>
     <% end %>
 
     <span class="text-muted"> &middot; <span title="Edition <%= publication.version_number %>">#<%= publication.version_number %></span></span>

--- a/app/views/shared/_history.html.erb
+++ b/app/views/shared/_history.html.erb
@@ -67,7 +67,7 @@
     <% elsif resource.safe_to_preview? %>
       Preview edition at <%= link_to preview_edition_path(resource), preview_edition_path(resource) %>.<br />
     <% else %>
-      This edition can’t be previewed yet.<br />
+      This edition can’t be previewed.<br />
     <% end %>
     Send fact check responses to <%= mail_to resource.fact_check_email_address %>
   </p>

--- a/test/integration/edition_history_test.rb
+++ b/test/integration/edition_history_test.rb
@@ -35,6 +35,16 @@ class EditionHistoryTest < JavascriptIntegrationTest
       assert page.has_link?("/test-slug", href: "#{Plek.new.website_root}/#{@answer.slug}")
     end
 
+    should "not show the view link for archived editions" do
+      @answer.update_attribute(:state, 'archived')
+
+      visit "/editions/#{@answer.id}"
+      click_on "History and notes"
+
+      refute page.has_css?('#edition-history p.add-bottom-margin', text: "Preview edition at")
+      refute page.has_css?('#edition-history p.add-bottom-margin', text: "View this on the GOV.UK website")
+    end
+
     should "have the first history actions visible" do
       visit "/editions/#{@guide.id}"
       click_on "History and notes"

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -249,6 +249,13 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     assert_not page.has_content? "Create new edition"
   end
 
+  test "cannot preview an archived article" do
+    guide.update_attribute(:state, 'archived')
+
+    visit_edition guide
+    assert page.has_css?('#edit div div.navbar.navbar-inverse.navbar-fixed-bottom.text-center div div div a:nth-child(2)', text: 'Preview')
+  end
+
   test "should link to a newer sibling" do
     artefact = FactoryGirl.create(:artefact)
     old_edition = FactoryGirl.create(


### PR DESCRIPTION
- For archived content, Publisher shouldn't link to the draft content
  store because it might be inaccurate (and show a published edition).
  So, disable the preview button, remove the link on the slug on the
  index page, and remove the preview link on the history and notes page.
- This relies on a change in content_models to the `GuideEdition` and
  `Edition` `safe_to_preview?` method to make it false for archived
  content.

https://trello.com/c/5d86KxiY/685-make-ui-changes-in-publisher-for-previewing-published-and-archived-editions-2

Before:

<img width="1174" alt="screenshot 2017-03-15 17 10 35" src="https://cloud.githubusercontent.com/assets/355033/23961269/55077d32-09a2-11e7-8a0e-fd2ab86140c1.png">

<img width="475" alt="screenshot 2017-03-15 17 10 58" src="https://cloud.githubusercontent.com/assets/355033/23961282/613884c0-09a2-11e7-89f2-b31294dc2c96.png">

<img width="719" alt="screenshot 2017-03-15 17 11 25" src="https://cloud.githubusercontent.com/assets/355033/23961310/711e8376-09a2-11e7-9266-7530906ede45.png">

After:

<img width="1173" alt="screenshot 2017-03-15 17 08 33" src="https://cloud.githubusercontent.com/assets/355033/23961224/2e6f7f26-09a2-11e7-8cdd-6ab75b78cb59.png">

<img width="499" alt="screenshot 2017-03-15 17 07 49" src="https://cloud.githubusercontent.com/assets/355033/23961205/1b15932a-09a2-11e7-95b8-f1c2025fad07.png">

<img width="235" alt="screenshot 2017-03-15 17 08 00" src="https://cloud.githubusercontent.com/assets/355033/23961213/248f7c90-09a2-11e7-83f3-6781e50e0041.png">

