### PR TITLE
Add rake task to publish Service Sign In pages

### DIFF
--- a/app/services/service_sign_in_publish_service.rb
+++ b/app/services/service_sign_in_publish_service.rb
@@ -1,0 +1,8 @@
+class ServiceSignInPublishService
+  def self.call(content)
+    content_id = content.content_id
+    Services.publishing_api.put_content(content_id, content.render_for_publishing_api)
+    Services.publishing_api.patch_links(content_id, links: content.links)
+    Services.publishing_api.publish(content_id)
+  end
+end

--- a/lib/tasks/service_sign_in.rake
+++ b/lib/tasks/service_sign_in.rake
@@ -1,0 +1,23 @@
+require 'yaml'
+
+namespace :service_sign_in do
+  desc "publish service_sign_in format"
+  task :publish, [:yaml_file] => :environment do |_, args|
+    USAGE_MESSAGE = "> usage: rake service_sign_in:publish[example.yaml]\n".freeze +
+      "> service_sign_in YAML files live here: lib/service_sign_in"
+    VALID_FILE_MESSAGE = "> You have not provided a valid file\n".freeze
+
+    abort USAGE_MESSAGE unless args[:yaml_file]
+
+    begin
+      file = YAML.load_file("lib/service_sign_in/#{args[:yaml_file]}")
+    rescue SystemCallError
+      abort VALID_FILE_MESSAGE + USAGE_MESSAGE
+    end
+
+    content = Formats::ServiceSignInPresenter.new(file)
+    ServiceSignInPublishService.call(content)
+
+    puts "> #{args[:yaml_file]} has been published"
+  end
+end

--- a/test/unit/services/service_sign_in_publish_service_test.rb
+++ b/test/unit/services/service_sign_in_publish_service_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class ServiceSignInPublishServiceTest < ActiveSupport::TestCase
+  setup do
+    Services.publishing_api.stubs(:put_content)
+    Services.publishing_api.stubs(:patch_links)
+    Services.publishing_api.stubs(:publish)
+  end
+
+  should "publish edition to PublishingAPI" do
+    Services.publishing_api.expects(:put_content).with(content_id, payload)
+    Services.publishing_api.expects(:patch_links).with(content_id, links: links)
+    Services.publishing_api.expects(:publish).with(content_id)
+
+    ServiceSignInPublishService.call(presenter)
+  end
+
+  def presenter
+    stub(
+      render_for_publishing_api: payload,
+      content_id: content_id,
+      links: links,
+    )
+  end
+
+  def content_id
+    'a-content-id'
+  end
+
+  def links
+    { parent: ["6a2bf66e-2313-4204-afd5-9940de5e1d66"] }
+  end
+
+  def payload
+    @_payload ||= stub
+  end
+end


### PR DESCRIPTION
For [Trello](https://trello.com/c/yuhxNVMY/254-create-a-rake-task-to-publish-servicesignin-pages)

Currently content designers aren't able to create "Service Sign In" content in
the Publisher UI. This adds a rake task which will take a YAML file containing
content for a "Service Sign In" page and publish to the Publishing API using
`ServiceSignInPublishService`.