### PR TITLE
Don't silently fail to unpublish archived editions

### DIFF
--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -1,8 +1,6 @@
 class UnpublishService
   class << self
     def call(artefact, user, redirect_url = "")
-      return false if archived?(artefact)
-
       if update_artefact_in_shared_db(artefact, user, redirect_url)
         remove_from_rummager_search artefact
         unpublish_in_publishing_api artefact, redirect_url
@@ -10,10 +8,6 @@ class UnpublishService
     end
 
   private
-
-    def archived?(artefact)
-      artefact.state == 'archived'
-    end
 
     def update_artefact_in_shared_db(artefact, user, redirect_url)
       artefact.update_attributes_as(

--- a/test/unit/services/unpublish_service_test.rb
+++ b/test/unit/services/unpublish_service_test.rb
@@ -126,19 +126,6 @@ class UnpublishServiceTest < ActiveSupport::TestCase
     end
   end
 
-  context "when an artefact is already archived" do
-    should "return false early" do
-      @artefact.expects(:state).returns("archived")
-      @artefact.expects(:update_attributes_as).never
-
-      @rummager.expects(:delete_content).never
-      @publishing_api.expects(:unpublish).never
-
-      result = UnpublishService.call(@artefact, @user)
-      assert result == false
-    end
-  end
-
   context "when an artefact is not in Rummager" do
     should "continue to unpublish" do
       @rummager.expects(:delete_content)


### PR DESCRIPTION
Archived editions are probably unpublished in the Publishing API, but
unpublishing them again is useful to update the way which they were
unpublished to change the page they redirect to.