### PR TITLE
Fix the `link_to` parameters for viewing published editions on GOV.UK

### DIFF
--- a/app/views/root/_publication.html.erb
+++ b/app/views/root/_publication.html.erb
@@ -11,7 +11,7 @@
     </h4>
 
     <% if publication.published? %>
-      <%= link_to "#{Plek.new.website_root}/#{publication.slug}", class: 'link-muted' %>
+      <%= link_to "/#{publication.slug}", "#{Plek.new.website_root}/#{publication.slug}", class: 'link-muted' %>
     <% elsif publication.safe_to_preview? %>
       <%= link_to "/#{publication.slug}", preview_edition_path(publication), class: 'link-muted' %>
     <% else %>

--- a/app/views/shared/_history.html.erb
+++ b/app/views/shared/_history.html.erb
@@ -63,7 +63,7 @@
 
   <p class="add-bottom-margin">
     <% if resource.published? %>
-      View this on the GOV.UK website <%= link_to "#{Plek.new.website_root}/#{resource.slug}" %>.<br />
+      View this on the GOV.UK website <%= link_to "#{Plek.new.website_root}/#{resource.slug}", "#{Plek.new.website_root}/#{resource.slug}" %>.<br />
     <% elsif resource.safe_to_preview? %>
       Preview edition at <%= link_to preview_edition_path(resource), preview_edition_path(resource) %>.<br />
     <% else %>

--- a/test/integration/edition_history_test.rb
+++ b/test/integration/edition_history_test.rb
@@ -8,7 +8,7 @@ class EditionHistoryTest < JavascriptIntegrationTest
 
   context "viewing the history and notes tab" do
     setup do
-      @answer = FactoryGirl.create(:answer_edition, :state => "published")
+      @answer = FactoryGirl.create(:answer_edition, state: "published", slug: "test-slug")
 
       @answer.new_action(@author, Action::SEND_FACT_CHECK, {:comment => "first", :email_addresses => 'a@a.com, b@b.com'})
       @answer.new_action(@author, Action::RECEIVE_FACT_CHECK, {:comment => "second"})
@@ -32,6 +32,7 @@ class EditionHistoryTest < JavascriptIntegrationTest
       click_on "History and notes"
 
       assert page.has_css?('#edition-history p.add-bottom-margin', text: "View this on the GOV.UK website")
+      assert page.has_link?("/test-slug", href: "#{Plek.new.website_root}/#{@answer.slug}")
     end
 
     should "have the first history actions visible" do

--- a/test/integration/root_overview_test.rb
+++ b/test/integration/root_overview_test.rb
@@ -218,4 +218,16 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
 
     assert page.has_css?("#publication-list-container tbody tr:first-child td:nth-child(6)", text: "")
   end
+
+  test "filtering by published should show a table with an edition with a slug as a link" do
+    FactoryGirl.create(:user)
+    FactoryGirl.create(:guide_edition, state: "published", title: "Test", slug: "test-slug")
+
+    visit "/"
+    filter_by_user("All")
+
+    click_on "Published"
+
+    assert page.has_link?("/test-slug", href: "#{Plek.new.website_root}/test-slug")
+  end
 end


### PR DESCRIPTION
- I made a mistake in #587 - `link_to` didn't have enough arguments, so it was showing the entire URL as link text.

Before:

<img width="489" alt="screenshot 2017-03-17 15 03 36" src="https://cloud.githubusercontent.com/assets/355033/24049175/21e69758-0b23-11e7-8b5c-1ecffaf5d931.png">


After:

<img width="490" alt="screenshot 2017-03-17 15 02 53" src="https://cloud.githubusercontent.com/assets/355033/24049155/10e75ce4-0b23-11e7-9618-420bd46a31ae.png">
