### PR TITLE
Add missing default value for start button text

### DIFF
--- a/db/migrate/20180103150147_update_default_edition_start_button_text.rb
+++ b/db/migrate/20180103150147_update_default_edition_start_button_text.rb
@@ -1,0 +1,9 @@
+class UpdateDefaultEditionStartButtonText < Mongoid::Migration
+  def self.up
+    TransactionEdition.where(start_button_text: nil).update_all(start_button_text: "Start now")
+  end
+
+  def self.down
+    # This cannot be rolled back because we don't know which editions had a missing start_button_text field
+  end
+end


### PR DESCRIPTION
Ensure that all unarchived editions in the DB have a value for the start button text, which is a required field.

This field already had a default value (see https://github.com/alphagov/publisher/pull/638) which means that the correct button text was displayed even for older editions which were created before the field was added. But because the default value was missing in the DB, it caused validation errors when unpublishing an old edition: https://govuk.zendesk.com/agent/tickets/2544691

Paired with @Davidslv 

cc @tuzz 