### PR TITLE
Add docs for how to publish service sign-in pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,12 @@ The diagram can be (re)generated using the [state_machines-graphviz gem](https:/
 
 `bundle exec rake state_machines:draw CLASS=Edition`
 
-This will generate a diagram in the `doc/state_machines` folder. 
+This will generate a diagram in the `doc/state_machines` folder.
+
+### How to publish Service Sign-in pages
+These pages do not have an admin interface and are instead published through rake tasks.
+
+See the [README](lib/service_sign_in/README.md) for more details.
 
 ## Licence
 

--- a/lib/service_sign_in/README.md
+++ b/lib/service_sign_in/README.md
@@ -1,0 +1,27 @@
+# How to publish Service Sign-in pages
+
+If a Content Designer adds a new page via Github, there's a good chance they'll be an external contributor.
+
+See [How to merge a change from an external contributor](https://docs.publishing.service.gov.uk/manual/howto-merge-a-pull-request-from-an-external-contributor.html) in the developer docs
+
+The examples below are from a [release from the Start Pages team](https://github.com/alphagov/publisher/pull/687)
+
+## Releasing the new page
+
+Once the change is merged, you can release these in two steps.
+
+1. [Deploy publisher](https://docs.publishing.service.gov.uk/manual/deploying.html)
+2. Run the Rake task to publish the new page
+
+### Running the Rake task
+
+Go to the [Jenkins Rake task job (Staging)](https://deploy.staging.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=publisher&MACHINE_CLASS=backend&RAKE_TASK=service_sign_in:publish[check-update-company-car-tax.en.yaml]) ([Production](https://deploy.publishing.service.gov.uk/job/run-rake-task/parambuild/?TARGET_APPLICATION=publisher&MACHINE_CLASS=backend&RAKE_TASK=service_sign_in:publish[check-update-company-car-tax.en.yaml]))
+
+
+Run the task with the following parameters
+
+| Field              | Value                                                         |
+|--------------------|---------------------------------------------------------------|
+| TARGET_APPLICATION | publisher                                                     |
+| MACHINE_CLASS      | backend                                                       |
+| RAKE_TASK          | service_sign_in:publish[check-update-company-car-tax.en.yaml] |


### PR DESCRIPTION
This documentation was written alongside the process with Tom Hughes one of our Content Designers.

We can then link this README to the [developer docs](https://github.com/alphagov/govuk-developer-docs/search?utf8=%E2%9C%93&q=ExternalDoc&type=)

As part of https://trello.com/c/yIvCgbxI/233-document-how-to-add-a-new-interstitial-page-for-a-service-for-developers