### PR TITLE
Add Link Report Creator Service

### DIFF
--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -1,15 +1,20 @@
 require "gds_api/publishing_api_v2"
 require "gds_api/calendars"
+require "gds_api/link_checker_api"
 
 module Services
   def self.publishing_api
     @publishing_api ||= GdsApi::PublishingApiV2.new(
-      Plek.new.find('publishing-api'),
-      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
+      Plek.new.find("publishing-api"),
+      bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example"
     )
   end
 
   def self.calendars
-    @calendars ||= GdsApi::Calendars.new(Plek.new.find('calendars'))
+    @calendars ||= GdsApi::Calendars.new(Plek.new.find("calendars"))
+  end
+
+  def self.link_checker_api
+    @link_checker_api ||= GdsApi::LinkCheckerApi.new(Plek.new.find("link-checker-api"))
   end
 end

--- a/app/services/edition_link_extractor.rb
+++ b/app/services/edition_link_extractor.rb
@@ -1,0 +1,43 @@
+require "govspeak/link_extractor"
+
+class EditionLinkExtractor
+  def initialize(edition:)
+    @edition = edition
+  end
+
+  def call
+    if has_parts?
+      links_in_govspeak_fields + links_in_parts
+    else
+      links_in_govspeak_fields
+    end
+  end
+
+private
+
+  attr_reader :edition
+
+  def has_parts?
+    edition.parts.any?
+  rescue NoMethodError
+    false
+  end
+
+  def links_in_govspeak_fields
+    edition.class::GOVSPEAK_FIELDS.flat_map do |govspeak_field_name|
+      govspeak_body = edition.read_attribute(govspeak_field_name)
+
+      govspeak_document(govspeak_body).extracted_links
+    end
+  end
+
+  def links_in_parts
+    edition.parts.flat_map do |part|
+      govspeak_document(part.body).extracted_links
+    end
+  end
+
+  def govspeak_document(string)
+    Govspeak::Document.new(string)
+  end
+end

--- a/app/services/link_check_report_creator.rb
+++ b/app/services/link_check_report_creator.rb
@@ -1,0 +1,66 @@
+class LinkCheckReportCreator
+  include Rails.application.routes.url_helpers
+
+  CALLBACK_HOST = Plek.find("manuals-publisher")
+
+  class InvalidReport < RuntimeError
+    def initialize(original_error)
+      @message = original_error.message
+    end
+  end
+
+  def initialize(edition:)
+    @edition = edition
+  end
+
+  def call
+    return if uris.empty?
+
+    link_report = call_link_checker_api.deep_symbolize_keys
+
+    report = edition.link_check_reports.build(
+      batch_id: link_report.fetch(:id),
+      completed_at: link_report.fetch(:completed_at),
+      status: link_report.fetch(:status),
+      links: link_report.fetch(:links).map { |link| map_link_attrs(link) }
+    )
+
+    report.save!
+
+    report
+  rescue Mongoid::Errors::Validations => e
+    raise InvalidReport.new(e)
+  end
+
+private
+
+  attr_reader :edition
+
+  def uris
+    @uris ||= EditionLinkExtractor.new(edition: edition).call
+  end
+
+  def callback_url
+    link_checker_api_callback_url(host: CALLBACK_HOST)
+  end
+
+  def call_link_checker_api
+    Services.link_checker_api.create_batch(
+      uris,
+      webhook_uri: callback_url,
+      webhook_secret_token: Rails.application.secrets.link_checker_api_secret_token
+    )
+  end
+
+  def map_link_attrs(link)
+    {
+      uri: link.fetch(:uri),
+      status: link.fetch(:status),
+      checked_at: link.fetch(:checked),
+      check_warnings: link.fetch(:warnings, []),
+      check_errors: link.fetch(:errors, []),
+      problem_summary: link.fetch(:problem_summary),
+      suggested_fix: link.fetch(:suggested_fix)
+    }
+  end
+end

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -245,6 +245,18 @@ FactoryGirl.define do
     end
   end
 
+  factory :travel_advice_edition_with_parts, parent: :travel_advice_edition do
+    summary "This is [link](https://www.gov.uk) text."
+
+    after :create do |getp|
+      getp.parts.build(title: "Some Part Title!",
+                       body: "This is some **version** text.", slug: "part-one")
+      getp.parts.build(title: "Another Part Title",
+                       body: "This is [link](http://example.com) text.",
+                       slug: "part-two")
+    end
+  end
+
   factory :rendered_manual do
     sequence(:slug) { |n| "test-rendered-manual-#{n}" }
     sequence(:title) { |n| "Test Rendered Manual #{n}" }

--- a/test/unit/services/edition_link_extractor_test.rb
+++ b/test/unit/services/edition_link_extractor_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class EditionLinkExtractorTest < ActiveSupport::TestCase
+  context ".call" do
+    should "extract links from editions with links in govspeak fields" do
+      result = call_edition_link_extractor(edition_with_links_in_govspeak_fields)
+
+      assert_same_elements ["https://www.example.co.uk"], result
+    end
+
+    should "extract links from editions with links in parts" do
+      result = call_edition_link_extractor(edition_with_links_in_parts)
+
+      assert_same_elements ["http://example.net/"], result
+    end
+
+    should "extract links from editions with links in parts and govspeak" do
+      result = call_edition_link_extractor(edition_with_links_in_govspeak_fields_and_parts)
+
+      assert_same_elements ["https://www.gov.uk", "http://example.com"], result
+    end
+  end
+
+  def call_edition_link_extractor(edition)
+    EditionLinkExtractor.new(edition: edition).call
+  end
+
+  def edition_with_links_in_govspeak_fields
+    FactoryGirl.create(:place_edition, introduction: "This is [link](https://www.example.co.uk) text.")
+  end
+
+  def edition_with_links_in_parts
+    FactoryGirl.create(:guide_edition_with_two_govspeak_parts)
+  end
+
+  def edition_with_links_in_govspeak_fields_and_parts
+    FactoryGirl.create(:travel_advice_edition_with_parts)
+  end
+end

--- a/test/unit/services/link_check_report_creator_test.rb
+++ b/test/unit/services/link_check_report_creator_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+require "gds_api/test_helpers/link_checker_api"
+
+class LinkCheckReportCreatorTest < ActiveSupport::TestCase
+  include GdsApi::TestHelpers::LinkCheckerApi
+  include Rails.application.routes.url_helpers
+
+  def create_edition(govspeak)
+    @edition ||= FactoryGirl.create(:place_edition, introduction: govspeak)
+  end
+
+  setup do
+    @stubbed_api_request = link_checker_api_create_batch(
+      uris: ["https://www.gov.uk"],
+      id: "a-batch-id",
+      webhook_uri: link_checker_api_callback_url(host: Plek.find("manuals-publisher")),
+      webhook_secret_token: Rails.application.secrets.link_checker_api_secret_token
+    )
+  end
+
+  context ".call" do
+    should "make a request the link checker api when the edition has links" do
+      LinkCheckReportCreator.new(
+        edition: create_edition("This is [link](https://www.gov.uk) text.")
+      ).call
+
+      @edition.reload
+
+      assert_requested(@stubbed_api_request)
+      assert @edition.link_check_reports
+      assert "a-batch-id", @edition.link_check_reports.first.batch_id
+    end
+
+    should "not make a request the link checker api when the edition has no links" do
+      LinkCheckReportCreator.new(
+        edition: create_edition("This is had no links.")
+      ).call
+
+      @edition.reload
+
+      assert_not_requested(@stubbed_api_request)
+      assert @edition.link_check_reports.empty?
+    end
+  end
+end


### PR DESCRIPTION
This PR adds two service classes, one [`LinkCheckReportCreator`] to call the `link-checker-api` to create reports, and another [`EditionLinkExtractor`] to extract links from various subclasses of `Edition`