### PR TITLE
Fix equality typo in republishing business_support migration

### DIFF
--- a/db/migrate/20171012124313_republish_business_support_editions_as_publishing_api_redirects_or_gones.rb
+++ b/db/migrate/20171012124313_republish_business_support_editions_as_publishing_api_redirects_or_gones.rb
@@ -44,7 +44,7 @@ class RepublishBusinessSupportEditionsAsPublishingApiRedirectsOrGones < Mongoid:
   end
 
   def self.handle_jobcentre_plus_vacancy_filling_system_uk(live_artefacts)
-    jobcentre_plus_vacany_fill_system_uk = live_artefacts.detect { |x| x.slug = 'jobcentre-plus-vacancy-filling-system-uk'}
+    jobcentre_plus_vacany_fill_system_uk = live_artefacts.detect { |x| x.slug == 'jobcentre-plus-vacancy-filling-system-uk'}
     raise "Didn't expect 'jobcentre-plus-vacancy-filling-system-uk' to be missing from live business support artefacts" if jobcentre_plus_vacany_fill_system_uk.nil?
 
     say_with_time "Checking 'jobcentre-plus-vacancy-filling-system-uk' is already migrated by short-url-manager" do


### PR DESCRIPTION
We had `=` instead of `==` when detecting the
`jobcentre-plus-vacancy-filling-system-uk` artefact which means we picked
the wrong artefact to check the redirect against.  Unluckily for us this
artefact's routes had the same conditions as the
`jobcentre-plus-vacancy-filling-system-uk` one so picking the wrong
artefact didn't cause an exception to be raised.  Ultimately what this
does is mean we filtered this artefact out of the list of live ones to
process and don't redirect it properly.  Replacing the `=` with `==`
means we pick the correct artefact for
`jobcentre-plus-vacancy-filling-system-uk` and only filter it out.