### PR TITLE
Alter the text and subject of the fact checking email

### DIFF
--- a/app/mailers/noisy_workflow.rb
+++ b/app/mailers/noisy_workflow.rb
@@ -17,8 +17,8 @@ class NoisyWorkflow < ActionMailer::Base
     @edition = action.edition
     fact_check_address = @edition.fact_check_email_address
     mail(:to => action.email_addresses, :reply_to => fact_check_address,
-      :from => "GOV.UK Editorial Team <#{fact_check_address}>",
-      :subject => "[FACT CHECK REQUESTED] #{@edition.title}") do |format|
+      from: "GOV.UK Editorial Team <#{fact_check_address}>",
+      subject: "‘[#{@edition.title}]’ GOV.UK preview of new edition") do |format|
      format.text { render :text => action.customised_message }
     end
   end

--- a/app/views/noisy_workflow/request_fact_check.text.erb
+++ b/app/views/noisy_workflow/request_fact_check.text.erb
@@ -1,27 +1,49 @@
-Hello.
+Hi,
 
-The following piece of GOV.UK content needs to be fact checked because
+We need you to check the factual accuracy of changes made to '<%= @edition.title%>' before it’s published on GOV.UK.
 
-Title: <%= @edition.title %>
+The GOV.UK Content Team made the changes because
+
+**Deadline: 5 working days**
+
+Preview the changes:
 <%= preview_edition_path(@edition) %>
 
-Please reply to this email and either:
+---------------------------------------------------
 
-- confirm that the content is correct
-- provide clear specific details of what's incorrect, why and what changes should be made
+**What to do**
 
-Only include factual errors - we'll rewrite any content as needed.
+Reply and confirm the content is correct.
 
-You must make sure:
+Or, if you spot something that's not correct, reply to this email and tell us:
 
-- you only send 1 reply
-- your reply is in plain text (eg no colours, italics or highlighted text)
-- you don't send any attachments
+- which paragraph or section isn’t right - for example chapter 2, under heading ‘How much it costs’
+- what’s wrong and why - for example the text implies a legal obligation, when there isn't one
 
-Please reply within 5 working days. Let us know as soon as possible if you're not able to meet this deadline.
+---------------------------------------------------
 
-Please don't reply to this email to ask questions or include the address in any email conversations. Email factcheck-help@digital.cabinet-office.gov.uk if you have any questions.
+**How to do it**
 
-Many thanks,
+When fact checking, please:
 
-GOV.UK content team.
+- only point out factual errors - don’t suggest wording (GDS is responsible for the style)
+- use plain text - GDS systems don’t display text formatting, colours or attachments
+
+To get the content published more quickly:
+
+- only include comments about sections that GDS has changed
+- only reply once - it’ll help if you co-ordinate your response before replying
+
+---------------------------------------------------
+
+**When to contact your GOV.UK lead**
+
+Ask your GOV.UK lead if:
+
+- you’ve spotted a new issue - they’ll raise a new request with GDS
+- you’ve got any questions - they can ask GDS any queries via the Zendesk system
+- you need an extension to the deadline
+
+Thank you.
+
+


### PR DESCRIPTION
Trello: https://trello.com/c/VsZrR0D0/143-updating-the-fact-check-email-work

Currently missing the `[current date + 5 business days]` functionality - this will come as a later piece of work.