### PR TITLE
Add welsh button options for welsh pages

### DIFF
--- a/app/views/transactions/_fields.html.erb
+++ b/app/views/transactions/_fields.html.erb
@@ -9,7 +9,7 @@
 
   <div class="form-group">
     <label for="edition_start_button_text">Start button text:</label><br/>
-    <% ["Start now", "Sign in"].each do |option| %>
+    <% ["Start now", "Sign in", "Dechrau nawr", "Mewngofnodi"].each do |option| %>
       <%# radio_button(object_name, method, tag_value, options = {}) %>
       <%= f.radio_button :start_button_text, option, {class: "input-md-7", disabled: @resource.locked_for_edits?} %>
       <%= f.label "start_button_text_#{option.gsub(" ","_").underscore}", option %><br>


### PR DESCRIPTION
This commit gives the option to the publisher to decide to add the welsh text
to the buttons on start page/simple smart answers buttons.

This doesn't solve the existing welsh pages where the buttons have been set in English.

> On Publisher app, the radio button to select the button has a english value of "Start now", that's why it's showing in english instead of welsh. 
There's a tab for metadata, where people have set the language to be "cy", I would expect this to use the welsh settings.
The frontend application only checks if the text is present in the details hash, if it isn't then there's a default based on the locale?
As seen here: https://github.com/alphagov/frontend/blob/d1788be0587b32781dfd42fa50281c6f422d66cd/app/presenters/transaction_presenter.rb#L45

> The workflow on Publisher is to create an artefact first, this takes information such as the language of the artefact, when the language is set to welsh the radio button values should be added in welsh, this is currently not happening.
I suspect this will also need a migration to fix existing pages as all the existing welsh pages will have english buttons.
I'm trying to work on a fix for future pages.

Although this value is set, so there's no fallback into the locales.

https://govuk.zendesk.com/agent/tickets/2430403

## Actions before merging

- [ ] is the welsh wording correct?

## How it looks now
![screen shot 2017-10-03 at 14 13 39](https://user-images.githubusercontent.com/136777/31126893-12ea3402-a845-11e7-87a0-3ae9b563f12a.png)
