### PR TITLE
Add explicit date to fact check deadline message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'erubis'
 gem 'formtastic', '2.3.0'
 gem 'formtastic-bootstrap', '3.0.0'
 gem 'gds-sso', '~> 11.2'
-gem 'gds-api-adapters', '~> 41.0.0'
+gem 'gds-api-adapters', '45.0.0'
 gem 'govspeak', '~> 3.4.0'
 gem 'govuk_admin_template', '4.2.0'
 if ENV["API_DEV"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
       actionpack (>= 3.0)
     formtastic-bootstrap (3.0.0)
       formtastic (>= 2.2)
-    gds-api-adapters (41.0.0)
+    gds-api-adapters (45.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -458,7 +458,7 @@ DEPENDENCIES
   factory_girl_rails
   formtastic (= 2.3.0)
   formtastic-bootstrap (= 3.0.0)
-  gds-api-adapters (~> 41.0.0)
+  gds-api-adapters (= 45.0.0)
   gds-sso (~> 11.2)
   govspeak (~> 3.4.0)
   govuk-content-schema-test-helpers (~> 1.4)

--- a/app/helpers/working_days_helper.rb
+++ b/app/helpers/working_days_helper.rb
@@ -1,0 +1,7 @@
+require 'working_days_calculator'
+
+module WorkingDaysHelper
+  def working_days_after(date, how_many:)
+    WorkingDaysCalculator.new(date).after(how_many)
+  end
+end

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -1,5 +1,6 @@
 require "gds_api/publishing_api_v2"
 require "gds_api/rummager"
+require "gds_api/calendars"
 
 module Services
   def self.publishing_api
@@ -11,5 +12,9 @@ module Services
 
   def self.rummager
     @rummager ||= GdsApi::Rummager.new(Plek.new.find("search"))
+  end
+
+  def self.calendars
+    @calendars ||= GdsApi::Calendars.new(Plek.new.find('calendars'))
   end
 end

--- a/app/views/noisy_workflow/request_fact_check.text.erb
+++ b/app/views/noisy_workflow/request_fact_check.text.erb
@@ -4,7 +4,7 @@ We need you to check the factual accuracy of changes made to '<%= @edition.title
 
 The GOV.UK Content Team made the changes because
 
-**Deadline: 5 working days**
+**Deadline: <%= working_days_after(Date.current, how_many: 5).to_s(:govuk_date) %> (5 working days from today - <%= Date.current.to_s(:govuk_date) %>)**
 
 Preview the changes:
 <%= preview_edition_path(@edition) %>

--- a/lib/working_days_calculator.rb
+++ b/lib/working_days_calculator.rb
@@ -1,16 +1,30 @@
+require 'gds_api/calendars'
+
 class WorkingDaysCalculator
-  def initialize(starting_from)
+  def initialize(starting_from, in_division: :england_and_wales)
     @starting_from = starting_from
+    @calendar_division = in_division
   end
 
   def after(how_many_days, skip_days: 0)
     days = (@starting_from.tomorrow..(@starting_from + how_many_days + skip_days))
-    calculated_skip_days = days.select { |day| holiday?(day) }.count
+    calculated_skip_days = days.count { |day| holiday?(day) }
     return days.last if calculated_skip_days == skip_days
     after(how_many_days, skip_days: calculated_skip_days)
   end
 
   def holiday?(date)
-    date.saturday? || date.sunday?
+    date.saturday? || date.sunday? || public_holidays.include?(date)
+  end
+
+  def public_holidays
+    @public_holidays ||= fetch_public_holidays
+  end
+
+private
+
+  def fetch_public_holidays
+    public_holidays_json = Services.calendars.bank_holidays(@calendar_division)
+    public_holidays_json['events'].map { |event| Date.parse(event["date"]) }
   end
 end

--- a/lib/working_days_calculator.rb
+++ b/lib/working_days_calculator.rb
@@ -1,0 +1,16 @@
+class WorkingDaysCalculator
+  def initialize(starting_from)
+    @starting_from = starting_from
+  end
+
+  def after(how_many_days, skip_days: 0)
+    days = (@starting_from.tomorrow..(@starting_from + how_many_days + skip_days))
+    calculated_skip_days = days.select { |day| holiday?(day) }.count
+    return days.last if calculated_skip_days == skip_days
+    after(how_many_days, skip_days: calculated_skip_days)
+  end
+
+  def holiday?(date)
+    date.saturday? || date.sunday?
+  end
+end

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -4,6 +4,7 @@ class EditionsControllerTest < ActionController::TestCase
   setup do
     login_as_stub_user
     stub_linkables
+    stub_holidays_used_by_fact_check
   end
 
   context "#create" do

--- a/test/integration/add_artefact_test.rb
+++ b/test/integration/add_artefact_test.rb
@@ -4,6 +4,7 @@ class AddArtefactTest < ActionDispatch::IntegrationTest
   setup do
     setup_users
     stub_linkables
+    stub_holidays_used_by_fact_check
   end
 
   should "create a new artefact" do

--- a/test/integration/adding_parts_to_guides_test.rb
+++ b/test/integration/adding_parts_to_guides_test.rb
@@ -4,6 +4,7 @@ class AddingPartsToGuidesTest < JavascriptIntegrationTest
   setup do
     setup_users
     stub_linkables
+    stub_holidays_used_by_fact_check
   end
 
   context 'creating a guide with parts' do

--- a/test/integration/change_edition_type_test.rb
+++ b/test/integration/change_edition_type_test.rb
@@ -8,6 +8,7 @@ class ChangeEditionTypeTest < JavascriptIntegrationTest
     stub_linkables
     FactoryGirl.create(:user)
     stub_mapit_areas_requests(Plek.current.find('imminence'))
+    stub_holidays_used_by_fact_check
   end
 
   teardown do

--- a/test/integration/completed_transactions_create_edit_test.rb
+++ b/test/integration/completed_transactions_create_edit_test.rb
@@ -30,7 +30,7 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
                                    :panopticon_id => @artefact.id,
                                    :title => "All bar done")
 
-      visit "/editions/#{completed_transaction.to_param}"
+      visit_edition completed_transaction
 
       assert page.has_content? 'All bar done #1'
       assert page.has_field?("Title", :with => "All bar done")
@@ -49,7 +49,7 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
                                  :state => 'published',
                                  :title => "All bar done")
 
-    visit "/editions/#{completed_transaction.to_param}"
+    visit_edition completed_transaction
 
     click_on "Create new edition"
 
@@ -63,7 +63,7 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
                                   :state => 'published',
                                   :title => "All bar done")
 
-    visit "/editions/#{edition.to_param}"
+    visit_edition edition
     assert_all_edition_fields_disabled(page)
   end
 
@@ -71,7 +71,7 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
     edition = FactoryGirl.create(:completed_transaction_edition, :panopticon_id => @artefact.id)
     organ_donor_registration_promotion_url = "https://www.organdonation.nhs.uk/how_to_become_a_donor/registration/consent.asp?campaign=2244&v=7"
 
-    visit "/editions/#{edition.to_param}"
+    visit_edition edition
     assert page.has_unchecked_field? "Promote organ donation"
 
     choose "Promote organ donation"
@@ -87,7 +87,7 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
     edition = FactoryGirl.create(:completed_transaction_edition, panopticon_id: @artefact.id)
     register_to_vote_promotion_url = "https://gov.uk/register-to-vote"
 
-    visit "/editions/#{edition.to_param}"
+    visit_edition edition
 
     assert page.has_unchecked_field? "Promote register to vote"
 

--- a/test/integration/completed_transactions_create_edit_test.rb
+++ b/test/integration/completed_transactions_create_edit_test.rb
@@ -12,6 +12,7 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
 
     setup_users
     stub_linkables
+    stub_holidays_used_by_fact_check
   end
 
   should "create a new CompletedTransactionEdition" do

--- a/test/integration/delete_edition_test.rb
+++ b/test/integration/delete_edition_test.rb
@@ -16,6 +16,7 @@ class DeleteEditionTest < ActionDispatch::IntegrationTest
 
     setup_users
     stub_linkables
+    stub_holidays_used_by_fact_check
   end
 
   teardown do

--- a/test/integration/delete_edition_test.rb
+++ b/test/integration/delete_edition_test.rb
@@ -24,7 +24,7 @@ class DeleteEditionTest < ActionDispatch::IntegrationTest
   end
 
   test "deleting a draft edition discards the draft in the publishing api" do
-    visit "/editions/#{@edition.id}"
+    visit_edition @edition
 
     click_on "Admin"
 

--- a/test/integration/edit_artefact_test.rb
+++ b/test/integration/edit_artefact_test.rb
@@ -4,6 +4,7 @@ class EditArtefactTest < ActionDispatch::IntegrationTest
   setup do
     setup_users
     stub_linkables
+    stub_holidays_used_by_fact_check
   end
 
   should "edit a draft artefact" do

--- a/test/integration/edition_history_test.rb
+++ b/test/integration/edition_history_test.rb
@@ -29,7 +29,7 @@ class EditionHistoryTest < JavascriptIntegrationTest
     end
 
     should "direct the user to view a published edition on GOV.UK directly, not draft" do
-      visit "/editions/#{@answer.id}"
+      visit_edition @answer
       click_on "History and notes"
 
       assert page.has_css?('#edition-history p.add-bottom-margin', text: "View this on the GOV.UK website")
@@ -39,7 +39,7 @@ class EditionHistoryTest < JavascriptIntegrationTest
     should "not show the view link for archived editions" do
       @answer.update_attribute(:state, 'archived')
 
-      visit "/editions/#{@answer.id}"
+      visit_edition @answer
       click_on "History and notes"
 
       refute page.has_css?('#edition-history p.add-bottom-margin', text: "Preview edition at")
@@ -47,14 +47,14 @@ class EditionHistoryTest < JavascriptIntegrationTest
     end
 
     should "have the first history actions visible" do
-      visit "/editions/#{@guide.id}"
+      visit_edition @guide
       click_on "History and notes"
 
       assert page.has_css?('#edition-history div.panel:first-of-type div.panel-collapse.in')
     end
 
     should "have clickable links in notes" do
-      visit "/editions/#{@guide.id}"
+      visit_edition @guide
       click_on "History and notes"
 
       assert page.has_css?('.panel a[href="http://www.some-link.com"]', text: 'http://www.some-link.com')
@@ -63,7 +63,7 @@ class EditionHistoryTest < JavascriptIntegrationTest
     should "hide everything but the latest reply in fact check responses behind a toggle" do
       @guide.new_action(@author, Action::RECEIVE_FACT_CHECK, {:comment => "email reply\n-----Original Message-----\noriginal email request"})
 
-      visit "/editions/#{@guide.id}"
+      visit_edition @guide
       click_on "History and notes"
 
       assert page.has_css?('p', text: 'email reply')
@@ -76,7 +76,7 @@ class EditionHistoryTest < JavascriptIntegrationTest
     end
 
     should "include the email addresses of fact check request recipients" do
-      visit "/editions/#{@guide.id}"
+      visit_edition @guide
       click_on "History and notes"
       click_on "Edition 1"
       assert page.has_css?('p', text: "first")
@@ -85,7 +85,7 @@ class EditionHistoryTest < JavascriptIntegrationTest
     end
 
     should "hide actions when the edition title is clicked" do
-      visit "/editions/#{@guide.id}"
+      visit_edition @guide
       click_on "History and notes"
       click_on "Edition 2"
       assert page.has_no_css?('#edition-history div.panel:first-of-type div.panel-collapse.in')
@@ -95,20 +95,20 @@ class EditionHistoryTest < JavascriptIntegrationTest
       should "be able to add and resolve a note" do
         add_important_note("This is an important note. Take note.")
 
-        visit "/editions/#{@guide.id}"
+        visit_edition @guide
         assert page.has_content? "This is an important note. Take note."
         assert page.has_css?('.callout-important-note')
 
         click_on "History and notes"
         click_on "Delete important note"
-        visit "/editions/#{@guide.id}"
+        visit_edition @guide
         assert page.has_no_css?('.callout-important-note')
       end
 
       should "prepopulate with an existing note" do
         add_important_note("This is an important note. Take note.")
 
-        visit "/editions/#{@guide.id}"
+        visit_edition @guide
         click_on "History and notes"
         click_on "Update important note"
 
@@ -135,7 +135,7 @@ class EditionHistoryTest < JavascriptIntegrationTest
         @edition.actions.create(:request_type => Action::IMPORTANT_NOTE,
                                 :comment => "This is an important note. Take note.")
 
-        visit "/editions/#{@edition.id}"
+        visit_edition @edition
         assert page.has_content? "This is an important note. Take note."
 
         click_on "Create new edition"
@@ -174,7 +174,7 @@ class EditionHistoryTest < JavascriptIntegrationTest
   end
 
   def add_important_note(note)
-    visit "/editions/#{@guide.id}"
+    visit_edition @guide
     click_on "History and notes"
     click_on "Update important note"
 

--- a/test/integration/edition_history_test.rb
+++ b/test/integration/edition_history_test.rb
@@ -4,6 +4,7 @@ class EditionHistoryTest < JavascriptIntegrationTest
   setup do
     setup_users
     stub_linkables
+    stub_holidays_used_by_fact_check
   end
 
   context "viewing the history and notes tab" do

--- a/test/integration/edition_major_change_test.rb
+++ b/test/integration/edition_major_change_test.rb
@@ -5,6 +5,7 @@ class EditionMajorChangeTest < JavascriptIntegrationTest
   setup do
     setup_users
     stub_linkables
+    stub_holidays_used_by_fact_check
   end
 
   teardown do

--- a/test/integration/edition_scheduled_publishing_test.rb
+++ b/test/integration/edition_scheduled_publishing_test.rb
@@ -5,6 +5,7 @@ class EditionScheduledPublishingTest < JavascriptIntegrationTest
   setup do
     setup_users
     stub_linkables
+    stub_holidays_used_by_fact_check
     # queue up the edition, don't perform inline
     Sidekiq::Testing.fake!
   end

--- a/test/integration/edition_tab_test.rb
+++ b/test/integration/edition_tab_test.rb
@@ -5,6 +5,7 @@ class EditionTabTest < JavascriptIntegrationTest
   setup do
     setup_users
     stub_linkables
+    stub_holidays_used_by_fact_check
 
     @guide = FactoryGirl.create(:guide_edition, state: 'draft')
   end

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -1,6 +1,8 @@
 require 'integration_test_helper'
+require 'gds_api/test_helpers/calendars'
 
 class EditionWorkflowTest < JavascriptIntegrationTest
+  include GdsApi::TestHelpers::Calendars
   attr_reader :alice, :bob, :guide
 
   setup do
@@ -34,6 +36,24 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     visit_edition guide
 
     refute page.has_xpath?("//select[@id='edition_assigned_to_id']/option[text() = '#{disabled_user.name}']")
+  end
+
+  test "the customised message for fact-check is pre-loaded with a 5 working days deadline message" do
+    today = Date.parse('2017-04-28')
+    calendars_has_a_bank_holiday_on(Date.parse('2017-05-01'), in_division: 'england-and-wales')
+
+    Timecop.freeze(today) do
+      guide.update_attribute(:state, 'ready')
+      visit_edition guide
+
+      page.find_link('Fact check').trigger('click')
+
+      within "#send_fact_check_form" do
+        customised_message = page.find_field('Customised message')
+        assert customised_message
+        assert customised_message.value.include? 'Deadline: 8 May 2017 (5 working days from today - 28 April 2017)'
+      end
+    end
   end
 
   test "can send guide to fact-check when in ready state" do

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -7,6 +7,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
 
   setup do
     stub_linkables
+    stub_holidays_used_by_fact_check
 
     @alice = FactoryGirl.create(:user, name: "Alice")
     @bob = FactoryGirl.create(:user, name: "Bob")

--- a/test/integration/guide_create_edit_test.rb
+++ b/test/integration/guide_create_edit_test.rb
@@ -32,7 +32,7 @@ class GuideCreateEditTest < JavascriptIntegrationTest
     guide.parts.build(:title => "Placeholder", :body => "placeholder", :slug => 'placeholder', :order => 1)
     guide.save!
 
-    visit "/editions/#{guide.to_param}"
+    visit_edition guide
 
     assert page.has_content? 'Foo bar #1'
 
@@ -64,7 +64,7 @@ class GuideCreateEditTest < JavascriptIntegrationTest
                                  :title => "Foo bar")
     guide.save!
 
-    visit "/editions/#{guide.to_param}"
+    visit_edition guide
     click_on "Create new edition"
 
     assert page.has_content? 'Foo bar #2'
@@ -80,7 +80,7 @@ class GuideCreateEditTest < JavascriptIntegrationTest
                                  :state => 'published',
                                  :title => "Foo bar")
 
-    visit "/editions/#{edition.to_param}"
+    visit_edition edition
     assert_all_edition_fields_disabled(page)
   end
 end

--- a/test/integration/guide_create_edit_test.rb
+++ b/test/integration/guide_create_edit_test.rb
@@ -5,6 +5,7 @@ class GuideCreateEditTest < JavascriptIntegrationTest
   setup do
     setup_users
     stub_linkables
+    stub_holidays_used_by_fact_check
 
     @artefact = FactoryGirl.create(:artefact,
         slug: "hedgehog-topiary",

--- a/test/integration/help_page_create_edit_test.rb
+++ b/test/integration/help_page_create_edit_test.rb
@@ -30,7 +30,7 @@ class HelpPageCreateEditTest < JavascriptIntegrationTest
                                    :panopticon_id => @artefact.id,
                                    :title => "Foo bar",
                                    :body => "Body content")
-      visit "/editions/#{help_page.to_param}"
+      visit_edition help_page
 
       assert page.has_content? 'Foo bar #1'
       assert page.has_field?("Title", :with => "Foo bar")
@@ -52,7 +52,7 @@ class HelpPageCreateEditTest < JavascriptIntegrationTest
                                    :title => "Foo bar",
                                    :body => "This is really helpful")
 
-      visit "/editions/#{help_page.to_param}"
+      visit_edition help_page
       click_on "Create new edition"
 
       assert page.has_content? 'Foo bar #2'
@@ -67,7 +67,7 @@ class HelpPageCreateEditTest < JavascriptIntegrationTest
                                  :title => "Foo bar",
                                  :body => "This is really helpful")
 
-    visit "/editions/#{edition.to_param}"
+    visit_edition edition
     assert_all_edition_fields_disabled(page)
   end
 end

--- a/test/integration/help_page_create_edit_test.rb
+++ b/test/integration/help_page_create_edit_test.rb
@@ -12,6 +12,7 @@ class HelpPageCreateEditTest < JavascriptIntegrationTest
 
     setup_users
     stub_linkables
+    stub_holidays_used_by_fact_check
   end
 
   should "create a new HelpPageEdition" do

--- a/test/integration/licence_create_edit_test.rb
+++ b/test/integration/licence_create_edit_test.rb
@@ -12,6 +12,7 @@ class LicenceCreateEditTest < JavascriptIntegrationTest
 
     setup_users
     stub_linkables
+    stub_holidays_used_by_fact_check
   end
 
   should "create a new LicenceEdition" do

--- a/test/integration/licence_create_edit_test.rb
+++ b/test/integration/licence_create_edit_test.rb
@@ -42,7 +42,7 @@ class LicenceCreateEditTest < JavascriptIntegrationTest
                                    :will_continue_on => "The HMRC website",
                                    :continuation_link => "http://www.hmrc.gov.uk")
 
-      visit "/editions/#{licence.to_param}"
+      visit_edition licence
 
       assert page.has_content? 'Foo bar #1'
 
@@ -78,7 +78,7 @@ class LicenceCreateEditTest < JavascriptIntegrationTest
                                  :will_continue_on => "The HMRC website",
                                  :continuation_link => "http://www.hmrc.gov.uk")
 
-    visit "/editions/#{licence.to_param}"
+    visit_edition licence
     click_on "Create new edition"
 
     assert page.has_content? 'Foo bar #2'
@@ -101,7 +101,7 @@ class LicenceCreateEditTest < JavascriptIntegrationTest
                                   :will_continue_on => "The HMRC website",
                                   :continuation_link => "http://www.hmrc.gov.uk")
 
-    visit "/editions/#{edition.to_param}"
+    visit_edition edition
     assert_all_edition_fields_disabled(page)
   end
 end

--- a/test/integration/local_transaction_create_edit_test.rb
+++ b/test/integration/local_transaction_create_edit_test.rb
@@ -63,7 +63,7 @@ class LocalTransactionCreateEditTest < JavascriptIntegrationTest
         lgil_code: 2
       )
 
-      visit "/editions/#{edition.to_param}"
+      visit_edition edition
 
       assert page.has_content? 'Foo transaction #1'
       assert page.has_field?('LGSL code', with: '1', disabled: true)
@@ -92,7 +92,7 @@ class LocalTransactionCreateEditTest < JavascriptIntegrationTest
         lgil_code: 1
       )
 
-      visit "/editions/#{edition.to_param}"
+      visit_edition edition
       fill_in "Title", with: ""
 
       save_edition_and_assert_error
@@ -110,7 +110,7 @@ class LocalTransactionCreateEditTest < JavascriptIntegrationTest
       lgil_code: 1
     )
 
-    visit "/editions/#{edition.to_param}"
+    visit_edition edition
     assert_all_edition_fields_disabled(page)
   end
 end

--- a/test/integration/local_transaction_create_edit_test.rb
+++ b/test/integration/local_transaction_create_edit_test.rb
@@ -14,6 +14,7 @@ class LocalTransactionCreateEditTest < JavascriptIntegrationTest
 
     setup_users
     stub_linkables
+    stub_holidays_used_by_fact_check
   end
 
   test "creating a local transaction sends the right emails" do

--- a/test/integration/mark_edition_in_beta_test.rb
+++ b/test/integration/mark_edition_in_beta_test.rb
@@ -4,6 +4,7 @@ class MarkEditionInBetaTest < JavascriptIntegrationTest
   setup do
     setup_users
     stub_linkables
+    stub_holidays_used_by_fact_check
   end
 
   with_and_without_javascript do

--- a/test/integration/previous_edition_differences_test.rb
+++ b/test/integration/previous_edition_differences_test.rb
@@ -5,6 +5,7 @@ class PreviousEditionDifferencesTest < JavascriptIntegrationTest
     stub_register_published_content
     setup_users
     stub_linkables
+    stub_holidays_used_by_fact_check
 
     @first_edition = FactoryGirl.create(:answer_edition,
                                         :state => "published",

--- a/test/integration/previous_edition_differences_test.rb
+++ b/test/integration/previous_edition_differences_test.rb
@@ -14,7 +14,7 @@ class PreviousEditionDifferencesTest < JavascriptIntegrationTest
 
   context "First edition" do
     should "not have a link to show changes" do
-      visit "/editions/#{@first_edition.id}"
+      visit_edition @first_edition
       click_on "History and notes"
 
       assert page.has_no_link?("Compare with previous")
@@ -27,7 +27,7 @@ class PreviousEditionDifferencesTest < JavascriptIntegrationTest
       @second_edition.update_attributes(body: "Test Body 2")
       @second_edition.reload
 
-      visit "/editions/#{@second_edition.id}"
+      visit_edition @second_edition
       click_on "History and notes"
     end
 
@@ -67,7 +67,7 @@ class PreviousEditionDifferencesTest < JavascriptIntegrationTest
       @second_edition.reload
       assert_equal "published", @second_edition.state
 
-      visit "/editions/#{@second_edition.id}"
+      visit_edition @second_edition
       click_on "History and notes"
       click_on "Compare with edition 1"
 

--- a/test/integration/root_overview_test.rb
+++ b/test/integration/root_overview_test.rb
@@ -1,6 +1,10 @@
 require_relative '../integration_test_helper'
 
 class RootOverviewTest < ActionDispatch::IntegrationTest
+  setup do
+    stub_holidays_used_by_fact_check
+  end
+
   test "filtering by assigned user" do
     # This isn't right, really need a way to run actions when
     # logged in as particular users without having Signonotron running.

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -13,6 +13,7 @@ class SimpleSmartAnswersTest < JavascriptIntegrationTest
     setup_users
     GDS::SSO.test_user = @author
     stub_linkables
+    stub_holidays_used_by_fact_check
   end
 
   context "creating a new edition" do

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -365,7 +365,7 @@ class SimpleSmartAnswersTest < JavascriptIntegrationTest
     end
 
     should "not save using ajax" do
-      visit "/editions/#{@edition.id}"
+      visit_edition @edition
       save_edition
 
       assert page.has_no_css?('.workflow-message', text: 'Saving')
@@ -373,7 +373,7 @@ class SimpleSmartAnswersTest < JavascriptIntegrationTest
     end
 
     should "correctly render the form" do
-      visit "/editions/#{@edition.id}"
+      visit_edition @edition
 
       within ".page-title" do
         assert page.has_content? "Can I get a driving licence?"
@@ -427,7 +427,7 @@ class SimpleSmartAnswersTest < JavascriptIntegrationTest
     end
 
     should "delete an existing node and option" do
-      visit "/editions/#{@edition.id}"
+      visit_edition @edition
 
       within ".nodes .node:first-child .option:nth-child(2)" do
         click_link "Remove option"
@@ -451,7 +451,7 @@ class SimpleSmartAnswersTest < JavascriptIntegrationTest
     end
 
     should "reset the next node value in options when a node is deleted" do
-      visit "/editions/#{@edition.id}"
+      visit_edition @edition
 
       within ".nodes .outcome:nth-child(3)" do
         click_link "Remove node"
@@ -469,7 +469,7 @@ class SimpleSmartAnswersTest < JavascriptIntegrationTest
     should "correctly number new nodes" do
       @edition.nodes.where(:slug => "outcome-2").first.update_attribute(:slug, "outcome-3")
 
-      visit "/editions/#{@edition.id}"
+      visit_edition @edition
 
       assert page.has_css?(".nodes .question", count: 1)
       assert page.has_css?(".nodes .outcome", count: 2)
@@ -483,7 +483,7 @@ class SimpleSmartAnswersTest < JavascriptIntegrationTest
     end
 
     should "correctly order new nodes" do
-      visit "/editions/#{@edition.id}"
+      visit_edition @edition
 
       within ".nodes" do
         assert_equal "1", find(:css, '.node:nth-child(1) .node-order', :visible => false).value
@@ -505,7 +505,7 @@ class SimpleSmartAnswersTest < JavascriptIntegrationTest
     end
 
     should "highlight an error on the select field when the next node is blank" do
-      visit "/editions/#{@edition.id}"
+      visit_edition @edition
 
       within ".nodes .question:first-child .option:first-child" do
         select "Select a node..", :from => "next-node-list"

--- a/test/integration/skip_review_test.rb
+++ b/test/integration/skip_review_test.rb
@@ -10,6 +10,7 @@ class SkipReviewTest < JavascriptIntegrationTest
 
 
     stub_linkables
+    stub_holidays_used_by_fact_check
 
     @artefact = FactoryGirl.create(:artefact,
                                     slug: "hedgehog-topiary",

--- a/test/integration/tagging_test.rb
+++ b/test/integration/tagging_test.rb
@@ -4,6 +4,7 @@ class TaggingTest < JavascriptIntegrationTest
   setup do
     setup_users
     stub_linkables
+    stub_holidays_used_by_fact_check
 
     @edition = FactoryGirl.create(:guide_edition)
     @artefact = @edition.artefact

--- a/test/integration/tagging_test.rb
+++ b/test/integration/tagging_test.rb
@@ -14,7 +14,7 @@ class TaggingTest < JavascriptIntegrationTest
 
   context "Tagging to linkables" do
     should "tag to browse pages" do
-      visit edition_path(@edition)
+      visit_edition @edition
       switch_tab 'Tagging'
 
       select 'Tax / VAT', from: 'Mainstream browse pages'
@@ -34,7 +34,7 @@ class TaggingTest < JavascriptIntegrationTest
     end
 
     should "tag to topics" do
-      visit edition_path(@edition)
+      visit_edition @edition
       switch_tab 'Tagging'
 
       select 'Oil and Gas / Fields', from: 'Topics'
@@ -54,7 +54,7 @@ class TaggingTest < JavascriptIntegrationTest
     end
 
     should "tag to organisations" do
-      visit edition_path(@edition)
+      visit_edition @edition
       switch_tab 'Tagging'
 
       select 'Student Loans Company', from: 'Organisations'
@@ -73,7 +73,7 @@ class TaggingTest < JavascriptIntegrationTest
     end
 
     should "tag to parent" do
-      visit edition_path(@edition)
+      visit_edition @edition
       switch_tab 'Tagging'
 
       select 'Tax / RTI', from: 'Breadcrumb'
@@ -101,7 +101,7 @@ class TaggingTest < JavascriptIntegrationTest
         },
       )
 
-      visit edition_path(@edition)
+      visit_edition @edition
       switch_tab 'Tagging'
 
       select 'Tax / RTI (draft)', from: 'Mainstream browse pages'
@@ -134,7 +134,7 @@ class TaggingTest < JavascriptIntegrationTest
         },
       )
 
-      visit edition_path(@edition)
+      visit_edition @edition
 
       switch_tab 'Tagging'
 
@@ -154,7 +154,7 @@ class TaggingTest < JavascriptIntegrationTest
       stub_request(:get, "#{PUBLISHING_API_V2_ENDPOINT}/links/#{@content_id}")
         .to_return(status: 404)
 
-      visit edition_path(@edition)
+      visit_edition @edition
 
       assert page.has_content?('Test guide')
     end
@@ -162,7 +162,7 @@ class TaggingTest < JavascriptIntegrationTest
 
   context "Tagging to external links" do
     should "add new external links when the item is not tagged" do
-      visit edition_path(@edition)
+      visit_edition @edition
       switch_tab 'Related external links'
 
       assert 0, @artefact.external_links.count
@@ -184,7 +184,7 @@ class TaggingTest < JavascriptIntegrationTest
       @artefact.external_links = [{ title: "GOVUK", url: "https://www.gov.uk" }]
       assert 1, @artefact.external_links.count
 
-      visit edition_path(@edition)
+      visit_edition @edition
       switch_tab 'Related external links'
       click_on "Add related external link"
 
@@ -200,7 +200,7 @@ class TaggingTest < JavascriptIntegrationTest
     end
 
     should "not save when no links are added" do
-      visit edition_path(@edition)
+      visit_edition @edition
       switch_tab 'Related external links'
       click_on "Save links"
 
@@ -211,7 +211,7 @@ class TaggingTest < JavascriptIntegrationTest
       @artefact.external_links = [{ title: "GOVUK", url: "https://www.gov.uk" }]
       assert 1, @artefact.external_links.count
 
-      visit edition_path(@edition)
+      visit_edition @edition
       switch_tab "Related external links"
       click_on "Remove this URL"
       click_on "Save links"
@@ -221,7 +221,7 @@ class TaggingTest < JavascriptIntegrationTest
     end
 
     should "not add invalid links" do
-      visit edition_path(@edition)
+      visit_edition @edition
       switch_tab 'Related external links'
 
       click_on "Add related external link"

--- a/test/integration/transaction_create_edit_test.rb
+++ b/test/integration/transaction_create_edit_test.rb
@@ -12,6 +12,7 @@ class TransactionCreateEditTest < JavascriptIntegrationTest
 
     setup_users
     stub_linkables
+    stub_holidays_used_by_fact_check
 
     login_as @author
   end

--- a/test/integration/transaction_create_edit_test.rb
+++ b/test/integration/transaction_create_edit_test.rb
@@ -45,7 +45,7 @@ class TransactionCreateEditTest < JavascriptIntegrationTest
                                    :introduction => "Become a space pilot",
                                    :will_continue_on => "UK Space Recruitment",)
 
-      visit "/editions/#{transaction.to_param}"
+      visit_edition transaction
 
       assert page.has_content? 'Register for space flight'
       assert page.has_field?("Introductory paragraph", :with => "Become a space pilot")
@@ -66,7 +66,7 @@ class TransactionCreateEditTest < JavascriptIntegrationTest
                                    :panopticon_id => @artefact.id,
                                    :title => "Register for space flight")
 
-      visit "/editions/#{transaction.to_param}"
+      visit_edition transaction
 
       fill_in "Service analytics profile", :with => "UA-INVALID-SPACE-FLIGHT"
       save_edition_and_assert_error
@@ -87,7 +87,7 @@ class TransactionCreateEditTest < JavascriptIntegrationTest
                                   :title => "Foo transaction"
                                 )
 
-    visit "/editions/#{edition.to_param}"
+    visit_edition edition
     assert_all_edition_fields_disabled(page)
   end
 end

--- a/test/integration/unpublish_test.rb
+++ b/test/integration/unpublish_test.rb
@@ -17,7 +17,7 @@ class UnpublishTest < ActionDispatch::IntegrationTest
   end
 
   should "unpublishing an artefact archives all editions" do
-    visit "/editions/#{@edition.id}"
+    visit_edition @edition
 
     select_tab "Unpublish"
 
@@ -33,7 +33,7 @@ class UnpublishTest < ActionDispatch::IntegrationTest
 
     @artefact.update(state: 'archived')
 
-    visit "/editions/#{@edition.id}"
+    visit_edition @edition
 
     within(".callout-danger") do
       assert page.has_content?("You can’t edit this publication")

--- a/test/integration/unpublish_test.rb
+++ b/test/integration/unpublish_test.rb
@@ -13,6 +13,7 @@ class UnpublishTest < ActionDispatch::IntegrationTest
                                    body: "They're quite gross.")
     setup_users
     stub_linkables
+    stub_holidays_used_by_fact_check
   end
 
   should "unpublishing an artefact archives all editions" do

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -27,6 +27,14 @@ class ActionDispatch::IntegrationTest
     super(user)
   end
 
+  def visit_edition(edition)
+    visit "/editions/#{edition.to_param}"
+  end
+
+  def visit_editions
+    visit "/editions"
+  end
+
   def assert_field_contains(expected, field)
     found_field = find_field(field)
     assert(found_field.value.include?(expected),
@@ -106,14 +114,6 @@ class JavascriptIntegrationTest < ActionDispatch::IntegrationTest
     end
     clear_cookies
     GDS::SSO.test_user = user
-  end
-
-  def visit_edition(edition)
-    visit "/editions/#{edition.to_param}"
-  end
-
-  def visit_editions
-    visit "/editions"
   end
 
   # Fill in some sample sections for a guide

--- a/test/support/holidays_test_helpers.rb
+++ b/test/support/holidays_test_helpers.rb
@@ -1,0 +1,9 @@
+require 'gds_api/test_helpers/calendars'
+
+module HolidaysTestHelpers
+  include GdsApi::TestHelpers::Calendars
+
+  def stub_holidays_used_by_fact_check
+    calendars_has_no_bank_holidays(in_division: 'england-and-wales')
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,7 @@ require 'gds_api/test_helpers/publishing_api_v2'
 require 'govuk_content_models/test_helpers/factories'
 require 'support/tag_test_helpers'
 require 'support/tab_test_helpers'
+require 'support/holidays_test_helpers'
 require 'govuk_content_models/test_helpers/action_processor_helpers'
 require 'govuk-content-schema-test-helpers'
 require 'govuk-content-schema-test-helpers/test_unit'
@@ -95,4 +96,5 @@ class ActiveSupport::TestCase
   include GdsApi::TestHelpers::PublishingApiV2
   include TagTestHelpers
   include TabTestHelpers
+  include HolidaysTestHelpers
 end

--- a/test/unit/lib/working_days_calculator_test.rb
+++ b/test/unit/lib/working_days_calculator_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class WorkingDaysCalculatorTest < ActiveSupport::TestCase
+  test ".after returns the correct weekday" do
+    calculator = WorkingDaysCalculator.new(Date.parse('2017-04-27'))
+    assert_equal Date.parse('2017-04-28'), calculator.after(1)
+  end
+
+  test ".after returns the Monday if the next day falls on a Saturday" do
+    calculator = WorkingDaysCalculator.new(Date.parse('2017-04-21'))
+    assert_equal Date.parse('2017-04-24'), calculator.after(1)
+  end
+
+  test ".after returns the Tuesday if the next day falls on a Sunday" do
+    calculator = WorkingDaysCalculator.new(Date.parse('2017-04-21'))
+    assert_equal Date.parse('2017-04-25'), calculator.after(2)
+  end
+
+  test ".after accounts for weekends crossed even if they're not the 'next day'" do
+    calculator = WorkingDaysCalculator.new(Date.parse('2017-04-21'))
+    assert_equal Date.parse('2017-04-26'), calculator.after(3)
+  end
+end

--- a/test/unit/lib/working_days_calculator_test.rb
+++ b/test/unit/lib/working_days_calculator_test.rb
@@ -1,6 +1,43 @@
 require 'test_helper'
+require 'gds_api/test_helpers/calendars'
 
 class WorkingDaysCalculatorTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::Calendars
+
+  test "cares about england-and-wales holidays by default" do
+    calculator = WorkingDaysCalculator.new(Date.parse('2017-04-27'))
+    english_and_welsh_holidays = stub_request(:get, calendars_endpoint(in_division: 'england-and-wales')).to_return(status: 200, body: '{"events":[]}')
+    scottish_holidays = stub_request(:get, calendars_endpoint(in_division: 'scotland')).to_return(status: 200, body: '{"events":[]}')
+    northern_irish_holidays = stub_request(:get, calendars_endpoint(in_division: 'northern-ireland')).to_return(status: 200, body: '{"events":[]}')
+    all_holidays = stub_request(:get, calendars_endpoint).to_return(status: 200, body: '{"events":[]}')
+
+    calculator.public_holidays
+
+    assert_requested(english_and_welsh_holidays)
+    assert_not_requested(scottish_holidays)
+    assert_not_requested(northern_irish_holidays)
+    assert_not_requested(all_holidays)
+  end
+
+  test "cares about the division it is told to care about" do
+    calculator = WorkingDaysCalculator.new(Date.parse('2017-04-27'), in_division: :scotland)
+    english_and_welsh_holidays = stub_request(:get, calendars_endpoint(in_division: 'england-and-wales')).to_return(status: 200, body: '{"events":[]}')
+    scottish_holidays = stub_request(:get, calendars_endpoint(in_division: 'scotland')).to_return(status: 200, body: '{"events":[]}')
+    northern_irish_holidays = stub_request(:get, calendars_endpoint(in_division: 'northern-ireland')).to_return(status: 200, body: '{"events":[]}')
+    all_holidays = stub_request(:get, calendars_endpoint).to_return(status: 200, body: '{"events":[]}')
+
+    calculator.public_holidays
+
+    assert_not_requested(english_and_welsh_holidays)
+    assert_requested(scottish_holidays)
+    assert_not_requested(northern_irish_holidays)
+    assert_not_requested(all_holidays)
+  end
+
+  setup do
+    calendars_has_no_bank_holidays(in_division: 'england-and-wales')
+  end
+
   test ".after returns the correct weekday" do
     calculator = WorkingDaysCalculator.new(Date.parse('2017-04-27'))
     assert_equal Date.parse('2017-04-28'), calculator.after(1)
@@ -19,5 +56,29 @@ class WorkingDaysCalculatorTest < ActiveSupport::TestCase
   test ".after accounts for weekends crossed even if they're not the 'next day'" do
     calculator = WorkingDaysCalculator.new(Date.parse('2017-04-21'))
     assert_equal Date.parse('2017-04-26'), calculator.after(3)
+  end
+
+  test ".after returns the Tuesday if the next day is a holiday Monday" do
+    calendars_has_a_bank_holiday_on(Date.parse('2017-05-01'), in_division: 'england-and-wales')
+    calculator = WorkingDaysCalculator.new(Date.parse('2017-04-21'))
+    assert_equal Date.parse('2017-05-2'), calculator.after(6)
+  end
+
+  test ".after returns the Monday if the next day is a holiday Friday" do
+    calendars_has_a_bank_holiday_on(Date.parse('2016-01-01'), in_division: 'england-and-wales')
+    calculator = WorkingDaysCalculator.new(Date.parse('2015-12-31'))
+    assert_equal Date.parse('2016-01-4'), calculator.after(1)
+  end
+
+  test ".after returns the Tuesday if the next day is a holiday on both Friday and Monday" do
+    calendars_has_bank_holidays_on([Date.parse('2017-04-14'), Date.parse('2017-04-17')], in_division: 'england-and-wales')
+    calculator = WorkingDaysCalculator.new(Date.parse('2017-04-13'))
+    assert_equal Date.parse('2017-04-18'), calculator.after(1)
+  end
+
+  test ".after accounts for holidays crossed even if they're not the 'next day'" do
+    calendars_has_a_bank_holiday_on(Date.parse('2014-01-01'), in_division: 'england-and-wales')
+    calculator = WorkingDaysCalculator.new(Date.parse('2013-12-31'))
+    assert_equal Date.parse('2014-01-03'), calculator.after(2)
   end
 end


### PR DESCRIPTION
The default text for the email that is sent when requesting fact check had a "Deadline: 5 working days" added in #620.  This PR extends that to include actual dates.  We need to get a list of public holidays, so we're using the new `GdsApi::Calendars` adapter to read them from https://www.gov.uk/bank-holidays.json.

Relies on https://github.com/alphagov/gds-api-adapters/pull/702

For: https://trello.com/c/VSg9iWPO/156-factcheck-email-include-the-date-in-email

Text before:

```
**Deadline: 5 working days**
```

Text now:

```
**Deadline: 8 May 2017 (5 working days from today - 27 April 2017)**
```