### PR TITLE
Send fact check emails as text not HTML

### DIFF
--- a/app/mailers/noisy_workflow.rb
+++ b/app/mailers/noisy_workflow.rb
@@ -22,7 +22,7 @@ class NoisyWorkflow < ActionMailer::Base
       from: "GOV.UK Editorial Team <#{fact_check_address}>",
       subject: "‘[#{@edition.title}]’ GOV.UK preview of new edition"
     ) do |format|
-      format.text { render html: "<strong>HTML</strong> #{action.customised_message}" }
+      format.text { render plain: action.customised_message }
     end
   end
 

--- a/app/views/noisy_workflow/request_fact_check.text.erb
+++ b/app/views/noisy_workflow/request_fact_check.text.erb
@@ -1,6 +1,6 @@
 Hi,
 
-We need you to check the factual accuracy of changes made to '<%= @edition.title%>' before it’s published on GOV.UK.
+We need you to check the factual accuracy of changes made to ‘<%= @edition.title%>’ before it’s published on GOV.UK.
 
 The GOV.UK Content Team made the changes because
 


### PR DESCRIPTION
`format.text` should use `render :plain` not `render :html`

Before:
```
&lt;strong&gt;HTML&lt;/strong&gt; Hi,

We need you to check the factual accuracy of changes made to &#39;Student finance: how to apply&#39; before it’s published on GOV.UK.
```

After:
```
Hi,

We need you to check the factual accuracy of changes made to 'Student finance: how to apply' before it’s published on GOV.UK.
```

Fixes https://govuk.zendesk.com/agent/tickets/2296781