### PR TITLE
Add Link and LinkCheckReport models

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -35,6 +35,8 @@ class Edition
 
   belongs_to :assigned_to, class_name: "User", optional: true
 
+  embeds_many :link_check_reports
+
   # state_machine comes from Workflow
   state_machine.states.map(&:name).each do |state|
     scope state, lambda { where(state: state) }

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,0 +1,17 @@
+class Link
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  embedded_in :link_check_report
+
+  field :uri, type: String
+  field :status, type: String
+  field :checked_at, type: DateTime
+  field :check_warnings, type: Array
+  field :check_errors, type: Array
+  field :problem_summary, type: String
+  field :suggested_fix, type: String
+
+  validates :uri, presence: true
+  validates :status, presence: true
+end

--- a/app/models/link_check_report.rb
+++ b/app/models/link_check_report.rb
@@ -1,0 +1,17 @@
+class LinkCheckReport
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  embedded_in :edition
+  embeds_many :links
+
+  accepts_nested_attributes_for :links
+
+  field :batch_id, type: Integer
+  field :status, type: String
+  field :completed_at, type: DateTime
+
+  validates :batch_id, presence: true, uniqueness: true
+  validates :status, presence: true
+  validates :links, presence: true
+end

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -1107,4 +1107,17 @@ class EditionTest < ActiveSupport::TestCase
       assert_equal edition1, edition3.first_edition_of_published
     end
   end
+
+  context "link_check_reports" do
+    should "not have any link_check_reports by default" do
+      edition = FactoryGirl.create(:edition, :published)
+      assert_equal 0, edition.link_check_reports.size
+    end
+
+    should "add a new link_check_report" do
+      edition = FactoryGirl.create(:edition, :published)
+      edition.link_check_reports.build(FactoryGirl.attributes_for(:link_check_report))
+      assert_equal 1, edition.link_check_reports.size
+    end
+  end
 end

--- a/test/models/link_check_report_test.rb
+++ b/test/models/link_check_report_test.rb
@@ -1,0 +1,30 @@
+require_relative '../test_helper'
+
+class LinkCheckReportTest < ActiveSupport::TestCase
+  context "validations" do
+    should "be valid when all fields set" do
+      link_check_report = FactoryGirl.build(:link_check_report, :completed)
+      assert link_check_report.valid?
+    end
+
+    should "be valid without a completed at time" do
+      link_check_report = FactoryGirl.build(:link_check_report, completed_at: nil)
+      assert link_check_report.valid?
+    end
+
+    should "be invalid without links" do
+      link_check_report = FactoryGirl.build(:link_check_report, links: [])
+      refute link_check_report.valid?
+    end
+
+    should "be invalid without a batch id" do
+      link_check_report = FactoryGirl.build(:link_check_report, batch_id: nil)
+      refute link_check_report.valid?
+    end
+
+    should "be invalid without a status" do
+      link_check_report = FactoryGirl.build(:link_check_report, status: nil)
+      refute link_check_report.valid?
+    end
+  end
+end

--- a/test/models/link_test.rb
+++ b/test/models/link_test.rb
@@ -1,0 +1,55 @@
+require_relative '../test_helper'
+
+class LinkTest < ActiveSupport::TestCase
+  context "validations" do
+    should "be valid when all fields set" do
+      link = FactoryGirl.build(:link)
+      assert link.valid?
+    end
+
+    should "be valid without a checked time" do
+      link = FactoryGirl.build(:link, checked_at: nil)
+      assert link.valid?
+    end
+
+    should "be valid without check warnings" do
+      link = FactoryGirl.build(:link, check_warnings: [])
+      assert link.valid?
+    end
+
+    should "be valid without check errors" do
+      link = FactoryGirl.build(:link, check_errors: [])
+      assert link.valid?
+    end
+
+    should "be valid without a problem summary" do
+      link = FactoryGirl.build(:link, problem_summary: nil)
+      assert link.valid?
+    end
+
+    should "be valid without a suggested fix" do
+      link = FactoryGirl.build(:link, suggested_fix: nil)
+      assert link.valid?
+    end
+
+    should "be invalid without a uri" do
+      link = FactoryGirl.build(:link, uri: nil)
+      refute link.valid?
+    end
+
+    should "be invalid without a status" do
+      link = FactoryGirl.build(:link, status: nil)
+      refute link.valid?
+    end
+
+    should "store warnings as an array" do
+      link = FactoryGirl.build(:link)
+      assert_kind_of Array, link.check_warnings
+    end
+
+    should "store errors as an array" do
+      link = FactoryGirl.build(:link)
+      assert_kind_of Array, link.check_errors
+    end
+  end
+end

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -235,4 +235,25 @@ FactoryGirl.define do
     title "Simple smart answer"
     body "Introduction to the smart answer"
   end
+
+  factory :link do
+    uri "https://www.gov.uk"
+    status "ok"
+    checked_at Time.parse("2017-12-01").iso8601
+    check_warnings ["example check warnings"]
+    check_errors ["example check errors"]
+    problem_summary "example problem"
+    suggested_fix "example fix"
+  end
+
+  factory :link_check_report do
+    batch_id 1
+    status "in_progress"
+    links { [FactoryGirl.build(:link)] }
+
+    trait :completed do
+      status "completed"
+      completed_at Time.now.iso8601
+    end
+  end
 end


### PR DESCRIPTION
This PR adds the models required for the integration of the Link Checker API into publisher.

Its the first in a series of PR to add link checking. In future PRs we will add;

- A callback endpoint for the Link Checker API to callback to
- Controller action to create link checks for editions
- A frontend UI to trigger a checker