### PR TITLE
Change dig to fetch when searching through hash

### DIFF
--- a/app/presenters/organisation_content_presenter.rb
+++ b/app/presenters/organisation_content_presenter.rb
@@ -52,8 +52,8 @@ private
   end
 
   def join_strings(response, keys, pattern_to_remove)
-    results = response.dig('expanded_links', keys[0])
-    values = results.map { |result| result.dig(*keys.drop(1)) }
+    results = response.fetch('expanded_links', {}).fetch(keys[0], {})
+    values = results.map { |result| result.dig(*keys.drop(1)) }.compact
     values = values.map { |value| value.gsub(pattern_to_remove, '') } unless pattern_to_remove.nil?
     values.join(',')
   end


### PR DESCRIPTION
Changes dig to fetch when searching through the hash that is returned from publishing_api in organisation_content_presenter.rb. This allows us to give the value a default empty hash if it can't find it, whereas dig returns nil if the key is not present, and map cannot be called on a nil object.