### PR TITLE
Add YAML validator to service sign in rake task

### DIFF
--- a/lib/tasks/service_sign_in.rake
+++ b/lib/tasks/service_sign_in.rake
@@ -9,15 +9,23 @@ namespace :service_sign_in do
 
     abort USAGE_MESSAGE unless args[:yaml_file]
 
+    validator = ServiceSignInYamlValidator.new("lib/service_sign_in/#{args[:yaml_file]}")
+
     begin
-      file = YAML.load_file("lib/service_sign_in/#{args[:yaml_file]}")
+      file = validator.validate
+
+      if file.is_a?(Hash)
+        content = Formats::ServiceSignInPresenter.new(file)
+      else
+        puts "Validation errors occurred:"
+        puts file
+        abort
+      end
     rescue SystemCallError
       abort VALID_FILE_MESSAGE + USAGE_MESSAGE
     end
 
-    content = Formats::ServiceSignInPresenter.new(file)
     ServiceSignInPublishService.call(content)
-
     puts "> #{args[:yaml_file]} has been published"
   end
 end

--- a/lib/tasks/service_sign_in.rake
+++ b/lib/tasks/service_sign_in.rake
@@ -28,4 +28,22 @@ namespace :service_sign_in do
     ServiceSignInPublishService.call(content)
     puts "> #{args[:yaml_file]} has been published"
   end
+
+  desc "Validate a service_sign_in YAML file"
+  task :validate, [:yaml_file] => :environment do |_, args|
+    USAGE_MESSAGE = "> usage: rake service_sign_in:validate[example.yaml]\n".freeze +
+      "> service_sign_in YAML files live here: lib/service_sign_in"
+
+    abort USAGE_MESSAGE unless args[:yaml_file]
+
+    validator = ServiceSignInYamlValidator.new("lib/service_sign_in/#{args[:yaml_file]}")
+    file = validator.validate
+
+    if file.is_a?(Hash)
+      puts "This is a valid YAML file"
+    else
+      puts "Validation errors occurred:"
+      puts file
+    end
+  end
 end


### PR DESCRIPTION
For [Trello](https://trello.com/c/axBb1P1R/295-add-service-sign-in-yaml-validator-to-the-rake-task)

Now we have a `ServiceSignInValidator` (see [PR](https://github.com/alphagov/publisher/pull/674)) to check that the contents of a service_sign_in YAML file are valid, we update `service_sign_in:publish` rake task to call it before we prepare a suitable payload to
send to the Publishing API.
This PR also adds a rake task to validate the YAML file independently of the publish task.