### PR TITLE
Add licence identifier to Rummager

### DIFF
--- a/app/presenters/search_payload_presenter.rb
+++ b/app/presenters/search_payload_presenter.rb
@@ -28,14 +28,39 @@ class SearchPayloadPresenter
       indexable_content: indexable_content,
       link: "/#{slug}",
       public_timestamp: public_timestamp,
-      content_store_document_type: publishing_api_payload.fetch(:document_type),
-    }
+      content_store_document_type: content_store_document_type,
+    }.merge(licence_details)
   end
 
   def publishing_api_payload
     @publishing_api_payload ||= begin
       presenter = EditionPresenterFactory.get_presenter(registerable_edition)
       presenter.render_for_publishing_api
+    end
+  end
+
+  def content_store_document_type
+    publishing_api_payload.fetch(:document_type)
+  end
+
+  def licence_details
+    return {} unless content_store_document_type == 'licence'
+
+    {
+      licence_identifier: licence_identifier,
+      licence_short_description: licence_short_description
+    }
+  end
+
+  def licence_short_description
+    if registerable_edition.respond_to?(:licence_short_description)
+      registerable_edition.licence_short_description
+    end
+  end
+
+  def licence_identifier
+    if registerable_edition.respond_to?(:licence_identifier)
+      registerable_edition.licence_identifier
     end
   end
 end

--- a/test/unit/services/search_indexer_test.rb
+++ b/test/unit/services/search_indexer_test.rb
@@ -79,4 +79,40 @@ class SearchIndexerTest < ActiveSupport::TestCase
 
     SearchIndexer.call(search_index_presenter)
   end
+
+  def test_indexing_licences_to_rummager_includes_licence_identifier_and_short_description
+    artefact = FactoryGirl.create(
+      :artefact,
+      kind: "licence",
+      content_id: "content-id",
+    )
+    edition = FactoryGirl.create(
+      :licence_edition,
+      title: "A title",
+      overview: "An overview",
+      licence_identifier: '1258-4-1',
+      licence_short_description: 'This is a licence short description.',
+      panopticon_id: artefact.id,
+    )
+    search_index_presenter = SearchIndexPresenter.new(edition)
+
+    Services.rummager.expects(:add_document).with(
+      'edition',
+      "/#{edition.slug}",
+      content_id: "content-id",
+      rendering_app: "frontend",
+      publishing_app: "publisher",
+      format: "licence",
+      title: "A title",
+      description: "An overview",
+      indexable_content: "This is a licence short description. This is a licence overview.",
+      link: "/#{edition.slug}",
+      public_timestamp: search_index_presenter.public_timestamp,
+      content_store_document_type: "licence",
+      licence_identifier: "1258-4-1",
+      licence_short_description: 'This is a licence short description.'
+    )
+
+    SearchIndexer.call(search_index_presenter)
+  end
 end


### PR DESCRIPTION
For licences only, we should index the following fields:
- `licence_identifier`;
- `licence_short_description`.

This is so we can replace calls to the Content API with calls to Rummager.

Trello: https://trello.com/c/vlqSHmTZ/76-make-licence-finder-use-something-else-to-fetch-licenses

Dependencies:
- [x] https://github.com/alphagov/rummager/pull/778