### PR TITLE
Add controller actions and UI for  triggering and visualising LinkCheckReports

### DIFF
--- a/app/assets/javascripts/publications.js
+++ b/app/assets/javascripts/publications.js
@@ -26,4 +26,11 @@ $(function () {
       return 'You have unsaved changes to this edition.';
     }
   });
+
+  $('.link-check-report').on('submit', '#link-checker-form', function () {
+    if (GOVUKAdmin.Data.editionFormDirty) {
+      alert('Please save your changes before running a link check.');
+      return false;
+    }
+  });
 });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@
 @import 'diff';
 @import 'notes';
 @import 'workflow';
+@import 'broken_links_report';
 
 // Pages
 @import 'downtime';

--- a/app/assets/stylesheets/broken_links_report.scss
+++ b/app/assets/stylesheets/broken_links_report.scss
@@ -1,0 +1,46 @@
+.link-check-report {
+  float: right;
+  margin-top: 25px;
+}
+
+.broken-links-report {
+  .issue-summary {
+    font-weight: normal;
+  }
+
+  .issue-list {
+    list-style: none;
+    padding-left: 0;
+
+    li {
+      margin-top: 5px;
+    }
+  }
+
+  .issue-status-description {
+    margin-top: 10px;
+  }
+
+  .issue-list + .issue-status-description {
+    margin: 15px 0;
+  }
+
+  .display-issue-details {
+    display: block;
+    font-weight: bold;
+    padding-top: 5px;
+  }
+
+  .display-issue-details::-webkit-details-marker {
+    display: none;
+  }
+
+  .display-issue-details::before {
+    content: '\25B6';
+    padding-right: 3px;
+  }
+
+  details[open] > .display-issue-details::before {
+    content: '\25BC';
+  }
+}

--- a/app/controllers/link_check_reports_controller.rb
+++ b/app/controllers/link_check_reports_controller.rb
@@ -1,0 +1,13 @@
+class LinkCheckReportsController < ApplicationController
+  before_filter :find_reportable
+
+  def create
+
+  end
+
+private
+
+  def find_reportable
+    @reportable = Edition.find(params[:edition_id])
+  end
+end

--- a/app/controllers/link_check_reports_controller.rb
+++ b/app/controllers/link_check_reports_controller.rb
@@ -14,7 +14,28 @@ class LinkCheckReportsController < ApplicationController
     end
   end
 
+  def show
+    service = LinkCheckReportFinder.new(
+      report_id: convert_to_bson_object_id(permitted_params[:id])
+    )
+
+    @report = service.call
+
+    respond_to do |format|
+      format.js { render 'link_check_reports/show' }
+      format.html { redirect_to edition_url(@edition.id) }
+    end
+  end
+
 private
+
+  def convert_to_bson_object_id(id)
+    BSON::ObjectId.from_string(id)
+  end
+
+  def permitted_params
+    params.permit(:edition_id, :id)
+  end
 
   def find_edition
     @edition = Edition.find(params[:edition_id])

--- a/app/controllers/link_check_reports_controller.rb
+++ b/app/controllers/link_check_reports_controller.rb
@@ -1,13 +1,22 @@
 class LinkCheckReportsController < ApplicationController
-  before_filter :find_reportable
+  before_filter :find_edition
 
   def create
+    service = LinkCheckReportCreator.new(
+      edition: @edition
+    )
 
+    @report = service.call
+
+    respond_to do |format|
+      format.js { render 'link_check_reports/create' }
+      format.html { redirect_to edition_url(@edition.id) }
+    end
   end
 
 private
 
-  def find_reportable
-    @reportable = Edition.find(params[:edition_id])
+  def find_edition
+    @edition = Edition.find(params[:edition_id])
   end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -441,6 +441,10 @@ class Edition
     artefact.content_id
   end
 
+  def latest_link_check_report
+    link_check_reports.last
+  end
+
 private
 
   def base_field_keys

--- a/app/models/link_check_report.rb
+++ b/app/models/link_check_report.rb
@@ -14,4 +14,20 @@ class LinkCheckReport
   validates :batch_id, presence: true, uniqueness: true
   validates :status, presence: true
   validates :links, presence: true
+
+  def completed?
+    status == "completed"
+  end
+
+  def in_progress?
+    !completed?
+  end
+
+  def broken_links
+    links.select { |l| l.status == "broken" }
+  end
+
+  def caution_links
+    links.select { |l| l.status == "caution" }
+  end
 end

--- a/app/services/link_check_report_creator.rb
+++ b/app/services/link_check_report_creator.rb
@@ -1,7 +1,7 @@
 class LinkCheckReportCreator
   include Rails.application.routes.url_helpers
 
-  CALLBACK_HOST = Plek.find("manuals-publisher")
+  CALLBACK_HOST = Plek.find("publisher")
 
   class InvalidReport < RuntimeError
     def initialize(original_error)

--- a/app/services/link_check_report_finder.rb
+++ b/app/services/link_check_report_finder.rb
@@ -1,0 +1,21 @@
+class LinkCheckReportFinder
+  def initialize(report_id:)
+    @report_id = report_id
+  end
+
+  def call
+    link_check_report
+  end
+
+private
+
+  attr_reader :report_id
+
+  def edition
+    @edition ||= Edition.find_by("link_check_reports._id": report_id)
+  end
+
+  def link_check_report
+    @link_check_report ||= edition.link_check_reports.find_by(id: report_id)
+  end
+end

--- a/app/views/answers/_fields.html.erb
+++ b/app/views/answers/_fields.html.erb
@@ -1,6 +1,10 @@
-<%= f.inputs do %>
-  <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
-  <%= f.input :body, :as => :text, :input_html => { :disabled => @resource.locked_for_edits?, class: 'input-md-10' } %>
-<% end %>
+<div class="row">
+  <div class="col-md-8">
+    <%= f.inputs do %>
+      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+      <%= f.input :body, :as => :text, :input_html => { :disabled => @resource.locked_for_edits?, class: 'input-md-10' } %>
+    <% end %>
+  </div>
+</div>
 
 <%= render partial: 'shared/workflow_buttons', locals: { f: f } %>

--- a/app/views/campaigns/_fields.html.erb
+++ b/app/views/campaigns/_fields.html.erb
@@ -1,5 +1,9 @@
 <%= f.inputs do %>
-  <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+  <div class="row">
+    <div class="col-md-8">
+      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+    </div>
+  </div>
 
   <%= f.inputs "Campaign images" do %>
     <table class="table table-bordered image-upload remove-bottom-margin">

--- a/app/views/completed_transactions/_fields.html.erb
+++ b/app/views/completed_transactions/_fields.html.erb
@@ -1,11 +1,14 @@
-<%= f.inputs do %>
-  <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
-  <%= f.input :body,
-              :as => :text,
-              :hint => 'The body text is overwritten by the service feedback survey',
-              :input_html => { :disabled => 'disabled', class: 'input-md-10' } %>
-<% end %>
-
+<div class="row">
+  <div class="col-md-8">
+    <%= f.inputs do %>
+      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+      <%= f.input :body,
+                  :as => :text,
+                  :hint => 'The body text is overwritten by the service feedback survey',
+                  :input_html => { :disabled => 'disabled', class: 'input-md-10' } %>
+    <% end %>
+  </div>
+</div>
 
 <hr />
 <div class="row">

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -10,14 +10,19 @@
     </ul>
 
     <div class="tab-content add-top-margin">
-      <%= resource_form do |f| %>
         <div role="tabpanel" class="tab-pane <% if active_tab.name == 'edit'%>active<% end %>" id="edit">
-          <div class="well">
-            <%= render resource_fields, f: f %>
+          <div class="link-check-report col-md-4">
+            <%= render 'link_check_reports/link_check_report', edition: @edition, report: @edition.latest_link_check_report %>
           </div>
-        </div>
-        <%= edition_activities_fields(f, @resource) %>
-      <% end %>
+
+          <%= resource_form do |f| %>
+            <div class="well">
+              <%= render resource_fields, f: f %>
+            </div>
+
+            <%= edition_activities_fields(f, @resource) %>
+          <% end %>
+      </div>
       <%= # cancel scheduled publishing doesn't require the edition to be saved when requesting an activity,
         # because this action is triggered from a view where editing is not allowed.
         edition_activities_forms(@resource, Edition::CANCEL_SCHEDULED_PUBLISHING_ACTION) %>

--- a/app/views/guides/_fields.html.erb
+++ b/app/views/guides/_fields.html.erb
@@ -1,6 +1,11 @@
-<%= f.inputs do %>
-  <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
-<% end %>
+
+<div class="row">
+  <div class="col-md-8">
+    <%= f.inputs do %>
+      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+    <% end %>
+  </div>
+</div>
 
 <hr>
 

--- a/app/views/help_pages/_fields.html.erb
+++ b/app/views/help_pages/_fields.html.erb
@@ -1,6 +1,10 @@
-<%= f.inputs do %>
-  <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
-  <%= f.input :body, :as => :text, :input_html => { :disabled => @resource.locked_for_edits? } %>
-<% end %>
+<div class="row">
+  <div class="col-md-8">
+    <%= f.inputs do %>
+      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+      <%= f.input :body, :as => :text, :input_html => { :disabled => @resource.locked_for_edits? } %>
+    <% end %>
+  </div>
+</div>
 
 <%= render partial: 'shared/workflow_buttons', locals: { f: f } %>

--- a/app/views/licences/_fields.html.erb
+++ b/app/views/licences/_fields.html.erb
@@ -1,25 +1,29 @@
-<%= f.inputs do %>
-  <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
-  <%= f.input :licence_identifier, :input_html => { class: 'input-md-3', disabled: @resource.locked_for_edits? } %>
+<div class="row">
+  <div class="col-md-8">
+    <%= f.inputs do %>
+      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+      <%= f.input :licence_identifier, :input_html => { class: 'input-md-3', disabled: @resource.locked_for_edits? } %>
 
-  <%= f.input :will_continue_on,
-              :hint => 'Text to follow the statement "This will continue on. eg. "the HMRC website"',
-              :input_html => { :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>
+      <%= f.input :will_continue_on,
+                  :hint => 'Text to follow the statement "This will continue on. eg. "the HMRC website"',
+                  :input_html => { :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>
 
-  <%= f.input :continuation_link,
-              :label => 'Link to competent authority',
-              :hint => 'Link as deep as possible.',
-              :input_html => { :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>
+      <%= f.input :continuation_link,
+                  :label => 'Link to competent authority',
+                  :hint => 'Link as deep as possible.',
+                  :input_html => { :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>
 
-  <%= f.input :licence_short_description,
-        :as => :text,
-        :hint => 'One line curated description, will appear in Licence Finder results',
-        :input_html => { :rows => 2, :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>
+      <%= f.input :licence_short_description,
+            :as => :text,
+            :hint => 'One line curated description, will appear in Licence Finder results',
+            :input_html => { :rows => 2, :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>
 
-  <%= f.input :licence_overview,
-        :as => :text,
-        :input_html => { :disabled => @resource.locked_for_edits?, class: 'input-md-10' } %>
+      <%= f.input :licence_overview,
+            :as => :text,
+            :input_html => { :disabled => @resource.locked_for_edits?, class: 'input-md-10' } %>
 
-<% end %>
+    <% end %>
+  </div>
+</div>
 
 <%= render partial: 'shared/workflow_buttons', locals: { f: f } %>

--- a/app/views/link_check_reports/_form.html.erb
+++ b/app/views/link_check_reports/_form.html.erb
@@ -1,0 +1,4 @@
+<%= form_tag link_check_reports_path, remote: true do %>
+  <%= hidden_field_tag :edition_id, edition.id %>
+  <%= submit_tag button_text, id: "link-check-report", class: "btn btn-default add-top-margin remove-bottom-margin" %>
+<% end %>

--- a/app/views/link_check_reports/_form.html.erb
+++ b/app/views/link_check_reports/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag link_check_reports_path, remote: true do %>
+<%= form_tag link_check_reports_path, id: "link-checker-form", remote: true do %>
   <%= hidden_field_tag :edition_id, edition.id %>
   <%= submit_tag button_text, id: "link-check-report", class: "btn btn-default add-top-margin remove-bottom-margin" %>
 <% end %>

--- a/app/views/link_check_reports/_link_check_report.html.erb
+++ b/app/views/link_check_reports/_link_check_report.html.erb
@@ -2,6 +2,9 @@
   <% if !report.present? %>
     <section class="alert alert-info alert-link-info">
       <p>Check this edition for broken links. The report will take a few moments to complete. It only runs against GovSpeak fields.</p>
+      <noscript>
+        <p>Please save ensure you have saved your changes before running a link check.</p>
+      </noscript>
       <%= render 'link_check_reports/form', edition: edition, button_text: 'Check for broken links' %>
     </section>
   <% elsif report.in_progress? %>

--- a/app/views/link_check_reports/_link_check_report.html.erb
+++ b/app/views/link_check_reports/_link_check_report.html.erb
@@ -1,0 +1,42 @@
+<div class="broken-links-report">
+  <% if !report.present? %>
+    <section class="alert alert-info alert-link-info">
+      <p>Check this edition for broken links. The report will take a few moments to complete. It only runs against GovSpeak fields.</p>
+      <%= render 'link_check_reports/form', edition: edition, button_text: 'Check for broken links' %>
+    </section>
+  <% elsif report.in_progress? %>
+    <section class="alert alert-info alert-link-info">
+      <%= image_tag('admin/ajax_loader_blue_32.gif', width: 24, height: 24, class: 'pull-left add-right-margin') %>
+      Broken link report in progress.<br />Please wait.
+      Refresh the page to view to see the result.
+    </section>
+  <% elsif report.broken_links.any? || report.caution_links.any? %>
+    <section class="alert alert-warning">
+      <h3 class="remove-top-margin">Links</h3>
+      <% report.links.sort_by(&:status).group_by(&:status).each do |status, links| %>
+        <% next unless %w(broken caution).include? status %>
+        <p class="issue-status-description"><%= status.capitalize %></p>
+        <ul class="issue-list">
+          <% links.each do |link| %>
+            <li>
+              <%= link_to link.uri.truncate(50), link.uri, title: link.uri, class: 'link-inherit' %>
+              <details>
+                <summary class="display-issue-details">See more details about this link</summary>
+                <p class="issue-summary"><%= link.problem_summary %></p>
+                <% if link.suggested_fix %>
+                  <p class="issue-summary">Suggested fix: <%= link.suggested_fix %></p>
+                <% end %>
+              </details>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+      <%= render 'link_check_reports/form', edition: edition, button_text: 'Check again' %>
+    </section>
+  <% else %>
+    <section class='alert alert-success'>
+      <p><span class="glyphicon glyphicon-ok add-right-margin"></span> This edition contains no broken links.</p>
+      <%= render 'link_check_reports/form', edition: edition, button_text: 'Check again' %>
+    </section>
+  <% end %>
+</div>

--- a/app/views/link_check_reports/_link_check_report.html.erb
+++ b/app/views/link_check_reports/_link_check_report.html.erb
@@ -6,9 +6,11 @@
     </section>
   <% elsif report.in_progress? %>
     <section class="alert alert-info alert-link-info">
-      <%= image_tag('admin/ajax_loader_blue_32.gif', width: 24, height: 24, class: 'pull-left add-right-margin') %>
       Broken link report in progress.<br />Please wait.
-      Refresh the page to view to see the result.
+      <%= link_to "Refresh",
+                  link_check_report_path(report.id, edition_id: edition.id),
+                  class: 'js-broken-links-refresh js-hidden',
+                  remote: true %>
     </section>
   <% elsif report.broken_links.any? || report.caution_links.any? %>
     <section class="alert alert-warning">

--- a/app/views/link_check_reports/create.js.erb
+++ b/app/views/link_check_reports/create.js.erb
@@ -1,0 +1,1 @@
+$('.broken-links-report').replaceWith('<%=escape_javascript render("link_check_reports/link_check_report", report: @report, edition: @edition ) %>');

--- a/app/views/link_check_reports/show.js.erb
+++ b/app/views/link_check_reports/show.js.erb
@@ -1,0 +1,3 @@
+<% if @report.completed? %>
+  $('.broken-links-report').replaceWith('<%=escape_javascript render("link_check_reports/link_check_report", report: @report, edition: @edition ) %>');
+<% end %>

--- a/app/views/local_transactions/_fields.html.erb
+++ b/app/views/local_transactions/_fields.html.erb
@@ -1,25 +1,29 @@
-<%= f.inputs do %>
-  <%= f.input :lgsl_code,
-    :label => 'LGSL code',
-    :input_html => {:disabled => true, class: 'input-md-4'} %>
+<div class="row">
+  <div class="col-md-8">
+    <%= f.inputs do %>
+      <%= f.input :lgsl_code,
+        :label => 'LGSL code',
+        :input_html => {:disabled => true, class: 'input-md-4'} %>
 
-  <%= f.input :lgil_code,
-    :label => 'LGIL code',
-    :hint => 'LGIL code',
-    :input_html => { :disabled => @resource.locked_for_edits?, class: 'input-md-4' } %>
+      <%= f.input :lgil_code,
+        :label => 'LGIL code',
+        :hint => 'LGIL code',
+        :input_html => { :disabled => @resource.locked_for_edits?, class: 'input-md-4' } %>
 
-  <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
 
-  <%= f.input :introduction, :label => 'Introductory paragraph', :hint => 'Set the scene for the user. Explain that it\'s the responsibility of the local council and that we\'ll take you there.', :as => :text, :input_html => {:rows => 8, :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>
+      <%= f.input :introduction, :label => 'Introductory paragraph', :hint => 'Set the scene for the user. Explain that it\'s the responsibility of the local council and that we\'ll take you there.', :as => :text, :input_html => {:rows => 8, :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>
 
-  <%= f.input :more_information,
-    :as => :text,
-    :input_html => { :disabled => @resource.locked_for_edits?,  class: 'input-md-10' } %>
+      <%= f.input :more_information,
+        :as => :text,
+        :input_html => { :disabled => @resource.locked_for_edits?,  class: 'input-md-10' } %>
 
-  <%= f.input :need_to_know,
-    :as => :text,
-    :label => 'What you need to know',
-    :input_html => { :rows => 4, :disabled => @resource.locked_for_edits?, class: 'input-md-7'  } %>
-<% end %>
+      <%= f.input :need_to_know,
+        :as => :text,
+        :label => 'What you need to know',
+        :input_html => { :rows => 4, :disabled => @resource.locked_for_edits?, class: 'input-md-7'  } %>
+    <% end %>
+  </div>
+</div>
 
 <%= render partial: 'shared/workflow_buttons', locals: { f: f } %>

--- a/app/views/places/_fields.html.erb
+++ b/app/views/places/_fields.html.erb
@@ -1,22 +1,26 @@
-<%= f.inputs do %>
-  <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+<div class="row">
+  <div class="col-md-8">
+    <%= f.inputs do %>
+      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
 
-  <%= f.input :place_type,
-    :hint => "This is the 'slug' assigned in the imminence app",
-    :input_html => { :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>
+      <%= f.input :place_type,
+        :hint => "This is the 'slug' assigned in the imminence app",
+        :input_html => { :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>
 
-  <%= f.input :introduction,
-    :as => :text,
-    :input_html => {:rows => 5, :disabled => @resource.locked_for_edits?, class: 'input-md-10'  } %>
+      <%= f.input :introduction,
+        :as => :text,
+        :input_html => {:rows => 5, :disabled => @resource.locked_for_edits?, class: 'input-md-10'  } %>
 
-  <%= f.input :more_information,
-    :as => :text,
-    :input_html => { :disabled => @resource.locked_for_edits?, class: 'input-md-10'  } %>
+      <%= f.input :more_information,
+        :as => :text,
+        :input_html => { :disabled => @resource.locked_for_edits?, class: 'input-md-10'  } %>
 
-  <%= f.input :need_to_know,
-    :as => :text,
-    :label => 'What you need to know',
-    :input_html => { :rows => 4, :disabled => @resource.locked_for_edits?, class: 'input-md-7'  } %>
-<% end %>
+      <%= f.input :need_to_know,
+        :as => :text,
+        :label => 'What you need to know',
+        :input_html => { :rows => 4, :disabled => @resource.locked_for_edits?, class: 'input-md-7'  } %>
+    <% end %>
+  </div>
+</div>
 
 <%= render partial: 'shared/workflow_buttons', locals: { f: f } %>

--- a/app/views/programmes/_fields.html.erb
+++ b/app/views/programmes/_fields.html.erb
@@ -1,6 +1,10 @@
-<%= f.inputs do %>
-  <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
-<% end %>
+<div class="row">
+  <div class="col-md-8">
+    <%= f.inputs do %>
+      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+    <% end %>
+  </div>
+</div>
 
 <hr>
 

--- a/app/views/simple_smart_answers/_fields.html.erb
+++ b/app/views/simple_smart_answers/_fields.html.erb
@@ -1,11 +1,15 @@
-<%= f.inputs do %>
-  <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
-  <div class="row">
-    <div class="col-md-10">
-      <%= f.input :body, :as => :text, :input_html => { :rows => 5, :disabled => @resource.locked_for_edits? } %>
-    </div>
+<div class="row">
+  <div class="col-md-8">
+    <%= f.inputs do %>
+      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+      <div class="row">
+        <div class="col-md-10">
+          <%= f.input :body, :as => :text, :input_html => { :rows => 5, :disabled => @resource.locked_for_edits? } %>
+        </div>
+      </div>
+    <% end %>
   </div>
-<% end %>
+</div>
 
 <div class="builder-container">
   <div class="row">

--- a/app/views/transactions/_fields.html.erb
+++ b/app/views/transactions/_fields.html.erb
@@ -1,52 +1,56 @@
-<%= f.inputs do %>
-  <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+<div class="row">
+  <div class="col-md-8">
+    <%= f.inputs do %>
+      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
 
-  <%= f.input :introduction,
-              :as => :text,
-              :label => 'Introductory paragraph',
-              :hint => 'Set the scene for the user. What is about to happen? (eg. "you will need to fill in a form, print it out and take it to the post office")',
-              :input_html => { :rows => 8, :disabled => @resource.locked_for_edits?, :class => 'input-md-7' } %>
+      <%= f.input :introduction,
+                  :as => :text,
+                  :label => 'Introductory paragraph',
+                  :hint => 'Set the scene for the user. What is about to happen? (eg. "you will need to fill in a form, print it out and take it to the post office")',
+                  :input_html => { :rows => 8, :disabled => @resource.locked_for_edits?, :class => 'input-md-7' } %>
 
-  <div class="form-group">
-    <label for="edition_start_button_text">Start button text:</label><br/>
-    <% ["Start now", "Sign in"].each do |option| %>
-      <%# radio_button(object_name, method, tag_value, options = {}) %>
-      <%= f.radio_button :start_button_text, option, {class: "input-md-7", disabled: @resource.locked_for_edits?} %>
-      <%= f.label "start_button_text_#{option.gsub(" ","_").underscore}", option %><br>
+      <div class="form-group">
+        <label for="edition_start_button_text">Start button text:</label><br/>
+        <% ["Start now", "Sign in"].each do |option| %>
+          <%# radio_button(object_name, method, tag_value, options = {}) %>
+          <%= f.radio_button :start_button_text, option, {class: "input-md-7", disabled: @resource.locked_for_edits?} %>
+          <%= f.label "start_button_text_#{option.gsub(" ","_").underscore}", option %><br>
+        <% end %>
+      </div>
+
+      <%= f.input :will_continue_on,
+                  :hint => 'Text to follow the statement "This will continue on". eg. "the HMRC website"',
+                  :input_html => { :disabled => @resource.locked_for_edits?, :class => 'input-md-7' } %>
+
+      <%= f.input :link,
+                  :label => 'Link to start of transaction',
+                  :hint => 'Link as deep as possible.',
+                  :input_html => { :disabled => @resource.locked_for_edits?, :class => 'input-md-7' } %>
+
+      <%= f.input :more_information,
+                  :as => :text,
+                  :input_html => { :disabled => @resource.locked_for_edits?, :class => 'input-md-10' } %>
+
+      <%= f.input :alternate_methods,
+                  :as => :text,
+                  :label => "Other ways to apply",
+                  :hint => "Alternative ways of completing this transaction. Not displayed on front end if left blank.",
+                  :input_html => { :disabled => @resource.locked_for_edits?, :class => 'input-md-10' } %>
+
+      <%= f.input :need_to_know,
+                  :as => :text,
+                  :label => 'What you need to know',
+                  :wrapper_html => { :class => 'add-top-margin' },
+                  :input_html => { :rows => 4, :disabled => @resource.locked_for_edits?, :class => 'input-md-7' } %>
+
+      <%= f.input :department_analytics_profile,
+                  :label => 'Service analytics profile',
+                  :placeholder => 'UA-XXXXXX-X',
+                  :hint => 'Let service teams track user journeys between GOV.UK and their service using Google Analytics.',
+                  :wrapper_html => { :class => 'add-top-margin' },
+                  :input_html => { :rows => 4, :disabled => @resource.locked_for_edits?, :class => 'input-md-2' } %>
     <% end %>
   </div>
-
-  <%= f.input :will_continue_on,
-              :hint => 'Text to follow the statement "This will continue on". eg. "the HMRC website"',
-              :input_html => { :disabled => @resource.locked_for_edits?, :class => 'input-md-7' } %>
-
-  <%= f.input :link,
-              :label => 'Link to start of transaction',
-              :hint => 'Link as deep as possible.',
-              :input_html => { :disabled => @resource.locked_for_edits?, :class => 'input-md-7' } %>
-
-  <%= f.input :more_information,
-              :as => :text,
-              :input_html => { :disabled => @resource.locked_for_edits?, :class => 'input-md-10' } %>
-
-  <%= f.input :alternate_methods,
-              :as => :text,
-              :label => "Other ways to apply",
-              :hint => "Alternative ways of completing this transaction. Not displayed on front end if left blank.",
-              :input_html => { :disabled => @resource.locked_for_edits?, :class => 'input-md-10' } %>
-
-  <%= f.input :need_to_know,
-              :as => :text,
-              :label => 'What you need to know',
-              :wrapper_html => { :class => 'add-top-margin' },
-              :input_html => { :rows => 4, :disabled => @resource.locked_for_edits?, :class => 'input-md-7' } %>
-
-  <%= f.input :department_analytics_profile,
-              :label => 'Service analytics profile',
-              :placeholder => 'UA-XXXXXX-X',
-              :hint => 'Let service teams track user journeys between GOV.UK and their service using Google Analytics.',
-              :wrapper_html => { :class => 'add-top-margin' },
-              :input_html => { :rows => 4, :disabled => @resource.locked_for_edits?, :class => 'input-md-2' } %>
-<% end %>
+</div>
 
 <%= render partial: 'shared/workflow_buttons', locals: { f: f } %>

--- a/app/views/videos/_fields.html.erb
+++ b/app/views/videos/_fields.html.erb
@@ -1,36 +1,40 @@
-<%= f.inputs do %>
-  <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+<div class="row">
+  <div class="col-md-8">
+    <%= f.inputs do %>
+      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
 
-  <%= f.input :video_url,
-              :label => "Video URL",
-              :hint => 'Put the YouTube URL in here if it exists',
-              :input_html => { :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>
+      <%= f.input :video_url,
+                  :label => "Video URL",
+                  :hint => 'Put the YouTube URL in here if it exists',
+                  :input_html => { :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>
 
-  <%= f.input :video_summary,
-              :as => :text,
-              :label => "Video Summary",
-              :input_html => { :rows => 2, :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>
+      <%= f.input :video_summary,
+                  :as => :text,
+                  :label => "Video Summary",
+                  :input_html => { :rows => 2, :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>
 
-  <%= f.inputs "Caption file" do %>
-    <% if @edition.caption_file %>
-      <div class="uploaded-caption-file">
-        <h4>Current caption file</h4>
-        <p><%= link_to @edition.caption_file.name, @edition.caption_file.file_url %></p>
-        <p><%= label_tag do %>Remove caption file? <%= check_box_tag "edition[remove_caption_file]", "1", false, disabled: @resource.locked_for_edits?, class: 'js-no-ajax' %><% end %></p>
+      <%= f.inputs "Caption file" do %>
+        <% if @edition.caption_file %>
+          <div class="uploaded-caption-file">
+            <h4>Current caption file</h4>
+            <p><%= link_to @edition.caption_file.name, @edition.caption_file.file_url %></p>
+            <p><%= label_tag do %>Remove caption file? <%= check_box_tag "edition[remove_caption_file]", "1", false, disabled: @resource.locked_for_edits?, class: 'js-no-ajax' %><% end %></p>
+          </div>
+
+          <h4>Replace caption file</h4>
+        <% end %>
+
+        <p><%= f.input :caption_file, :as => :file, :label => "Upload a new caption file", input_html: { disabled: @resource.locked_for_edits? } %></p>
+      <% end %>
+      <hr />
+
+      <div class="row">
+        <div class="col-md-10">
+          <%= f.input :body, :as => :text, :input_html => { :disabled => @resource.locked_for_edits? } %>
+        </div>
       </div>
-
-      <h4>Replace caption file</h4>
     <% end %>
-
-    <p><%= f.input :caption_file, :as => :file, :label => "Upload a new caption file", input_html: { disabled: @resource.locked_for_edits? } %></p>
-  <% end %>
-  <hr />
-
-  <div class="row">
-    <div class="col-md-10">
-      <%= f.input :body, :as => :text, :input_html => { :disabled => @resource.locked_for_edits? } %>
-    </div>
   </div>
-<% end %>
+</div>
 
 <%= render partial: 'shared/workflow_buttons', locals: { f: f } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,7 +44,7 @@ Rails.application.routes.draw do
 
   get 'user_search' => 'user_search#index'
 
-  resources :link_check_reports, only: [:create]
+  resources :link_check_reports, only: %i(create show)
 
   post "/link-checker-api-callback" => "link_checker_api#callback", as: "link_checker_api_callback"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,8 @@ Rails.application.routes.draw do
 
   get 'user_search' => 'user_search#index'
 
+  resources :link_check_reports, only: [:create]
+
   post "/link-checker-api-callback" => "link_checker_api#callback", as: "link_checker_api_callback"
 
   resources :publications

--- a/test/functional/link_check_reports_controller_test.rb
+++ b/test/functional/link_check_reports_controller_test.rb
@@ -42,4 +42,23 @@ class LinkCheckReportsControllerTest < ActionController::TestCase
       assert "a-batch-id", @edition.link_check_reports.last.batch_id
     end
   end
+
+  context "#show" do
+    setup do
+      @link_check_report = @edition.link_check_reports.create(FactoryGirl.attributes_for(:link_check_report))
+    end
+
+    should "find the link_check_report and redirect on a GET request" do
+      get :show, params: { id: @link_check_report.id, edition_id: @edition.id }
+
+      assert_redirected_to(controller: "editions", action: "show", id: @edition.id)
+    end
+
+    should "find the link_check_report and render the show template on AJAX" do
+      get :show, params: { id: @link_check_report.id, edition_id: @edition.id }, xhr: true
+
+      assert_response :success
+      assert_template :show
+    end
+  end
 end

--- a/test/functional/link_check_reports_controller_test.rb
+++ b/test/functional/link_check_reports_controller_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+require "gds_api/test_helpers/link_checker_api"
+
+class LinkCheckReportsControllerTest < ActionController::TestCase
+  include GdsApi::TestHelpers::LinkCheckerApi
+  include Rails.application.routes.url_helpers
+
+  setup do
+    login_as_stub_user
+    @edition = FactoryGirl.create(:place_edition, introduction: "[link](https://www.gov.uk)")
+  end
+
+  context "#create" do
+    setup do
+      @stubbed_api_request = link_checker_api_create_batch(
+        uris: ["https://www.gov.uk"],
+        id: "a-batch-id",
+        webhook_uri: link_checker_api_callback_url(host: Plek.find("publisher")),
+        webhook_secret_token: Rails.application.secrets.link_checker_api_secret_token
+      )
+    end
+
+    should "create and link report and redirect on a normal request" do
+      post :create, params: { edition_id: @edition.id }
+
+      @edition.reload
+
+      assert_redirected_to(controller: 'editions', action: 'show', id: @edition.id)
+      assert @edition.link_check_reports.any?
+      assert 'a-batch-id', @edition.link_check_reports.last.batch_id
+    end
+
+    should 'create and render the create template on AJAX' do
+      post :create, params: { edition_id: @edition.id }, xhr: true
+
+      assert_response :success
+      assert_template :create
+
+      assert @edition.link_check_reports.any?
+      assert 'a-batch-id', @edition.link_check_reports.last.batch_id
+    end
+  end
+end

--- a/test/functional/link_check_reports_controller_test.rb
+++ b/test/functional/link_check_reports_controller_test.rb
@@ -25,19 +25,21 @@ class LinkCheckReportsControllerTest < ActionController::TestCase
 
       @edition.reload
 
-      assert_redirected_to(controller: 'editions', action: 'show', id: @edition.id)
+      assert_redirected_to(controller: "editions", action: "show", id: @edition.id)
       assert @edition.link_check_reports.any?
-      assert 'a-batch-id', @edition.link_check_reports.last.batch_id
+      assert "a-batch-id", @edition.link_check_reports.last.batch_id
     end
 
-    should 'create and render the create template on AJAX' do
+    should "create and render the create template on AJAX" do
       post :create, params: { edition_id: @edition.id }, xhr: true
 
       assert_response :success
       assert_template :create
 
+      @edition.reload
+
       assert @edition.link_check_reports.any?
-      assert 'a-batch-id', @edition.link_check_reports.last.batch_id
+      assert "a-batch-id", @edition.link_check_reports.last.batch_id
     end
   end
 end

--- a/test/integration/change_edition_type_test.rb
+++ b/test/integration/change_edition_type_test.rb
@@ -71,7 +71,7 @@ class ChangeEditionTypeTest < JavascriptIntegrationTest
         if edition.respond_to?(:parts)
           assert(sample_parts.subset?(edition_parts(edition)))
         else
-          assert_selector("form#edition-form .tab-pane textarea", text: /\s*#{Regexp.quote(edition_whole_body)}\s*/, visible: true)
+          assert_selector("form#edition-form .well textarea", text: /\s*#{Regexp.quote(edition_whole_body)}\s*/, visible: true)
         end
       end
     end

--- a/test/integration/edition_link_check_test.rb
+++ b/test/integration/edition_link_check_test.rb
@@ -1,0 +1,44 @@
+require "integration_test_helper"
+require "gds_api/test_helpers/link_checker_api"
+
+
+class EditionLinkCheckTest < JavascriptIntegrationTest
+  include GdsApi::TestHelpers::LinkCheckerApi
+
+  setup do
+    setup_users
+    stub_linkables
+    stub_holidays_used_by_fact_check
+
+    @stubbed_api_request = link_checker_api_create_batch(
+      uris: ["https://www.gov.uk"],
+      id: "a-batch-id",
+      webhook_uri: link_checker_api_callback_url(host: Plek.find("publisher")),
+      webhook_secret_token: Rails.application.secrets.link_checker_api_secret_token
+    )
+
+    @place = FactoryGirl.create(:place_edition, introduction: "This is [link](https://www.gov.uk) text.")
+  end
+
+  with_and_without_javascript do
+    should "create a link check report" do
+      visit_edition @place
+
+      within(".broken-links-report") do
+        click_on "Check for broken links"
+        page.has_content?("Broken link report in progress.")
+      end
+
+      assert_requested(@stubbed_api_request)
+
+      @place.reload
+
+      @place.latest_link_check_report.update(status: "completed")
+
+      within(".broken-links-report") do
+        click_on "Refresh"
+        page.has_content?("This edition contains no broken links")
+      end
+    end
+  end
+end

--- a/test/integration/skip_review_test.rb
+++ b/test/integration/skip_review_test.rb
@@ -38,7 +38,7 @@ class SkipReviewTest < JavascriptIntegrationTest
 
     visit "/publications/#{@artefact.id}"
 
-    within(".alert-info") do
+    within(".alert-info:not(.alert-link-info)") do
       assert page.has_content? "Skip review"
       click_on "Skip review"
     end
@@ -66,7 +66,7 @@ class SkipReviewTest < JavascriptIntegrationTest
 
     visit "/publications/#{@artefact.id}"
 
-    within(".alert-info") do
+    within(".alert-info:not(.alert-link-info)") do
       assert page.has_no_content? "Skip review"
     end
 

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -174,7 +174,7 @@ class JavascriptIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   def assert_all_edition_fields_disabled(page)
-    selector = '#edit input:not([disabled]):not([type="hidden"]), #edit select:not([disabled]), #edit textarea:not([disabled])'
+    selector = '#edit input:not(#link-check-report):not([disabled]):not([type="hidden"]), #edit select:not([disabled]), #edit textarea:not([disabled])'
     inputs = page.all(selector)
     input_description = ""
     inputs.each { |i| input_description = "#{input_description}\n##{i['id']}" }

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -1120,4 +1120,19 @@ class EditionTest < ActiveSupport::TestCase
       assert_equal 1, edition.link_check_reports.size
     end
   end
+
+  context "latest_link_check_report" do
+    should "be nil if no reports" do
+      edition = FactoryGirl.create(:edition, :published)
+      assert_nil edition.latest_link_check_report
+    end
+
+    should "return the last report created" do
+      edition = FactoryGirl.create(:edition, :published)
+      edition.link_check_reports.create(FactoryGirl.attributes_for(:link_check_report))
+      latest_report = edition.link_check_reports.create(FactoryGirl.attributes_for(:link_check_report, batch_id: 2))
+
+      assert latest_report, edition.latest_link_check_report
+    end
+  end
 end

--- a/test/models/link_check_report_test.rb
+++ b/test/models/link_check_report_test.rb
@@ -27,4 +27,45 @@ class LinkCheckReportTest < ActiveSupport::TestCase
       refute link_check_report.valid?
     end
   end
+
+  context "#completed?" do
+    should "return true when complete" do
+      link_check_report = FactoryGirl.build(:link_check_report, :completed)
+      assert link_check_report.completed?
+    end
+
+    should "return false when not complete" do
+      link_check_report = FactoryGirl.build(:link_check_report)
+      refute link_check_report.completed?
+    end
+  end
+
+  context "#in_progress?" do
+    should "retun true when in progress" do
+      link_check_report = FactoryGirl.build(:link_check_report)
+      assert link_check_report.in_progress?
+    end
+  end
+
+  context "#broken_links" do
+    should "return an array of broken links" do
+      link_check_report = FactoryGirl.build(:link_check_report, :with_links,
+                                                                link_uris: ["https://www.gov.uk"],
+                                                                link_status: "broken")
+      assert_kind_of Array, link_check_report.broken_links
+      assert link_check_report.broken_links.any?
+      assert "https://www.gov.uk", link_check_report.broken_links.first.uri
+    end
+  end
+
+  context "#caution_links" do
+    should "return an array of caution links" do
+      link_check_report = FactoryGirl.build(:link_check_report, :with_links,
+                                                                link_uris: ["https://www.gov.uk"],
+                                                                link_status: "caution")
+      assert_kind_of Array, link_check_report.caution_links
+      assert link_check_report.caution_links.any?
+      assert "https://www.gov.uk", link_check_report.caution_links.first.uri
+    end
+  end
 end

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -291,10 +291,11 @@ FactoryGirl.define do
     trait :with_links do
       transient do
         link_uris []
+        link_status "pending"
       end
 
       links do
-        link_uris.map { |uri| FactoryGirl.build(:link, uri: uri) }
+        link_uris.map { |uri| FactoryGirl.build(:link, uri: uri, status: link_status) }
       end
     end
   end

--- a/test/unit/services/link_check_report_creator_test.rb
+++ b/test/unit/services/link_check_report_creator_test.rb
@@ -13,7 +13,7 @@ class LinkCheckReportCreatorTest < ActiveSupport::TestCase
     @stubbed_api_request = link_checker_api_create_batch(
       uris: ["https://www.gov.uk"],
       id: "a-batch-id",
-      webhook_uri: link_checker_api_callback_url(host: Plek.find("manuals-publisher")),
+      webhook_uri: link_checker_api_callback_url(host: Plek.find("publisher")),
       webhook_secret_token: Rails.application.secrets.link_checker_api_secret_token
     )
   end

--- a/test/unit/services/link_check_report_finder_test.rb
+++ b/test/unit/services/link_check_report_finder_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class LinkCheckReportFinderTest < ActiveSupport::TestCase
+  def link_check_report
+    @link_check_report ||= FactoryGirl.create(:edition, :with_link_check_report,
+      link_uris: ['https://www.gov.uk']).latest_link_check_report
+  end
+
+  context ".call" do
+    should "find the link check report" do
+      result = LinkCheckReportFinder.new(report_id: link_check_report.id).call
+
+      assert result
+      assert_same_elements ['https://www.gov.uk'], result.links.map(&:uri)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds `LinkCheckReportsController#create` and `LinkCheckReportsController#show` endpoints to publisher as well as the front end UI that calls these new endpoints.

![screen shot 2018-01-08 at 14 38 41](https://user-images.githubusercontent.com/881759/34782477-bf7d7d04-f620-11e7-9149-af829db4b882.png)

Close https://github.com/alphagov/publisher/pull/740