### PR TITLE
Add UI for resending fact check emails

### DIFF
--- a/app/helpers/edition_activity_buttons_helper.rb
+++ b/app/helpers/edition_activity_buttons_helper.rb
@@ -23,6 +23,10 @@ module EditionActivityButtonsHelper
     }.join("\n").html_safe
   end
 
+  def resend_fact_check_buttons(edition)
+    build_review_button(edition, 'resend_fact_check', 'Resend fact check email')
+  end
+
   def progress_buttons(edition, options = {})
     [
       ["Fact check", "send_fact_check"],

--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -24,6 +24,7 @@ class Action
     IMPORTANT_NOTE       = "important_note".freeze,
     IMPORTANT_NOTE_RESOLVED = "important_note_resolved".freeze,
     ASSIGN = "assign".freeze,
+    RESEND_FACT_CHECK = "resend_fact_check".freeze
   ].freeze
 
   embedded_in :edition

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -75,6 +75,7 @@ class Edition
 
   ACTIONS = {
     send_fact_check: "Send to Fact check",
+    resend_fact_check: "Resend fact check email",
     request_review: "Send to 2nd pair of eyes",
     schedule_for_publishing: "Schedule for publishing",
     publish: "Send to publish",

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -105,6 +105,16 @@ module Workflow
     end
   end
 
+  def can_resend_fact_check?
+    fact_check? && latest_status_action&.is_fact_check_request?
+  end
+
+  def resend_fact_check
+    # no-op because the fact check is resent by the action processor
+    # as that's where all emails are handled
+    true
+  end
+
   def fact_checked?
     self.actions.where(request_type: Action::APPROVE_FACT_CHECK).count.positive?
   end

--- a/app/views/noisy_workflow/_resend_fact_check.text.erb
+++ b/app/views/noisy_workflow/_resend_fact_check.text.erb
@@ -1,0 +1,1 @@
+Fact check email resent for "<%= @action.edition.title %>" (<%= @action.edition.format %>) by <%= @action.requester.name %> at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>

--- a/app/views/shared/_edition_activity_fields.html.erb
+++ b/app/views/shared/_edition_activity_fields.html.erb
@@ -18,6 +18,15 @@
         <textarea id="edition_activity_send_fact_check_attributes_customised_message"
                   name="edition[activity_send_fact_check_attributes][customised_message]"
                   class="form-control" cols="60" rows="14"><%= render :template => 'noisy_workflow/request_fact_check', formats: [:text] %></textarea>
+      <% elsif activity == :resend_fact_check %>
+        <% latest_status_action = form_builder.object.latest_status_action %>
+        <% if latest_status_action&.is_fact_check_request? %>
+          <%= activity_fields.label :email_addresses %>
+          <p class="form-control-static"><%= latest_status_action.email_addresses %></p>
+
+          <%= activity_fields.label :customised_message %>
+          <div class="form-control-static"><%= format_and_auto_link_plain_text(latest_status_action.customised_message) %></div>
+        <% end %>
       <% else %>
         <%= activity_fields.input :comment, :as => :text, :input_html => { :cols => 60, :rows => 6 } %>
       <% end %>

--- a/app/views/shared/_fact_check.html.erb
+++ b/app/views/shared/_fact_check.html.erb
@@ -1,6 +1,7 @@
 <div class="alert alert-info">
   <% if @resource.latest_status_action %>
     <p><%= @resource.latest_status_action.requester.name %> requested this edition be fact checked. We&rsquo;re awaiting a response.</p>
+    <%= resend_fact_check_buttons(@resource) %>
   <% else %>
     <p>Someone requested this edition be fact checked. We&rsquo;re awaiting a response.</p>
   <% end %>

--- a/lib/govuk_content_models/action_processors.rb
+++ b/lib/govuk_content_models/action_processors.rb
@@ -8,6 +8,7 @@ module GovukContentModels
       request_review: 'RequestReviewProcessor',
       approve_review: 'ApproveReviewProcessor',
       send_fact_check: 'SendFactCheckProcessor',
+      resend_fact_check: 'ResendFactCheckProcessor',
       receive_fact_check: 'ReceiveFactCheckProcessor',
       approve_fact_check: 'ApproveFactCheckProcessor',
       skip_fact_check: 'SkipFactCheckProcessor',

--- a/lib/govuk_content_models/action_processors/base_processor.rb
+++ b/lib/govuk_content_models/action_processors/base_processor.rb
@@ -60,6 +60,7 @@ module GovukContentModels
       def make_record_action_noises(new_action, action_name)
         NoisyWorkflow.make_noise(new_action).deliver_now
         NoisyWorkflow.request_fact_check(new_action).deliver_now if action_name.to_s == "send_fact_check"
+        NoisyWorkflow.resend_fact_check(new_action).deliver_now if action_name.to_s == "resend_fact_check"
       end
     end
   end

--- a/lib/govuk_content_models/action_processors/resend_fact_check_processor.rb
+++ b/lib/govuk_content_models/action_processors/resend_fact_check_processor.rb
@@ -1,0 +1,10 @@
+module GovukContentModels
+  module ActionProcessors
+    class ResendFactCheckProcessor < BaseProcessor
+      def process
+        return false unless edition.latest_status_action.is_fact_check_request?
+        edition.resend_fact_check
+      end
+    end
+  end
+end

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -85,7 +85,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     assert page.has_content? guide.title
   end
 
-  test "a guide in the fact check state can be requested to make more amendments" do
+  test "a guide in the fact-check state can be requested to make more amendments" do
     guide.update_attribute(:state, 'fact_check')
 
     visit_edition guide
@@ -193,7 +193,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     assert page.has_content? guide.title
   end
 
-  test "can skip fact check" do
+  test "can skip fact-check" do
     guide.update_attribute(:state, 'fact_check')
 
     visit_edition guide
@@ -213,7 +213,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     assert page.has_content? "Needs more work"
   end
 
-  test "can progress from fact check" do
+  test "can progress from fact-check" do
     guide.update_attribute(:state, 'fact_check_received')
 
     visit_edition guide
@@ -224,7 +224,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     assert page.has_content? guide.title
   end
 
-  test "can go back to fact check from fact check received" do
+  test "can go back to fact-check from fact-check received" do
     guide.update_attribute(:state, 'fact_check_received')
 
     visit_edition guide

--- a/test/support/action_processor_helpers.rb
+++ b/test/support/action_processor_helpers.rb
@@ -11,6 +11,10 @@ module ActionProcessorHelpers
     user.progress(edition, request_type: :send_fact_check, comment: comment, email_addresses: "test@test.com")
   end
 
+  def resend_fact_check(user, edition)
+    user.progress(edition, request_type: :resend_fact_check)
+  end
+
   def receive_fact_check(user, edition, comment = "Please verify these facts.")
     user.progress(edition, request_type: :receive_fact_check, comment: comment)
   end


### PR DESCRIPTION
For: https://trello.com/c/nmcSC29S/300-make-it-easier-to-re-send-a-fact-check

We add an action that presents the previous fact check details and allows the user to re-send it.  We don't send any details though, we just look it up in the db once we're asked to perform this action and re-use that previous fact check action to send it's email again.

## Screenshots

The "Resend fact check email" button only appears when the edition is in the "fact check" state (e.g. you've sent a fact check email, but not received a response).

![publisher dev gov uk_editions_59c1266fe5274a533fcd8570 laptop with mdpi screen](https://user-images.githubusercontent.com/608/33951723-a9bf8516-e027-11e7-825b-f8f36989e850.png)

Pressing the button represents the fact check email details to you so you can check what you're about to send.  

![publisher dev gov uk_editions_59c1266fe5274a533fcd8570 laptop with mdpi screen 1](https://user-images.githubusercontent.com/608/33951722-a9a896f8-e027-11e7-9c95-f8436a1fcba7.png)

If the details are very long you have to scroll the modal to get to the button to actually send the email.

![publisher dev gov uk_editions_59c1266fe5274a533fcd8570 laptop with mdpi screen 2](https://user-images.githubusercontent.com/608/33951721-a990a14c-e027-11e7-9ee4-cf7e884a07e7.png)

The fact check being resent is recorded in the history and notes.

![publisher dev gov uk_editions_59c1266fe5274a533fcd8570 laptop with mdpi screen 3](https://user-images.githubusercontent.com/608/33951720-a971f9a4-e027-11e7-9776-da7fdfaaac05.png)
