### PR TITLE
Add rake tasks to publish Start Page A/B test pages

### DIFF
--- a/lib/tasks/publish_start_page_ab_test_pages.rake
+++ b/lib/tasks/publish_start_page_ab_test_pages.rake
@@ -1,26 +1,55 @@
-desc "Publish interstitial page"
-task publish_interstitial_page: :environment do
-  content_id = "4dc3b42e-4e96-4f66-b9d1-0cb5e9676e3c"
-  params = {
-    base_path: "/interstitial",
-    document_type: "generic_with_external_related_links",
-    locale: "en",
-    public_updated_at: "2016-11-10T12:58:31.000+00:00",
-    publishing_app: "publisher",
-    rendering_app: "government-frontend",
-    schema_name: "generic",
-    update_type: "major",
-    title: "Pick method",
-    routes: [
-      {
-        path: "/interstitial",
-        type: "exact"
-      }
-    ],
-    description: "",
-    details: {}
-  }
+namespace :start_page_ab_test_pages do
+  desc "Publish interstitial page"
+  task publish_interstitial_page: :environment do
+    content_id = "f34ebcbc-4955-4f57-89bd-4d6aa7e72edf"
+    params = {
+      base_path: "/log-in-file-self-assessment-tax-return/interstitial",
+      document_type: "generic_with_external_related_links",
+      locale: "en",
+      public_updated_at: "2016-11-10T12:58:31.000+00:00",
+      publishing_app: "publisher",
+      rendering_app: "government-frontend",
+      schema_name: "generic",
+      update_type: "major",
+      title: "Pick method",
+      routes: [
+        {
+          path: "/log-in-file-self-assessment-tax-return/interstitial",
+          type: "exact"
+        }
+      ],
+      description: "",
+      details: {}
+    }
 
-  Services.publishing_api.put_content(content_id, params)
-  Services.publishing_api.publish(content_id)
+    Services.publishing_api.put_content(content_id, params)
+    Services.publishing_api.publish(content_id)
+  end
+
+  desc "Publish create account page"
+  task publish_create_account_page: :environment do
+    content_id = "8897173c-583a-47c7-b23f-c8624434dd1a"
+    params = {
+      base_path: "/log-in-file-self-assessment-tax-return/create-account",
+      document_type: "generic_with_external_related_links",
+      locale: "en",
+      public_updated_at: "2016-11-10T12:58:31.000+00:00",
+      publishing_app: "publisher",
+      rendering_app: "government-frontend",
+      schema_name: "generic",
+      update_type: "major",
+      title: "Create an account",
+      routes: [
+        {
+          path: "/log-in-file-self-assessment-tax-return/create-account",
+          type: "exact"
+        }
+      ],
+      description: "",
+      details: {}
+    }
+
+    Services.publishing_api.put_content(content_id, params)
+    Services.publishing_api.publish(content_id)
+  end
 end

--- a/lib/tasks/publish_start_page_ab_test_pages.rake
+++ b/lib/tasks/publish_start_page_ab_test_pages.rake
@@ -1,0 +1,26 @@
+desc "Publish interstitial page"
+task publish_interstitial_page: :environment do
+  content_id = "4dc3b42e-4e96-4f66-b9d1-0cb5e9676e3c"
+  params = {
+    base_path: "/interstitial",
+    document_type: "generic_with_external_related_links",
+    locale: "en",
+    public_updated_at: "2016-11-10T12:58:31.000+00:00",
+    publishing_app: "publisher",
+    rendering_app: "government-frontend",
+    schema_name: "generic",
+    update_type: "major",
+    title: "Pick method",
+    routes: [
+      {
+        path: "/interstitial",
+        type: "exact"
+      }
+    ],
+    description: "",
+    details: {}
+  }
+
+  Services.publishing_api.put_content(content_id, params)
+  Services.publishing_api.publish(content_id)
+end


### PR DESCRIPTION
For [Trello](https://trello.com/c/zfJiG9v8/145-sa-a-b-test-make-changes-to-government-frontend)

This adds two rake tasks to publish content for the upcoming Start Pages A/B test in Government Frontend.  These pages don't use a standard publishing format and the content will be hardcoded in Government Frontend, so we can't use the standard Publisher UI workflow to create them.  Instead we create rake tasks to send the necessary information to the Publishing API and subsequently to Content Store in order to create a content item that Government Frontend can read from.  The content created by these tasks are:

1) An interstitial page for displaying login options to a user
2) A 'create an account' page for users who don't already have a Verify or Government Gateway account

Note, we intend to remove these rake tasks once the A/B test has concluded see [Trello](https://trello.com/c/xdmgIGIO/163-tear-down-a-b-test).