### PR TITLE
Fix circular dependency in dev?

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -92,9 +92,9 @@ class Edition
   PUBLISHING_API_DRAFT_STATES = %w(fact_check amends_needed fact_check_received draft ready in_review scheduled_for_publishing).freeze
 
   EXACT_ROUTE_EDITION_CLASSES = [
-    CampaignEdition,
-    HelpPageEdition,
-    TransactionEdition
+    "CampaignEdition",
+    "HelpPageEdition",
+    "TransactionEdition"
   ].freeze
 
   validates :title, presence: true
@@ -396,7 +396,7 @@ class Edition
   end
 
   def exact_route?
-    self.class.in? EXACT_ROUTE_EDITION_CLASSES
+    self.class.name.in? EXACT_ROUTE_EDITION_CLASSES
   end
 
   def publish_anonymously!


### PR DESCRIPTION
When loading `Edition`, the classes in the `EXACT_ROUTE_EDITION_CLASSES` array
were also loaded. Because `Edition` hadn't finished loading, it was loaded as
these classes inherit from it.  And so on.

I'm not sure how this isn't a problem in production, but it seems OK at the
moment.

I think this is a result of a slightly different loading order in Edition given that the exact
route logic used to be in a `lib/enhancements/edition.rb` file, but has now been 
subsumed into the model after the govuk_content_models retirement.