### PR TITLE
Add conditionals to allow running publisher in production on E2E tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,7 @@ ADD Gemfile* $APP_HOME/
 RUN bundle install
 ADD . $APP_HOME
 
+ARG COMPILE_ASSETS=false
+RUN if [ "$COMPILE_ASSETS" = "true" ] ; then bundle exec rails assets:precompile ; fi
+
 CMD bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p $PORT -b '0.0.0.0'"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -101,3 +101,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   # config.active_record.dump_schema_after_migration = false
 end
+
+if ENV['DISABLE_EMAIL']
+  ActionMailer::Base.perform_deliveries = false
+end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,5 +2,5 @@
 
 Rails.application.config.session_store :cookie_store,
   key: '_publisher_session',
-  secure: Rails.env.production?,
+  secure: Rails.env.production? && !ENV['DISABLE_SECURE_COOKIES'],
   http_only: true


### PR DESCRIPTION
Hey :wave:,

The publishing-e2e-tests are being built in production mode now, and as part of that initial work we need to disable secure cookie due to not using SSL and sending emails due to no mail server.

The Dockerfile ARG allows us to only compile the assets when we require allowing for easy switching back to development mode and not slowing down any existing usage of this Docker image.
