### PR TITLE
Update NoisyWorkflow partials preview URL

### DIFF
--- a/app/helpers/paths_helper.rb
+++ b/app/helpers/paths_helper.rb
@@ -4,15 +4,13 @@ module PathsHelper
   end
 
   def preview_edition_path(edition)
-    params = []
-    params << "edition=#{edition.version_number}" unless edition.migrated?
+    path = edition_front_end_path(edition)
 
     if should_have_auth_bypass_id?(edition)
       token = jwt_token(sub: edition.auth_bypass_id)
-      params << "token=#{token}"
+      path << "?token=#{token}"
     end
-
-    edition_front_end_path(edition) + "?" + params.join("&")
+    path
   end
 
   def start_work_path(edition)
@@ -42,18 +40,12 @@ protected
   end
 
   def preview_url(edition)
-    if edition.migrated?
-      Plek.current.find("draft-origin")
-    else
-      Plek.current.find("private-frontend")
-    end
+    Plek.current.find("draft-origin")
   end
 
 private
 
   def should_have_auth_bypass_id?(edition)
-    edition.migrated? &&
-    %w(published archived).exclude?(edition.state) &&
-      edition.auth_bypass_id
+    %w(published archived).exclude?(edition.state) && edition.auth_bypass_id
   end
 end

--- a/app/mailers/noisy_workflow.rb
+++ b/app/mailers/noisy_workflow.rb
@@ -1,11 +1,12 @@
 # encoding: utf-8
 
 class NoisyWorkflow < ActionMailer::Base
+  include PathsHelper
   default :from => "Winston (GOV.UK Publisher) <winston@alphagov.co.uk>"
 
   def make_noise(action)
     @action = action
-
+    @preview_url = preview_edition_path(@action.edition)
     subject = "[PUBLISHER] #{describe_action(@action)}"
     recipient_emails = (EMAIL_GROUPS[:citizen] + EMAIL_GROUPS[:business]).uniq
 

--- a/app/views/noisy_workflow/_approve_fact_check.text.erb
+++ b/app/views/noisy_workflow/_approve_fact_check.text.erb
@@ -2,4 +2,4 @@
 
 Comment: <%= @action.comment %>
 
-<%= "#{Plek.current.find("private-frontend")}/#{@action.edition.slug}?edition=#{@action.edition.version_number}" %>
+<%= "#{@preview_url}" %>

--- a/app/views/noisy_workflow/_approve_review.text.erb
+++ b/app/views/noisy_workflow/_approve_review.text.erb
@@ -2,4 +2,4 @@
 
 Comment: <%= @action.comment %>
 
-<%= "#{Plek.current.find("private-frontend")}/#{@action.edition.slug}?edition=#{@action.edition.version_number}" %>
+<%= "#{@preview_url}" %>

--- a/app/views/noisy_workflow/_assign.text.erb
+++ b/app/views/noisy_workflow/_assign.text.erb
@@ -3,4 +3,4 @@
 <% else -%>
 "<%= @action.edition.title %>" (<%= @action.edition.format %>) has been unassigned at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
 <% end -%>
-<%= "#{Plek.current.find("private-frontend")}/#{@action.edition.slug}?edition=#{@action.edition.version_number}" %>
+<%= "#{@preview_url}" %>

--- a/app/views/noisy_workflow/_cancel_scheduled_publishing.text.erb
+++ b/app/views/noisy_workflow/_cancel_scheduled_publishing.text.erb
@@ -1,3 +1,3 @@
 <%= @action.requester.name %> cancelled scheduled publishing of "<%= @action.edition.title %>" (<%= @action.edition.format %>) at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>.
 
-<%= "#{Plek.current.find("private-frontend")}/#{@action.edition.slug}" %>
+<%= "#{@preview_url}" %>

--- a/app/views/noisy_workflow/_create.text.erb
+++ b/app/views/noisy_workflow/_create.text.erb
@@ -1,3 +1,3 @@
 "<%= @action.edition.title %>" (<%= @action.edition.format %>) created by <%= @action.requester.name %> at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
 
-<%= "#{Plek.current.find("private-frontend")}/#{@action.edition.slug}?edition=#{@action.edition.version_number}" %>
+<%= "#{@preview_url}" %>

--- a/app/views/noisy_workflow/_new_version.text.erb
+++ b/app/views/noisy_workflow/_new_version.text.erb
@@ -1,3 +1,3 @@
 New version of "<%= @action.edition.title %>" (<%= @action.edition.format %>) created by <%= @action.requester.name %> at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
 
-<%= "#{Plek.current.find("private-frontend")}/#{@action.edition.slug}?edition=#{@action.edition.version_number}" %>
+<%= "#{@preview_url}" %>

--- a/app/views/noisy_workflow/_publish.text.erb
+++ b/app/views/noisy_workflow/_publish.text.erb
@@ -1,3 +1,3 @@
 <%= @action.requester.name %> published "<%= @action.edition.title %>" (<%= @action.edition.format %>) at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
 
-<%= "#{Plek.current.find("private-frontend")}/#{@action.edition.slug}" %>
+<%= "#{@preview_url}" %>

--- a/app/views/noisy_workflow/_receive_fact_check.text.erb
+++ b/app/views/noisy_workflow/_receive_fact_check.text.erb
@@ -1,4 +1,4 @@
 Fact check response received for "<%= @action.edition.title %>" (<%= @action.edition.format %>) at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
 
 
-<%= "#{Plek.current.find("private-frontend")}/#{@action.edition.slug}?edition=#{@action.edition.version_number}" %>
+<%= "#{@preview_url}" %>

--- a/app/views/noisy_workflow/_request_amendments.text.erb
+++ b/app/views/noisy_workflow/_request_amendments.text.erb
@@ -3,4 +3,4 @@
 Further amends required:
 <%= @action.comment %>
 
-<%= "#{Plek.current.find("private-frontend")}/#{@action.edition.slug}?edition=#{@action.edition.version_number}" %>
+<%= "#{@preview_url}" %>

--- a/app/views/noisy_workflow/_request_review.text.erb
+++ b/app/views/noisy_workflow/_request_review.text.erb
@@ -5,4 +5,4 @@ Comment: <%= @action.comment %>
 Requested by <%= @action.requester.name %> at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
 
 View:
-<%= "#{Plek.current.find("private-frontend")}/#{@action.edition.slug}?edition=#{@action.edition.version_number}" %>
+<%= "#{@preview_url}" %>

--- a/app/views/noisy_workflow/_schedule_for_publishing.text.erb
+++ b/app/views/noisy_workflow/_schedule_for_publishing.text.erb
@@ -1,3 +1,3 @@
 <%= @action.requester.name %> scheduled "<%= @action.edition.title %>" (<%= @action.edition.format %>) to be published at <%= @action.edition.publish_at.strftime("%R on %d/%m/%Y") %>. This change was made at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>.
 
-<%= "#{Plek.current.find("private-frontend")}/#{@action.edition.slug}" %>
+<%= "#{@preview_url}" %>

--- a/app/views/noisy_workflow/_send_fact_check.text.erb
+++ b/app/views/noisy_workflow/_send_fact_check.text.erb
@@ -7,4 +7,4 @@ Response expected by: <%= ((Date.today)+7).to_s %>
 Comment: <%= @action.comment %>
 
 View:
-<%= "#{Plek.current.find("private-frontend")}/#{@action.edition.slug}?edition=#{@action.edition.version_number}" %>
+<%= "#{@preview_url}" %>

--- a/app/views/noisy_workflow/_skip_fact_check.text.erb
+++ b/app/views/noisy_workflow/_skip_fact_check.text.erb
@@ -1,3 +1,3 @@
 <%= @action.requester.name %> skipped fact check for "<%= @action.edition.title %>" (<%= @action.edition.format %>) at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
 
-<%= "#{Plek.current.find("private-frontend")}/#{@action.edition.slug}?edition=#{@action.edition.version_number}" %>
+<%= "#{@preview_url}" %>

--- a/app/views/noisy_workflow/_skip_review.text.erb
+++ b/app/views/noisy_workflow/_skip_review.text.erb
@@ -2,4 +2,4 @@
 
 Comment: <%= @action.comment %>
 
-<%= "#{Plek.current.find("private-frontend")}/#{@action.edition.slug}?edition=#{@action.edition.version_number}" %>
+<%= "#{@preview_url}" %>

--- a/app/views/noisy_workflow/_start_work.text.erb
+++ b/app/views/noisy_workflow/_start_work.text.erb
@@ -1,3 +1,3 @@
 Work was started on "<%= @action.edition.title %>" (<%= @action.edition.format %>) by <%= @action.requester.name %> at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
 
-<%= "#{Plek.current.find("private-frontend")}/#{@action.edition.slug}?edition=#{@action.edition.version_number}" %>
+<%= "#{@preview_url}" %>

--- a/test/unit/helpers/admin/paths_helper_test.rb
+++ b/test/unit/helpers/admin/paths_helper_test.rb
@@ -12,14 +12,6 @@ class PathsHelperTest < ActionView::TestCase
       )
     end
 
-    context "for non-migrated formats" do
-      should "return path for private frontend" do
-        edition = stub(version_number: 1, migrated?: false, id: 999, slug: "for-funzies")
-        expected_path = "#{private_frontend}/for-funzies?edition=1"
-        assert_equal expected_path, preview_edition_path(edition)
-      end
-    end
-
     context "when the edition returns an auth_bypass_id" do
       should "append a valid JWT token to the preview path" do
         edition = stub(auth_bypass_id: '123', migrated?: true, state: 'draft', slug: 'foo')
@@ -45,9 +37,5 @@ class PathsHelperTest < ActionView::TestCase
 
   def draft_origin
     Plek.current.find("draft-origin")
-  end
-
-  def private_frontend
-    Plek.current.find("private-frontend")
   end
 end


### PR DESCRIPTION
Private Frontend is being turned off, and many of the NoisyWorkflow partials had preview links to it, so we update them to point to draft origin instead.

[Trello](https://trello.com/c/JYT9roQm/709-turn-off-private-frontend)

After speaking to the content team we discovered that emails have not been sent using NoisyWorkflow since 2014, but it is functionality that they would like to have.  There is a card in the backlog for that piece of work, so we have decided to leave the code in place for whoever picks that up in future.