### PR TITLE
Upgrade gds-sso to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
       plek (>= 1.9.0)
       rack-cache
       rest-client (~> 2.0)
-    gds-sso (13.2.0)
+    gds-sso (13.4.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
@@ -491,4 +491,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.14.6
+   1.16.0


### PR DESCRIPTION
This is needed by the E2E tests to run signon in mock mode while the applications run in production.