### PR TITLE
Remove require_signin_permission!

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,6 @@ class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
 
   before_action :authenticate_user!
-  before_action :require_signin_permission!
 
   rescue_from Mongoid::Errors::DocumentNotFound, with: :record_not_found
 

--- a/app/controllers/link_checker_api_controller.rb
+++ b/app/controllers/link_checker_api_controller.rb
@@ -1,7 +1,6 @@
 class LinkCheckerApiController < ApplicationController
   skip_before_action :verify_authenticity_token
   skip_before_action :authenticate_user!
-  skip_before_action :require_signin_permission!
   before_action :verify_signature
 
   rescue_from Mongoid::Errors::DocumentNotFound, with: :render_no_content


### PR DESCRIPTION
This is now enforced by Signon instead. The ApplicationController
still calls authenticate_user!, so users are still required to sign
in.