### PR TITLE
HUB-73: Roll out new service sign in in page for the personal tax account service

### DIFF
--- a/lib/service_sign_in/personal-tax-account.en.yaml
+++ b/lib/service_sign_in/personal-tax-account.en.yaml
@@ -1,0 +1,49 @@
+start_page_slug: personal-tax-account
+locale: en
+choose_sign_in:
+  title: Prove your identity to continue
+  slug: prove-identity
+  options:
+    - text: Use Government Gateway
+      url: https://www.tax.service.gov.uk/personal-account/start-government-gateway
+      hint_text: You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.
+    - text: Use GOV.UK Verify
+      url: https://www.tax.service.gov.uk/personal-account/start-verify
+      hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
+    - text: Create an account
+      slug: create-account
+create_new_account:
+  title: Create an account
+  slug: create-account
+  body: |
+    To use this service, you need to create either a Government Gateway or GOV.UK Verify account. These are used to help fight identity theft.
+
+    Once you have an account, you can use it to access other government services online.
+
+    ## Choose a way to prove your identity
+
+    ### Government Gateway
+
+    Registering with Government Gateway usually takes about 10 minutes. It works best if you have:
+
+    * your National Insurance number
+    * a recent payslip or P60 or a valid UK passport
+
+    [Create a Government Gateway account](https://www.tax.service.gov.uk/personal-account/start-government-gateway).
+
+    ### GOV.UK Verify
+
+    Registering with GOV.UK Verify usually takes about 15 minutes. It works best if you have:
+
+    - a UK address
+    - a valid passport or photocard driving licence
+
+    [Create a GOV.UK Verify account](https://www.tax.service.gov.uk/personal-account/start-verify).
+
+    A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.
+
+    ## Personal tax account
+
+    Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
+update_type: major
+change_note: First published.


### PR DESCRIPTION
Jira card: HUB-73: https://govukverify.atlassian.net/browse/HUB-73

Added personal-tax-account.yml file to service_sign_in folder so that the changes made to the personal tax account service can be released to staging for approval.

The wireframe for the changes to the  https://www.gov.uk/personal-tax-account page can be seen here:
https://draft-origin.publishing.service.gov.uk/personal-tax-account?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjYzk1YmYzNC0xMWI2LTRkNTMtYjU0Mi05YjNmY2VkOGM5NDkifQ.f7rRcYNbTVEnVLgnHsWWRW8xFy5tOMpWXSqHze1XZtY

As part of the requirements for this story we need to move the personal tax account service over to use the new start page/interstitial page/create account pattern deployed in Q3 for Self Assessment, Company Car Tax and Check This Year's Tax. The personal-tax-account page "sigin in" button will change to be a "start now" button that takes the user to https://www.gov.uk/personal-tax-account/sign-in/prove-identity form page. This commit adds a yml file to hold the content for the new sign in in and create account pages. The content of the yml is very similar to that used on the Company Car Tax and Check This Year's Tax pages with only the links and page slug changing. 

Please note the content for the create account pages for Company Car Tax and Check This Year's Tax currently displayed in production is a trial version hard coded in government front end for the duration of the trial. The content added for personal tax account here reflects the content held for this services by publisher rather than the new trial versions.

Co-authored-by: Simon Wilson <simon.wilson@digital.cabinet-office.gov.uk>