### PR TITLE
Convert paths to urls before sending to link checker

### DIFF
--- a/app/services/edition_link_extractor.rb
+++ b/app/services/edition_link_extractor.rb
@@ -6,16 +6,28 @@ class EditionLinkExtractor
   end
 
   def call
+    convert_paths_to_urls(find_links_in_edition)
+  end
+
+private
+
+  attr_reader :edition
+
+  def convert_paths_to_urls(links)
+    links.map { |link| link.starts_with?('/') ? "#{public_root}#{link}" : link }
+  end
+
+  def public_root
+    @public_root ||= Plek.new.website_root
+  end
+
+  def find_links_in_edition
     if has_parts?
       links_in_govspeak_fields + links_in_parts
     else
       links_in_govspeak_fields
     end
   end
-
-private
-
-  attr_reader :edition
 
   def has_parts?
     edition.parts.any?

--- a/test/unit/services/edition_link_extractor_test.rb
+++ b/test/unit/services/edition_link_extractor_test.rb
@@ -2,6 +2,13 @@ require "test_helper"
 
 class EditionLinkExtractorTest < ActiveSupport::TestCase
   context ".call" do
+    should "not error when edition has no links" do
+      result = call_edition_link_extractor(edition_with_no_links)
+
+      assert_kind_of Array, result
+      assert_empty result
+    end
+
     should "extract links from editions with links in govspeak fields" do
       result = call_edition_link_extractor(edition_with_links_in_govspeak_fields)
 
@@ -19,14 +26,28 @@ class EditionLinkExtractorTest < ActiveSupport::TestCase
 
       assert_same_elements ["https://www.gov.uk", "http://example.com"], result
     end
+
+    should "convert absolute paths to full urls" do
+      result = call_edition_link_extractor(edition_with_absolute_paths_in_govspeak_fields)
+
+      assert_same_elements ["https://www.example.co.uk", "#{Plek.new.website_root}/id-for-driving-licence"], result
+    end
   end
 
   def call_edition_link_extractor(edition)
     EditionLinkExtractor.new(edition: edition).call
   end
 
+  def edition_with_no_links
+    FactoryGirl.create(:place_edition, introduction: "No Links Here")
+  end
+
   def edition_with_links_in_govspeak_fields
     FactoryGirl.create(:place_edition, introduction: "This is [link](https://www.example.co.uk) text.")
+  end
+
+  def edition_with_absolute_paths_in_govspeak_fields
+    FactoryGirl.create(:place_edition, introduction: "This is [link](https://www.example.co.uk) text. This is an [absolute link](/id-for-driving-licence) text.")
   end
 
   def edition_with_links_in_parts


### PR DESCRIPTION
This PR converts absolute paths to URLs before sending them to be checked by the link checker API.

Not doing this would cause false positives.
  