### PR TITLE
Validate fact check emails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ group :development do
 end
 
 group :development, :test do
-  gem 'govuk-lint', '~> 3.4.0'
+  gem 'govuk-lint', '~> 3.5.0'
   gem 'jasmine', '2.5.2'
   gem 'jasmine-core', '2.5.2'
   gem 'rack', '2.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,7 +144,7 @@ GEM
       sanitize (~> 2.1.0)
     govuk-content-schema-test-helpers (1.6.0)
       json-schema (~> 2.8.0)
-    govuk-lint (3.4.0)
+    govuk-lint (3.5.0)
       rubocop (~> 0.51.0)
       rubocop-rspec (~> 1.19.0)
       scss_lint
@@ -464,7 +464,7 @@ DEPENDENCIES
   gds-sso (~> 13.5)
   govspeak (~> 5.3.0)
   govuk-content-schema-test-helpers (~> 1.6)
-  govuk-lint (~> 3.4.0)
+  govuk-lint (~> 3.5.0)
   govuk_admin_template (= 4.3.0)
   govuk_app_config (~> 0.2.0)
   govuk_sidekiq (~> 2.0.0)

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -83,7 +83,13 @@ class EditionsController < InheritedResources::Base
     # https://github.com/josevalim/inherited_resources/blob/master/lib/inherited_resources/actions.rb#L42
     update! do |success, failure|
       success.html {
-        progress_edition(resource, activity_params) if attempted_activity
+        if attempted_activity
+          if progress_edition(resource, activity_params)
+            flash[:success] = @command.status_message
+          else
+            flash[:danger] = @command.status_message
+          end
+        end
 
         update_assignment resource, assign_to
 

--- a/app/views/shared/_edition_activity_fields.html.erb
+++ b/app/views/shared/_edition_activity_fields.html.erb
@@ -10,7 +10,7 @@
       <%= activity_fields.hidden_field :request_type, value: activity %>
 
       <% if activity == :send_fact_check %>
-        <%= activity_fields.input :email_addresses %>
+        <%= activity_fields.input :email_addresses, hint: 'You can enter multiple email addresses if you comma separate them as follows: <code>fact-checker-one@example.com, fact-checker-two@example.com</code>.'.html_safe %>
 
         <%= activity_fields.label :customised_message do %>
           Customised message<abbr title="required">*</abbr>

--- a/app/views/shared/_unpublish.html.erb
+++ b/app/views/shared/_unpublish.html.erb
@@ -10,17 +10,16 @@
 <div class="well">
   <%= form_tag("/editions/#{@resource.id}/process_unpublish", method: "post") do %>
     <h3 class="remove-top-margin add-bottom-margin">Unpublish</h3>
-      <div class="form-group">
-        <label>Redirect to</label>
-        <span class="normal">
-          For example: <code>https://www.gov.uk/redirect-to-replacement-page</code>
-        </span>
-        <%= text_field_tag 'redirect_url', '', class: "form-control input-md-12" %>
-      </div>
-      <%= button_tag 'Unpublish',
+    <div class="form-group">
+      <label>Redirect to</label>
+      <span class="normal">
+        For example: <code>https://www.gov.uk/redirect-to-replacement-page</code>
+      </span>
+      <%= text_field_tag 'redirect_url', '', class: "form-control input-md-12" %>
+    </div>
+    <%= button_tag 'Unpublish',
       "data-module" => 'confirm',
       "data-message" => "This will remove ‘#{@artefact.name}’ from the website.\n\n Are you sure?",
       :class => "btn btn-danger" %>
-    </div>
   <% end %>
 </div>

--- a/lib/edition_progressor.rb
+++ b/lib/edition_progressor.rb
@@ -1,4 +1,6 @@
 class EditionProgressor
+  EMAIL_REGEX = /\A[\w\d]+[^@]*@[\w\d]+[^@]*\.[\w\d]+[^@]*\z/
+
   attr_accessor :edition, :actor, :activity, :status_message
 
   # existing_edition: The existing edition to be duplicated
@@ -44,12 +46,12 @@ protected
 
   def invalid_email_addresses?(addresses)
     addresses.split(",").any? do |address|
-      !address.include?("@")
+      address.strip !~ EMAIL_REGEX
     end
   end
 
-  def fact_check_error_message(activity)
-    "Couldn't #{activity.to_s.humanize.downcase} for " +
+  def fact_check_error_message(_activity)
+    "Couldn't send to fact check for " +
       "#{description(edition).downcase}. The email addresses " +
       "you entered appear to be invalid."
   end

--- a/test/unit/edition_progressor_test.rb
+++ b/test/unit/edition_progressor_test.rb
@@ -53,6 +53,20 @@ class EditionProgressorTest < ActiveSupport::TestCase
     refute command.progress(activity)
   end
 
+  test "should not progress to fact check if any of the email addresses were invalid" do
+    @guide.update_attribute(:state, :ready)
+
+    activity = {
+      request_type: "send_fact_check",
+      comment: "Blah",
+      email_addresses: "user1@example.com, another-user AT example DOT com",
+      customised_message: "Hello"
+    }
+
+    command = EditionProgressor.new(@guide, @laura)
+    refute command.progress(activity)
+  end
+
   context "publishing" do
     teardown do
       ScheduledPublisher.jobs.clear


### PR DESCRIPTION
For: https://trello.com/c/ZCCftdjb/301-sending-factcheck-requests-from-publisher-to-multiple-emails

Our goal is to make it clearer that you can add multiple emails to fact check if you comma separate them, and to make sure we provide errors to the user if the emails they provide can't be parsed.