### PR TITLE
Set up application for removal of alphagov-deployment

### DIFF
--- a/config/fact_check.yml
+++ b/config/fact_check.yml
@@ -1,18 +1,13 @@
 # Configuration for the fact check system
-# This file is overwritten on deployment
 
 # The main address pattern sent out as the From address on fact check emails
 # If we ever want to change this format, we'll need to support some notion of
 # legacy formats, so we still pick up emails to old addresses
-address_format: "factcheck+dev-{id}@alphagov.co.uk"
+address_format: <%=ENV.fetch("FACT_CHECK_ADDRESS_FORMAT", "factcheck+dev-{id}@alphagov.co.uk") %>
 
-# In deployed versions, this contains connection details for the fact check
-# account, eg:
-#
-#     address: imap.example.com
-#     port: 993
-#     user_name: factcheck@example.com
-#     password: correct horse battery staple
-#     enable_ssl: true
-#
-fetcher: {}
+fetcher:
+  address: <%=ENV.fetch("FACT_CHECK_ADDRESS", "imap.gmail.com") %>
+  port: <%=ENV.fetch("FACT_CHECK_PORT", 993) %>
+  user_name: <%=ENV["FACT_CHECK_USERNAME"] %>
+  password: <%=ENV["FACT_CHECK_PASSWORD"] %>
+  enable_ssl: true

--- a/config/initializers/email_groups.rb
+++ b/config/initializers/email_groups.rb
@@ -1,5 +1,5 @@
 EMAIL_GROUPS = {
-    dev: ['govuk-dev@digital.cabinet-office.gov.uk'],
-    business: ['publisher-alerts-business@digital.cabinet-office.gov.uk'],
-    citizen: ['publisher-alerts-citizen@digital.cabinet-office.gov.uk']
+    dev: [ENV.fetch('EMAIL_GROUP_DEV', 'govuk-dev@digital.cabinet-office.gov.uk')],
+    business: [ENV.fetch('EMAIL_GROUP_BUSINESS', 'publisher-alerts-business@digital.cabinet-office.gov.uk')],
+    citizen: [ENV.fetch('EMAIL_GROUP_CITIZEN', 'publisher-alerts-citizen@digital.cabinet-office.gov.uk')],
   }

--- a/config/initializers/fact_check.rb
+++ b/config/initializers/fact_check.rb
@@ -3,7 +3,10 @@ require 'mail_fetcher_config'
 require 'fact_check_config'
 
 config_file_path = Rails.root.join("config", "fact_check.yml")
-config = YAML.load_file(config_file_path)
+
+config = YAML.load(
+  ERB.new(File.read(config_file_path)).result
+)
 
 Publisher::Application.fact_check_config = FactCheckConfig.new(
   config.fetch("address_format")

--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -1,6 +1,6 @@
 GDS::SSO.config do |config|
   config.user_model   = "User"
-  config.oauth_id     = ENV['PUBLISHER_OAUTH_ID'] || "abcdefghjasndjkasndpublisher"
-  config.oauth_secret = ENV['PUBLISHER_OAUTH_SECRET'] || "secret"
+  config.oauth_id     = ENV['OAUTH_ID'] || "abcdefghjasndjkasndpublisher"
+  config.oauth_secret = ENV['OAUTH_SECRET'] || "secret"
   config.oauth_root_url = Plek.current.find("signon")
 end

--- a/config/initializers/gds_api.rb
+++ b/config/initializers/gds_api.rb
@@ -1,6 +1,3 @@
-# This file is overwritten on deploy (see alphagov-deployment), so be careful
-# about relying on this content
-
 require 'gds_api/base'
 require 'gds_api/asset_manager'
 require 'plek'
@@ -12,4 +9,7 @@ GdsApi::Base.logger = Logger.new(Rails.root.join("log/#{Rails.env}.api_client.lo
 # be overwritten with the correct details on deploy.
 # See README.md for details of how to generate a bearer token.
 
-Attachable.asset_api_client = GdsApi::AssetManager.new(Plek.current.find('asset-manager'), bearer_token: ENV['PUBLISHER_ASSET_MANAGER_CLIENT_BEARER_TOKEN'] || 'also_set_at_deploy_time',)
+Attachable.asset_api_client = GdsApi::AssetManager.new(
+  Plek.current.find('asset-manager'),
+  bearer_token: ENV['ASSET_MANAGER_BEARER_TOKEN'] || 'example',
+)

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,1 +1,13 @@
-# This file is overwritten on deploy
+set :output, error: 'log/cron.error.log', standard: 'log/cron.log'
+
+schedule_task_prefix = ENV.fetch('SCHEDULE_TASK_PREFIX', '/usr/local/bin/govuk_setenv publisher')
+job_type :rake, "cd :path && #{schedule_task_prefix} bundle exec rake :task :output"
+job_type :run_script, "cd :path && RAILS_ENV=:environment #{schedule_task_prefix} script/:task :output"
+
+every 5.minutes do
+  run_script "mail_fetcher"
+end
+
+every 1.hour do
+  rake "reports:generate"
+end

--- a/lib/mail_fetcher_config.rb
+++ b/lib/mail_fetcher_config.rb
@@ -6,11 +6,9 @@ class MailFetcherConfig
       raise ArgumentError, "Non-symbolic keys: #{keys_string}"
     end
 
-    if config_hash.empty?
-      @imap_details = nil
-    else
-      @imap_details = config_hash.dup
-    end
+    @imap_details = if ENV["RUN_FACT_CHECK_FETCHER"] && config_hash.present?
+                      config_hash.dup
+                    end
   end
 
   def configure(mail_module = Mail)

--- a/test/unit/mail_fetcher_config_test.rb
+++ b/test/unit/mail_fetcher_config_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require 'mail_fetcher_config'
+require 'mail'
 
 class MailFetcherConfigTest < ActiveSupport::TestCase
   # Because the `defaults` method on `Mail` calls `instance_eval` with a block,
@@ -9,6 +10,15 @@ class MailFetcherConfigTest < ActiveSupport::TestCase
     def defaults(&block)
       instance_eval(&block)
     end
+  end
+
+  setup do
+    @env_run_fact_check_fetcher = ENV["RUN_FACT_CHECK_FETCHER"]
+    ENV["RUN_FACT_CHECK_FETCHER"] = "1"
+  end
+
+  teardown do
+    ENV["RUN_FACT_CHECK_FETCHER"] = @env_run_fact_check_fetcher
   end
 
   should "raise an error if given strings as keys" do
@@ -32,5 +42,12 @@ class MailFetcherConfigTest < ActiveSupport::TestCase
     mail = StubMail.new
     mail.expects(:defaults).never
     MailFetcherConfig.new({}).configure(mail)
+  end
+
+  should "not configure email settings if RUN_FACT_CHECKER_FETCHER is not set" do
+    mail = StubMail.new
+    mail.expects(:defaults).never
+    ENV.delete("RUN_FACT_CHECK_FETCHER")
+    MailFetcherConfig.new(user_name: "bob@example.com").configure(mail)
   end
 end


### PR DESCRIPTION
This sets up environment variable conditionals for the various configurations set up in [alphagov-deployment](https://github.com/alphagov/alphagov-deployment/tree/master/publisher) to make way for it's removal.

More details on individual commits.