### PR TITLE
Fix Service Sign In Presenter bug

### DIFF
--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -80,12 +80,18 @@ module Formats
     end
 
     def choose_sign_in
-      {
+      choose_sign_in = {
         title: content[:choose_sign_in][:title],
         slug: content[:choose_sign_in][:slug],
-        description: govspeak_content(content[:choose_sign_in][:description]),
         options: options,
       }
+
+      description = content[:choose_sign_in][:description]
+      if description.present?
+        choose_sign_in[:description] = govspeak_content(description)
+      end
+
+      choose_sign_in
     end
 
     def options

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -139,14 +139,21 @@ class ServiceSignInTest < ActiveSupport::TestCase
           result[:details][:choose_sign_in][:slug]
       end
 
-      should "[:description]" do
-        expected = [
-          {
-            content_type: "text/govspeak",
-            content: @content[:choose_sign_in][:description]
-          }
-        ]
-        assert_equal expected, result[:details][:choose_sign_in][:description]
+      context "[:description]" do
+        should "be present in the payload when it is present in the YAML file" do
+          expected = [
+            {
+              content_type: "text/govspeak",
+              content: @content[:choose_sign_in][:description]
+            }
+          ]
+          assert_equal expected, result[:details][:choose_sign_in][:description]
+        end
+
+        should "not be present in the payload when it is not present in the YAML file" do
+          @content[:choose_sign_in].delete(:description)
+          refute result[:details][:choose_sign_in].has_key?(:description)
+        end
       end
 
       context "[:options]" do


### PR DESCRIPTION
The `service_sign_in` format considers `choose_sign_in` `description` to be an
optional field.  We found a bug in the Service Sign In Presenter where
`choose_sign_in` `description` is always included in the payload regardless of
whether it is provided in a service_sign_in YAML file, causing the
`service_sign_in` schema validation to fail when `description` is not provided.
This makes the inclusion of `choose_sign_in` `description` in the payload
dependent on its presence in the YAML file.