### PR TITLE
Collapse all edition history

### DIFF
--- a/app/assets/javascripts/modules/collapsible_group.js
+++ b/app/assets/javascripts/modules/collapsible_group.js
@@ -17,6 +17,7 @@
 
       element.on('click', '.js-toggle-all', toggleAll);
       element.on('shown.bs.collapse hidden.bs.collapse nested:fieldRemoved nested:fieldAdded', updateLinkText);
+      updateLinkText();
 
       function toggleAll(event) {
         var action = hasOpenItems() ? 'hide' : 'show';

--- a/app/views/shared/_history.html.erb
+++ b/app/views/shared/_history.html.erb
@@ -47,8 +47,12 @@
   </div>
 </div>
 
-<div id="edition-history">
+<div id="edition-history" data-module="collapsible-group" data-expand-text="Expand all notes" data-collapse-text="Collapse all notes">
   <h3 class="remove-top-margin add-bottom-margin">History and notes</h3>
+
+  <p class="add-bottom-margin if-no-js-hide">
+    <a href="#" class="js-toggle-all">Expand all notes</a>
+  </p>
 
   <div class="add-bottom-margin">
     <a href="#save-edition-note" class="btn btn-primary" data-toggle="modal"><i class="glyphicon glyphicon-comment add-right-margin"></i>Add edition note</a>

--- a/spec/javascripts/spec/collapsible_group.spec.js
+++ b/spec/javascripts/spec/collapsible_group.spec.js
@@ -27,7 +27,6 @@ describe('A collapsible group module', function() {
     $('body').append(element);
 
     group = new GOVUKAdmin.Modules.CollapsibleGroup();
-    group.start(element);
   });
 
   afterEach(function() {
@@ -37,71 +36,112 @@ describe('A collapsible group module', function() {
     delete $.fn.collapse;
   });
 
-  describe('when all items are closed and the toggle is clicked', function() {
+  describe('when first initialized', function() {
+    describe('and all items are open', function() {
+      beforeEach(function() {
+        element.find('.collapse').addClass('in');
+        group.start(element);
+      });
+
+      it('changes the trigger text to the collapse text', function() {
+        expect(element.find('.js-toggle-all').text()).toBe('Collapse');
+      });
+    });
+
+    describe('and some items are open', function() {
+      beforeEach(function() {
+        element.find('.collapse').removeClass('in');
+        element.find('.collapse').first().addClass('in');
+        group.start(element);
+      });
+
+      it('changes the trigger text to the collapse text', function() {
+        expect(element.find('.js-toggle-all').text()).toBe('Collapse');
+      });
+    });
+
+    describe('and all items are closed', function() {
+      beforeEach(function() {
+        element.find('.collapse').removeClass('in');
+        group.start(element);
+      });
+
+      it('changes the trigger text to the expand text', function() {
+        expect(element.find('.js-toggle-all').text()).toBe('Expand');
+      });
+    });
+  });
+
+  describe('when already running', function() {
     beforeEach(function() {
-      element.find('.js-toggle-all').trigger('click');
+      group.start(element);
     });
 
-    it('expands all items' , function() {
-      expect(element.find('.collapse.in').length).toBe(3);
+    describe('when all items are closed and the toggle is clicked', function() {
+      beforeEach(function() {
+        element.find('.js-toggle-all').trigger('click');
+      });
+
+      it('expands all items' , function() {
+        expect(element.find('.collapse.in').length).toBe(3);
+      });
+
+      it('then shows the collapse text' , function() {
+        expect(element.find('.js-toggle-all').text()).toBe('Collapse');
+      });
     });
 
-    it('then shows the collapse text' , function() {
-      expect(element.find('.js-toggle-all').text()).toBe('Collapse');
+    describe('when all items are open and the toggle is clicked', function() {
+      beforeEach(function() {
+        element.find('.collapse').addClass('in');
+        expect(element.find('.collapse.in').length).toBe(3);
+        element.find('.js-toggle-all').trigger('click');
+      });
+
+      it('collapses all items' , function() {
+        expect(element.find('.collapse.in').length).toBe(0);
+      });
+
+      it('then shows the expand text' , function() {
+        expect(element.find('.js-toggle-all').text()).toBe('Expand');
+      });
+    });
+
+    describe('when at least one item is open and the toggle is clicked', function() {
+      beforeEach(function() {
+        element.find('.collapse').first().addClass('in');
+        expect(element.find('.collapse.in').length).toBe(1);
+        element.find('.js-toggle-all').trigger('click');
+      });
+
+      it('collapses all items' , function() {
+        expect(element.find('.collapse.in').length).toBe(0);
+        expect(element.find('.js-toggle-all').text()).toBe('Expand');
+      });
+    });
+
+    describe('when a user manually collapses or expands items', function() {
+      it('updates the link text', function() {
+        element.find('.collapse').first().addClass('in');
+        element.trigger('shown.bs.collapse');
+        expect(element.find('.js-toggle-all').text()).toBe('Collapse');
+
+        element.find('.collapse').first().removeClass('in');
+        element.trigger('hidden.bs.collapse');
+        expect(element.find('.js-toggle-all').text()).toBe('Expand');
+      });
+    });
+
+    describe('when a new group is added or removed', function() {
+      it('updates the link text', function() {
+        element.find('.collapse').first().addClass('in');
+        element.trigger('nested:fieldAdded');
+        expect(element.find('.js-toggle-all').text()).toBe('Collapse');
+
+        element.find('.collapse.in').first().hide();
+        element.trigger('nested:fieldRemoved');
+        expect(element.find('.js-toggle-all').text()).toBe('Expand');
+      });
     });
   });
-
-  describe('when all items are open and the toggle is clicked', function() {
-    beforeEach(function() {
-      element.find('.collapse').addClass('in');
-      expect(element.find('.collapse.in').length).toBe(3);
-      element.find('.js-toggle-all').trigger('click');
-    });
-
-    it('collapses all items' , function() {
-      expect(element.find('.collapse.in').length).toBe(0);
-    });
-
-    it('then shows the expand text' , function() {
-      expect(element.find('.js-toggle-all').text()).toBe('Expand');
-    });
-  });
-
-  describe('when at least one item is open and the toggle is clicked', function() {
-    beforeEach(function() {
-      element.find('.collapse').first().addClass('in');
-      expect(element.find('.collapse.in').length).toBe(1);
-      element.find('.js-toggle-all').trigger('click');
-    });
-
-    it('collapses all items' , function() {
-      expect(element.find('.collapse.in').length).toBe(0);
-      expect(element.find('.js-toggle-all').text()).toBe('Expand');
-    });
-  });
-
-  describe('when a user manually collapses or expands items', function() {
-    it('updates the link text', function() {
-      element.find('.collapse').first().addClass('in');
-      element.trigger('shown.bs.collapse');
-      expect(element.find('.js-toggle-all').text()).toBe('Collapse');
-
-      element.find('.collapse').first().removeClass('in');
-      element.trigger('hidden.bs.collapse');
-      expect(element.find('.js-toggle-all').text()).toBe('Expand');
-    });
-  });
-
-  describe('when a new group is added or removed', function() {
-    it('updates the link text', function() {
-      element.find('.collapse').first().addClass('in');
-      element.trigger('nested:fieldAdded');
-      expect(element.find('.js-toggle-all').text()).toBe('Collapse');
-
-      element.find('.collapse.in').first().hide();
-      element.trigger('nested:fieldRemoved');
-      expect(element.find('.js-toggle-all').text()).toBe('Expand');
-    });
-  });
-
 });


### PR DESCRIPTION
For: https://trello.com/c/E0AkfL26/299-publisher-edition-notes-expand-all-option

We want to introduce expand all / collapse all to the history & notes tab.  Luckily it uses bootstrap collapse, and we already have our own collapsible-group module to provide a expand/collapse all toggle so we can use that.

One downside is that the behaviour of this is to always collapse if any item in the group is open, and only expand if all are closed.  We start with the first item open and would probably expect that the toggle would open the rest of them, but it will instead close the first one and then change to an expand all option.

I'm checking to see if that's ok, or if we should change the collapsible-group behaviour to always expand if none are closed, and only collapse if all are open.  I don't think this would change would make the experience worse where it's already used in other places (part editing on guides and programmes) but it would change it so it's worth checking.
