### PR TITLE
Remove the conditional for precompiling assets in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ ADD Gemfile* $APP_HOME/
 RUN bundle install
 ADD . $APP_HOME
 
-ARG COMPILE_ASSETS=false
-RUN if [ "$COMPILE_ASSETS" = "true" ] ; then bundle exec rails assets:precompile ; fi
+RUN GOVUK_APP_DOMAIN=www.gov.uk RAILS_ENV=production bundle exec rails assets:precompile
 
 HEALTHCHECK CMD curl --silent --fail localhost:$PORT || exit 1
 


### PR DESCRIPTION
As part of the work to use the built images pushed up to Docker Hub for E2E testing, where we run the tests in the production RAILS_ENV, we will need the image pushed up to contain the compiled assets.

We can't see a reason to keep the conditional for now as any performance hit will be experienced only as part of CI.