### PR TITLE
Remove Vanished content from publishing-api

### DIFF
--- a/lib/tasks/bulk_unpublish_placeholder_content.rake
+++ b/lib/tasks/bulk_unpublish_placeholder_content.rake
@@ -3,33 +3,7 @@ require 'csv'
 module TheUnpublisher
 module_function
 
-  def unpublish_with_exact_redirect(row)
-    Services.publishing_api.unpublish(
-      row['CONTENT_ID'],
-      locale: row['LOCALE'] || 'en',
-      type: 'redirect',
-      alternative_path: row['REDIRECT'],
-      discard_drafts: true
-    )
-  end
-
-  def unpublish_wth_prefix_redirect(row)
-    Services.publishing_api.unpublish(
-      row['CONTENT_ID'],
-      locale: row['LOCALE'] || 'en',
-      type: 'redirect',
-      redirects: [
-        {
-          path: row['BASE_PATH'],
-          type: 'prefix',
-          destination: row['REDIRECT']
-        }
-      ],
-      discard_drafts: true
-    )
-  end
-
-  def unpublish_without_redirect(row)
+  def gone(row)
     Services.publishing_api.unpublish(
       row['CONTENT_ID'],
       locale: row['LOCALE'] || 'en',
@@ -37,34 +11,31 @@ module_function
       discard_drafts: true
     )
   end
+
+  def vanish(row)
+    Services.publishing_api.unpublish(
+      row['CONTENT_ID'],
+      locale: row['LOCALE'] || 'en',
+      type: 'vanish',
+      discard_drafts: true
+    )
+  end
 end
 
 task bulk_unpublish_placeholder_content: :environment do
   filename = File.join(Rails.root, 'data', 'placeholders.csv')
+  redirect_to_own_url = [
+    "/broadband-connection-voucher-scheme-newport",
+    "/family-separation-support"
+  ]
+
   CSV.read(filename, headers: true).each do |row|
-    begin
-      if row['PROCESSED']
-        puts row['PROCESSED']
-      elsif row['REDIRECT']
-        if 'exact' == row['REDIRECT_TYPE']
-          TheUnpublisher.unpublish_with_exact_redirect(row)
-          puts '✅'
-        elsif 'prefix' == row['REDIRECT_TYPE']
-          TheUnpublisher.unpublish_wth_prefix_redirect(row)
-          puts '✅'
-        else
-          puts '❌'
-        end
-      elsif row['410 (GONE)']
-        TheUnpublisher.unpublish_without_redirect(row)
-        puts '✅'
-      elsif row['404 (NOT FOUND)']
-        puts '🕵'
-      else
-        puts '🆘'
-      end
-    rescue
-      puts '😱'
+    if row['404 (NOT FOUND)']
+      TheUnpublisher.vanish(row)
+      puts "✅ #{row['BASE_PATH']}"
+    elsif redirect_to_own_url.include? row['BASE_PATH']
+      TheUnpublisher.gone(row)
+      puts "✅ #{row['BASE_PATH']}"
     end
   end
 end


### PR DESCRIPTION
Update this one-shot task to account for the ~50 documents in publishing-api with the `placeholder` schema that currently 404 in router.