### PR TITLE
Add ability to switch the rendering app depending on format

### DIFF
--- a/app/presenters/formats/answer_presenter.rb
+++ b/app/presenters/formats/answer_presenter.rb
@@ -10,6 +10,10 @@ module Formats
       'answer'
     end
 
+    def rendering_app
+      "government-frontend"
+    end
+
     def details
       {
         body: [

--- a/app/presenters/formats/edition_format_presenter.rb
+++ b/app/presenters/formats/edition_format_presenter.rb
@@ -37,7 +37,7 @@ module Formats
         need_ids: [],
         public_updated_at: public_updated_at.to_datetime.rfc3339(3),
         publishing_app: "publisher",
-        rendering_app: "frontend",
+        rendering_app: rendering_app,
         routes: routes,
         redirects: [],
         update_type: update_type(republish),
@@ -57,6 +57,10 @@ module Formats
 
     def details
       {}
+    end
+
+    def rendering_app
+      "frontend"
     end
 
     def external_related_links

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,9 +1,11 @@
 namespace :publishing_api do
+  desc 'republish content'
   task republish_content: [:environment] do
     republish Edition.published
     republish_draft Edition.draft_in_publishing_api
   end
 
+  desc 'republish by format'
   task :republish_by_format, [:format] => :environment do |_, args|
     format_editions = Edition.by_format(args[:format])
 
@@ -11,6 +13,7 @@ namespace :publishing_api do
     republish_draft format_editions.draft_in_publishing_api
   end
 
+  desc 'republish drafts by format'
   task :republish_drafts_by_format, [:format] => :environment do |_, args|
     format_editions = Edition.by_format(args[:format])
 

--- a/test/unit/presenters/formats/answer_presenter_test.rb
+++ b/test/unit/presenters/formats/answer_presenter_test.rb
@@ -60,4 +60,8 @@ class AnswerPresenterTest < ActiveSupport::TestCase
     ]
     assert_equal expected, result[:routes]
   end
+
+  should "[:rendering_app]" do
+    assert_equal "government-frontend", result[:rendering_app]
+  end
 end


### PR DESCRIPTION
this is part of the work to consolidate applications and moves
the answers format to government frontend. the frontend work
has been done for this.