### PR TITLE
Modify ordered related items and user needs from Editions tagging tab

### DIFF
--- a/app/assets/javascripts/modules/related_content_items_select.js
+++ b/app/assets/javascripts/modules/related_content_items_select.js
@@ -7,7 +7,7 @@
       var $inputFields = element.find("input");
       $inputFields.prop('readonly', true);
       $inputFields.wrap('<div class="input-group"></div>');
-      $inputFields.before('<span class="input-group-addon">&updownarrow;</span>');
+      $inputFields.before('<span class="input-group-addon vertical-drag">&updownarrow;</span>');
       $inputFields.after(buildRemoveRelaltedItemEl());
 
       $('.js-list-sortable').sortable();

--- a/app/assets/javascripts/modules/related_content_items_select.js
+++ b/app/assets/javascripts/modules/related_content_items_select.js
@@ -8,8 +8,83 @@
       $inputFields.prop('readonly', true);
       $inputFields.wrap('<div class="input-group"></div>');
       $inputFields.before('<span class="input-group-addon">&updownarrow;</span>');
+      $inputFields.after(buildRemoveRelaltedItemEl());
 
       $('.js-list-sortable').sortable();
+
+      element.append(buildAddRelatedItemEl())
+    }
+
+    var buildRemoveRelaltedItemEl = function() {
+      var $buttonGroupEl = $('<span class="input-group-btn">');
+      var $buttonEl = $('<button class="btn btn-default" type="button">Remove</button>');
+
+      $buttonEl.on('click', function(e) {
+        $(this).closest('li').remove();
+      });
+
+      $buttonGroupEl.append($buttonEl);
+      return $buttonGroupEl;
+    }
+
+    var buildAddRelatedItemEl = function() {
+      var $inputGroupEl = $('<div class="input-group">');
+      var $inputEl = $('<input type="text" class="form-control js-path-field" placeholder="URL or path">');
+      var $buttonGroupEl = $('<span class="input-group-btn"></span>');
+      var $buttonEl = $('<button class="btn btn-default" type="button">Add related item</button>')
+
+      $inputEl.on('keypress', function(e) {
+        if (e.keyCode == 13) { // Enter key
+          e.preventDefault();
+          if (this.value.length == 0) return;
+          lookupBasePath(this.value);
+        }
+      });
+
+      $buttonEl.on('click', function(e) {
+        var inputValue = $("input.js-path-field").val();
+        if (inputValue.length == 0) return;
+        lookupBasePath(inputValue);
+      });
+
+      $inputGroupEl.append($inputEl);
+      $buttonGroupEl.append($buttonEl);
+      $inputGroupEl.append($buttonGroupEl);
+
+      return $inputGroupEl;
+    }
+
+    var buildInputGroupEl = function(path) {
+      var $listItemEl = $('<li></li>');
+      var $inputGroupEl = $('<div class="input-group"></div>');
+      var $dragEl = $('<span class="input-group-addon">↕</span>');
+      var $inputEl = $('<input />', {
+        type: 'text',
+        name: 'tagging_tagging_update_form[ordered_related_items][]',
+        value: path,
+        class: 'form-control',
+        readonly: true
+      });
+
+      $listItemEl.append($inputGroupEl);
+      $inputGroupEl.append($dragEl);
+      $inputGroupEl.append($inputEl);
+      $inputGroupEl.append(buildRemoveRelaltedItemEl());
+
+      return $listItemEl;
+    }
+
+    var lookupBasePath = function(path) {
+      $.getJSON("/api/lookup-by-base-path?base_path=" + encodeURIComponent(path))
+        .done(function(contentId) {
+          $(".js-path-field").removeClass('field-with-error')
+          $(".js-add-path-error").addClass('hide')
+          $('ul.js-base-path-list').append(buildInputGroupEl(path));
+          $("input.js-path-field").val('');
+        }).fail(function(error) {
+          $(".js-add-path-error").removeClass('hide');
+          $(".js-path-field").addClass('field-with-error')
+        });
     }
   };
 })(window.GOVUKAdmin.Modules);

--- a/app/assets/javascripts/modules/related_content_items_select.js
+++ b/app/assets/javascripts/modules/related_content_items_select.js
@@ -1,0 +1,15 @@
+(function(Modules) {
+  "use strict";
+  Modules.RelatedContentItemsSelect = function() {
+    this.start = function(element) {
+      element.find("input[value='']").closest('li').remove();
+
+      var $inputFields = element.find("input");
+      $inputFields.prop('readonly', true);
+      $inputFields.wrap('<div class="input-group"></div>');
+      $inputFields.before('<span class="input-group-addon">&updownarrow;</span>');
+
+      $('.js-list-sortable').sortable();
+    }
+  };
+})(window.GOVUKAdmin.Modules);

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -62,3 +62,7 @@
   font-weight: bold;
   color: $state-danger-text;
 }
+
+.vertical-drag {
+  cursor: ns-resize;
+}

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -51,3 +51,14 @@
     right: 15px
   }
 }
+
+.field-with-error {
+  border: 2px solid $state-danger-text;
+}
+
+.error-block {
+  margin-top: 5px;
+  margin-bottom: 10px;
+  font-weight: bold;
+  color: $state-danger-text;
+}

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -129,8 +129,14 @@ class EditionsController < InheritedResources::Base
   end
 
   def update_tagging
-    Tagging::TaggingUpdateForm.new(tagging_update_form_params).publish!
-    redirect_to tagging_edition_path, flash: { success: "Tags have been updated!" }
+    form = Tagging::TaggingUpdateForm.new(tagging_update_form_params)
+    if form.valid?
+      form.publish!
+      flash[:success] = "Tags have been updated!"
+    else
+      flash[:danger] = form.errors.full_messages.join("\n")
+    end
+    redirect_to tagging_edition_path
   rescue GdsApi::HTTPConflict
     redirect_to tagging_edition_path,
     flash: {
@@ -356,6 +362,7 @@ private
       topics: [],
       organisations: [],
       meets_user_needs: [],
+      ordered_related_items: [],
     ).to_h
   end
 

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -354,7 +354,8 @@ private
       :parent,
       mainstream_browse_pages: [],
       topics: [],
-      organisations: []
+      organisations: [],
+      meets_user_needs: [],
     ).to_h
   end
 

--- a/app/controllers/publishing_api_proxy_controller.rb
+++ b/app/controllers/publishing_api_proxy_controller.rb
@@ -1,0 +1,11 @@
+class PublishingApiProxyController < ActionController::Base
+  def lookup_by_base_path
+    content_id = Services.publishing_api.lookup_content_id(base_path: params[:base_path])
+
+    if content_id.present?
+      render json: { content_id: content_id }
+    else
+      render json: {}, status: 404
+    end
+  end
+end

--- a/app/views/shared/_metadata.html.erb
+++ b/app/views/shared/_metadata.html.erb
@@ -7,7 +7,6 @@
       </div>
     </div>
     <%= f.submit 'Update metadata', class: "btn btn-success btn-large" %>
-    <%= link_to "Add or edit related GOV.UK links and user needs", content_tagger_url(publication), class: "btn btn-primary" %>
   <% end %>
 <% else %>
   <div class="row">
@@ -18,5 +17,4 @@
       <% end %>
     </div>
   </div>
-  <%= link_to "Add or edit related GOV.UK links and user needs", content_tagger_url(publication), class: "btn btn-primary" %>
 <% end %>

--- a/app/views/shared/_tagging.html.erb
+++ b/app/views/shared/_tagging.html.erb
@@ -98,8 +98,8 @@
             Related content items
           </label>
 
-          <fieldset>
-            <ul class="list-unstyled">
+          <fieldset data-module="related-content-items-select">
+            <ul class="list-unstyled js-list-sortable">
             <% Array(@tagging_update.ordered_related_items).each do |related_item| %>
               <li>
                 <%= text_field_tag 'tagging_tagging_update_form[ordered_related_items][]',

--- a/app/views/shared/_tagging.html.erb
+++ b/app/views/shared/_tagging.html.erb
@@ -92,6 +92,35 @@
              content.
            </p>
         </div>
+
+        <div class="form-group">
+          <label>
+            Related content items
+          </label>
+
+          <fieldset>
+            <ul class="list-unstyled">
+            <% Array(@tagging_update.ordered_related_items).each do |related_item| %>
+              <li>
+                <%= text_field_tag 'tagging_tagging_update_form[ordered_related_items][]',
+                      related_item['base_path'],
+                      class: 'form-control',
+                      data: { title: related_item['title'] } %>
+              </li>
+            <% end %>
+            <% 5.times do %>
+              <li>
+                <%= text_field_tag 'tagging_tagging_update_form[ordered_related_items][]', '',
+                      class: 'form-control' %>
+              </li>
+            <% end %>
+            </ul>
+          </fieldset>
+
+          <p class='help-block'>
+            Related items are displayed in the sidebar. Enter the URL or path of a GOV.UK page, such as /pay-vat or /benefit-cap-calculator
+          </p>
+        </div>
       </div>
     </div>
 

--- a/app/views/shared/_tagging.html.erb
+++ b/app/views/shared/_tagging.html.erb
@@ -99,7 +99,7 @@
           </label>
 
           <fieldset data-module="related-content-items-select">
-            <ul class="list-unstyled js-list-sortable">
+            <ul class="list-unstyled js-list-sortable js-base-path-list">
             <% Array(@tagging_update.ordered_related_items).each do |related_item| %>
               <li>
                 <%= text_field_tag 'tagging_tagging_update_form[ordered_related_items][]',
@@ -116,6 +116,10 @@
             <% end %>
             </ul>
           </fieldset>
+
+          <p class='error-block js-add-path-error hide'>
+            Not a known URL or path on GOV.UK
+          </p>
 
           <p class='help-block'>
             Related items are displayed in the sidebar. Enter the URL or path of a GOV.UK page, such as /pay-vat or /benefit-cap-calculator

--- a/app/views/shared/_tagging.html.erb
+++ b/app/views/shared/_tagging.html.erb
@@ -76,9 +76,25 @@
            Example: <a href="https://www.gov.uk/search?q=taxes&amp;filter_organisations%5B%5D=hm-revenue-customs">search for documents published by HMRC</a>.
            </p>
         </div>
+
+        <div class="form-group">
+          <%= f.label :meets_user_needs, 'User Needs', class: 'control-label' %>
+          <%= f.select :meets_user_needs,
+                       @linkables.meets_user_needs,
+                       {},
+                       { multiple: true,
+                         class: 'select2',
+                         data: { module: "tagging", placeholder: 'Choose user needs…' } } %>
+
+           <p class='help-block'>
+             Needs are managed through Maslow, and the list of user needs which a
+             item of content meets is displayed on the info page for that
+             content.
+           </p>
+        </div>
       </div>
     </div>
 
     <hr/>
     <%= f.submit 'Update tags', class: "btn btn-success btn-large" %>
-<% end %> 
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ Rails.application.routes.draw do
   resources :link_check_reports, only: %i(create show)
 
   post "/link-checker-api-callback" => "link_checker_api#callback", as: "link_checker_api_callback"
+  get 'api/lookup-by-base-path', to: "publishing_api_proxy#lookup_by_base_path"
 
   resources :publications
   root to: 'root#index'

--- a/lib/tagging/link_set.rb
+++ b/lib/tagging/link_set.rb
@@ -3,7 +3,7 @@ module Tagging
     attr_reader :links, :expanded_links, :version
 
     def self.find(content_id)
-      link_set = Services.publishing_api.get_expanded_links(content_id)
+      link_set = Services.publishing_api.get_expanded_links(content_id, generate: true)
       new(link_set.to_h)
     rescue GdsApi::HTTPNotFound
       new({})

--- a/lib/tagging/link_set.rb
+++ b/lib/tagging/link_set.rb
@@ -1,17 +1,22 @@
 module Tagging
   class LinkSet
-    attr_reader :links, :version
+    attr_reader :links, :expanded_links, :version
 
     def self.find(content_id)
-      link_set = Services.publishing_api.get_links(content_id)
+      link_set = Services.publishing_api.get_expanded_links(content_id)
       new(link_set.to_h)
     rescue GdsApi::HTTPNotFound
       new({})
     end
 
     def initialize(data)
-      @links = data['links'] || {}
+      @links = extract_content_ids(data['expanded_links'] || {})
+      @expanded_links = data['expanded_links'] || {}
       @version = data['version'] || 0
+    end
+
+    def extract_content_ids(expanded_links)
+      expanded_links.transform_values { |v| v.collect { |h| h['content_id'] } }
     end
   end
 end

--- a/lib/tagging/linkables.rb
+++ b/lib/tagging/linkables.rb
@@ -20,6 +20,10 @@ module Tagging
       @organisations ||= for_document_type('organisation')
     end
 
+    def meets_user_needs
+      @meets_user_needs ||= for_document_type('need')
+    end
+
     def mainstream_browse_pages
       @mainstream_browse_pages ||= for_nested_document_type('mainstream_browse_page')
     end

--- a/lib/tagging/tagging_update_form.rb
+++ b/lib/tagging/tagging_update_form.rb
@@ -2,7 +2,7 @@ module Tagging
   class TaggingUpdateForm
     include ActiveModel::Model
     attr_accessor :content_id, :previous_version
-    attr_accessor :topics, :organisations, :mainstream_browse_pages, :parent
+    attr_accessor :topics, :organisations, :meets_user_needs, :mainstream_browse_pages, :parent
 
     def self.build_from_publishing_api(content_id)
       link_set = LinkSet.find(content_id)
@@ -12,6 +12,7 @@ module Tagging
         previous_version: link_set.version,
         topics: link_set.links['topics'],
         organisations: link_set.links['organisations'],
+        meets_user_needs: link_set.links['meets_user_needs'],
         mainstream_browse_pages: link_set.links['mainstream_browse_pages'],
         parent: link_set.links['parent'],
       )
@@ -29,6 +30,7 @@ module Tagging
       {
         topics: clean_content_ids(topics),
         organisations: clean_content_ids(organisations),
+        meets_user_needs: clean_content_ids(meets_user_needs),
         mainstream_browse_pages: clean_content_ids(mainstream_browse_pages),
         parent: clean_content_ids(parent),
       }

--- a/lib/tagging/tagging_update_form.rb
+++ b/lib/tagging/tagging_update_form.rb
@@ -2,7 +2,9 @@ module Tagging
   class TaggingUpdateForm
     include ActiveModel::Model
     attr_accessor :content_id, :previous_version
-    attr_accessor :topics, :organisations, :meets_user_needs, :mainstream_browse_pages, :parent
+    attr_accessor :topics, :organisations, :meets_user_needs, :mainstream_browse_pages, :ordered_related_items, :parent
+
+    validate :ordered_related_items_paths_exist
 
     def self.build_from_publishing_api(content_id)
       link_set = LinkSet.find(content_id)
@@ -14,6 +16,7 @@ module Tagging
         organisations: link_set.links['organisations'],
         meets_user_needs: link_set.links['meets_user_needs'],
         mainstream_browse_pages: link_set.links['mainstream_browse_pages'],
+        ordered_related_items: link_set.expanded_links['ordered_related_items'],
         parent: link_set.links['parent'],
       )
     end
@@ -32,6 +35,7 @@ module Tagging
         organisations: clean_content_ids(organisations),
         meets_user_needs: clean_content_ids(meets_user_needs),
         mainstream_browse_pages: clean_content_ids(mainstream_browse_pages),
+        ordered_related_items: transform_base_paths_to_content_ids(ordered_related_items),
         parent: clean_content_ids(parent),
       }
     end
@@ -40,6 +44,25 @@ module Tagging
 
     def clean_content_ids(select_form_input)
       Array(select_form_input).select(&:present?)
+    end
+
+    def ordered_related_items_paths_exist
+      (Array(ordered_related_items) - ordered_related_items_path_by_ids.keys).each do |missing_path|
+        next if missing_path.blank?
+        errors.add(:ordered_related_items, "#{missing_path} is not a known URL on GOV.UK")
+      end
+    end
+
+    def ordered_related_items_path_by_ids
+      @_ordered_related_items_path_by_ids ||= begin
+        Services.publishing_api.lookup_content_ids(base_paths: ordered_related_items)
+      end
+    end
+
+    def transform_base_paths_to_content_ids(base_paths)
+      Array(base_paths).reject!(&:blank?)
+      return [] if base_paths.blank?
+      base_paths.map { |base_path| ordered_related_items_path_by_ids[base_path] }
     end
   end
 end

--- a/test/integration/tagging_test.rb
+++ b/test/integration/tagging_test.rb
@@ -26,6 +26,7 @@ class TaggingTest < JavascriptIntegrationTest
         links: {
           topics: [],
           organisations: [],
+          meets_user_needs: [],
           mainstream_browse_pages: ["CONTENT-ID-RTI", "CONTENT-ID-VAT"],
           parent: [],
         },
@@ -46,6 +47,7 @@ class TaggingTest < JavascriptIntegrationTest
         links: {
           topics: ['CONTENT-ID-DISTILL', 'CONTENT-ID-FIELDS'],
           organisations: [],
+          meets_user_needs: [],
           mainstream_browse_pages: [],
           parent: [],
         },
@@ -65,6 +67,27 @@ class TaggingTest < JavascriptIntegrationTest
         links: {
           topics: [],
           organisations: ["9a9111aa-1db8-4025-8dd2-e08ec3175e72"],
+          meets_user_needs: [],
+          mainstream_browse_pages: [],
+          parent: [],
+        },
+        previous_version: 0
+      )
+    end
+
+    should 'tag to user needs' do
+      visit_edition @edition
+      switch_tab 'Tagging'
+
+      select 'As a user, I need to pay a VAT bill, so that I can pay HMRC what I owe (100550)', from: 'User Needs'
+
+      save_tags_and_assert_success
+      assert_publishing_api_patch_links(
+        @edition.artefact.content_id,
+        links: {
+          topics: [],
+          organisations: [],
+          meets_user_needs: ['CONTENT-ID-USER-NEED'],
           mainstream_browse_pages: [],
           parent: [],
         },
@@ -84,6 +107,7 @@ class TaggingTest < JavascriptIntegrationTest
         links: {
           topics: [],
           organisations: [],
+          meets_user_needs: [],
           mainstream_browse_pages: [],
           parent: ['CONTENT-ID-RTI'],
         },
@@ -117,6 +141,7 @@ class TaggingTest < JavascriptIntegrationTest
         links: {
           topics: ['CONTENT-ID-FIELDS', 'CONTENT-ID-WELLS'],
           organisations: [],
+          meets_user_needs: [],
           mainstream_browse_pages: ['CONTENT-ID-RTI', 'CONTENT-ID-VAT'],
           parent: ['CONTENT-ID-CAPITAL'],
         },

--- a/test/integration/tagging_test.rb
+++ b/test/integration/tagging_test.rb
@@ -101,18 +101,20 @@ class TaggingTest < JavascriptIntegrationTest
     end
 
     should 'tag to related content items' do
-      publishing_api_has_expanded_links(
-        'content_id' => @edition.artefact.content_id,
-        'expanded_links' => {
-          'ordered_related_items' => [
-            {
-              'content_id' => 'CONTENT-ID-VAT-RETURNS',
-              'base_path' => '/vat-returns',
-              'internal_name' => 'VAT Returns',
-            }
-          ],
-        },
-      )
+      expanded_links_url = "#{Plek.current.find('publishing-api')}/v2/expanded-links/#{@edition.artefact.content_id}?generate=true"
+      stub_request(:get, expanded_links_url)
+        .to_return(status: 200, body: {
+          'content_id' => @edition.artefact.content_id,
+          'expanded_links' => {
+            'ordered_related_items' => [
+              {
+                'content_id' => 'CONTENT-ID-VAT-RETURNS',
+                'base_path' => '/vat-returns',
+                'internal_name' => 'VAT Returns',
+              }
+            ],
+          },
+        }.to_json)
 
       visit_edition @edition
       switch_tab 'Tagging'
@@ -189,31 +191,33 @@ class TaggingTest < JavascriptIntegrationTest
     end
 
     should "mutate existing tags" do
-      publishing_api_has_expanded_links(
-        "content_id" => @content_id,
-        "expanded_links" => {
-          'topics' => [
-            {
-              'content_id' => 'CONTENT-ID-WELLS',
-              'base_path' => '/topic/oil-and-gas/wells',
-              'internal_name' => 'Oil and Gas / Wells',
-            }
-          ],
-          'mainstream_browse_pages' => [
-            {
-              'content_id' => 'CONTENT-ID-RTI',
-              'base_path' => '/browse/tax/rti',
-              'internal_name' => 'Tax / RTI',
-            }
-          ],
-          'parent' => [
-            {
-              'content_id' => 'CONTENT-ID-RTI',
-              'document_type' => 'mainstream_browse_pages',
-            }
-          ],
-        },
-      )
+      expanded_links_url = "#{Plek.current.find('publishing-api')}/v2/expanded-links/#{@content_id}?generate=true"
+      stub_request(:get, expanded_links_url)
+        .to_return(status: 200, body: {
+          "content_id" => @content_id,
+          "expanded_links" => {
+            'topics' => [
+              {
+                'content_id' => 'CONTENT-ID-WELLS',
+                'base_path' => '/topic/oil-and-gas/wells',
+                'internal_name' => 'Oil and Gas / Wells',
+              }
+            ],
+            'mainstream_browse_pages' => [
+              {
+                'content_id' => 'CONTENT-ID-RTI',
+                'base_path' => '/browse/tax/rti',
+                'internal_name' => 'Tax / RTI',
+              }
+            ],
+            'parent' => [
+              {
+                'content_id' => 'CONTENT-ID-RTI',
+                'document_type' => 'mainstream_browse_pages',
+              }
+            ],
+          },
+        }.to_json)
 
       visit_edition @edition
       switch_tab 'Tagging'

--- a/test/support/tag_test_helpers.rb
+++ b/test/support/tag_test_helpers.rb
@@ -4,7 +4,7 @@ module TagTestHelpers
   include GdsApi::TestHelpers::PublishingApiV2
 
   def stub_linkables
-    stub_request(:get, %r{\A#{PUBLISHING_API_V2_ENDPOINT}/links/.+})
+    stub_request(:get, %r{\A#{PUBLISHING_API_V2_ENDPOINT}/expanded-links/.+})
       .to_return(status: 200, body: "{}", headers: {})
 
     publishing_api_has_linkables([

--- a/test/support/tag_test_helpers.rb
+++ b/test/support/tag_test_helpers.rb
@@ -32,5 +32,10 @@ module TagTestHelpers
         },
       ],
       document_type: "organisation")
+
+    publishing_api_has_linkables([
+      { internal_name: 'As a user, I need to pay a VAT bill, so that I can pay HMRC what I owe (100550)',
+        publication_state: 'published', content_id: 'CONTENT-ID-USER-NEED', },
+    ], document_type: 'need')
   end
 end


### PR DESCRIPTION
The metadata tab of the Editions page in Publisher had a link to Content Tagger where the user could manage the links/user needs. However, for non-English pages, Content Tagger is unable to edit these taggings. In this PR, we've removed the link to Content Tagger and have moved similar functionality to the taggings tab of an Edition:

<img width="562" alt="screen shot 2018-02-19 at 12 03 19" src="https://user-images.githubusercontent.com/885223/36376921-e92ddf20-156c-11e8-9e61-43ce7ea83588.png">

Trello: https://trello.com/c/oJ2L4qyt/89-make-it-possible-to-edit-welsh-language-content-in-content-tagger