### PR TITLE
Update govuk_content_models 44.3.0 -> 44.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'govuk_admin_template', '4.2.0'
 if ENV["API_DEV"]
   gem "govuk_content_models", path: "../govuk_content_models"
 else
-  gem 'govuk_content_models', "44.3.0"
+  gem 'govuk_content_models', "44.4.0"
 end
 gem 'govuk_sidekiq', '0.0.4'
 gem 'has_scope'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
-    govuk_content_models (44.3.0)
+    govuk_content_models (44.4.0)
       bson_ext
       gds-api-adapters (>= 10.9.0)
       gds-sso (~> 11.2)
@@ -464,7 +464,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint (~> 0.7)
   govuk_admin_template (= 4.2.0)
-  govuk_content_models (= 44.3.0)
+  govuk_content_models (= 44.4.0)
   govuk_sidekiq (= 0.0.4)
   has_scope
   inherited_resources

--- a/test/integration/unpublish_test.rb
+++ b/test/integration/unpublish_test.rb
@@ -58,16 +58,5 @@ class UnpublishTest < ActionDispatch::IntegrationTest
         assert page.has_content?("Content unpublished and redirected")
       end
     end
-
-    should "show an error when using an external redirect" do
-      visit "editions/#{@edition.id}/unpublish"
-
-      fill_in "redirect_url", with: "https://www.example.com/bar"
-
-      click_button "Unpublish"
-
-      assert_selector ".alert-danger"
-      assert page.has_content?("Redirect URL is not a valid redirect target")
-    end
   end
 end


### PR DESCRIPTION
This removes validation from redirect_url, which means that Publisher
can now unpublish content and use a redirect_url that didn't match the
previous validation criteria, but is now valid for either the
Publishing API or GOV.UK Content Schemas, e.g. redirecting to
a *.gov.uk subdomain.