### PR TITLE
Handle optional create_new_account in Service Sign In Presenter

### DIFF
--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -72,10 +72,11 @@ module Formats
     end
 
     def details
-      {
-        choose_sign_in: choose_sign_in,
-        create_new_account: create_new_account,
-      }
+      details = { choose_sign_in: choose_sign_in }
+      if content[:create_new_account].present?
+        details[:create_new_account] = create_new_account
+      end
+      details
     end
 
     def choose_sign_in

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -184,25 +184,34 @@ class ServiceSignInTest < ActiveSupport::TestCase
     end
 
     context "[:create_new_account]" do
-      should "[:title]" do
-        assert_equal @content[:create_new_account][:title],
+      context "when create_new_account is not present in the file" do
+        should "not be present in the payload" do
+          @content.delete(:create_new_account)
+          refute result.has_key?(:create_new_account)
+        end
+      end
+
+      context "when create_new_account is present in the file" do
+        should "[:title]" do
+          assert_equal @content[:create_new_account][:title],
           result[:details][:create_new_account][:title]
-      end
+        end
 
-      should "[:slug]" do
-        assert_equal @content[:create_new_account][:slug],
+        should "[:slug]" do
+          assert_equal @content[:create_new_account][:slug],
           result[:details][:create_new_account][:slug]
-      end
+        end
 
-      should "[:body]" do
-        expected = [
-          {
-            content_type: "text/govspeak",
-            content: @content[:create_new_account][:body],
-          }
-        ]
+        should "[:body]" do
+          expected = [
+            {
+              content_type: "text/govspeak",
+              content: @content[:create_new_account][:body],
+            }
+          ]
 
-        assert_equal expected, result[:details][:create_new_account][:body]
+          assert_equal expected, result[:details][:create_new_account][:body]
+        end
       end
     end
   end


### PR DESCRIPTION
For [Trello](https://trello.com/c/ydt46bDm/276-make-the-create-new-account-page-optional-in-the-schema)

`create_new_account` is now an optional field for the `service_sign_in` schema (see [commit](https://github.com/alphagov/govuk-content-schemas/pull/689/commits/24019d2e980ae0d003103e0d4b46d0704d71069d)),
so we update the `ServiceSignInPresenter` to handle this.