### PR TITLE
Add service_sign in_presenter

### DIFF
--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -1,0 +1,12 @@
+module Formats
+  class ServiceSignInPresenter
+    def initialize
+    end
+
+    def render_for_publishing_api
+      {
+        schema_name: "service_sign_in",
+      }
+    end
+  end
+end

--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -87,7 +87,18 @@ module Formats
             content: content[:choose_sign_in][:description]
           }
         ],
+        options: options,
       }
+    end
+
+    def options
+      options = content[:choose_sign_in][:options]
+      options.each do |option|
+        if option.key?(:slug)
+          option[:slug] = "#{base_path}/#{option[:slug]}"
+          option[:url] = option.delete :slug
+        end
+      end
     end
 
     def parent

--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -105,6 +105,7 @@ module Formats
     def create_new_account
       {
         title: content[:create_new_account][:title],
+        slug: content[:create_new_account][:slug],
       }
     end
 

--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -15,6 +15,7 @@ module Formats
         locale: locale,
         update_type: update_type,
         change_note: change_note,
+        base_path: base_path,
       }
     end
 
@@ -30,6 +31,10 @@ module Formats
 
     def change_note
       content[:change_note]
+    end
+
+    def base_path
+      "/#{content[:start_page_slug]}/sign-in"
     end
   end
 end

--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -16,6 +16,7 @@ module Formats
         update_type: update_type,
         change_note: change_note,
         base_path: base_path,
+        routes: routes,
       }
     end
 
@@ -35,6 +36,12 @@ module Formats
 
     def base_path
       "/#{content[:start_page_slug]}/sign-in"
+    end
+
+    def routes
+      [
+        { path: base_path.to_s, type: "prefix" },
+      ]
     end
   end
 end

--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -18,6 +18,7 @@ module Formats
         base_path: base_path,
         routes: routes,
         title: title,
+        description: description,
       }
     end
 
@@ -46,7 +47,15 @@ module Formats
     end
 
     def title
-      Edition.where(slug: parent_slug).last.title
+      parent.title
+    end
+
+    def description
+      parent.overview
+    end
+
+    def parent
+      @parent ||= Edition.where(slug: parent_slug).last
     end
 
     def parent_slug

--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -81,6 +81,12 @@ module Formats
       {
         title: content[:choose_sign_in][:title],
         slug: content[:choose_sign_in][:slug],
+        description: [
+          {
+            content_type: "text/govspeak",
+            content: content[:choose_sign_in][:description]
+          }
+        ],
       }
     end
 

--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -19,6 +19,7 @@ module Formats
         routes: routes,
         title: title,
         description: description,
+        details: details,
       }
       payload[:public_updated_at] = public_updated_at if public_updated_at.present?
       payload
@@ -68,6 +69,18 @@ module Formats
 
     def public_updated_at
       DateTime.now.rfc3339 if update_type == "major"
+    end
+
+    def details
+      {
+        choose_sign_in: choose_sign_in,
+      }
+    end
+
+    def choose_sign_in
+      {
+        title: content[:choose_sign_in][:title],
+      }
     end
 
     def parent

--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -14,6 +14,7 @@ module Formats
         document_type: "service_sign_in",
         locale: locale,
         update_type: update_type,
+        change_note: change_note,
       }
     end
 
@@ -25,6 +26,10 @@ module Formats
 
     def update_type
       content[:update_type]
+    end
+
+    def change_note
+      content[:change_note]
     end
   end
 end

--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -13,6 +13,7 @@ module Formats
         publishing_app: "publisher",
         document_type: "service_sign_in",
         locale: locale,
+        update_type: update_type,
       }
     end
 
@@ -20,6 +21,10 @@ module Formats
 
     def locale
       content[:locale]
+    end
+
+    def update_type
+      content[:update_type]
     end
   end
 end

--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -8,6 +8,7 @@ module Formats
         schema_name: "service_sign_in",
         rendering_app: "government-frontend",
         publishing_app: "publisher",
+        document_type: "service_sign_in",
       }
     end
   end

--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -7,7 +7,7 @@ module Formats
     end
 
     def render_for_publishing_api
-      {
+      payload = {
         schema_name: "service_sign_in",
         rendering_app: "government-frontend",
         publishing_app: "publisher",
@@ -20,6 +20,8 @@ module Formats
         title: title,
         description: description,
       }
+      payload[:public_updated_at] = public_updated_at if public_updated_at.present?
+      payload
     end
 
   private
@@ -52,6 +54,10 @@ module Formats
 
     def description
       parent.overview
+    end
+
+    def public_updated_at
+      DateTime.now.rfc3339 if update_type == "major"
     end
 
     def parent

--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -74,6 +74,7 @@ module Formats
     def details
       {
         choose_sign_in: choose_sign_in,
+        create_new_account: create_new_account,
       }
     end
 
@@ -99,6 +100,12 @@ module Formats
           option[:url] = option.delete :slug
         end
       end
+    end
+
+    def create_new_account
+      {
+        title: content[:create_new_account][:title],
+      }
     end
 
     def parent

--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -28,6 +28,12 @@ module Formats
       @content_id ||= existing_content_id || SecureRandom.uuid
     end
 
+    def links
+      {
+        parent: [parent.content_id]
+      }
+    end
+
   private
 
     def locale

--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -6,6 +6,7 @@ module Formats
     def render_for_publishing_api
       {
         schema_name: "service_sign_in",
+        rendering_app: "government-frontend",
       }
     end
   end

--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -24,6 +24,10 @@ module Formats
       payload
     end
 
+    def content_id
+      @content_id ||= existing_content_id || SecureRandom.uuid
+    end
+
   private
 
     def locale
@@ -66,6 +70,10 @@ module Formats
 
     def parent_slug
       content[:start_page_slug]
+    end
+
+    def existing_content_id
+      Services.publishing_api.lookup_content_id(base_path: base_path)
     end
   end
 end

--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -1,6 +1,9 @@
 module Formats
   class ServiceSignInPresenter
-    def initialize
+    attr_reader :content
+
+    def initialize(content)
+      @content = content.deep_symbolize_keys
     end
 
     def render_for_publishing_api
@@ -9,7 +12,14 @@ module Formats
         rendering_app: "government-frontend",
         publishing_app: "publisher",
         document_type: "service_sign_in",
+        locale: locale,
       }
+    end
+
+  private
+
+    def locale
+      content[:locale]
     end
   end
 end

--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -82,12 +82,7 @@ module Formats
       {
         title: content[:choose_sign_in][:title],
         slug: content[:choose_sign_in][:slug],
-        description: [
-          {
-            content_type: "text/govspeak",
-            content: content[:choose_sign_in][:description]
-          }
-        ],
+        description: govspeak_content(content[:choose_sign_in][:description]),
         options: options,
       }
     end
@@ -106,7 +101,17 @@ module Formats
       {
         title: content[:create_new_account][:title],
         slug: content[:create_new_account][:slug],
+        body: govspeak_content(content[:create_new_account][:body])
       }
+    end
+
+    def govspeak_content(content)
+      [
+        {
+          content_type: "text/govspeak",
+          content: content,
+        }
+      ]
     end
 
     def parent

--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -7,6 +7,7 @@ module Formats
       {
         schema_name: "service_sign_in",
         rendering_app: "government-frontend",
+        publishing_app: "publisher",
       }
     end
   end

--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -17,6 +17,7 @@ module Formats
         change_note: change_note,
         base_path: base_path,
         routes: routes,
+        title: title,
       }
     end
 
@@ -35,13 +36,21 @@ module Formats
     end
 
     def base_path
-      "/#{content[:start_page_slug]}/sign-in"
+      "/#{parent_slug}/sign-in"
     end
 
     def routes
       [
         { path: base_path.to_s, type: "prefix" },
       ]
+    end
+
+    def title
+      Edition.where(slug: parent_slug).last.title
+    end
+
+    def parent_slug
+      content[:start_page_slug]
     end
   end
 end

--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -80,6 +80,7 @@ module Formats
     def choose_sign_in
       {
         title: content[:choose_sign_in][:title],
+        slug: content[:choose_sign_in][:slug],
       }
     end
 

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -178,5 +178,12 @@ class ServiceSignInTest < ActiveSupport::TestCase
         end
       end
     end
+
+    context "[:create_new_account]" do
+      should "[:title]" do
+        assert_equal @content[:create_new_account][:title],
+          result[:details][:create_new_account][:title]
+      end
+    end
   end
 end

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -129,6 +129,11 @@ class ServiceSignInTest < ActiveSupport::TestCase
         assert_equal @content[:choose_sign_in][:title],
           result[:details][:choose_sign_in][:title]
       end
+
+      should "[:slug]" do
+        assert_equal @content[:choose_sign_in][:slug],
+          result[:details][:choose_sign_in][:slug]
+      end
     end
   end
 end

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -42,4 +42,8 @@ class ServiceSignInTest < ActiveSupport::TestCase
   should "[:locale]" do
     assert_equal @content[:locale], result[:locale]
   end
+
+  should "[:update_type]" do
+    assert_equal @content[:update_type], result[:update_type]
+  end
 end

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -122,4 +122,13 @@ class ServiceSignInTest < ActiveSupport::TestCase
 
     assert_equal expected, subject.links
   end
+
+  context "[:details]" do
+    context "[:choose_sign_in]" do
+      should "[:title]" do
+        assert_equal @content[:choose_sign_in][:title],
+          result[:details][:choose_sign_in][:title]
+      end
+    end
+  end
 end

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -83,4 +83,19 @@ class ServiceSignInTest < ActiveSupport::TestCase
   should "[:description]" do
     assert_equal @parent.overview, result[:description]
   end
+
+  context "[:public_updated_at]" do
+    should "return current timestamp when update_type is 'major'" do
+      Timecop.freeze do
+        assert_equal DateTime.now.rfc3339, result[:public_updated_at]
+      end
+    end
+
+    should "not be present in the payload when update_type is not 'major'" do
+      @content[:update_type] = "minor"
+      Timecop.freeze do
+        refute_includes result, public_updated_at: DateTime.now.rfc3339
+      end
+    end
+  end
 end

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -4,7 +4,19 @@ class ServiceSignInTest < ActiveSupport::TestCase
   include GovukContentSchemaTestHelpers::TestUnit
 
   def subject
-    Formats::ServiceSignInPresenter.new
+    Formats::ServiceSignInPresenter.new(@content)
+  end
+
+  def file_name
+    "example.yaml"
+  end
+
+  def load_content_from_file(file_name)
+    @content ||= YAML.load_file(Rails.root.join("lib", "service_sign_in", file_name)).deep_symbolize_keys
+  end
+
+  def setup
+    load_content_from_file(file_name)
   end
 
   def result
@@ -25,5 +37,9 @@ class ServiceSignInTest < ActiveSupport::TestCase
 
   should "[:document_type]" do
     assert_equal 'service_sign_in', result[:document_type]
+  end
+
+  should "[:locale]" do
+    assert_equal @content[:locale], result[:locale]
   end
 end

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -79,4 +79,8 @@ class ServiceSignInTest < ActiveSupport::TestCase
   should "[:title]" do
     assert_equal @parent.title, result[:title]
   end
+
+  should "[:description]" do
+    assert_equal @parent.overview, result[:description]
+  end
 end

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -58,4 +58,11 @@ class ServiceSignInTest < ActiveSupport::TestCase
   should "[:base_path]" do
     assert_equal base_path, result[:base_path]
   end
+
+  should "[:routes]" do
+    expected = [
+      { path: base_path, type: "prefix" },
+    ]
+    assert_equal expected, result[:routes]
+  end
 end

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -19,6 +19,10 @@ class ServiceSignInTest < ActiveSupport::TestCase
     load_content_from_file(file_name)
   end
 
+  def base_path
+    "/log-in-file-self-assessment-tax-return/sign-in"
+  end
+
   def result
     subject.render_for_publishing_api
   end
@@ -49,5 +53,9 @@ class ServiceSignInTest < ActiveSupport::TestCase
 
   should "[:change_note]" do
     assert_equal @content[:change_note], result[:change_note]
+  end
+
+  should "[:base_path]" do
+    assert_equal base_path, result[:base_path]
   end
 end

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -189,6 +189,17 @@ class ServiceSignInTest < ActiveSupport::TestCase
         assert_equal @content[:create_new_account][:slug],
           result[:details][:create_new_account][:slug]
       end
+
+      should "[:body]" do
+        expected = [
+          {
+            content_type: "text/govspeak",
+            content: @content[:create_new_account][:body],
+          }
+        ]
+
+        assert_equal expected, result[:details][:create_new_account][:body]
+      end
     end
   end
 end

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -184,6 +184,11 @@ class ServiceSignInTest < ActiveSupport::TestCase
         assert_equal @content[:create_new_account][:title],
           result[:details][:create_new_account][:title]
       end
+
+      should "[:slug]" do
+        assert_equal @content[:create_new_account][:slug],
+          result[:details][:create_new_account][:slug]
+      end
     end
   end
 end

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -22,4 +22,8 @@ class ServiceSignInTest < ActiveSupport::TestCase
   should "[:publishing_app]" do
     assert_equal 'publisher', result[:publishing_app]
   end
+
+  should "[:document_type]" do
+    assert_equal 'service_sign_in', result[:document_type]
+  end
 end

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -144,6 +144,39 @@ class ServiceSignInTest < ActiveSupport::TestCase
         ]
         assert_equal expected, result[:details][:choose_sign_in][:description]
       end
+
+      context "[:options]" do
+        should "include standard options with an external url" do
+          option_one = @content[:choose_sign_in][:options][0]
+          option_two = @content[:choose_sign_in][:options][1]
+
+          expected = [
+            {
+              text: option_one[:text],
+              url: option_one[:url],
+              hint_text: option_one[:hint_text],
+            },
+            {
+              text: option_two[:text],
+              url: option_two[:url],
+              hint_text: option_two[:hint_text],
+            },
+          ]
+          assert_includes result[:details][:choose_sign_in][:options], expected[0]
+          assert_includes result[:details][:choose_sign_in][:options], expected[1]
+        end
+
+        should "convert internal slug to url and prepend content item base_path" do
+          option_three = @content[:choose_sign_in][:options][2]
+
+          expected = {
+            text: option_three[:text],
+            url: "#{base_path}/#{option_three[:slug]}",
+          }
+
+          assert_includes result[:details][:choose_sign_in][:options], expected
+        end
+      end
     end
   end
 end

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -134,6 +134,16 @@ class ServiceSignInTest < ActiveSupport::TestCase
         assert_equal @content[:choose_sign_in][:slug],
           result[:details][:choose_sign_in][:slug]
       end
+
+      should "[:description]" do
+        expected = [
+          {
+            content_type: "text/govspeak",
+            content: @content[:choose_sign_in][:description]
+          }
+        ]
+        assert_equal expected, result[:details][:choose_sign_in][:description]
+      end
     end
   end
 end

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class ServiceSignInTest < ActiveSupport::TestCase
+  include GovukContentSchemaTestHelpers::TestUnit
+
+  def subject
+    Formats::ServiceSignInPresenter.new
+  end
+
+  def result
+    subject.render_for_publishing_api
+  end
+
+  should "[:schema_name]" do
+    assert_equal 'service_sign_in', result[:schema_name]
+  end
+end

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -37,6 +37,22 @@ class ServiceSignInTest < ActiveSupport::TestCase
     subject.render_for_publishing_api
   end
 
+  context "#content_id" do
+    should "create a new content id if we are creating a new content item" do
+      SecureRandom.stub :uuid, "random-uuid-string" do
+        publishing_api_has_lookups(base_path => nil)
+        assert_equal "random-uuid-string", subject.content_id
+      end
+    end
+
+    should "use existing content_id if content_item already exists in content-store" do
+      content_id = "random-content-id"
+      publishing_api_has_lookups(base_path => content_id)
+
+      assert_equal content_id, subject.content_id
+    end
+  end
+
   should "[:schema_name]" do
     assert_equal 'service_sign_in', result[:schema_name]
   end

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -114,4 +114,12 @@ class ServiceSignInTest < ActiveSupport::TestCase
       end
     end
   end
+
+  should "#links" do
+    expected = {
+      parent: [@parent.content_id]
+    }
+
+    assert_equal expected, subject.links
+  end
 end

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -53,6 +53,10 @@ class ServiceSignInTest < ActiveSupport::TestCase
     end
   end
 
+  should "be valid against schema" do
+    assert_valid_against_schema(result, 'service_sign_in')
+  end
+
   should "[:schema_name]" do
     assert_equal 'service_sign_in', result[:schema_name]
   end

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -17,10 +17,20 @@ class ServiceSignInTest < ActiveSupport::TestCase
 
   def setup
     load_content_from_file(file_name)
+    @artefact ||= FactoryGirl.create(:artefact, kind: "transaction")
+    @parent ||= FactoryGirl.create(
+      :transaction_edition,
+      panopticon_id: @artefact.id,
+      slug: parent_slug
+    )
+  end
+
+  def parent_slug
+    "log-in-file-self-assessment-tax-return"
   end
 
   def base_path
-    "/log-in-file-self-assessment-tax-return/sign-in"
+    "/#{parent_slug}/sign-in"
   end
 
   def result
@@ -64,5 +74,9 @@ class ServiceSignInTest < ActiveSupport::TestCase
       { path: base_path, type: "prefix" },
     ]
     assert_equal expected, result[:routes]
+  end
+
+  should "[:title]" do
+    assert_equal @parent.title, result[:title]
   end
 end

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -14,4 +14,8 @@ class ServiceSignInTest < ActiveSupport::TestCase
   should "[:schema_name]" do
     assert_equal 'service_sign_in', result[:schema_name]
   end
+
+  should "[:rendering_app]" do
+    assert_equal 'government-frontend', result[:rendering_app]
+  end
 end

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -18,4 +18,8 @@ class ServiceSignInTest < ActiveSupport::TestCase
   should "[:rendering_app]" do
     assert_equal 'government-frontend', result[:rendering_app]
   end
+
+  should "[:publishing_app]" do
+    assert_equal 'publisher', result[:publishing_app]
+  end
 end

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -46,4 +46,8 @@ class ServiceSignInTest < ActiveSupport::TestCase
   should "[:update_type]" do
     assert_equal @content[:update_type], result[:update_type]
   end
+
+  should "[:change_note]" do
+    assert_equal @content[:change_note], result[:change_note]
+  end
 end


### PR DESCRIPTION
For [Trello](https://trello.com/c/obBGmd3o/244-create-a-presenter-for-servicesignin-pages-in-publisher-3)
Paired with @leenagupte 

Due to time restrictions in Q3, we are not creating a UI for content designers to create "Service Sign In" pages themselves so we decided to import content item data from a YAML file (see https://github.com/alphagov/publisher/pull/664).  For these reasons we also decided not to create a "ServiceSignIn" model to persist the YAML data to a database and instead decided to follow the Specialist Publisher model of sending the data directly to the Publishing API.

We now create a presenter that reads the content of a given YAML file and constructs a payload that can be sent to the Publishing API and is valid against the `service_sign_in` content schema.
