### PR TITLE
Add Service Sign In YAML validator

### DIFF
--- a/lib/service_sign_in_yaml_validator.rb
+++ b/lib/service_sign_in_yaml_validator.rb
@@ -1,15 +1,27 @@
 class ServiceSignInYamlValidator
+  attr_reader :yaml_file
+
   def initialize(file_name)
     @file_name = file_name
+    @errors = []
   end
 
   def validate
-    load_yaml_file
+    valid? ? @yaml_file : @errors
   end
 
 private
 
+  def valid?
+    load_yaml_file
+  end
+
   def load_yaml_file
-    YAML.load_file(@file_name)
+    begin
+      @yaml_file = YAML.load_file(@file_name)
+    rescue SystemCallError
+      @errors << "Invalid file path: #{@file_name}"
+      return false
+    end
   end
 end

--- a/lib/service_sign_in_yaml_validator.rb
+++ b/lib/service_sign_in_yaml_validator.rb
@@ -1,6 +1,9 @@
 class ServiceSignInYamlValidator
   attr_reader :yaml_file
 
+  REQUIRED_TOP_LEVEL_FIELDS =
+    %w(change_note choose_sign_in locale start_page_slug update_type).freeze
+
   def initialize(file_name)
     @file_name = file_name
     @errors = []
@@ -14,6 +17,8 @@ private
 
   def valid?
     load_yaml_file
+    return unless @yaml_file.present?
+    check_for_top_level_required_fields
     @errors.empty?
   end
 
@@ -25,6 +30,12 @@ private
       end
     rescue SystemCallError
       @errors << "Invalid file path: #{@file_name}"
+    end
+  end
+
+  def check_for_top_level_required_fields
+    REQUIRED_TOP_LEVEL_FIELDS.each do |field|
+      @errors << "Missing field: #{field}" unless @yaml_file.has_key?(field)
     end
   end
 end

--- a/lib/service_sign_in_yaml_validator.rb
+++ b/lib/service_sign_in_yaml_validator.rb
@@ -3,6 +3,7 @@ class ServiceSignInYamlValidator
 
   REQUIRED_TOP_LEVEL_FIELDS =
     %w(change_note choose_sign_in locale start_page_slug update_type).freeze
+  REQUIRED_CHOOSE_SIGN_IN_FIELDS = %w(options slug title).freeze
 
   def initialize(file_name)
     @file_name = file_name
@@ -19,6 +20,7 @@ private
     load_yaml_file
     return unless @yaml_file.present?
     check_for_top_level_required_fields
+    check_for_choose_sign_in_required_fields if choose_sign_in.present?
     @errors.empty?
   end
 
@@ -37,5 +39,23 @@ private
     REQUIRED_TOP_LEVEL_FIELDS.each do |field|
       @errors << "Missing field: #{field}" unless @yaml_file.has_key?(field)
     end
+  end
+
+  def check_for_choose_sign_in_required_fields
+    error_message = "Missing choose_sign_in field: "
+    unless choose_sign_in.is_a?(Hash)
+      @errors << error_message + REQUIRED_CHOOSE_SIGN_IN_FIELDS.join(", ")
+      return
+    end
+
+    REQUIRED_CHOOSE_SIGN_IN_FIELDS.each do |field|
+      unless choose_sign_in.has_key?(field)
+        @errors << error_message + field
+      end
+    end
+  end
+
+  def choose_sign_in
+    @yaml_file["choose_sign_in"]
   end
 end

--- a/lib/service_sign_in_yaml_validator.rb
+++ b/lib/service_sign_in_yaml_validator.rb
@@ -48,9 +48,30 @@ private
       return
     end
 
+    check_choose_sign_in_top_level_fields(error_message)
+    return unless choose_sign_in["options"].present?
+    check_choose_sign_in_options_fields(error_message)
+  end
+
+  def check_choose_sign_in_top_level_fields(error_message)
     REQUIRED_CHOOSE_SIGN_IN_FIELDS.each do |field|
       unless choose_sign_in.has_key?(field)
         @errors << error_message + field
+      end
+    end
+  end
+
+  def check_choose_sign_in_options_fields(error_message)
+    error_message += "option > "
+    unless choose_sign_in["options"].is_a?(Array)
+      @errors << error_message + "text, slug or url"
+      return
+    end
+
+    choose_sign_in["options"].each do |option|
+      @errors << error_message + "text" unless option.has_key?("text")
+      unless option.has_key?("slug") || option.has_key?("url")
+        @errors << error_message + "slug or url"
       end
     end
   end

--- a/lib/service_sign_in_yaml_validator.rb
+++ b/lib/service_sign_in_yaml_validator.rb
@@ -14,14 +14,17 @@ private
 
   def valid?
     load_yaml_file
+    @errors.empty?
   end
 
   def load_yaml_file
     begin
       @yaml_file = YAML.load_file(@file_name)
+      unless @yaml_file.present?
+        @errors << "Invalid file type"
+      end
     rescue SystemCallError
       @errors << "Invalid file path: #{@file_name}"
-      return false
     end
   end
 end

--- a/lib/service_sign_in_yaml_validator.rb
+++ b/lib/service_sign_in_yaml_validator.rb
@@ -21,6 +21,7 @@ private
     load_yaml_file
     return unless @yaml_file.present?
     check_for_top_level_required_fields
+    check_for_valid_start_page_slug
     check_for_choose_sign_in_required_fields if choose_sign_in.present?
     check_for_create_new_account_required_fields if create_new_account.present?
     @errors.empty?
@@ -40,6 +41,14 @@ private
   def check_for_top_level_required_fields
     REQUIRED_TOP_LEVEL_FIELDS.each do |field|
       @errors << "Missing field: #{field}" unless @yaml_file.has_key?(field)
+    end
+  end
+
+  def check_for_valid_start_page_slug
+    slug = @yaml_file["start_page_slug"]
+    content = Services.publishing_api.lookup_content_id(base_path: "/#{slug}")
+    unless content.present?
+      @errors << "start_page_slug '#{slug}' cannot be found in Publishing API"
     end
   end
 

--- a/lib/service_sign_in_yaml_validator.rb
+++ b/lib/service_sign_in_yaml_validator.rb
@@ -1,0 +1,15 @@
+class ServiceSignInYamlValidator
+  def initialize(file_name)
+    @file_name = file_name
+  end
+
+  def validate
+    load_yaml_file
+  end
+
+private
+
+  def load_yaml_file
+    YAML.load_file(@file_name)
+  end
+end

--- a/lib/service_sign_in_yaml_validator.rb
+++ b/lib/service_sign_in_yaml_validator.rb
@@ -4,6 +4,7 @@ class ServiceSignInYamlValidator
   REQUIRED_TOP_LEVEL_FIELDS =
     %w(change_note choose_sign_in locale start_page_slug update_type).freeze
   REQUIRED_CHOOSE_SIGN_IN_FIELDS = %w(options slug title).freeze
+  REQUIRED_CREATE_NEW_ACCOUNT_FIELDS = %w(body slug title).freeze
 
   def initialize(file_name)
     @file_name = file_name
@@ -21,6 +22,7 @@ private
     return unless @yaml_file.present?
     check_for_top_level_required_fields
     check_for_choose_sign_in_required_fields if choose_sign_in.present?
+    check_for_create_new_account_required_fields if create_new_account.present?
     @errors.empty?
   end
 
@@ -76,7 +78,19 @@ private
     end
   end
 
+  def check_for_create_new_account_required_fields
+    REQUIRED_CREATE_NEW_ACCOUNT_FIELDS.each do |field|
+      unless create_new_account.has_key?(field)
+        @errors << "Missing create_new_account field: #{field}"
+      end
+    end
+  end
+
   def choose_sign_in
     @yaml_file["choose_sign_in"]
+  end
+
+  def create_new_account
+    @yaml_file["create_new_account"]
   end
 end

--- a/test/fixtures/service_sign_in/invalid_start_page_slug.yaml
+++ b/test/fixtures/service_sign_in/invalid_start_page_slug.yaml
@@ -1,0 +1,1 @@
+start_page_slug: invalid-slug

--- a/test/fixtures/service_sign_in/missing_choose_sign_in_fields.yaml
+++ b/test/fixtures/service_sign_in/missing_choose_sign_in_fields.yaml
@@ -1,0 +1,2 @@
+choose_sign_in:
+  invalid_field: invalid

--- a/test/fixtures/service_sign_in/missing_choose_sign_in_option_fields.yaml
+++ b/test/fixtures/service_sign_in/missing_choose_sign_in_option_fields.yaml
@@ -1,0 +1,3 @@
+choose_sign_in:
+  options:
+    - invalid_field: invalid

--- a/test/fixtures/service_sign_in/missing_create_new_account_fields.yaml
+++ b/test/fixtures/service_sign_in/missing_create_new_account_fields.yaml
@@ -1,0 +1,2 @@
+create_new_account:
+  invalid_field: invalid

--- a/test/fixtures/service_sign_in/missing_top_level_fields.yaml
+++ b/test/fixtures/service_sign_in/missing_top_level_fields.yaml
@@ -1,0 +1,1 @@
+a_field: a value

--- a/test/fixtures/service_sign_in/no_choose_sign_in_fields.yaml
+++ b/test/fixtures/service_sign_in/no_choose_sign_in_fields.yaml
@@ -1,0 +1,1 @@
+choose_sign_in: no fields here

--- a/test/fixtures/service_sign_in/no_choose_sign_in_option_fields.yaml
+++ b/test/fixtures/service_sign_in/no_choose_sign_in_option_fields.yaml
@@ -1,0 +1,2 @@
+choose_sign_in:
+  options: no fields here

--- a/test/unit/lib/service_sign_in_yaml_validator_test.rb
+++ b/test/unit/lib/service_sign_in_yaml_validator_test.rb
@@ -21,6 +21,14 @@ class ServiceSignInYamlValidatorTest < ActiveSupport::TestCase
     @file ||= YAML.load_file(valid_yaml_file)
   end
 
+  def required_top_level_fields
+    ServiceSignInYamlValidator::REQUIRED_TOP_LEVEL_FIELDS
+  end
+
+  def missing_top_level_fields
+    "test/fixtures/service_sign_in/missing_top_level_fields.yaml"
+  end
+
   context "#validate" do
     context "when a YAML file is valid" do
       should "return the YAML file as a hash" do
@@ -40,6 +48,15 @@ class ServiceSignInYamlValidatorTest < ActiveSupport::TestCase
       should "log an 'Invalid file type' error" do
         validator = service_sign_in_yaml_validator(invalid_file_type)
         assert_includes validator.validate, "Invalid file type"
+      end
+    end
+
+    context "when a required top level field is missing in the YAML file" do
+      should "log a 'Missing field: field_name' error" do
+        validator = service_sign_in_yaml_validator(missing_top_level_fields)
+        required_top_level_fields.each do |field|
+          assert_includes validator.validate, "Missing field: #{field}"
+        end
       end
     end
   end

--- a/test/unit/lib/service_sign_in_yaml_validator_test.rb
+++ b/test/unit/lib/service_sign_in_yaml_validator_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class ServiceSignInYamlValidatorTest < ActiveSupport::TestCase
+  def service_sign_in_yaml_validator(file)
+    ServiceSignInYamlValidator.new(file)
+  end
+
+  def valid_yaml_file
+    "lib/service_sign_in/example.yaml"
+  end
+
+  def content
+    @file ||= YAML.load_file(valid_yaml_file)
+  end
+
+  context "#validate" do
+    context "when a YAML file is valid" do
+      should "return the YAML file as a hash" do
+        validator = service_sign_in_yaml_validator(valid_yaml_file)
+        assert_equal content, validator.validate
+      end
+    end
+  end
+end

--- a/test/unit/lib/service_sign_in_yaml_validator_test.rb
+++ b/test/unit/lib/service_sign_in_yaml_validator_test.rb
@@ -29,6 +29,10 @@ class ServiceSignInYamlValidatorTest < ActiveSupport::TestCase
     ServiceSignInYamlValidator::REQUIRED_CHOOSE_SIGN_IN_FIELDS
   end
 
+  def required_create_new_account_fields
+    ServiceSignInYamlValidator::REQUIRED_CREATE_NEW_ACCOUNT_FIELDS
+  end
+
   def missing_top_level_fields
     "test/fixtures/service_sign_in/missing_top_level_fields.yaml"
   end
@@ -47,6 +51,10 @@ class ServiceSignInYamlValidatorTest < ActiveSupport::TestCase
 
   def no_choose_sign_in_option_fields
     "test/fixtures/service_sign_in/no_choose_sign_in_option_fields.yaml"
+  end
+
+  def missing_create_new_account_fields
+    "test/fixtures/service_sign_in/missing_create_new_account_fields.yaml"
   end
 
   context "#validate" do
@@ -110,6 +118,15 @@ class ServiceSignInYamlValidatorTest < ActiveSupport::TestCase
         validator = service_sign_in_yaml_validator(no_choose_sign_in_option_fields)
         assert_includes validator.validate,
           "Missing choose_sign_in field: option > text, slug or url"
+      end
+    end
+
+    context "when create_new_account is present but required fields are missing in the YAML file" do
+      should "log a 'Missing create_new_account: field_name' error" do
+        validator = service_sign_in_yaml_validator(missing_create_new_account_fields)
+        required_create_new_account_fields.each do |field|
+          assert_includes validator.validate, "Missing create_new_account field: #{field}"
+        end
       end
     end
   end

--- a/test/unit/lib/service_sign_in_yaml_validator_test.rb
+++ b/test/unit/lib/service_sign_in_yaml_validator_test.rb
@@ -41,6 +41,14 @@ class ServiceSignInYamlValidatorTest < ActiveSupport::TestCase
     "test/fixtures/service_sign_in/no_choose_sign_in_fields.yaml"
   end
 
+  def missing_choose_sign_in_option_fields
+    "test/fixtures/service_sign_in/missing_choose_sign_in_option_fields.yaml"
+  end
+
+  def no_choose_sign_in_option_fields
+    "test/fixtures/service_sign_in/no_choose_sign_in_option_fields.yaml"
+  end
+
   context "#validate" do
     context "when a YAML file is valid" do
       should "return the YAML file as a hash" do
@@ -86,6 +94,22 @@ class ServiceSignInYamlValidatorTest < ActiveSupport::TestCase
         validator = service_sign_in_yaml_validator(no_choose_sign_in_fields)
         assert_includes validator.validate,
           "Missing choose_sign_in field: #{required_choose_sign_in_fields.join(', ')}"
+      end
+    end
+
+    context "when a required choose_sign_in option field is missing in the YAML file" do
+      should "log a 'Missing choose sign_in field: option > field_name' error" do
+        validator = service_sign_in_yaml_validator(missing_choose_sign_in_option_fields)
+        assert_includes validator.validate, "Missing choose_sign_in field: option > text"
+        assert_includes validator.validate, "Missing choose_sign_in field: option > slug or url"
+      end
+    end
+
+    context "when the choose_sign_in option field is not an array of options" do
+      should "log a 'Missing choose sign_in field: option > text, slug or url' error" do
+        validator = service_sign_in_yaml_validator(no_choose_sign_in_option_fields)
+        assert_includes validator.validate,
+          "Missing choose_sign_in field: option > text, slug or url"
       end
     end
   end

--- a/test/unit/lib/service_sign_in_yaml_validator_test.rb
+++ b/test/unit/lib/service_sign_in_yaml_validator_test.rb
@@ -25,8 +25,20 @@ class ServiceSignInYamlValidatorTest < ActiveSupport::TestCase
     ServiceSignInYamlValidator::REQUIRED_TOP_LEVEL_FIELDS
   end
 
+  def required_choose_sign_in_fields
+    ServiceSignInYamlValidator::REQUIRED_CHOOSE_SIGN_IN_FIELDS
+  end
+
   def missing_top_level_fields
     "test/fixtures/service_sign_in/missing_top_level_fields.yaml"
+  end
+
+  def missing_choose_sign_in_fields
+    "test/fixtures/service_sign_in/missing_choose_sign_in_fields.yaml"
+  end
+
+  def no_choose_sign_in_fields
+    "test/fixtures/service_sign_in/no_choose_sign_in_fields.yaml"
   end
 
   context "#validate" do
@@ -57,6 +69,23 @@ class ServiceSignInYamlValidatorTest < ActiveSupport::TestCase
         required_top_level_fields.each do |field|
           assert_includes validator.validate, "Missing field: #{field}"
         end
+      end
+    end
+
+    context "when a required choose_sign_in field is missing in the YAML file" do
+      should "log a 'Missing choose_sign_in field: field_name' error" do
+        validator = service_sign_in_yaml_validator(missing_choose_sign_in_fields)
+        required_choose_sign_in_fields.each do |field|
+          assert_includes validator.validate, "Missing choose_sign_in field: #{field}"
+        end
+      end
+    end
+
+    context "when choose_sign_in is not a hash of fields" do
+      should "log a 'Missing choose_sign_in field: title, slug, options' error" do
+        validator = service_sign_in_yaml_validator(no_choose_sign_in_fields)
+        assert_includes validator.validate,
+          "Missing choose_sign_in field: #{required_choose_sign_in_fields.join(', ')}"
       end
     end
   end

--- a/test/unit/lib/service_sign_in_yaml_validator_test.rb
+++ b/test/unit/lib/service_sign_in_yaml_validator_test.rb
@@ -9,6 +9,10 @@ class ServiceSignInYamlValidatorTest < ActiveSupport::TestCase
     "lib/service_sign_in/example.yaml"
   end
 
+  def invalid_file_path
+    "invalid/file/path.yaml"
+  end
+
   def content
     @file ||= YAML.load_file(valid_yaml_file)
   end
@@ -18,6 +22,13 @@ class ServiceSignInYamlValidatorTest < ActiveSupport::TestCase
       should "return the YAML file as a hash" do
         validator = service_sign_in_yaml_validator(valid_yaml_file)
         assert_equal content, validator.validate
+      end
+    end
+
+    context "when an invalid file path is provided" do
+      should "log an 'Invalid file path' error" do
+        validator = service_sign_in_yaml_validator(invalid_file_path)
+        assert_includes validator.validate, "Invalid file path: #{invalid_file_path}"
       end
     end
   end

--- a/test/unit/lib/service_sign_in_yaml_validator_test.rb
+++ b/test/unit/lib/service_sign_in_yaml_validator_test.rb
@@ -13,6 +13,10 @@ class ServiceSignInYamlValidatorTest < ActiveSupport::TestCase
     "invalid/file/path.yaml"
   end
 
+  def invalid_file_type
+    "test/fixtures/service_sign_in/invalid.txt"
+  end
+
   def content
     @file ||= YAML.load_file(valid_yaml_file)
   end
@@ -29,6 +33,13 @@ class ServiceSignInYamlValidatorTest < ActiveSupport::TestCase
       should "log an 'Invalid file path' error" do
         validator = service_sign_in_yaml_validator(invalid_file_path)
         assert_includes validator.validate, "Invalid file path: #{invalid_file_path}"
+      end
+    end
+
+    context "when a file is provided that is not YAML" do
+      should "log an 'Invalid file type' error" do
+        validator = service_sign_in_yaml_validator(invalid_file_type)
+        assert_includes validator.validate, "Invalid file type"
       end
     end
   end


### PR DESCRIPTION
For [Trello](https://trello.com/c/UHPwDcmd/273-validate-the-contents-of-the-yaml-file)

In https://github.com/alphagov/publisher/pull/668 we created a rake task that takes the contents of a YAML file and prepares a payload in order to publish "Service Sign In" content to the Publishing API.  In this PR we create a validator to ensure that the required content is present in the YAML file in order to perform this task successfully.  After merging this PR we will update the rake task to use this validator.