### PR TITLE
Fix bug with downtime messages not being published when no draft present

### DIFF
--- a/app/services/publishing_api_workflow_bypass_publisher.rb
+++ b/app/services/publishing_api_workflow_bypass_publisher.rb
@@ -49,7 +49,7 @@ private
   def draft_edition
     Edition
       .where(panopticon_id: artefact.id)
-      .where(state: { "$nin" => %w(published, archived) })
+      .where(state: { "$nin" => %w(published archived) })
       .first
   end
 end

--- a/test/unit/services/publishing_api_workflow_bypass_publisher_test.rb
+++ b/test/unit/services/publishing_api_workflow_bypass_publisher_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 
 class PublishingApiWorkflowBypassPublisherTest < ActiveSupport::TestCase
   setup do
-    Services.publishing_api.stubs(:discard_draft)
     UpdateService.stubs(:call)
     PublishService.stubs(:call)
   end


### PR DESCRIPTION
`%w(published, archived)` produces: 
`["published, ", "archived"]` rather than the expected:
`["published", "archived"]`

* Use `%w(published archived)`
  We should have some rubocop protection against using `,` within `%w`

This fix prevents unnecessary calls to `discard_draft` which were throwing an error because no draft existed. This error stopped the downtime message from being published:
https://github.com/alphagov/publisher/blob/fix-downtime/app/services/publishing_api_workflow_bypass_publisher.rb#L14

Error that was being thrown:
```
Response body: {"error":{"code":422,"message":"There is not a draft
edition of this document to discard"}} Request body: {}
```
This error was also masked by the way `discard_draft` was being stubbed on an instance of publishing_api. Removing the stub revealed the failing test.

I'm still not entirely sure why the stubbed method in the test was masking that the method was being called: https://github.com/alphagov/publisher/blob/fix-downtime/test/unit/services/publishing_api_workflow_bypass_publisher_test.rb#L33

Zen: https://govuk.zendesk.com/agent/tickets/1963886

cc @whoojemaflip @cbaines 