### PR TITLE
Change artefact kind when we change edition format

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -328,6 +328,10 @@ class Edition
     format
   end
 
+  def kind_for_artefact
+    format.underscore
+  end
+
   def has_video?
     false
   end

--- a/db/migrate/20171009143335_synchronise_artefact_kinds_with_latest_edition_formats.rb
+++ b/db/migrate/20171009143335_synchronise_artefact_kinds_with_latest_edition_formats.rb
@@ -1,0 +1,21 @@
+class SynchroniseArtefactKindsWithLatestEditionFormats < Mongoid::Migration
+  def self.up
+    # We don't want to run any update callbacks, just change the column
+    Artefact.skip_callback(:update, :after, :update_editions)
+
+    Artefact.each do |artefact|
+      latest_edition = artefact.latest_edition
+      next if latest_edition.nil?
+      next if latest_edition.kind_for_artefact == artefact.kind
+
+      puts "Changing #{artefact.slug} (#{artefact.content_id}) from #{artefact.kind} to #{latest_edition.kind_for_artefact}"
+      artefact.update_attribute(:kind, latest_edition.kind_for_artefact)
+    end
+
+    # restore the update callback for future migrations
+    Artefact.set_callback(:update, :after, :update_editions)
+  end
+
+  def self.down
+  end
+end

--- a/lib/edition_duplicator.rb
+++ b/lib/edition_duplicator.rb
@@ -16,6 +16,7 @@ class EditionDuplicator
 
     if new_edition && new_edition.save(validate: false)
       update_assignment(assign_to)
+      new_edition.artefact.update_attribute(:kind, new_edition.kind_for_artefact) if new_format.present?
       true
     else
       false

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -67,7 +67,7 @@ FactoryGirl.define do
 
   factory :edition, class: AnswerEdition do
     panopticon_id {
-      a = create(:artefact)
+      a = create(:artefact, kind: kind_for_artefact)
       a.id
     }
     transient do
@@ -108,6 +108,11 @@ FactoryGirl.define do
   end
 
   factory :completed_transaction_edition, traits: [:with_body], parent: :edition, class: 'CompletedTransactionEdition' do
+    sequence(:slug) { |n| "done/slug-#{n}" }
+    panopticon_id {
+      a = create(:artefact, kind: kind_for_artefact, slug: slug)
+      a.id
+    }
   end
 
   factory :video_edition, traits: [:with_body], parent: :edition, class: 'VideoEdition' do


### PR DESCRIPTION
Tangentially for: https://trello.com/c/RRJOTFQo/252-remove-business-support-code-that-still-exist-in-publisher

While exploring how best to remove and properly redirect business finance support editions from publisher I noticed that artefacts did not always have the a `kind` that matched up with the `format` of their `latest_edition`.  Since #428 we've allowed users to create a new edition of a published document with a new type, but we never made sure the artefact kind and edition format synced up.

It's unlikely to cause any real problems, but it felt strange to me so I thought I'd attempt to fix it.  There are notes on each commit, so worth reading them one-by-one.