### PR TITLE
Stop sending JSON as part of routes payload

### DIFF
--- a/app/presenters/formats/edition_format_presenter.rb
+++ b/app/presenters/formats/edition_format_presenter.rb
@@ -71,16 +71,11 @@ module Formats
     def routes
       [
         { path: "#{base_path}", type: path_type },
-        { path: "#{json_path}", type: "exact" }
       ]
     end
 
     def base_path
       "/#{edition.slug}"
-    end
-
-    def json_path
-      "#{base_path}.json"
     end
 
     # TransactionEdition, CampaignEdition, HelpPageEdition

--- a/test/unit/presenters/formats/answer_presenter_test.rb
+++ b/test/unit/presenters/formats/answer_presenter_test.rb
@@ -57,7 +57,6 @@ class AnswerPresenterTest < ActiveSupport::TestCase
     edition.update_attribute(:slug, 'foo')
     expected = [
       { path: '/foo', type: 'prefix' },
-      { path: '/foo.json', type: 'exact' }
     ]
     assert_equal expected, result[:routes]
   end

--- a/test/unit/presenters/formats/completed_transaction_presenter_test.rb
+++ b/test/unit/presenters/formats/completed_transaction_presenter_test.rb
@@ -75,7 +75,6 @@ class CompletedTransactionPresenterTest < ActiveSupport::TestCase
     edition.update_attribute(:slug, 'foo')
     expected = [
       { path: '/foo', type: 'prefix' },
-      { path: '/foo.json', type: 'exact' }
     ]
     assert_equal expected, result[:routes]
   end

--- a/test/unit/presenters/formats/edition_format_presenter_test.rb
+++ b/test/unit/presenters/formats/edition_format_presenter_test.rb
@@ -109,7 +109,6 @@ class EditionFormatPresenterTest < ActiveSupport::TestCase
         edition.stubs(:exact_route?).returns(false)
         expected = [
           { path: '/foo', type: 'prefix' },
-          { path: '/foo.json', type: 'exact' }
         ]
         assert_equal expected, result[:routes]
       end
@@ -121,7 +120,6 @@ class EditionFormatPresenterTest < ActiveSupport::TestCase
         edition.stubs(:exact_route?).returns(true)
         expected = [
           { path: '/foo', type: 'exact' },
-          { path: '/foo.json', type: 'exact' }
         ]
         assert_equal expected, result[:routes]
       end

--- a/test/unit/presenters/formats/generic_edition_presenter_test.rb
+++ b/test/unit/presenters/formats/generic_edition_presenter_test.rb
@@ -35,7 +35,6 @@ class GenericEditionPresenterTest < ActiveSupport::TestCase
         rendering_app: "frontend",
         routes: [
           { path: "/#{@edition.slug}", type: "prefix" },
-          { path: "/#{@edition.slug}.json", type: "exact" }
         ],
         redirects: [],
         update_type: "major",
@@ -107,7 +106,6 @@ class GenericEditionPresenterTest < ActiveSupport::TestCase
     should "have a exact route type for both path and json path" do
       exact_routes = [
         { path: "/#{@edition.slug}", type: "exact" },
-        { path: "/#{@edition.slug}.json", type: "exact" }
       ]
 
       assert_equal @output[:routes], exact_routes

--- a/test/unit/presenters/formats/guide_presenter_test.rb
+++ b/test/unit/presenters/formats/guide_presenter_test.rb
@@ -100,7 +100,6 @@ class GuidePresenterTest < ActiveSupport::TestCase
     edition.update_attribute(:slug, 'foo')
     expected = [
       { path: '/foo', type: 'prefix' },
-      { path: '/foo.json', type: 'exact' }
     ]
     assert_equal expected, result[:routes]
   end

--- a/test/unit/presenters/formats/help_page_presenter_test.rb
+++ b/test/unit/presenters/formats/help_page_presenter_test.rb
@@ -57,7 +57,6 @@ class HelpPagePresenterTest < ActiveSupport::TestCase
     edition.update_attribute(:slug, 'foo')
     expected = [
       { path: '/foo', type: 'exact' },
-      { path: '/foo.json', type: 'exact' }
     ]
     assert_equal expected, result[:routes]
   end

--- a/test/unit/presenters/formats/licence_presenter_test.rb
+++ b/test/unit/presenters/formats/licence_presenter_test.rb
@@ -118,7 +118,6 @@ class LicencePresenterTest < ActiveSupport::TestCase
       edition.update_attribute(:slug, 'foo')
       expected = [
         { path: '/foo', type: 'prefix' },
-        { path: '/foo.json', type: 'exact' }
       ]
       assert_equal expected, result[:routes]
     end

--- a/test/unit/presenters/formats/local_transaction_presenter_test.rb
+++ b/test/unit/presenters/formats/local_transaction_presenter_test.rb
@@ -137,7 +137,6 @@ class LocalTransactionPresenterTest < ActiveSupport::TestCase
       edition.update_attribute(:slug, 'foo')
       expected = [
         { path: '/foo', type: 'prefix' },
-        { path: '/foo.json', type: 'exact' }
       ]
       assert_equal expected, result[:routes]
     end

--- a/test/unit/presenters/formats/place_presenter_test.rb
+++ b/test/unit/presenters/formats/place_presenter_test.rb
@@ -63,7 +63,6 @@ class PlacePresenterTest < ActiveSupport::TestCase
     edition.update_attribute(:slug, 'foo')
     expected = [
       { path: '/foo', type: 'prefix' },
-      { path: '/foo.json', type: 'exact' }
     ]
     assert_equal expected, result[:routes]
   end

--- a/test/unit/presenters/formats/simple_smart_answer_presenter_test.rb
+++ b/test/unit/presenters/formats/simple_smart_answer_presenter_test.rb
@@ -169,7 +169,6 @@ class SimpleSmartAnswerPresenterTest < ActiveSupport::TestCase
       edition.update_attribute(:slug, 'foo')
       expected = [
         { path: '/foo', type: 'prefix' },
-        { path: '/foo.json', type: 'exact' }
       ]
       assert_equal expected, result[:routes]
     end

--- a/test/unit/presenters/formats/transaction_presenter_test.rb
+++ b/test/unit/presenters/formats/transaction_presenter_test.rb
@@ -135,7 +135,6 @@ class TransactionPresenterTest < ActiveSupport::TestCase
     edition.update_attribute(:slug, 'foo')
     expected = [
       { path: '/foo', type: 'exact' },
-      { path: '/foo.json', type: 'exact' }
     ]
     assert_equal expected, result[:routes]
   end


### PR DESCRIPTION
Frontend's JSON API is being retired (see
https://github.com/alphagov/frontend/pull/1180) so we remove code that sends
JSON to Frontend as part of the routes payload.

Trello: https://trello.com/c/7IRxAVoJ/688-retire-frontend-s-json-api