### PR TITLE
Enable editing of Transaction Start button text

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -260,6 +260,7 @@ protected
     when :transaction_edition
       [
         :introduction,
+        :start_button_text,
         :will_continue_on,
         :link,
         :more_information,

--- a/app/models/transaction_edition.rb
+++ b/app/models/transaction_edition.rb
@@ -8,10 +8,12 @@ class TransactionEdition < Edition
   field :need_to_know, type: String
   field :department_analytics_profile, type: String
   field :alternate_methods, type: String
+  field :start_button_text, type: String, default: "Start now"
 
   GOVSPEAK_FIELDS = [:introduction, :more_information, :alternate_methods, :need_to_know].freeze
 
   validates_format_of :department_analytics_profile, with: /UA-\d+-\d+/i, allow_blank: true
+  validates_presence_of :start_button_text
   validates_with SafeHtml
 
   def indexable_content

--- a/app/presenters/formats/transaction_presenter.rb
+++ b/app/presenters/formats/transaction_presenter.rb
@@ -13,6 +13,7 @@ module Formats
     def details
       {
         introductory_paragraph: govspeak(:introduction),
+        start_button_text: edition.start_button_text,
         will_continue_on: edition.will_continue_on,
         transaction_start_link: edition.link,
         more_information: govspeak(:more_information),

--- a/app/views/transactions/_fields.html.erb
+++ b/app/views/transactions/_fields.html.erb
@@ -7,6 +7,15 @@
               :hint => 'Set the scene for the user. What is about to happen? (eg. "you will need to fill in a form, print it out and take it to the post office")',
               :input_html => { :rows => 8, :disabled => @resource.locked_for_edits?, :class => 'input-md-7' } %>
 
+  <div class="form-group">
+    <label for="edition_start_button_text">Start button text</label>
+    <%= f.select :start_button_text,
+        ["Start now", "Sign in"],
+        {},
+        class: "form-control input-md-7",
+        disabled: @resource.locked_for_edits? %>
+  </div>
+
   <%= f.input :will_continue_on,
               :hint => 'Text to follow the statement "This will continue on". eg. "the HMRC website"',
               :input_html => { :disabled => @resource.locked_for_edits?, :class => 'input-md-7' } %>

--- a/test/integration/transaction_create_edit_test.rb
+++ b/test/integration/transaction_create_edit_test.rb
@@ -24,6 +24,7 @@ class TransactionCreateEditTest < JavascriptIntegrationTest
       assert page.has_content? @artefact.name
 
       fill_in "Introductory paragraph", with: "Become a space pilot"
+      select "Sign in", from: "Start button text"
       fill_in "Will continue on", with: "UK Space Recruitment"
       fill_in "More information", with: "Take part in the final frontier"
 
@@ -34,6 +35,7 @@ class TransactionCreateEditTest < JavascriptIntegrationTest
       assert_equal @artefact.id.to_s, transaction.panopticon_id
 
       assert_equal "Become a space pilot", transaction.introduction
+      assert_equal "Sign in", transaction.start_button_text
       assert_equal "UK Space Recruitment", transaction.will_continue_on
       assert_equal "Take part in the final frontier", transaction.more_information
     end

--- a/test/unit/presenters/formats/transaction_presenter_test.rb
+++ b/test/unit/presenters/formats/transaction_presenter_test.rb
@@ -109,6 +109,11 @@ class TransactionPresenterTest < ActiveSupport::TestCase
       assert_equal 'UA-000000-2', result[:details][:department_analytics_profile]
     end
 
+    should "[:start_button_text]" do
+      edition.update_attribute(:start_button_text, 'Sign in')
+      assert_equal 'Sign in', result[:details][:start_button_text]
+    end
+
     context "[:downtime_message]" do
       context "when there is a downtime association" do
         should "show if we're in the publicize window" do


### PR DESCRIPTION
This change allows publishers to choose the text that appears in the
green “start” button on a Transaction. This behaviour is basically a
direct read-across from the similar functionality in Simple Smart
Answers.

Publishers will be able to select from a drop-down, which only contains
two choices:

- “Start now”
- “Sign in”

“Start now” is the text that is currently displayed, and remains the
default.

“Sign in” is the new copy requested specifically for the Universal
Credit Sign In page.

We use a drop-down to restrict the choices. Copy will need to go through
approval to be included in the drop-down, and having a list of these
items will help to keep consistency across GOV.UK (for example, we will
not have variations like “Sign in”, “Signin”, “Log in”, etc.).

## Before

![universal-credit-start-now](https://user-images.githubusercontent.com/12036746/29603221-328a713a-87db-11e7-83c3-76b8b95a3e2f.png)

## After

![universal-credit-sign-in](https://user-images.githubusercontent.com/12036746/29603223-381c0258-87db-11e7-95dd-0c756f50a7bb.png)
