### PR TITLE
Add organisation content report

### DIFF
--- a/app/presenters/organisation_content_presenter.rb
+++ b/app/presenters/organisation_content_presenter.rb
@@ -1,0 +1,60 @@
+class OrganisationContentPresenter < CSVPresenter
+  def initialize(scope = Artefact.where(owning_app: "publisher"))
+    super(scope)
+    self.column_headings = [
+        :id,
+        :name,
+        :format,
+        :slug,
+        :state,
+        :browse_pages,
+        :topics,
+        :organisations,
+        :need_ids
+    ]
+  end
+
+private
+
+  def artefact_contains_no_editions(artefact)
+    artefact.latest_edition.nil?
+  end
+
+  def get_value(header, artefact)
+    return super if artefact_contains_no_editions(artefact)
+
+    content_id = artefact.content_id
+
+    case header
+    when :browse_pages
+      expanded_links(content_id, %w(mainstream_browse_pages base_path), /\/browse\//)
+    when :topics
+      expanded_links(content_id, %w(topics base_path), /\/topic\//)
+    when :organisations
+      expanded_links(content_id, %w(organisations title))
+    when :need_ids
+      expanded_links(content_id, %w(meets_user_needs details need_id))
+    when :format
+      artefact.kind
+    else
+      super
+    end
+  end
+
+
+  def expanded_links(content_id, keys, pattern_to_remove = nil)
+    begin
+      response = Services.publishing_api.get_expanded_links(content_id)
+      join_strings(response.to_hash, keys, pattern_to_remove)
+    rescue GdsApi::HTTPNotFound, GdsApi::HTTPClientError
+      return ''
+    end
+  end
+
+  def join_strings(response, keys, pattern_to_remove)
+    results = response.dig('expanded_links', keys[0])
+    values = results.map { |result| result.dig(*keys.drop(1)) }
+    values = values.map { |value| value.gsub(pattern_to_remove, '') } unless pattern_to_remove.nil?
+    values.join(',')
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,6 +15,8 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
+  config.jwt_auth_secret = '123'
+
   # Enable/disable caching. By default caching is disabled.
   if Rails.root.join('tmp/caching-dev.txt').exist?
     config.action_controller.perform_caching = false

--- a/lib/csv_report_generator.rb
+++ b/lib/csv_report_generator.rb
@@ -30,6 +30,10 @@ class CsvReportGenerator
       EditionChurnPresenter.new(
         Edition.not_in(state: ["archived"]).order(created_at: 1)),
 
+      OrganisationContentPresenter.new(
+        Artefact.where(owning_app: "publisher").not_in(state: ["archived"])
+      ),
+
       ContentWorkflowPresenter.new(Edition.published.order(created_at: :desc)),
     ]
   end

--- a/test/unit/organisation_content_presenter_test.rb
+++ b/test/unit/organisation_content_presenter_test.rb
@@ -1,0 +1,86 @@
+require "test_helper"
+
+class OrganisationContentPresenterTest < ActiveSupport::TestCase
+  setup do
+    @response = {
+            "content_id" => "",
+            "expanded_links" => {
+              "mainstream_browse_pages" => [
+                {
+                  "base_path" => "/browse/business/support",
+                },
+                {
+                  "base_path" => "/browse/tax/vat",
+                }
+              ],
+              "meets_user_needs" => [
+                {
+                  "details" =>
+                  {
+                    "need_id" => '123456'
+                  }
+                },
+                {
+                  "details" =>
+                  {
+                    "need_id" => '123321'
+                  }
+                },
+                {
+                  "details" =>
+                  {
+                    "need_id" => '654321'
+                  }
+                }
+              ],
+              "organisations" => [
+                {
+                  "title" => "HMRC"
+                }
+              ],
+              "topics" => [
+                {
+                  "base_path" => "/topic/business-tax/vat"
+                }
+              ]
+            }
+    }
+  end
+
+  should "provide a CSV export of business support schemes" do
+    document = FactoryGirl.create(:artefact,
+                                  name: "Important document",
+                                  kind: "answer")
+
+    @response['content_id'] = document.content_id
+    publishing_api_has_expanded_links(@response)
+
+    FactoryGirl.create(:edition,
+                       panopticon_id: document.id)
+
+    csv = OrganisationContentPresenter.new(
+      Artefact.where(owning_app: "publisher").not_in(state: ["archived"])
+    ).to_csv
+    data = CSV.parse(csv, headers: true)
+
+    assert_equal "Important document", data[0]["Name"]
+    assert_equal "answer", data[0]["Format"]
+    assert_equal "123456,123321,654321", data[0]["Need ids"]
+    assert_equal "HMRC", data[0]["Organisations"]
+    assert_equal "business-tax/vat", data[0]["Topics"]
+    assert_equal "business/support,tax/vat", data[0]["Browse pages"]
+  end
+
+  should "handle artefacts without editions" do
+    FactoryGirl.create(:artefact,
+                       name: "Important document",
+                       need_ids: ["123456"])
+
+    csv = OrganisationContentPresenter.new(
+      Artefact.where(owning_app: "publisher").not_in(state: ["archived"])
+    ).to_csv
+    data = CSV.parse(csv, headers: true)
+
+    assert_equal "Important document", data[0]["Name"]
+  end
+end


### PR DESCRIPTION
For: https://trello.com/c/5oeDn5Xy

This commit brings back the organisation content report that was
removed before. A few of the columns are no longer stored in
the publisher app, but have been moved to the publishing_api.
As such, calls are made to the publishing_api to retrieve the
missing information.