### PR TITLE
Stop sending paths/prefixes to Rummager

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,4 +10,4 @@ Rake.application.options.trace = true
 
 Rails.application.load_tasks
 
-task :default => [:test, 'jasmine:ci']
+task :default => [:lint, :test, 'jasmine:ci']

--- a/app/presenters/search_index_presenter.rb
+++ b/app/presenters/search_index_presenter.rb
@@ -11,22 +11,6 @@ class SearchIndexPresenter < SimpleDelegator
     overview
   end
 
-  def paths
-    if exact_route?
-      ["/#{slug}", "/#{slug}.json"]
-    else
-      ["/#{slug}.json"]
-    end
-  end
-
-  def prefixes
-    if exact_route?
-      []
-    else
-      ["/#{slug}"]
-    end
-  end
-
   def public_timestamp
     public_updated_at
   end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Run govuk-lint with similar params to CI"
+task "lint" do
+  sh "bundle exec govuk-lint-ruby --rails --diff --format clang app test lib config"
+end

--- a/test/unit/presenters/search_index_presenter_test.rb
+++ b/test/unit/presenters/search_index_presenter_test.rb
@@ -74,36 +74,4 @@ class SearchIndexPresenterTest < ActiveSupport::TestCase
       assert_equal @edition_with_major_change.updated_at.to_i, @presenter.public_timestamp.to_i
     end
   end
-
-  context "paths and prefixes" do
-    context "for a HelpPageEdition" do
-      should "generate /slug and /slug.json path" do
-        edition = FactoryGirl.build(:help_page_edition, :slug => "help/a-slug")
-        presenter = SearchIndexPresenter.new(edition)
-
-        assert_equal [], presenter.prefixes
-        assert_equal ["/help/a-slug", "/help/a-slug.json"], presenter.paths
-      end
-    end
-
-    context "for a TransactionEdition" do
-      should "generate /slug and /slug.json path" do
-        edition = FactoryGirl.build(:transaction_edition, :slug => "a-slug")
-        presenter = SearchIndexPresenter.new(edition)
-
-        assert_equal [], presenter.prefixes
-        assert_equal ["/a-slug", "/a-slug.json"], presenter.paths
-      end
-    end
-
-    context "for other edition types" do
-      should "generate /slug prefix and /slug.json path" do
-        edition = FactoryGirl.build(:answer_edition, :slug => "a-slug")
-        presenter = SearchIndexPresenter.new(edition)
-
-        assert_equal ["/a-slug"], presenter.prefixes
-        assert_equal ["/a-slug.json"], presenter.paths
-      end
-    end
-  end
 end


### PR DESCRIPTION
Rummager doesn't care about paths and prefixes so there's little point in
continuing to send them.  We still send the `link`.

Any fields that are not part of [the schema for the type][1] we're sending [will be silently ignored][2]

Also adding the linter to the default rake task so that we pick up silly things that stop us merging PRs more quickly.

[1]: https://github.com/alphagov/rummager/blob/master/config/schema/base_elasticsearch_type.json
[2]: https://github.com/alphagov/rummager/blob/master/docs/documents.md#post-indexdocuments
