### PR TITLE
Add service sign in unpublish tasks

### DIFF
--- a/app/services/service_sign_in_unpublish_service.rb
+++ b/app/services/service_sign_in_unpublish_service.rb
@@ -1,11 +1,46 @@
 class ServiceSignInUnpublishService
   class << self
-    def call(content_id, locale)
+    def call(content_id, locale, redirect_path: nil)
+      @content_id = content_id
+      if redirect_path.present?
+        unpublish_redirect(locale, redirect_path)
+      else
+        unpublish_gone(locale)
+      end
+    end
+
+  private
+
+    def base_path
+      content_item["base_path"]
+    end
+
+    def content_item
+      @content_item ||= Services.publishing_api.get_content(@content_id)
+    end
+
+    def unpublish_gone(locale)
       Services.publishing_api.unpublish(
-        content_id,
+        @content_id,
         locale: locale,
         type: "gone",
         discard_drafts: true,
+      )
+    end
+
+    def unpublish_redirect(locale, redirect_path)
+      Services.publishing_api.unpublish(
+        @content_id,
+        locale: locale,
+        type: "redirect",
+        discard_drafts: true,
+        redirects: [
+          {
+            path: base_path,
+            type: "prefix",
+            destination: redirect_path,
+          },
+        ]
       )
     end
   end

--- a/app/services/service_sign_in_unpublish_service.rb
+++ b/app/services/service_sign_in_unpublish_service.rb
@@ -1,0 +1,12 @@
+class ServiceSignInUnpublishService
+  class << self
+    def call(content_id, locale)
+      Services.publishing_api.unpublish(
+        content_id,
+        locale: locale,
+        type: "gone",
+        discard_drafts: true,
+      )
+    end
+  end
+end

--- a/lib/tasks/service_sign_in.rake
+++ b/lib/tasks/service_sign_in.rake
@@ -44,5 +44,18 @@ namespace :service_sign_in do
     end
   end
 
+  desc "Unpublish service_sign_in content with type 'gone'"
+  task :unpublish_without_redirect, %i(content_id locale) => :environment do |_, args|
+    USAGE_MESSAGE =
+      "> usage: rake service_sign_in:unpublish_without_redirect[content-id-example,cy]\n".freeze
+
+    content_id = args[:content_id]
+    locale = args[:locale]
+    abort USAGE_MESSAGE unless content_id && locale
+
+    ServiceSignInUnpublishService.call(content_id, locale)
+    puts "> #{content_id} has been unpublished"
+  end
+
   YAML_LOCATION = "> service_sign_in YAML files live here: lib/service_sign_in".freeze
 end

--- a/lib/tasks/service_sign_in.rake
+++ b/lib/tasks/service_sign_in.rake
@@ -3,11 +3,10 @@ require 'yaml'
 namespace :service_sign_in do
   desc "publish service_sign_in format"
   task :publish, [:yaml_file] => :environment do |_, args|
-    USAGE_MESSAGE = "> usage: rake service_sign_in:publish[example.yaml]\n".freeze +
-      "> service_sign_in YAML files live here: lib/service_sign_in"
+    USAGE_MESSAGE = "> usage: rake service_sign_in:publish[example.yaml]\n".freeze
     VALID_FILE_MESSAGE = "> You have not provided a valid file\n".freeze
 
-    abort USAGE_MESSAGE unless args[:yaml_file]
+    abort USAGE_MESSAGE + YAML_LOCATION unless args[:yaml_file]
 
     validator = ServiceSignInYamlValidator.new("lib/service_sign_in/#{args[:yaml_file]}")
 
@@ -31,10 +30,8 @@ namespace :service_sign_in do
 
   desc "Validate a service_sign_in YAML file"
   task :validate, [:yaml_file] => :environment do |_, args|
-    USAGE_MESSAGE = "> usage: rake service_sign_in:validate[example.yaml]\n".freeze +
-      "> service_sign_in YAML files live here: lib/service_sign_in"
-
-    abort USAGE_MESSAGE unless args[:yaml_file]
+    USAGE_MESSAGE = "> usage: rake service_sign_in:validate[example.yaml]\n".freeze
+    abort USAGE_MESSAGE + YAML_LOCATION unless args[:yaml_file]
 
     validator = ServiceSignInYamlValidator.new("lib/service_sign_in/#{args[:yaml_file]}")
     file = validator.validate
@@ -46,4 +43,6 @@ namespace :service_sign_in do
       puts file
     end
   end
+
+  YAML_LOCATION = "> service_sign_in YAML files live here: lib/service_sign_in".freeze
 end

--- a/lib/tasks/service_sign_in.rake
+++ b/lib/tasks/service_sign_in.rake
@@ -57,5 +57,25 @@ namespace :service_sign_in do
     puts "> #{content_id} has been unpublished"
   end
 
+  desc "Unpublish service_sign_in content with type 'redirect'"
+  task :unpublish_with_redirect, %i(content_id locale redirect_path) => :environment do |_, args|
+    USAGE_MESSAGE =
+      "> usage: rake service_sign_in:unpublish_with_redirect[content-id-example,cy,/redirect/path]\n".freeze
+
+    content_id = args[:content_id]
+    locale = args[:locale]
+    redirect_path = args[:redirect_path]
+
+    abort USAGE_MESSAGE unless content_id && locale && redirect_path
+
+    ServiceSignInUnpublishService.call(
+      content_id,
+      locale,
+      redirect_path: redirect_path
+    )
+
+    puts "> #{content_id} has been unpublished"
+  end
+
   YAML_LOCATION = "> service_sign_in YAML files live here: lib/service_sign_in".freeze
 end

--- a/test/unit/services/service_sign_in_unpublish_service_test.rb
+++ b/test/unit/services/service_sign_in_unpublish_service_test.rb
@@ -17,6 +17,28 @@ class ServiceSignInUnpublishServiceTest < ActiveSupport::TestCase
     ServiceSignInUnpublishService.call(content_id, locale)
   end
 
+  should "unpublish a content item with type 'redirect'" do
+    Services.publishing_api.expects(:unpublish).with(
+      content_id,
+      locale: locale,
+      type: "redirect",
+      discard_drafts: true,
+      redirects: [
+        {
+          path: base_path,
+          type: "prefix",
+          destination: redirect_path
+        }
+      ]
+    )
+
+    ServiceSignInUnpublishService.call(
+      content_id,
+      locale,
+      redirect_path: redirect_path
+    )
+  end
+
   def content_id
     "a-content-id"
   end
@@ -25,9 +47,18 @@ class ServiceSignInUnpublishServiceTest < ActiveSupport::TestCase
     "cy"
   end
 
+  def redirect_path
+    "/alternative/path"
+  end
+
+  def base_path
+    "/path/sign-in"
+  end
+
   def content_item
     {
       "locale" => locale,
+      "base_path" => base_path,
     }
   end
 end

--- a/test/unit/services/service_sign_in_unpublish_service_test.rb
+++ b/test/unit/services/service_sign_in_unpublish_service_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class ServiceSignInUnpublishServiceTest < ActiveSupport::TestCase
+  setup do
+    Services.publishing_api.stubs(:unpublish)
+    Services.publishing_api.stubs(:get_content).returns(content_item)
+  end
+
+  should "unpublish a content item with type 'gone'" do
+    Services.publishing_api.expects(:unpublish).with(
+      content_id,
+      type: "gone",
+      locale: locale,
+      discard_drafts: true,
+    )
+
+    ServiceSignInUnpublishService.call(content_id, locale)
+  end
+
+  def content_id
+    "a-content-id"
+  end
+
+  def locale
+    "cy"
+  end
+
+  def content_item
+    {
+      "locale" => locale,
+    }
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/HewVN7nP/237-create-a-rake-task-to-unpublish-service-sign-in-pages

As `service_sign_in` content cannot be published through the UI, we create rake tasks to unpublish it with the `gone` and `redirect` unpublishing types.  We've decided not to unpublish `service_sign_in` as a withdrawal as having the withdrawal notice above the radio buttons could be confusing to users.  We expect that `redirect` and `gone` will be most commonly used.

We've also found that when redirecting `service_sign_in` content, the redirect does work but the last slug is retained in the path e.g. `/check-income-tax-current-year/sign-in/prove-identity` => `/national-minimum-wage-rates/prove-identity`.  This is consistent with what occurs when redirecting guides so it seems reasonable to maintain this behaviour for the purposes of this particular piece of work.
  