### PR TITLE
Remove empty description from YAML file

### DIFF
--- a/lib/service_sign_in/check-update-company-car-tax.en.yaml
+++ b/lib/service_sign_in/check-update-company-car-tax.en.yaml
@@ -3,14 +3,13 @@ locale: en
 choose_sign_in:
   title: Prove your identity to continue
   slug: prove-identity
-  description: 
   options:
     - text: Use Government Gateway
       url: https://www.tax.service.gov.uk/paye/company-car/start-government-gateway
       hint_text: You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.
     - text: Use GOV.UK Verify
       url: https://www.tax.service.gov.uk/paye/company-car/start-verify
-      hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity. 
+      hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
     - text: Create an account
       slug: create-account
 create_new_account:


### PR DESCRIPTION
We remove the empty `description` field from
`check-update-company-car-tax.en.yaml` as the `service_sign_in` schema is
expecting a string if `description` is present.