### PR TITLE
Add new Simple Smart Answer button text

### DIFF
--- a/app/views/simple_smart_answers/_fields.html.erb
+++ b/app/views/simple_smart_answers/_fields.html.erb
@@ -11,7 +11,7 @@
   <div class="row">
     <div class="col-md-8">
       <label for="edition_start_button_text" class="control-label">Start button text</label>
-      <%= f.select :start_button_text, ["Start now", "Continue", "Next"], {}, { :class => "form-control input-md-3", :disabled => @resource.locked_for_edits?, "data-module" => 'assignee-select'} %>
+      <%= f.select :start_button_text, ["Start now", "Continue", "Find contact details", "Next"], {}, { :class => "form-control input-md-3", :disabled => @resource.locked_for_edits?, "data-module" => 'assignee-select'} %>
     </div>
   </div>
   <div class="nodes" id="nodes">

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -32,7 +32,7 @@ class SimpleSmartAnswersTest < JavascriptIntegrationTest
 
       within ".builder-container" do
         assert page.has_content? "Start button text"
-        assert page.has_selector?("select#edition_start_button_text")
+        assert page.has_select?("edition_start_button_text", options: ["Start now", "Continue", "Find contact details", "Next"])
 
         assert page.has_content? "Question 1"
 


### PR DESCRIPTION
Based on our findings in Benchmarking Q1, we want to add "Find contact details" to the "Start button text" drop down options. This is to improve the success rate of users entering the "contact DVLA" service.

https://trello.com/c/WLEWKO6W/190-publish-deploy-final-dvla-changes