### PR TITLE
Add Service Sign In Architectural Decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ access that data for display. It is sometimes referred to as "mainstream publish
 - [Licence](https://www.gov.uk/day-nurseries-wales)
 - [Local transactions](https://www.gov.uk/complain-about-your-council)
 - [Place](https://www.gov.uk/ukonline-centre-internet-access-computer-training)
+- [Service sign in](https://www.gov.uk/log-in-file-self-assessment-tax-return/sign-in)
 - [Simple smart answer](https://www.gov.uk/qualify-tax-credits)
 - [Transaction](https://www.gov.uk/council-tax-bands)
 
@@ -30,6 +31,11 @@ access that data for display. It is sometimes referred to as "mainstream publish
   they're fully removed as editions and no longer visible in the app (although
   the artefacts do still exist).  They have been fully migrated to
   specialist-publisher.
+
+## Working with Service Sign In pages
+These pages do not have an admin interface and are instead managed through rake tasks.
+
+See the [README](lib/service_sign_in/README.md) for more details.
 
 ## Nomenclature
 
@@ -82,20 +88,15 @@ Or to specify the location explicitly:
 
 `GOVUK_CONTENT_SCHEMAS_PATH=/some/dir/govuk-content-schemas bundle exec rake`
 
-### State machine 
+### State machine
 
 Maps out the transitions between states for the `Edition` class. These transitions are defined in the [workflow](app/models/workflow.rb) module.
-A diagram of the current state machine can be seen here: [state machine diagram](doc/state_machines/state_machine_diagram_for_edition.png). 
+A diagram of the current state machine can be seen here: [state machine diagram](doc/state_machines/state_machine_diagram_for_edition.png).
 The diagram can be (re)generated using the [state_machines-graphviz gem](https://github.com/state-machines/state_machines-graphviz), by doing:
 
 `bundle exec rake state_machines:draw CLASS=Edition`
 
 This will generate a diagram in the `doc/state_machines` folder.
-
-### How to publish Service Sign-in pages
-These pages do not have an admin interface and are instead published through rake tasks.
-
-See the [README](lib/service_sign_in/README.md) for more details.
 
 ## Licence
 

--- a/doc/arch/adr-001-service-sign-in-pages-not-linked-to-with-content-id.md
+++ b/doc/arch/adr-001-service-sign-in-pages-not-linked-to-with-content-id.md
@@ -1,0 +1,23 @@
+# Decision record: Why Service sign in pages aren't linked to from transaction pages using a content id
+
+## Context
+Currently, when content designers create a transaction page they enter a URL for
+the service that the start button should link to, and this service is usually an
+external (to GOV.UK) URL.  Service sign in pages however will be GOV.UK content
+items, and ideally we should not link to specific content item URLs as they could
+change in future.  Instead, the links should reference a content_id, which never
+changes.  However as the field where content designers enter the URL that the
+start button should link to doesn't support content_ids currently, the only
+option available to them is to enter the URL for the service sign in page.
+
+## Decision
+After discussing this with @kevindew from the publishing platform team, we
+identified that the risk of things breaking because we're linking directly to a
+URL is quite low because if the base_path of the service sign in page changes,
+the publishing API will automatically create a redirect.
+
+## Consequences
+Ideally we should ensure that we're referencing the content_id instead of the
+service sign in page URL so that all risk is mitigated, so in future we should
+look at how we can support providing a content_id instead of a URL on the edit
+transaction page in Publisher.

--- a/doc/arch/adr-002-service-sign-in-new-format.md
+++ b/doc/arch/adr-002-service-sign-in-new-format.md
@@ -1,0 +1,44 @@
+# Decision record: Why "Service sign in" is its own format
+
+## Context
+The Q3 Start Pages mission goal was to make it easier for users to choose a sign
+in option in order to access a service.  It was decided that a page should sit
+in between the transaction/guide page and the service which allows users to
+select a sign in option such as GOV.UK Verify or Government Gateway, or to
+register for a new account (henceforth know as the service sign in page).
+
+We initially looked at whether we could use an existing format to house this page.
+At first glance, it felt that transaction pages might be a suitable place for
+it, as it would be tailored to the transaction.  Alternatively we could create a
+new format for this page.
+
+## Decision
+We ruled out incorporating service sign in pages into the transaction format for
+a few reasons.  Firstly, we realised that service sign pages could also be
+linked to from guides, as content designers sometimes embed start buttons in to
+them, so including them in the transaction format only wouldn't be suitable for
+guides.  Secondly, we felt that the scope of this mission did not include
+consolidating any product debt around transactions, which would be required in
+order to incorporate service sign pages, so it wasn't appropriate to follow this
+route.  Additionally, we knew from the outset that building a UI to support
+service sign in pages wasn't in scope for this mission, and in order to deliver
+a decent user experience for content designers we would probably need to alter
+the transaction UI.
+
+In order to have the flexibility of linking to service sign
+in pages from more than one format, and better handle the need for additional
+pages related to service sign in (e.g. create new account page) we decided to
+create a `service_sign_in` format.  We also made the decision that the format
+should house up to two pages; a required `choose_sign_in` page which contains
+the options that the user can choose from, and an optional `create_new_account`
+page which allows users to make a decision about which account they should sign
+up for.  We did consider creating a separate format for `create_new_account`
+however we felt that at the current time there is no need for a standalone page
+for this.
+
+## Consequences
+If we explored the user needs met by abusing the guide format, and consolidated
+hacky usage of other formats into transactions to meet those needs, it may make
+more sense to have a less flexible format or extension to transactions which
+could potentially make the publisher workflow easier and allow consistent
+iterations to start pages as a product.

--- a/doc/arch/adr-003-using-rake-to-create-service-sign-in-pages.md
+++ b/doc/arch/adr-003-using-rake-to-create-service-sign-in-pages.md
@@ -1,0 +1,35 @@
+# Decision record: Why "Service sign in" pages are created using rake tasks
+
+## Context
+For the Q3 Start Pages mission, we descoped creating a UI in Publisher to handle
+the workflow of managing Service sign in pages due to time constraints. As such
+we needed to find a way for developers to easily create and update service sign
+in pages.
+
+## Decision
+One of the options was to hardcode the content within their own views, which
+would require a developer to manually update content when needed. While this is
+a simple approach, it isn't very scalable and is prone to error. With this
+approach we would not be sending the content to the Publishing API. As such we
+would have to remember to register routes ourselves, and wouldn't have other
+benefits of the Publishing API such as maintaining content history.
+
+We knew that Smart Answers made use of rake tasks to import content, so we
+considered following a similar approach. This would involve a content designer
+providing a YAML file containing the content, which would be imported using a
+rake task and then presented in a data format that could be sent to the
+Publishing API. The downside of this approach is that we assume that content
+designers have some level of familiarity with YAML and would be able to provide
+the file to us via Git. However we felt that this would be the best approach as
+a developer tasked with publishing a service sign in page in future would only
+need to invoke a simple rake task instead of manually updating content
+themselves. We've also provided an example YAML file so that content designers
+are able follow a template and ensure that all the data is supplied in a
+suitable format.
+
+## Consequences
+Due to no UI being provided to create a Service sign in page, the workflow is
+unusual for content designers and as previously mentioned it does assume
+familiarity with YAML and Git. While we expect most content designers will have
+access to a developer who may be able to assist, we should acknowledge some
+potential risk here.

--- a/doc/arch/adr-004-rendering-service-sign-in-from-government-frontend.md
+++ b/doc/arch/adr-004-rendering-service-sign-in-from-government-frontend.md
@@ -1,0 +1,30 @@
+# Decision record: Rendering Service Sign In pages using Government Frontend
+
+## Context
+As Service Sign In is a new format, we needed to decide how to render it.
+
+## Decision
+We had a few options when deciding where this format should be rendered from.
+Firstly we considered building a new rendering app, however quickly ruled this
+out as the content wasn't expected to be radically different to existing
+content, so building a new rendering app specifically for it seemed like
+overkill.
+
+Next we looked at rendering the content from Frontend, and some existing
+Publisher formats are rendered from it and it already handles some page
+interaction. However there is technical debt associated with Frontend and some
+Publisher formats have been migrated to Government Frontend, so it seemed
+counterproductive to render Service Sign In pages from Frontend only for that to
+be changed at some point in the future.
+
+Finally we looked at using Government Frontend, which many formats have migrated
+to using. Currently Government Frontend is only concerned with read-only content
+such as documents, and doesn't handle interactive content. While we would be
+allowing Government Frontend to handle more complex content, we didn't feel that
+this would be making the app itself more complicated. Given that Government
+Frontend has a more certain future than Frontend, this seemed like the right
+rendering app for this new format.
+
+## Consequences
+We have had to add a radio button component to Government Frontend, which
+introduces interaction to to the app.

--- a/doc/arch/adr-005-forking-frontend-components-from-govuk-frontend.md
+++ b/doc/arch/adr-005-forking-frontend-components-from-govuk-frontend.md
@@ -1,0 +1,30 @@
+# Decision record: Forking frontend components from GOV.UK Frontend
+
+## Context
+We needed to add radio buttons to Government Frontend so that users can make a
+choice on the Service Sign In `choose_sign_in` page. The new
+[GOV.UK Frontend](https://github.com/alphagov/govuk-frontend) project has a
+component for radio buttons, as does [GOV.UK Elements](https://github.com/alphagov/govuk_elements),
+so we needed to make a decision about which one to use.
+
+## Decision
+GOV.UK Elements is quite an old project that hasn't been kept up to date, and
+there have been issues in the past where it has conflicted with existing CSS in
+other GOV.UK projects. As such, the general recommendation is that [GOV.UK
+Elements shouldn't be used](https://docs.google.com/document/d/1ZQ3qfMAdGQWIt5oklvKDhhGfYb-4bct75ZwVPUbnN2k/edit)
+for new GOV.UK projects.
+
+GOV.UK Frontend is expected to be the standard for future frontend work, and so
+ideally any new components should be
+[built to meet its conventions](https://docs.publishing.service.gov.uk/manual/components.html#building-components)
+so that in future GOV.UK will be compatible with it. However, GOV.UK Frontend is
+currently in alpha and not suitable for production use. In order to use it and
+future-proof the frontend for this format, we forked the current alpha build of
+GOV.UK Frontend and tested it ourselves before using in Government Frontend.
+This has been done in such a way that files are isolated and can be updated to
+use the GOV.UK Frontend project in the future, removing the need for our own CSS
+and instead relying on the upstream.
+
+## Consequences
+As we are using a fork of GOV.UK Frontend we may not always be using the most
+up-to-date version.


### PR DESCRIPTION
For https://trello.com/c/9XVir0Ug/235-document-our-architectural-decisions

This adds our architectural decisions for the development of the Service Sign In format.