### PR TITLE
Remove reference to business-support-api

### DIFF
--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -4,10 +4,7 @@ require "gds_api/helpers"
 class Area < OpenStruct
   extend GdsApi::Helpers
 
-  # This list should stay in sync with Business Support API's
-  # Scheme::WHITELISTED_AREA_CODES list:
-  # https://github.com/alphagov/business-support-api/blob/master/app/models/scheme.rb#L16-L18
-  # and Imminence's areas route constraint:
+  # This list should stay in sync with Imminence's areas route constraint:
   # https://github.com/alphagov/imminence/blob/master/config/routes.rb#L13-L17
   AREA_TYPES = ["EUR", "CTY", "DIS", "LBO", "LGD", "MTD", "UTA", "COI"]
 


### PR DESCRIPTION
This commit removes the reference to the `business-support-api` which has now been retired.