### PR TITLE
Remove references to migrated formats

### DIFF
--- a/app/views/noisy_workflow/request_fact_check.text.erb
+++ b/app/views/noisy_workflow/request_fact_check.text.erb
@@ -5,10 +5,6 @@ The following piece of GOV.UK content needs to be fact checked because
 Title: <%= @edition.title %>
 <%= preview_edition_path(@edition) %>
 
-<% unless @edition.migrated? %>
-You'll need your GOV.UK user name and password to view the content. Email factcheck-help@digital.cabinet-office.gov.uk if you've forgotten your username and password.
-
-<% end %>
 Please reply to this email and either:
 
 - confirm that the content is correct

--- a/lib/enhancements/edition.rb
+++ b/lib/enhancements/edition.rb
@@ -25,18 +25,6 @@ class Edition
   }
   PUBLISHING_API_DRAFT_STATES = %w(fact_check amends_needed fact_check_received draft ready in_review scheduled_for_publishing).freeze
 
-  MIGRATED_EDITION_CLASSES = [
-    AnswerEdition,
-    CompletedTransactionEdition,
-    GuideEdition,
-    HelpPageEdition,
-    LocalTransactionEdition,
-    LicenceEdition,
-    PlaceEdition,
-    SimpleSmartAnswerEdition,
-    TransactionEdition,
-  ].freeze
-
   EXACT_ROUTE_EDITION_CLASSES = [
     CampaignEdition,
     HelpPageEdition,
@@ -66,10 +54,6 @@ class Edition
   scope :user_search, lambda { |user, term|
     all_of(for_user(user).selector, internal_search(term).selector)
   }
-
-  def migrated?
-    self.class.in? MIGRATED_EDITION_CLASSES
-  end
 
   def exact_route?
     self.class.in? EXACT_ROUTE_EDITION_CLASSES
@@ -134,12 +118,10 @@ class Edition
 
   def auth_bypass_id
     @_auth_bypass_id ||= begin
-      if migrated?
-        ary = Digest::SHA256.digest(id.to_s).unpack('NnnnnN')
-        ary[2] = (ary[2] & 0x0fff) | 0x4000
-        ary[3] = (ary[3] & 0x3fff) | 0x8000
-        "%08x-%04x-%04x-%04x-%04x%08x" % ary
-      end
+      ary = Digest::SHA256.digest(id.to_s).unpack('NnnnnN')
+      ary[2] = (ary[2] & 0x0fff) | 0x4000
+      ary[3] = (ary[3] & 0x3fff) | 0x8000
+      "%08x-%04x-%04x-%04x-%04x%08x" % ary
     end
   end
 

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -44,83 +44,22 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   context "#auth_bypass_id" do
-    context "for a migrated format" do
-      should "return a deterministic hex id if edition is in fact-check state" do
-        edition = FactoryGirl.create(:edition, state: 'fact_check', id: 123)
-        edition.artefact.update_attribute(:kind, 'help_page')
-        assert_equal edition.auth_bypass_id, "a665a459-2042-4f9d-817e-4867efdc4fb8"
-      end
-
-      should "return a deterministic hex id if edition is in fact-check-received state" do
-        edition = FactoryGirl.create(:edition, state: 'fact_check_received', id: 123)
-        edition.artefact.update_attribute(:kind, 'help_page')
-        assert_equal edition.auth_bypass_id, "a665a459-2042-4f9d-817e-4867efdc4fb8"
-      end
-
-      should "return a deterministic hex id if edition is in ready state" do
-        edition = FactoryGirl.create(:edition, state: 'ready', id: 123)
-        edition.artefact.update_attribute(:kind, 'help_page')
-        assert_equal edition.auth_bypass_id, "a665a459-2042-4f9d-817e-4867efdc4fb8"
-      end
+    should "return a deterministic hex id if edition is in fact-check state" do
+      edition = FactoryGirl.create(:edition, state: 'fact_check', id: 123)
+      edition.artefact.update_attribute(:kind, 'help_page')
+      assert_equal edition.auth_bypass_id, "a665a459-2042-4f9d-817e-4867efdc4fb8"
     end
 
-    context "for a format that has not yet been migrated" do
-      should "return nil" do
-        edition = FactoryGirl.create(:video_edition, state: 'fact_check_received')
-        assert_nil edition.auth_bypass_id
-      end
-    end
-  end
-
-  context "#migrated?" do
-    should "return true for a HelpPageEdition" do
-      edition = FactoryGirl.build(:help_page_edition)
-      assert edition.migrated?
+    should "return a deterministic hex id if edition is in fact-check-received state" do
+      edition = FactoryGirl.create(:edition, state: 'fact_check_received', id: 123)
+      edition.artefact.update_attribute(:kind, 'help_page')
+      assert_equal edition.auth_bypass_id, "a665a459-2042-4f9d-817e-4867efdc4fb8"
     end
 
-    should "return true for an AnswerEdition" do
-      edition = FactoryGirl.build(:answer_edition)
-      assert edition.migrated?
-    end
-
-    should "return true for a CompletedTransactionEdition" do
-      edition = FactoryGirl.build(:completed_transaction_edition)
-      assert edition.migrated?
-    end
-
-    should "return true for an LocalTransactionEdition" do
-      edition = FactoryGirl.build(:local_transaction_edition)
-      assert edition.migrated?
-    end
-
-    should "return true for an LicenceEdition" do
-      edition = FactoryGirl.build(:licence_edition)
-      assert edition.migrated?
-    end
-
-    should "return true for an PlaceEdition" do
-      edition = FactoryGirl.build(:place_edition)
-      assert edition.migrated?
-    end
-
-    should "return true for an SimpleSmartAnswerEdition" do
-      edition = FactoryGirl.build(:simple_smart_answer_edition)
-      assert edition.migrated?
-    end
-
-    should "return false for an edition type that's not been migrated" do
-      edition = FactoryGirl.build(:video_edition)
-      assert_not edition.migrated?
-    end
-
-    should "return true for a GuideEdition" do
-      edition = FactoryGirl.build(:guide_edition)
-      assert edition.migrated?
-    end
-
-    should "return true for a TransactionEdition" do
-      edition = FactoryGirl.build(:transaction_edition)
-      assert edition.migrated?
+    should "return a deterministic hex id if edition is in ready state" do
+      edition = FactoryGirl.create(:edition, state: 'ready', id: 123)
+      edition.artefact.update_attribute(:kind, 'help_page')
+      assert_equal edition.auth_bypass_id, "a665a459-2042-4f9d-817e-4867efdc4fb8"
     end
   end
 end

--- a/test/unit/helpers/admin/paths_helper_test.rb
+++ b/test/unit/helpers/admin/paths_helper_test.rb
@@ -14,7 +14,7 @@ class PathsHelperTest < ActionView::TestCase
 
     context "when the edition returns an auth_bypass_id" do
       should "append a valid JWT token to the preview path" do
-        edition = stub(auth_bypass_id: '123', migrated?: true, state: 'draft', slug: 'foo')
+        edition = stub(auth_bypass_id: '123', state: 'draft', slug: 'foo')
         result = preview_edition_path(edition)
 
         path = result.gsub(/^(.*)\?.*$/, '\1')
@@ -28,7 +28,7 @@ class PathsHelperTest < ActionView::TestCase
 
     context "when the edition is published" do
       should "not append the JWT token" do
-        edition = stub(migrated?: true, state: 'published', slug: 'foo')
+        edition = stub(state: 'published', slug: 'foo')
         result = preview_edition_path(edition)
         assert_no_match %r(&token=), result
       end

--- a/test/unit/presenters/formats/generic_edition_presenter_test.rb
+++ b/test/unit/presenters/formats/generic_edition_presenter_test.rb
@@ -43,6 +43,9 @@ class GenericEditionPresenterTest < ActiveSupport::TestCase
           external_related_links: expected_external_related_links,
         },
         locale: 'en',
+        access_limited: {
+          auth_bypass_ids: [@edition.auth_bypass_id]
+        }
       }
     end
 


### PR DESCRIPTION
All publisher formats will have been migrated, so this code is no longer
necessary.