### PR TITLE
Update PhantomJS to use prebuilt version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,9 @@
 FROM ruby:2.4.2
 RUN apt-get update -qq && apt-get upgrade -y
 
+RUN curl -sL https://deb.nodesource.com/setup_9.x | bash -
 RUN apt-get install -y build-essential nodejs && apt-get clean
-
-ENV PHANTOM_JS phantomjs-2.1.1-linux-x86_64
-
-RUN wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2 && \
-    tar xvjf $PHANTOM_JS.tar.bz2 && \
-    mv $PHANTOM_JS /usr/local/share && \
-    ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /bin/phantomjs && \
-    rm $PHANTOM_JS.tar.bz2
+RUN npm install -g phantomjs-prebuilt@2 --unsafe-perm
 
 ENV GOVUK_APP_NAME publisher
 ENV MONGODB_URI mongodb://mongo/govuk_content_development


### PR DESCRIPTION
This resolves an issue we see with the main PhantomJS package being rate
limited and returning 429s from bitbucket which results in failing
builds.