### PR TITLE
Add rake task to publish "Lost account details" page

### DIFF
--- a/lib/tasks/publish_start_page_ab_test_pages.rake
+++ b/lib/tasks/publish_start_page_ab_test_pages.rake
@@ -52,4 +52,31 @@ namespace :start_page_ab_test_pages do
     Services.publishing_api.put_content(content_id, params)
     Services.publishing_api.publish(content_id)
   end
+
+  desc "Publish lost account details page"
+  task publish_lost_account_details_page: :environment do
+    content_id = "ec28dd82-8ac6-48e8-a34d-0ff00d0606b5"
+    params = {
+      base_path: "/log-in-file-self-assessment-tax-return/lost-account-details",
+      document_type: "generic_with_external_related_links",
+      locale: "en",
+      public_updated_at: "2016-11-10T12:58:31.000+00:00",
+      publishing_app: "publisher",
+      rendering_app: "government-frontend",
+      schema_name: "generic",
+      update_type: "major",
+      title: "Forgotten username or password",
+      routes: [
+        {
+          path: "/log-in-file-self-assessment-tax-return/lost-account-details",
+          type: "exact"
+        }
+      ],
+      description: "",
+      details: {}
+    }
+
+    Services.publishing_api.put_content(content_id, params)
+    Services.publishing_api.publish(content_id)
+  end
 end


### PR DESCRIPTION
For [Trello](https://trello.com/c/zfJiG9v8/145-sa-a-b-test-make-changes-to-government-frontend)

This adds a rake tasks to publish a "Lost account details" page for the upcoming Start Pages A/B test in Government Frontend.  This page doesn't use a standard publishing format and the content will be hardcoded in Government Frontend, so we can't use the standard Publisher UI workflow to create it.  Instead we create a rake task to send the necessary information to the Publishing API and subsequently to Content Store in order to create a content item that Government Frontend can read from. 

Note, we intend to remove these rake tasks once the A/B test has concluded see [Trello](https://trello.com/c/xdmgIGIO/163-tear-down-a-b-test).