### PR TITLE
Pass "locale" to service_sign_in publish call

### DIFF
--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -35,11 +35,11 @@ module Formats
       }
     end
 
-  private
-
     def locale
       content[:locale]
     end
+
+  private
 
     def update_type
       content[:update_type]

--- a/app/services/service_sign_in_publish_service.rb
+++ b/app/services/service_sign_in_publish_service.rb
@@ -1,8 +1,9 @@
 class ServiceSignInPublishService
   def self.call(content)
     content_id = content.content_id
+    update_type = nil
     Services.publishing_api.put_content(content_id, content.render_for_publishing_api)
     Services.publishing_api.patch_links(content_id, links: content.links)
-    Services.publishing_api.publish(content_id)
+    Services.publishing_api.publish(content_id, update_type, locale: content.locale)
   end
 end

--- a/test/unit/services/service_sign_in_publish_service_test.rb
+++ b/test/unit/services/service_sign_in_publish_service_test.rb
@@ -8,9 +8,10 @@ class ServiceSignInPublishServiceTest < ActiveSupport::TestCase
   end
 
   should "publish edition to PublishingAPI" do
+    update_type = nil
     Services.publishing_api.expects(:put_content).with(content_id, payload)
     Services.publishing_api.expects(:patch_links).with(content_id, links: links)
-    Services.publishing_api.expects(:publish).with(content_id)
+    Services.publishing_api.expects(:publish).with(content_id, update_type, locale: locale)
 
     ServiceSignInPublishService.call(presenter)
   end
@@ -20,6 +21,7 @@ class ServiceSignInPublishServiceTest < ActiveSupport::TestCase
       render_for_publishing_api: payload,
       content_id: content_id,
       links: links,
+      locale: locale
     )
   end
 
@@ -29,6 +31,10 @@ class ServiceSignInPublishServiceTest < ActiveSupport::TestCase
 
   def links
     { parent: ["6a2bf66e-2313-4204-afd5-9940de5e1d66"] }
+  end
+
+  def locale
+    "cy"
   end
 
   def payload


### PR DESCRIPTION
Related to PR #668 

Publishing-api assumes that the locale is "en" if you do not
explicitly pass the locale in the publish call. As we are also
publishing Welsh content, we should always pass the locale of the
content item.

We have to pass the update_type too now because of the order that
publishing-api expects to see the params.