### PR TITLE
Add an Link Checker API callback endpoint

### DIFF
--- a/app/controllers/link_checker_api_controller.rb
+++ b/app/controllers/link_checker_api_controller.rb
@@ -1,0 +1,50 @@
+class LinkCheckerApiController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  skip_before_action :authenticate_user!
+  skip_before_action :require_signin_permission!
+  before_action :verify_signature
+
+  rescue_from Mongoid::Errors::DocumentNotFound, with: :render_no_content
+
+  def callback
+    if link_check_report
+      LinkCheckReportUpdater.new(
+        report: link_check_report,
+        payload: params
+      ).call
+    end
+
+    render_no_content
+  end
+
+private
+
+  def render_no_content
+    head :no_content
+  end
+
+  def batch_id
+    params.require(:id)
+  end
+
+  def edition
+    @edition ||= Edition.find_by("link_check_reports.batch_id": batch_id)
+  end
+
+  def link_check_report
+    @link_check_report ||= edition.link_check_reports.find_by(batch_id: batch_id)
+  end
+
+  def verify_signature
+    return unless webhook_secret_token
+    given_signature = request.headers["X-LinkCheckerApi-Signature"]
+    return head :bad_request unless given_signature
+    body = request.raw_post
+    signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha1"), webhook_secret_token, body)
+    head :bad_request unless Rack::Utils.secure_compare(signature, given_signature)
+  end
+
+  def webhook_secret_token
+    Rails.application.secrets.link_checker_api_secret_token
+  end
+end

--- a/app/services/link_check_report_updater.rb
+++ b/app/services/link_check_report_updater.rb
@@ -1,0 +1,45 @@
+class LinkCheckReportUpdater
+  def initialize(report:, payload:)
+    @report = report
+    @payload = payload
+  end
+
+  def call
+    update_report!
+    links = payload.fetch("links", [])
+    update_links!(links)
+  end
+
+private
+
+  attr_reader :report, :payload
+
+  def update_report!
+    report.update!(
+      status: payload.fetch("status"),
+      completed_at: payload.fetch("completed_at"),
+    )
+  end
+
+  def update_links!(links_payload)
+    links_payload.each do |link_payload|
+      link = report.links.find_by(uri: link_payload.fetch("uri"))
+
+      attributes = link_attributes(link_payload)
+
+      link.update!(attributes)
+    end
+  end
+
+  def link_attributes(link)
+    {
+      uri: link.fetch(:uri),
+      status: link.fetch(:status),
+      checked_at: link.fetch(:checked),
+      check_warnings: link.fetch(:warnings, []),
+      check_errors: link.fetch(:errors, []),
+      problem_summary: link.fetch(:problem_summary),
+      suggested_fix: link.fetch(:suggested_fix)
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,8 @@ Rails.application.routes.draw do
 
   get 'user_search' => 'user_search#index'
 
+  post "/link-checker-api-callback" => "link_checker_api#callback", as: "link_checker_api_callback"
+
   resources :publications
   root to: 'root#index'
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,11 +12,14 @@
 
 development:
   secret_key_base: p647607dffea898a0f668fea448896db7ca3a0527f9e926db3ae629617cd64e16d2b4d357dcb312ed3f4ae5daaad98c589bb0ef1da4c251c0234b457d2e4a49f
+  link_checker_api_secret_token: stk3ffv3DvpKfHmsU4pbxsxc
 
 test:
   secret_key_base: 073ab37a8631ad8caf644cb52662e222b95cac9a0ed4b8523f86819e50c544dfc49c12aa58090604b490235424fa77d66c10b016ecc706acf83193d2c6090318
+  link_checker_api_secret_token: stk3ffv3DvpKfHmsU4pbxsxc
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  link_checker_api_secret_token: <%= ENV["LINK_CHECKER_API_SECRET_TOKEN"] %>

--- a/test/functional/link_checker_api_controller_test.rb
+++ b/test/functional/link_checker_api_controller_test.rb
@@ -1,0 +1,119 @@
+require "test_helper"
+require "gds_api/test_helpers/link_checker_api"
+
+class LinkCheckerApiControllerTest < ActionController::TestCase
+  include GdsApi::TestHelpers::LinkCheckerApi
+
+  def generate_signature(body, key)
+    OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha1"), key, body)
+  end
+
+  def create_edition_link_check_report
+    FactoryGirl.create(:edition, :with_link_check_report,
+                                 batch_id: 5,
+                                 link_uris: ['https://www.gov.uk']).link_check_reports.first
+  end
+
+  def create_answer_edition_with_link_check_report
+    FactoryGirl.create(:answer_edition_with_link_check_report, batch_id: 5,
+                                                               link_uris: ['https://www.gov.uk']).link_check_reports.first
+  end
+
+  def create_campaign_edition_with_link_check_report
+    FactoryGirl.create(:campaign_edition_with_link_check_report, batch_id: 5,
+                                                                 link_uris: ['https://www.gov.uk']).link_check_reports.first
+  end
+
+  def edition_link_check_report
+    @edition_link_check_report ||= create_edition_link_check_report
+  end
+
+  def answer_edition_link_check_report
+    @answer_edition_link_check_report ||= create_answer_edition_with_link_check_report
+  end
+
+  def campaign_edition_link_check_report
+    @campaign_edition_with_link_check_report ||= create_campaign_edition_with_link_check_report
+  end
+
+  def set_headers(post_body)
+    headers = {
+      "Content-Type": "application/json",
+      "X-LinkCheckerApi-Signature": generate_signature(post_body.to_json, Rails.application.secrets.link_checker_api_secret_token)
+    }
+
+    request.headers.merge! headers
+  end
+
+  context "when working on an edition" do
+    setup do
+      edition_link_check_report
+    end
+
+    should "update the LinkCheckerReport of edition on POST" do
+      post_body = link_checker_api_batch_report_hash(
+        id: 5,
+        links: [
+          { uri: @link, status: "ok" },
+        ]
+      )
+
+      set_headers(post_body)
+
+      post :callback, params: post_body
+
+      edition_link_check_report.reload
+
+      assert_response :success
+      assert 'completed', edition_link_check_report.status
+    end
+  end
+
+  context "Answer Edition a subclasses of edition" do
+    setup do
+      answer_edition_link_check_report
+    end
+
+    should "update LinkCheckerReport on POST" do
+      post_body = link_checker_api_batch_report_hash(
+        id: 5,
+        links: [
+          { uri: @link, status: "ok" },
+        ]
+      )
+
+      set_headers(post_body)
+
+      post :callback, params: post_body
+
+      answer_edition_link_check_report.reload
+
+      assert_response :success
+      assert 'completed', answer_edition_link_check_report.status
+    end
+  end
+
+  context "CampaignEdition a subclasses of edition" do
+    setup do
+      campaign_edition_link_check_report
+    end
+
+    should "update the LinkCheckerReport on POST" do
+      post_body = link_checker_api_batch_report_hash(
+        id: 5,
+        links: [
+          { uri: @link, status: "ok" },
+        ]
+      )
+
+      set_headers(post_body)
+
+      post :callback, params: post_body
+
+      campaign_edition_link_check_report.reload
+
+      assert_response :success
+      assert 'completed', campaign_edition_link_check_report.status
+    end
+  end
+end

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -97,8 +97,24 @@ FactoryGirl.define do
     trait :with_body do
       body 'Some body text'
     end
+
+    trait :with_link_check_report do
+      transient do
+        batch_id 1
+        link_uris []
+      end
+
+      link_check_reports do
+        [FactoryGirl.build(:link_check_report, :with_links,
+                                               batch_id: batch_id,
+                                               link_uris: link_uris)]
+      end
+    end
   end
   factory :answer_edition, traits: [:with_body], parent: :edition do
+  end
+
+  factory :answer_edition_with_link_check_report, traits: [:with_link_check_report], parent: :answer_edition do
   end
 
   factory :help_page_edition, traits: [:with_body], parent: :edition, class: 'HelpPageEdition' do
@@ -106,6 +122,10 @@ FactoryGirl.define do
 
   factory :campaign_edition, traits: [:with_body], parent: :edition, class: 'CampaignEdition' do
   end
+
+  factory :campaign_edition_with_link_check_report, traits: [:with_link_check_report], parent: :campaign_edition do
+  end
+
 
   factory :completed_transaction_edition, traits: [:with_body], parent: :edition, class: 'CompletedTransactionEdition' do
     sequence(:slug) { |n| "done/slug-#{n}" }
@@ -254,6 +274,16 @@ FactoryGirl.define do
     trait :completed do
       status "completed"
       completed_at Time.now.iso8601
+    end
+
+    trait :with_links do
+      transient do
+        link_uris []
+      end
+
+      links do
+        link_uris.map { |uri| FactoryGirl.build(:link, uri: uri) }
+      end
     end
   end
 end

--- a/test/unit/services/link_check_report_updater_test.rb
+++ b/test/unit/services/link_check_report_updater_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+
+class LinkCheckReportUpdaterTest < ActiveSupport::TestCase
+  def completed_at
+    @completed_at ||= Time.now.utc
+  end
+
+  def payload
+    {
+      status: 'complete',
+      completed_at: completed_at,
+      links: links_payload
+    }.with_indifferent_access
+  end
+
+  def links_payload
+    [{
+      uri: "http://www.example.com",
+      status: "ok",
+      checked: completed_at.try(:iso8601),
+      problem_summary: nil,
+      suggested_fix: nil
+    }, {
+      uri: "http://www.gov.com",
+      status: "broken",
+      checked: completed_at.try(:iso8601),
+      problem_summary: "Page Not Found",
+      suggested_fix: "Contact site administrator"
+    }]
+  end
+
+  def create_edition_with_link_check_report
+    FactoryGirl.create(:edition, :with_link_check_report,
+                                 batch_id: 1,
+                                 link_uris: ['http://www.example.com', 'http://www.gov.com'])
+  end
+
+  def link_check_report
+    @link_check_report ||= create_edition_with_link_check_report.link_check_reports.first
+  end
+
+  should 'update the link check report' do
+    LinkCheckReportUpdater.new(report: link_check_report, payload: payload).call
+
+    link_check_report.reload
+
+    assert "complete", link_check_report.status
+    assert completed_at, link_check_report.completed_at
+  end
+
+  should 'update the links status' do
+    LinkCheckReportUpdater.new(report: link_check_report, payload: payload).call
+
+    link_check_report.reload
+
+    assert "ok", link_check_report.links.first.status
+    assert completed_at.try(:iso8601), link_check_report.links.first.checked_at
+
+    assert "broken", link_check_report.links.last.status
+    assert completed_at.try(:iso8601), link_check_report.links.last.checked_at
+    assert "Page Not Found", link_check_report.links.last.problem_summary
+  end
+end


### PR DESCRIPTION
This PR adds an endpoint for the `link-checker-api` to POST the result of checks back to.