### PR TITLE
[DO NOT MERGE] Allow choosing mot reminders as a promo for completed transactions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ end
 
 group :development, :test do
   gem 'govuk-lint', '~> 2.1.0'
+  gem 'govuk_schemas'
   gem 'jasmine', '2.5.2'
   gem 'jasmine-core', '2.5.2'
   gem 'rack', '2.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,8 @@ GEM
       bootstrap-sass (= 3.3.5.1)
       jquery-rails (~> 4.1.1)
       rails (>= 3.2.0)
+    govuk_schemas (2.1.1)
+      json-schema (~> 2.5.0)
     govuk_sidekiq (1.0.3)
       airbrake (>= 3.1.0)
       gds-api-adapters (>= 19.1.0)
@@ -442,6 +444,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint (~> 2.1.0)
   govuk_admin_template (= 4.3.0)
+  govuk_schemas
   govuk_sidekiq (= 1.0.3)
   has_scope
   inherited_resources

--- a/app/presenters/formats/completed_transaction_presenter.rb
+++ b/app/presenters/formats/completed_transaction_presenter.rb
@@ -2,7 +2,7 @@ module Formats
   class CompletedTransactionPresenter < EditionFormatPresenter
   private
 
-    PROMOTIONS = %w(organ_donor register_to_vote)
+    PROMOTIONS = %w(organ_donor register_to_vote).freeze
 
     def schema_name
       'completed_transaction'

--- a/app/presenters/formats/completed_transaction_presenter.rb
+++ b/app/presenters/formats/completed_transaction_presenter.rb
@@ -2,7 +2,7 @@ module Formats
   class CompletedTransactionPresenter < EditionFormatPresenter
   private
 
-    PROMOTIONS = %w(organ_donor register_to_vote).freeze
+    PROMOTIONS = %w(organ_donor register_to_vote mot_reminders).freeze
 
     def schema_name
       'completed_transaction'

--- a/app/views/completed_transactions/_fields.html.erb
+++ b/app/views/completed_transactions/_fields.html.erb
@@ -6,7 +6,6 @@
               :input_html => { :disabled => 'disabled', class: 'input-md-10' } %>
 <% end %>
 
-
 <hr />
 <div class="row">
   <div class="col-md-8">
@@ -27,6 +26,10 @@
       <%= f.radio_button :promotion_choice, 'register_to_vote',
         { checked: (f.object.promotion_choice == "register_to_vote"), disabled: @resource.locked_for_edits? } %>
       <%= f.label :promotion_choice, "Promote register to vote", value: 'register_to_vote' %>
+      <br />
+      <%= f.radio_button :promotion_choice, 'mot_reminders',
+        { checked: (f.object.promotion_choice == "mot_reminders"), disabled: @resource.locked_for_edits? } %>
+      <%= f.label :promotion_choice, "Promote MOT reminders", value: 'mot_reminders' %>
 
       <%= f.input :promotion_choice_url,
           required: false,

--- a/lib/presentation_toggles.rb
+++ b/lib/presentation_toggles.rb
@@ -1,10 +1,12 @@
 module PresentationToggles
   extend ActiveSupport::Concern
 
+  PROMOTIONS = %w(organ_donor register_to_vote).freeze
+
   included do
     field :presentation_toggles, type: Hash, default: default_presentation_toggles
     validates :promotion_choice_url, presence: true, if: :promotes_something?
-    validates :promotion_choice, inclusion: { in: %w(none organ_donor register_to_vote) }
+    validates :promotion_choice, inclusion: { in: %w(none) + PresentationToggles::PROMOTIONS }
   end
 
   def promotion_choice=(value)

--- a/lib/presentation_toggles.rb
+++ b/lib/presentation_toggles.rb
@@ -1,7 +1,7 @@
 module PresentationToggles
   extend ActiveSupport::Concern
 
-  PROMOTIONS = %w(organ_donor register_to_vote).freeze
+  PROMOTIONS = %w(organ_donor register_to_vote mot_reminders).freeze
 
   included do
     field :presentation_toggles, type: Hash, default: default_presentation_toggles

--- a/test/integration/completed_transactions_create_edit_test.rb
+++ b/test/integration/completed_transactions_create_edit_test.rb
@@ -71,7 +71,10 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
     organ_donor_registration_promotion_url = "https://www.organdonation.nhs.uk/how_to_become_a_donor/registration/consent.asp?campaign=2244&v=7"
 
     visit_edition edition
+    assert page.has_checked_field? "Don't promote anything on this page"
     assert page.has_unchecked_field? "Promote organ donation"
+    assert page.has_unchecked_field? "Promote register to vote"
+    assert page.has_unchecked_field? "Promote MOT reminders"
 
     choose "Promote organ donation"
     fill_in "Promotion choice URL", with: organ_donor_registration_promotion_url
@@ -88,7 +91,10 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
 
     visit_edition edition
 
+    assert page.has_checked_field? "Don't promote anything on this page"
+    assert page.has_unchecked_field? "Promote organ donation"
     assert page.has_unchecked_field? "Promote register to vote"
+    assert page.has_unchecked_field? "Promote MOT reminders"
 
     choose "Promote register to vote"
     fill_in "Promotion choice URL", with: register_to_vote_promotion_url
@@ -96,6 +102,8 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
 
     assert page.has_checked_field? "Promote register to vote"
     assert page.has_field? "Promotion choice URL", with: register_to_vote_promotion_url
+    assert page.has_unchecked_field? "Don't promote anything on this page"
     assert page.has_unchecked_field? "Promote organ donation"
+    assert page.has_unchecked_field? "Promote MOT reminders"
   end
 end

--- a/test/models/completed_transaction_edition_test.rb
+++ b/test/models/completed_transaction_edition_test.rb
@@ -24,6 +24,20 @@ class CompletedTransactionEditionTest < ActiveSupport::TestCase
     assert_includes completed_transaction_edition.errors[:promotion_choice_url], "can't be blank"
   end
 
+  test "match the schema for allowed valies in `promotion_choice`" do
+    # NOTE: We don't do a full equality test here because otherwise we can
+    # get locked into failing tests when we try to add or remove a value
+    # On CI jenkins will use the production releases when testing against the
+    # schema which won't have the changes; and we can't publish the schema
+    # because it'll test against the production publisher which won't have
+    # been changed.  A subset test will allow us to have some confidence
+    # that we're not out of sync. We have to remember to remove values from
+    # publisher and deploy them before we remove them from content schemas
+    allowed_values = GovukSchemas::Schema.find(publisher_schema: 'completed_transaction')['definitions']['details']['properties']['promotion']['properties']['category']['enum']
+    extra_values_in_presenter = CompletedTransactionEdition::PROMOTIONS - allowed_values
+    assert extra_values_in_presenter.empty?, "CompletedTransactionEdition allows values for promotion that the schema does not.\nEdition allows: #{subject.class::PROMOTIONS.sort.inspect}\nSchema allows:  #{allowed_values.sort.inspect}\nDiff:           #{extra_values_in_presenter.sort.inspect}"
+  end
+
   test "invalid if promotion_choice is not one of the allowed ones" do
     completed_transaction_edition = FactoryGirl.build(:completed_transaction_edition, promotion_choice: 'cheese')
 

--- a/test/models/completed_transaction_edition_test.rb
+++ b/test/models/completed_transaction_edition_test.rb
@@ -66,5 +66,12 @@ class CompletedTransactionEditionTest < ActiveSupport::TestCase
 
     assert_equal "register_to_vote", completed_transaction_edition.reload.promotion_choice
     assert_equal "https://www.gov.uk/register-to-vote", completed_transaction_edition.promotion_choice_url
+
+    completed_transaction_edition.promotion_choice = "mot_reminders"
+    completed_transaction_edition.promotion_choice_url = "https://www.gov.uk/check-mot-status"
+    completed_transaction_edition.save!
+
+    assert_equal "mot_reminders", completed_transaction_edition.reload.promotion_choice
+    assert_equal "https://www.gov.uk/check-mot-status", completed_transaction_edition.promotion_choice_url
   end
 end


### PR DESCRIPTION
For: https://trello.com/c/gyrP0MaI/174-alternative-message-after-giving-feedback

DVSA want to promote MOT reminders and this adds it as an allowed value for promotion choice.  

We also add tests that make sure we're keeping the list of allowed promotion choices in publisher in sync with the list of allowed promotions in the schemas (see commit notes for some gnarly details).

Relies on https://github.com/alphagov/govuk-content-schemas/pull/632 and a TBD frontend PR to display the new promo.
