### PR TITLE
Add migration to remove Whitehall data

### DIFF
--- a/db/migrate/20170508130537_remove_whitehall_content_from_shared_db.rb
+++ b/db/migrate/20170508130537_remove_whitehall_content_from_shared_db.rb
@@ -1,0 +1,15 @@
+class RemoveWhitehallContentFromSharedDb < Mongoid::Migration
+  def self.up
+    # skip the callback which would discard publishing api drafts, this
+    # migration is only about removing redundant data from the shared database
+    Artefact.skip_callback(:destroy, :before, :discard_publishing_api_draft)
+
+    Artefact.where(owning_app: "whitehall").destroy_all
+
+    # restore the callback
+    Artefact.set_callback(:destroy, :before, :discard_publishing_api_draft)
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
Whitehall artefacts were sent to the shared database for tagging in Panopticon.
Panopticon has been retired, so this data is not needed anymore.

This reduces the count in the 'artefacts' collection in the shared database from 208586 to 4922.

I've checked that that this data can be removed with a few people, but please shout if you see any problems with this. The original data is still in Whitehall, and tagging has migrated from Panopticon to Content Tagger.

Also wasn't sure whether Publisher was the best place to add this migration, but seemed like the best access to the shared database.

Related to https://github.com/alphagov/govuk_content_models/pull/435