### PR TITLE
Substitute select tags with radio buttons

### DIFF
--- a/app/views/simple_smart_answers/_fields.html.erb
+++ b/app/views/simple_smart_answers/_fields.html.erb
@@ -10,8 +10,12 @@
 <div class="builder-container">
   <div class="row">
     <div class="col-md-8">
-      <label for="edition_start_button_text" class="control-label">Start button text</label>
-      <%= f.select :start_button_text, ["Start now", "Continue", "Find contact details", "Next"], {}, { :class => "form-control input-md-3", :disabled => @resource.locked_for_edits?, "data-module" => 'assignee-select'} %>
+    <label for="edition_start_button_text" class="control-label">Start button text:</label><br>
+      <% ["Start now", "Continue", "Find contact details", "Next"].each do |option| %>
+        <%= f.radio_button :start_button_text, option, disabled: @resource.locked_for_edits? %>
+        <%= f.label "start_button_text_#{option.gsub(" ","_").underscore}", option, class: "control-label input-md-3" %><br>
+      <% end %>
+      <br>
     </div>
   </div>
   <div class="nodes" id="nodes">

--- a/app/views/transactions/_fields.html.erb
+++ b/app/views/transactions/_fields.html.erb
@@ -8,12 +8,12 @@
               :input_html => { :rows => 8, :disabled => @resource.locked_for_edits?, :class => 'input-md-7' } %>
 
   <div class="form-group">
-    <label for="edition_start_button_text">Start button text</label>
-    <%= f.select :start_button_text,
-        ["Start now", "Sign in"],
-        {},
-        class: "form-control input-md-7",
-        disabled: @resource.locked_for_edits? %>
+    <label for="edition_start_button_text">Start button text:</label><br/>
+    <% ["Start now", "Sign in"].each do |option| %>
+      <%# radio_button(object_name, method, tag_value, options = {}) %>
+      <%= f.radio_button :start_button_text, option, {class: "input-md-7", disabled: @resource.locked_for_edits?} %>
+      <%= f.label "start_button_text_#{option.gsub(" ","_").underscore}", option %><br>
+    <% end %>
   </div>
 
   <%= f.input :will_continue_on,

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -31,8 +31,11 @@ class SimpleSmartAnswersTest < JavascriptIntegrationTest
       assert page.has_no_css?(".nodes .outcome")
 
       within ".builder-container" do
-        assert page.has_content? "Start button text"
-        assert page.has_select?("edition_start_button_text", options: ["Start now", "Continue", "Find contact details", "Next"])
+        assert page.has_content? "Start now"
+        assert page.has_checked_field? "edition_start_button_text_start_now"
+        ["Continue", "Find contact details", "Next"].each do |option|
+          assert page.has_unchecked_field? "edition_start_button_text_#{option.tr(' ', '_').underscore}"
+        end
 
         assert page.has_content? "Question 1"
 

--- a/test/integration/transaction_create_edit_test.rb
+++ b/test/integration/transaction_create_edit_test.rb
@@ -24,7 +24,7 @@ class TransactionCreateEditTest < JavascriptIntegrationTest
       assert page.has_content? @artefact.name
 
       fill_in "Introductory paragraph", with: "Become a space pilot"
-      select "Sign in", from: "Start button text"
+      choose "Sign in"
       fill_in "Will continue on", with: "UK Space Recruitment"
       fill_in "More information", with: "Take part in the final frontier"
 


### PR DESCRIPTION
Trello: https://trello.com/c/2JyPdctt/727-2-change-publisher-start-button-text-select-to-radio-buttons

According to [our guidance](https://paper.dropbox.com/doc/Select-boxes-v7PWDvPDV2tmc9pzDbm3s), we should avoid `select` elements where possible.

We should then use radio buttons instead of dropdowns on the "Start Button Text" fields for both Transactions and Simple Smart Answers.