### PR TITLE
Make the link check box work in smaller browser windows

### DIFF
--- a/app/assets/stylesheets/broken_links_report.scss
+++ b/app/assets/stylesheets/broken_links_report.scss
@@ -1,6 +1,11 @@
 .link-check-report {
-  float: right;
   margin-top: 25px;
+}
+
+@media (min-width: $screen-md-min) {
+  .link-check-report {
+    float: right;
+  }
 }
 
 .broken-links-report {


### PR DESCRIPTION
For browser windows below 992px, the link check box would cause the
form fields to get squashed into the left hand side of the well and
become unusable. For breakpoints below 992px (`md` in Bootstrap terms),
disable the float and force the box to appear above the form.

This is possibly not the best design decision, but it’s causing issues
at present for one of our partially sighted users.

Before:
<img width="955" alt="screen shot 2018-01-18 at 14 39 35" src="https://user-images.githubusercontent.com/18276/35103361-7dcfcf22-fc5d-11e7-9555-537380276ed8.png">

After:
<img width="955" alt="screen shot 2018-01-18 at 14 39 43" src="https://user-images.githubusercontent.com/18276/35103372-87f8a26c-fc5d-11e7-8dbd-d4f2bdf28e6c.png">

And above 992px:
<img width="1272" alt="screen shot 2018-01-18 at 14 40 53" src="https://user-images.githubusercontent.com/18276/35103400-9e68838c-fc5d-11e7-9451-e3be008c40c0.png">
