### PR TITLE
Republish business support editions as publishing api redirects or gones

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -294,7 +294,18 @@ class Artefact
     Downtime.for(self)
   end
 
+  def exact_route?
+    le = latest_edition
+    return le.exact_route? if le.present?
+    return edition_class_name.in? Edition::EXACT_ROUTE_EDITION_CLASSES if owning_app == 'publisher'
+    prefixes.empty?
+  end
+
 private
+
+  def edition_class_name
+    "#{kind.camelcase}Edition"
+  end
 
   def validate_prefixes_and_paths
     if ! self.prefixes.nil? && self.prefixes_changed?

--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -25,7 +25,7 @@ class UnpublishService
     end
 
     def unpublish_with_redirect(artefact, redirect_url)
-      if artefact.latest_edition.exact_route?
+      if artefact.exact_route?
         unpublish_with_exact_redirect(artefact, redirect_url)
       else
         unpublish_wth_prefix_redirect(artefact, redirect_url)

--- a/db/migrate/20171012124313_republish_business_support_editions_as_publishing_api_redirects_or_gones.rb
+++ b/db/migrate/20171012124313_republish_business_support_editions_as_publishing_api_redirects_or_gones.rb
@@ -10,6 +10,18 @@ class RepublishBusinessSupportEditionsAsPublishingApiRedirectsOrGones < Mongoid:
     handle_archived_business_support_artefacts(business_support_by_state['archived'])
   end
 
+  def self.handle_draft_business_support_artefacts(draft_artefacts)
+    raise "Didn't expect any editions for draft artefacts" if draft_artefacts.any? { |a| a.latest_edition.present? }
+    raise "Didn't expect any entries in router for draft artefacts" if draft_artefacts.any? { |a| router_response(a).present? }
+    raise "Didn't expect any entries in publishing-api for draft artefacts" if draft_artefacts.any? { |a| publishing_api_response(a).present? }
+
+    Artefact.skip_callback(:destroy, :before, :discard_publishing_api_draft)
+    say_with_time "Removing #{draft_artefacts.size} draft artefacts" do
+      draft_artefacts.each { |a| a.destroy }
+    end
+    Artefact.set_callback(:destroy, :before, :discard_publishing_api_draft)
+  end
+
   def self.router
     @router ||= GdsApi::Router.new(Plek.find('router-api'))
   end

--- a/db/migrate/20171012124313_republish_business_support_editions_as_publishing_api_redirects_or_gones.rb
+++ b/db/migrate/20171012124313_republish_business_support_editions_as_publishing_api_redirects_or_gones.rb
@@ -10,6 +10,52 @@ class RepublishBusinessSupportEditionsAsPublishingApiRedirectsOrGones < Mongoid:
     handle_archived_business_support_artefacts(business_support_by_state['archived'])
   end
 
+  def self.handle_live_business_support_artefacts(live_artefacts)
+    # 1. Exclude 'jobcentre-plus-vacancy-filling-system-uk' as it's already
+    #    been redirected by short-url-manager
+    live_artefacts = handle_jobcentre_plus_vacancy_filling_system_uk(live_artefacts)
+
+    # 2. Set the appropriate redirects from router-data as the redirect_uri on
+    #    the Artefact or set general purpose redirect_uri of
+    #    /business-finance-support if it's not currently a redirect
+    say_with_time "Checking #{live_artefacts.size} live artefacts status in router & publishing-api" do
+      live_artefacts.each do |live_artefact|
+        content_id = publishing_api.lookup_content_id(base_path: "/#{live_artefact.slug}", exclude_unpublishing_types: [], exclude_document_types: [])
+        raise "Didn't expect publishing-api to think some other content_id is the owner of a live artefact's path (#{live_artefact.slug}, #{live_artefact.content_id}, #{content_id})" if live_artefact.content_id != content_id
+        content_item = publishing_api.get_content(content_id).to_hash
+        raise "Didn't expect publishing-api content for live artefact not to be a business_support (#{live_artefact.slug}, #{live_artefact.content_id}, #{content_item['document_type']})" if content_item['document_type'] != 'business_support'
+        current_route = router_response(live_artefact)
+        raise "Didn't exxpect any live artefacts not to have a route in router-api (#{live_artefact.slug}, #{live_artefact.content_id})" if current_route.nil?
+
+        if current_route['handler'] == 'redirect'
+          live_artefact.redirect_url = current_route['redirect_to']
+        else
+          live_artefact.redirect_url = '/business-finance-support'
+        end
+      end
+    end
+
+    # 3. Use UnpublishService to generate a publishing-api redirect
+    say_with_time "Unpublishing #{live_artefacts.size} live artefacts as redirects via publishing-api" do
+      live_artefacts.each do |live_artefact|
+        UnpublishService.call(live_artefact, nil, live_artefact.redirect_url)
+      end
+    end
+  end
+
+  def self.handle_jobcentre_plus_vacancy_filling_system_uk(live_artefacts)
+    jobcentre_plus_vacany_fill_system_uk = live_artefacts.detect { |x| x.slug = 'jobcentre-plus-vacancy-filling-system-uk'}
+    raise "Didn't expect 'jobcentre-plus-vacancy-filling-system-uk' to be missing from live business support artefacts" if jobcentre_plus_vacany_fill_system_uk.nil?
+
+    say_with_time "Checking 'jobcentre-plus-vacancy-filling-system-uk' is already migrated by short-url-manager" do
+      content_id = publishing_api.lookup_content_id(base_path: "/jobcentre-plus-vacancy-filling-system-uk", exclude_unpublishing_types: [], exclude_document_types: [])
+      raise "Didn't expect publishing-api to think artefact is the content_id for /jobcentre-plus-vacancy-filling-system-uk path" if jobcentre_plus_vacany_fill_system_uk.content_id == content_id
+      content_item = publishing_api.get_content(content_id).to_hash
+      raise "Didn't expect publishing-api content for /jobcentre_plus_vacany_fill_system_uk not to be a redirect" if content_item['document_type'] != 'redirect'
+    end
+    live_artefacts.reject { |x| x.slug == jobcentre_plus_vacany_fill_system_uk.slug }
+  end
+
   def self.handle_draft_business_support_artefacts(draft_artefacts)
     raise "Didn't expect any editions for draft artefacts" if draft_artefacts.any? { |a| a.latest_edition.present? }
     raise "Didn't expect any entries in router for draft artefacts" if draft_artefacts.any? { |a| router_response(a).present? }

--- a/db/migrate/20171012124313_republish_business_support_editions_as_publishing_api_redirects_or_gones.rb
+++ b/db/migrate/20171012124313_republish_business_support_editions_as_publishing_api_redirects_or_gones.rb
@@ -1,0 +1,36 @@
+require 'gds_api/router'
+
+class RepublishBusinessSupportEditionsAsPublishingApiRedirectsOrGones < Mongoid::Migration
+  def self.up
+    business_support_by_state = Artefact.where(kind: 'business_support').group_by(&:state)
+    raise "Didn't expect any artefacts not in live, archived, or draft state" unless (business_support_by_state.keys - ['live', 'draft', 'archived']).empty?
+
+    handle_live_business_support_artefacts(business_support_by_state['live'])
+    handle_draft_business_support_artefacts(business_support_by_state['draft'])
+    handle_archived_business_support_artefacts(business_support_by_state['archived'])
+  end
+
+  def self.router
+    @router ||= GdsApi::Router.new(Plek.find('router-api'))
+  end
+
+  def self.router_response(artefact)
+    router.get_route("/#{artefact.slug}").to_hash
+  rescue GdsApi::HTTPNotFound
+    nil
+  end
+
+  def self.publishing_api_response(artefact)
+    publishing_api.get_content(artefact.content_id).to_hash
+  rescue GdsApi::HTTPNotFound
+    nil
+  end
+
+  def self.publishing_api
+    Services.publishing_api
+  end
+
+  def self.down
+    # nope, sorry
+  end
+end

--- a/db/migrate/20171012124313_republish_business_support_editions_as_publishing_api_redirects_or_gones.rb
+++ b/db/migrate/20171012124313_republish_business_support_editions_as_publishing_api_redirects_or_gones.rb
@@ -68,6 +68,17 @@ class RepublishBusinessSupportEditionsAsPublishingApiRedirectsOrGones < Mongoid:
     Artefact.set_callback(:destroy, :before, :discard_publishing_api_draft)
   end
 
+  def self.handle_archived_business_support_artefacts(archived_artefacts)
+    archived_artects_and_router_responses = say_with_time "Fetching router response for archived_artefacts" do
+      archived_artefacts.map { |a| [a, router_response(a)] }
+    end
+
+    archived_artefacts_by_router_availabilty = archived_artects_and_router_responses.group_by { |(a, r)| r.present? }
+
+    handle_archived_business_support_artefacts_in_router(archived_artefacts_by_router_availabilty.fetch(true, []))
+    handle_archived_business_support_artefacts_not_in_router(archived_artefacts_by_router_availabilty.fetch(false, []))
+  end
+
   def self.router
     @router ||= GdsApi::Router.new(Plek.find('router-api'))
   end

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -421,4 +421,66 @@ class ArtefactTest < ActiveSupport::TestCase
     refute published_artefact.archived?
     assert archived_artefact.archived?
   end
+
+  context "#exact_route?" do
+    context 'for artefacts without a latest edition' do
+      should 'be true if its owning_app is not publisher and it has no prefixes' do
+        assert FactoryGirl.build(:artefact, :non_publisher, prefixes: []).exact_route?
+      end
+
+      should 'be false if its owning_app is not publisher and it has prefixes' do
+        refute FactoryGirl.build(:artefact, :non_publisher, prefixes: ['/hats']).exact_route?
+      end
+
+      should 'be true if its owning_app is publisher and its kind is that of an exact route edition' do
+        assert FactoryGirl.build(:artefact, kind: 'campaign', prefixes: []).exact_route?
+        assert FactoryGirl.build(:artefact, kind: 'help_page', prefixes: []).exact_route?
+        assert FactoryGirl.build(:artefact, kind: 'transaction', prefixes: []).exact_route?
+
+        # regardless of prefixes
+        assert FactoryGirl.build(:artefact, kind: 'campaign', prefixes: ['/hats']).exact_route?
+        assert FactoryGirl.build(:artefact, kind: 'help_page', prefixes: ['/shoes']).exact_route?
+        assert FactoryGirl.build(:artefact, kind: 'transaction', prefixes: ['/scarves']).exact_route?
+      end
+
+      should 'be false if its owning_app is not publisher and its kind is not that of an exact route edition' do
+        refute FactoryGirl.build(:artefact, kind: 'answer', prefixes: []).exact_route?
+        refute FactoryGirl.build(:artefact, kind: 'business_support', prefixes: []).exact_route?
+        refute FactoryGirl.build(:artefact, kind: 'completed_transaction', prefixes: []).exact_route?
+        refute FactoryGirl.build(:artefact, kind: 'guide', prefixes: []).exact_route?
+        refute FactoryGirl.build(:artefact, kind: 'licence', prefixes: []).exact_route?
+        refute FactoryGirl.build(:artefact, kind: 'local_transaction', prefixes: []).exact_route?
+        refute FactoryGirl.build(:artefact, kind: 'place', prefixes: []).exact_route?
+        refute FactoryGirl.build(:artefact, kind: 'programme', prefixes: []).exact_route?
+        refute FactoryGirl.build(:artefact, kind: 'simple_smart_answer', prefixes: []).exact_route?
+        refute FactoryGirl.build(:artefact, kind: 'video', prefixes: []).exact_route?
+
+        # regardless of prefixes
+        refute FactoryGirl.build(:artefact, kind: 'answer', prefixes: ['/hats']).exact_route?
+        refute FactoryGirl.build(:artefact, kind: 'business_support', prefixes: ['/shoes']).exact_route?
+        refute FactoryGirl.build(:artefact, kind: 'completed_transaction', prefixes: ['/scarves']).exact_route?
+        refute FactoryGirl.build(:artefact, kind: 'guide', prefixes: ['/underwear']).exact_route?
+        refute FactoryGirl.build(:artefact, kind: 'licence', prefixes: ['/jumpers']).exact_route?
+        refute FactoryGirl.build(:artefact, kind: 'local_transaction', prefixes: ['/gloves']).exact_route?
+        refute FactoryGirl.build(:artefact, kind: 'place', prefixes: ['/belts']).exact_route?
+        refute FactoryGirl.build(:artefact, kind: 'programme', prefixes: ['/socks']).exact_route?
+        refute FactoryGirl.build(:artefact, kind: 'simple_smart_answer', prefixes: ['/onesies']).exact_route?
+        refute FactoryGirl.build(:artefact, kind: 'video', prefixes: ['/all-other-clothing']).exact_route?
+      end
+    end
+
+    context 'for artefacts with a latest edition' do
+      should 'delegate to it' do
+        latest_edition = mock
+        artefact = FactoryGirl.build(:artefact)
+        artefact.stubs(:latest_edition).returns(latest_edition)
+
+        latest_edition.expects(:exact_route?).returns true
+        assert artefact.exact_route?
+
+        latest_edition.expects(:exact_route?).returns false
+        refute artefact.exact_route?
+      end
+    end
+  end
 end

--- a/test/unit/services/unpublish_service_test.rb
+++ b/test/unit/services/unpublish_service_test.rb
@@ -3,8 +3,7 @@ require 'test_helper'
 class UnpublishServiceTest < ActiveSupport::TestCase
   setup do
     @content_id = 'foo'
-    @edition = stub(exact_route?: true)
-    @artefact = stub(update_attributes_as: true, content_id: @content_id, slug: "foo", state: "live", language: "en", latest_edition: @edition)
+    @artefact = stub(update_attributes_as: true, content_id: @content_id, slug: "foo", state: "live", language: "en", exact_route?: true)
     @user = stub
     @publishing_api = stub(unpublish: true)
 
@@ -57,7 +56,7 @@ class UnpublishServiceTest < ActiveSupport::TestCase
   context "when a valid redirect URL is provided" do
     context "for an artefact with prefix routes" do
       should "tell the publishing API about the change" do
-        @edition.expects(:exact_route?).returns(false)
+        @artefact.expects(:exact_route?).returns(false)
 
         @publishing_api.expects(:unpublish)
           .with(@content_id,


### PR DESCRIPTION
For: https://trello.com/c/RRJOTFQo/252-remove-business-support-code-that-still-exist-in-publisher

This is part 1 of the work for this card to remove business support code and data from publisher and make sure they're all redirected properly in publishing-api instead of router-data.  Part 2 actually deletes the code and edition data (see: #649), part 3 removes the entries from router-data (see: alphagov/router-data#5), and part 4 removes the schema from content-schemas (see: alphagov/govuk-content-schemas#653).

This is a migration that works through all the business_support artefacts in the publisher database and decides what to do with them.  Ultimately we unpublish with a redirect, create a new redirect content item, create a new gone content item, or destroy the artefact.  The choices are somewhat involved so it's best to review this PR commit by commit as we build up the migration in stages.

Open to any thoughts on an alternate approach to this.  For example should we always create new redirect/gone content items with new content_ids and claim they came from short-url-manager?