### PR TITLE
Revert "Remove rummager integration"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This is a Ruby on Rails application that publishes the content for mainstream do
 ###Dependencies
 
 - [imminence](https://github.com/alphagov/imminence) - provides geographical search tools
+- [rummager](https://github.com/alphagov/rummager) - search index for publisher. All changes are also sent to rummager to be indexed
 - [content-store](https://github.com/alphagov/content-store) - new central storage of published content on GOV.UK
 - [publishing-api](https://github.com/alphagov/publishing-api) - will provide workflow for all content published to GOV.UK - creating a new document, publishing it, etc. Content published here will end up in the content-store
 - [govuk-content-schemas](http://github.com/alphagov/govuk-content-schemas) - defines the schemas for new-style document formats. Required to run the tests.

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -1,4 +1,5 @@
 require "gds_api/publishing_api_v2"
+require "gds_api/rummager"
 require "gds_api/calendars"
 
 module Services
@@ -7,6 +8,10 @@ module Services
       Plek.new.find('publishing-api'),
       bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
     )
+  end
+
+  def self.rummager
+    @rummager ||= GdsApi::Rummager.new(Plek.new.find("search"))
   end
 
   def self.calendars

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -1,5 +1,5 @@
 require_dependency "workflow"
-
+require "search_index_presenter"
 require 'digest'
 
 class Edition
@@ -419,6 +419,12 @@ class Edition
     if artefact.state == "archived"
       raise ResurrectionError, "Cannot register archived artefact '#{artefact.slug}'"
     end
+  end
+
+  def register_with_rummager
+    check_if_archived
+    presenter = SearchIndexPresenter.new(self)
+    SearchIndexer.call(presenter)
   end
 
   def auth_bypass_id

--- a/app/presenters/search_index_presenter.rb
+++ b/app/presenters/search_index_presenter.rb
@@ -1,0 +1,17 @@
+class SearchIndexPresenter < SimpleDelegator
+  def state
+    case __getobj__.state
+    when 'published' then 'live'
+    when 'archived' then 'archived'
+    else 'draft'
+    end
+  end
+
+  def description
+    overview
+  end
+
+  def public_timestamp
+    public_updated_at
+  end
+end

--- a/app/presenters/search_payload_presenter.rb
+++ b/app/presenters/search_payload_presenter.rb
@@ -1,0 +1,66 @@
+class SearchPayloadPresenter
+  attr_reader :registerable_edition
+  delegate :slug,
+           :title,
+           :description,
+           :indexable_content,
+           :public_timestamp,
+           :artefact,
+           :format,
+           to: :registerable_edition
+
+  def initialize(registerable_edition)
+    @registerable_edition = registerable_edition
+  end
+
+  def self.present(registerable_edition)
+    new(registerable_edition).present
+  end
+
+  def present
+    {
+      content_id: artefact.content_id,
+      rendering_app: publishing_api_payload.fetch(:rendering_app),
+      publishing_app: publishing_api_payload.fetch(:publishing_app),
+      format: format.underscore,
+      title: title,
+      description: description,
+      indexable_content: indexable_content,
+      link: "/#{slug}",
+      public_timestamp: public_timestamp,
+      content_store_document_type: content_store_document_type,
+    }.merge(licence_details)
+  end
+
+  def publishing_api_payload
+    @publishing_api_payload ||= begin
+      presenter = EditionPresenterFactory.get_presenter(registerable_edition)
+      presenter.render_for_publishing_api
+    end
+  end
+
+  def content_store_document_type
+    publishing_api_payload.fetch(:document_type)
+  end
+
+  def licence_details
+    return {} unless content_store_document_type == 'licence'
+
+    {
+      licence_identifier: licence_identifier,
+      licence_short_description: licence_short_description
+    }
+  end
+
+  def licence_short_description
+    if registerable_edition.respond_to?(:licence_short_description)
+      registerable_edition.licence_short_description
+    end
+  end
+
+  def licence_identifier
+    if registerable_edition.respond_to?(:licence_identifier)
+      registerable_edition.licence_identifier
+    end
+  end
+end

--- a/app/services/publish_service.rb
+++ b/app/services/publish_service.rb
@@ -1,6 +1,7 @@
 class PublishService
   class << self
     def call(edition, update_type = nil)
+      edition.register_with_rummager
       publish_current_draft(edition, update_type)
     end
 

--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -1,0 +1,40 @@
+class SearchIndexer
+  attr_reader :edition
+  delegate :slug, to: :edition
+
+  def initialize(edition)
+    @edition = edition
+  end
+
+  def self.call(edition)
+    new(edition).call
+  end
+
+  def call
+    if indexable?
+      Services.rummager.add_document(type, document_id, payload)
+    end
+  end
+
+private
+
+  def kind
+    edition.artefact.kind
+  end
+
+  def indexable?
+    kind != "completed_transaction"
+  end
+
+  def type
+    'edition'
+  end
+
+  def document_id
+    "/#{slug}"
+  end
+
+  def payload
+    SearchPayloadPresenter.present(edition)
+  end
+end

--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -2,6 +2,7 @@ class UnpublishService
   class << self
     def call(artefact, user, redirect_url = "")
       if update_artefact_in_shared_db(artefact, user, redirect_url)
+        remove_from_rummager_search artefact
         unpublish_in_publishing_api artefact, redirect_url
       end
     end
@@ -14,6 +15,12 @@ class UnpublishService
         state: "archived",
         redirect_url: redirect_url
       )
+    end
+
+    def remove_from_rummager_search(artefact)
+      Services.rummager.delete_content("/#{artefact.slug}")
+    rescue GdsApi::HTTPNotFound
+      return
     end
 
     def unpublish_in_publishing_api(artefact, redirect_url)

--- a/lib/published_slug_registerer.rb
+++ b/lib/published_slug_registerer.rb
@@ -1,0 +1,95 @@
+require 'gds_api/rummager'
+
+class PublishedSlugRegisterer
+  attr_reader :logger
+
+  def initialize(logger, slugs)
+    @logger = logger
+    @slugs = slugs.sort.uniq
+  end
+
+  def do_rummager
+    @success_slugs = []
+    @not_found_slugs = []
+    @errored_slugs = []
+    @count = 0
+
+    logger.info "Registering #{@slugs.count} slugs"
+
+    @slugs.each do |slug|
+      @count += 1
+      logger.info "Registering #{slug} with Rummager [#{@count}/#{@slugs.count}]"
+      edition = published_edition(slug)
+      if edition
+        if register(edition) { edition.register_with_rummager }
+          @success_slugs << slug
+        else
+          @errored_slugs << slug
+        end
+      else
+        @not_found_slugs << slug
+        logger.error "No published edition found with slug #{slug}"
+      end
+    end
+
+    log_result
+  end
+
+private
+
+  def log_result
+    if @success_slugs.present?
+      logger.info "\nSuccessfully registered the following #{@success_slugs.count} slugs:"
+      @success_slugs.each do |slug|
+        logger.info slug
+      end
+    end
+
+    if @not_found_slugs.present?
+      logger.info "\nThe following #{@not_found_slugs.count} slugs weren't found:"
+      @not_found_slugs.each do |slug|
+        logger.info slug
+      end
+    end
+
+    if @errored_slugs.present?
+      logger.info "\nUnable to register the following #{@errored_slugs.count} slugs:"
+      @errored_slugs.each do |slug|
+        logger.info slug
+      end
+    end
+
+    logger.info <<-COMPLETE
+    \nRegistration complete: processed #{@success_slugs.count} slugs successfully,
+    #{@not_found_slugs.count} slugs not found, #{@errored_slugs.count} slugs had errors
+    COMPLETE
+  end
+
+  def published_edition(slug)
+    Edition.find_and_identify(slug, nil)
+  end
+
+  def register(edition, &_block)
+    retry_count = 0
+    begin
+      yield
+      return true
+    rescue Mongoid::Errors::DocumentNotFound
+      # This happens if an Edition doesn't have a corresponding Artefact
+      logger.warn "Missing Artefact for #{edition.class.name} #{edition.slug}"
+    rescue Edition::ResurrectionError
+      logger.error "Attempted to register archived edition '#{edition.slug}'"
+    rescue Timeout::Error, GdsApi::TimedOutException
+      if retry_count < 3
+        retry_count += 1
+        logger.warn "Encountered timeout for '#{edition.slug}', retrying (max 3 retries)"
+        retry
+      else
+        logger.error "Encountered 4 timeouts for '#{edition.slug}', skipping"
+      end
+    rescue GdsApi::HTTPErrorResponse => e
+      logger.error %{Failed to register '#{edition.slug}' with error #{e.code}: "#{e.error_details}"}
+    end
+    false
+  end
+end

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,0 +1,14 @@
+require "published_slug_registerer"
+
+namespace :rummager do
+  desc "Indexes all editions in Rummager"
+  task index: :environment do
+    task_logger.info "Sending published editions to rummager..."
+    slugs = Edition.published.map(&:slug)
+    PublishedSlugRegisterer.new(task_logger, slugs).do_rummager
+  end
+
+  def task_logger
+    @_task_logger ||= GdsApi::Base.logger = Logger.new(STDERR).tap { |l| l.level = Logger::INFO }
+  end
+end

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -1,5 +1,10 @@
 require "test_helper"
 
+class Edition
+  def update_in_search_index
+  end
+end
+
 class EditionTest < ActiveSupport::TestCase
   def setup
     @artefact = FactoryGirl.create(:artefact)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -67,12 +67,17 @@ class ActiveSupport::TestCase
   end
 
   def stub_register_published_content
+    stub_register_with_rummager
     stub_register_with_publishing_api
   end
 
   def stub_register_with_publishing_api
     WebMock.stub_request(:put, %r{publishing-api.dev.gov.uk/v2/content/.*})
     WebMock.stub_request(:post, %r{publishing-api.dev.gov.uk/v2/content/.*/publish})
+  end
+
+  def stub_register_with_rummager
+    WebMock.stub_request(:post, %r{search.dev.gov.uk/documents})
   end
 
   teardown do

--- a/test/unit/lib/published_slug_registerer_test.rb
+++ b/test/unit/lib/published_slug_registerer_test.rb
@@ -1,0 +1,61 @@
+require_relative '../../test_helper'
+
+class PublishedSlugRegistererTest < ActiveSupport::TestCase
+  def setup
+    @logger = stub("logger")
+
+    @slugs = %w{slug1 slug2 slug3}
+    @artefacts = Hash[@slugs.map { |slug|
+      [slug, FactoryGirl.create(:artefact, slug: slug)]
+    }]
+
+    @published_editions = [
+      make_edition("published", "slug1", 1),
+      make_edition("published", "slug2", 2),
+    ]
+
+    @draft_editions = [
+      make_edition("draft", "slug1", 2),
+      make_edition("draft", "slug2", 1),
+      make_edition("draft", "slug3", 2),
+    ]
+
+    @archived_editions = [
+      make_edition("archived", "slug1", 3),
+      make_edition("archived", "slug3", 1),
+    ]
+  end
+
+  def make_edition(state, slug, version)
+    FactoryGirl.create(:edition,
+      slug: slug,
+      panopticon_id: @artefacts[slug].id,
+      state: state,
+      version_number: version)
+  end
+
+  def stub_search_indexer(slug)
+    SearchIndexer.expects(:call).with(responds_with(:slug, slug)).once
+  end
+
+  def completion_message(success, not_found, errored)
+    <<-COMPLETE
+    \nRegistration complete: processed #{success} slugs successfully,
+    #{not_found} slugs not found, #{errored} slugs had errors
+    COMPLETE
+  end
+
+  def test_registers_published_editions_with_rummager
+    @registerer = PublishedSlugRegisterer.new(@logger, @slugs)
+
+    @logger.expects(:info).at_least_once
+    @logger.expects(:info).with(completion_message(2, 1, 0))
+    @logger.expects(:error).with("No published edition found with slug slug3")
+
+    %w{slug1 slug2}.each do |slug|
+      stub_search_indexer(slug).once
+    end
+
+    @registerer.do_rummager
+  end
+end

--- a/test/unit/presenters/search_index_presenter_test.rb
+++ b/test/unit/presenters/search_index_presenter_test.rb
@@ -1,0 +1,77 @@
+require "test_helper"
+
+class SearchIndexPresenterTest < ActiveSupport::TestCase
+  def template_answer(version_number = 1)
+    artefact = FactoryGirl.create(:artefact)
+    AnswerEdition.create(state: 'ready', slug: "childcare", panopticon_id: artefact.id,
+      title: 'Child care stuff', body: 'Lots of info', version_number: version_number)
+  end
+
+  def template_published_answer(version_number = 1)
+    answer = template_answer(version_number)
+    answer.publish
+    answer.save
+    answer
+  end
+
+  def template_transaction
+    artefact = FactoryGirl.create(:artefact)
+    TransactionEdition.create(title: 'One', introduction: 'introduction',
+      more_information: 'more info', panopticon_id: artefact.id, slug: "childcare")
+  end
+
+  def template_unpublished_answer(version_number = 1)
+    template_answer(version_number)
+  end
+
+  setup do
+    stub_register_published_content
+    @artefact = FactoryGirl.create(:artefact)
+    @edition = FactoryGirl.create(:guide_edition, state: "published", panopticon_id: @artefact.id)
+  end
+
+  context "state" do
+    should "return live if the edition is published" do
+      presenter = SearchIndexPresenter.new(@edition)
+      assert_equal 'live', presenter.state
+    end
+
+    should "return archived if the edition is archived" do
+      @edition.state = 'archived'
+      presenter = SearchIndexPresenter.new(@edition)
+      assert_equal 'archived', presenter.state
+    end
+
+    should "return draft if the edition is not published or archived" do
+      @edition.state = 'other'
+      presenter = SearchIndexPresenter.new(@edition)
+      assert_equal 'draft', presenter.state
+    end
+  end
+
+  context "description" do
+    should "return the overview" do
+      @edition.update_attribute(:overview, "Overviewiness")
+      presenter = SearchIndexPresenter.new(@edition)
+      assert_equal "Overviewiness", presenter.description
+    end
+  end
+
+  context "latest changes" do
+    setup do
+      @edition_with_major_change = FactoryGirl.create(:answer_edition, major_change: true,
+                                                                       change_note: 'First edition',
+                                                                       updated_at: 1.minute.ago,
+                                                                       state: 'published')
+      @presenter = SearchIndexPresenter.new(@edition_with_major_change)
+    end
+
+    should "return the latest_change_note" do
+      assert_equal 'First edition', @presenter.latest_change_note
+    end
+
+    should 'return the public_timestamp' do
+      assert_equal @edition_with_major_change.updated_at.to_i, @presenter.public_timestamp.to_i
+    end
+  end
+end

--- a/test/unit/services/publish_service_test.rb
+++ b/test/unit/services/publish_service_test.rb
@@ -5,6 +5,12 @@ class PublishServiceTest < ActiveSupport::TestCase
     Services.publishing_api.stubs(:publish)
   end
 
+  should "register edition with Rummager" do
+    edition.expects(:register_with_rummager)
+
+    PublishService.call(edition)
+  end
+
   should "publish edition to PublishingAPI" do
     Services.publishing_api.expects(:publish).with(
       content_id,
@@ -18,6 +24,7 @@ class PublishServiceTest < ActiveSupport::TestCase
   def edition
     @_edition ||= stub(
       id: 123,
+      register_with_rummager: true,
       artefact: stub(
         content_id: content_id,
         language: language

--- a/test/unit/services/search_indexer_test.rb
+++ b/test/unit/services/search_indexer_test.rb
@@ -1,0 +1,118 @@
+require "test_helper"
+
+class SearchIndexerTest < ActiveSupport::TestCase
+  def test_indexing_to_rummager
+    artefact = FactoryGirl.create(
+      :artefact,
+      kind: "answer",
+      content_id: "content-id",
+    )
+    edition = FactoryGirl.create(
+      :answer_edition,
+      title: "A title",
+      overview: "An overview",
+      panopticon_id: artefact.id,
+      body: "Indexable content",
+    )
+    search_index_presenter = SearchIndexPresenter.new(edition)
+
+    Services.rummager.expects(:add_document).with(
+      'edition',
+      "/#{edition.slug}",
+      content_id: "content-id",
+      rendering_app: "frontend",
+      publishing_app: "publisher",
+      format: "answer",
+      title: "A title",
+      description: "An overview",
+      indexable_content: "Indexable content",
+      link: "/#{edition.slug}",
+      public_timestamp: search_index_presenter.public_timestamp,
+      content_store_document_type: "answer",
+    )
+
+    SearchIndexer.call(search_index_presenter)
+  end
+
+  def test_completed_transactions_are_not_indexed
+    artefact = FactoryGirl.create(
+      :artefact,
+      kind: "completed_transaction",
+      slug: "done/something",
+      content_id: "content-id"
+    )
+
+    edition = FactoryGirl.create(:answer_edition, panopticon_id: artefact.id)
+    search_index_presenter = SearchIndexPresenter.new(edition)
+
+    Services.rummager.expects(:add_document).never
+
+    SearchIndexer.call(search_index_presenter)
+  end
+
+  def test_rummager_document_type_matches_content_store
+    artefact = FactoryGirl.create(
+      :artefact,
+      kind: "answer",
+      content_id: "content-id",
+    )
+    edition = FactoryGirl.create(
+      :answer_edition,
+      title: "A title",
+      overview: "An overview",
+      panopticon_id: artefact.id,
+      body: "Indexable content",
+    )
+
+    presenter = EditionPresenterFactory.get_presenter(edition)
+    document_type = presenter.render_for_publishing_api[:document_type]
+
+    search_index_presenter = SearchIndexPresenter.new(edition)
+
+    Services.rummager.expects(:add_document).with(
+      'edition',
+      "/#{edition.slug}",
+      has_entry(
+        content_store_document_type: document_type,
+      )
+    )
+
+    SearchIndexer.call(search_index_presenter)
+  end
+
+  def test_indexing_licences_to_rummager_includes_licence_identifier_and_short_description
+    artefact = FactoryGirl.create(
+      :artefact,
+      kind: "licence",
+      content_id: "content-id",
+    )
+    edition = FactoryGirl.create(
+      :licence_edition,
+      title: "A title",
+      overview: "An overview",
+      licence_identifier: '1258-4-1',
+      licence_short_description: 'This is a licence short description.',
+      panopticon_id: artefact.id,
+    )
+    search_index_presenter = SearchIndexPresenter.new(edition)
+
+    Services.rummager.expects(:add_document).with(
+      'edition',
+      "/#{edition.slug}",
+      content_id: "content-id",
+      rendering_app: "frontend",
+      publishing_app: "publisher",
+      format: "licence",
+      title: "A title",
+      description: "An overview",
+      indexable_content: "This is a licence short description. This is a licence overview.",
+      link: "/#{edition.slug}",
+      public_timestamp: search_index_presenter.public_timestamp,
+      content_store_document_type: "licence",
+      licence_identifier: "1258-4-1",
+      licence_short_description: 'This is a licence short description.'
+    )
+
+    SearchIndexer.call(search_index_presenter)
+  end
+end


### PR DESCRIPTION
Reverts alphagov/publisher#640

I'm temporarily rolling this back as I found a bug with unpublishing.

```
2017-09-06T09:57:05.595Z 31960 TID-ou3hnf6uc GovukIndex::PublishingEventWorker JID-d8ac7d27ec85a81707860edf INFO: guide.major -> INDEX /hello-world-2-testing-sometimes-fails edition
2017-09-06T09:57:05.643Z 31960 TID-ou3hnf6uc GovukIndex::PublishingEventWorker JID-d8ac7d27ec85a81707860edf INFO: done: 0.049 sec
2017-09-06T09:57:35.390Z 31960 TID-ou3hnf698 GovukIndex::PublishingEventWorker JID-b2189eff18e075a5fef15099 INFO: start
2017-09-06T09:57:35.394Z 31960 TID-ou3hnf698 GovukIndex::PublishingEventWorker JID-b2189eff18e075a5fef15099 INFO: redirect.unpublish -> SKIPPED /hello-world-2-testing-sometimes-fails edition
```

https://github.com/alphagov/rummager/blob/master/lib/govuk_index/publishing_event_worker.rb#L52