### PR TITLE
Convert the `downtime_id` to be a string for the `perform` worker action

### DIFF
--- a/app/workers/downtime_scheduler.rb
+++ b/app/workers/downtime_scheduler.rb
@@ -15,7 +15,7 @@ class DowntimeScheduler
   end
 
   def perform(downtime_id)
-    downtime = Downtime.where(id: downtime_id).first
+    downtime = Downtime.where(id: downtime_id.to_s).first
     return if downtime.nil?
 
     artefact = downtime.artefact


### PR DESCRIPTION
- According to http://stackoverflow.com/a/17277093, this is the fix for
  the Errbit errors we've been seeing (https://errbit.publishing.service.gov.uk/apps/5304e0520da11511b0000011/problems/58d536ee65786370a1900000).
- I'm doing this `.to_s` directly here, because I think this is the only
  place in the file where the `downtime_id` parameter isn't previously
  stringified. The other `downtime_id` parameters are used from other
  methods (`self.schedule_publish_and_expiry`, for example) which have
  already had the `downtime.id.to_s` treatment, but `perform` isn't
  called from any of these. I did try to trace this through the
  workers/controllers/models to see where `perform` was being called
  directly, but I couldn't - I presume it's a purely Sidekiq thing.