### PR TITLE
HUB-77: Change wording on the service sign-in pages to be more sign-in focused

### DIFF
--- a/lib/service_sign_in/check-income-tax.en.yaml
+++ b/lib/service_sign_in/check-income-tax.en.yaml
@@ -1,13 +1,13 @@
 start_page_slug: check-income-tax-current-year
 locale: en
 choose_sign_in:
-  title: Prove your identity to continue
+  title: How do you want to sign in?
   slug: prove-identity
   options:
-    - text: Use Government Gateway
+    - text: Sign in with Government Gateway
       url: https://www.tax.service.gov.uk/check-income-tax/start-government-gateway?_ga=2.67571155.398886849.1513589676-373904926.1473694521
       hint_text: You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.
-    - text: Use GOV.UK Verify
+    - text: Sign in with GOV.UK Verify
       url: https://www.tax.service.gov.uk/check-income-tax/start-verify?_ga=2.265317837.398886849.1513589676-373904926.1473694521
       hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
     - text: Create an account
@@ -45,5 +45,5 @@ create_new_account:
     ## Personal tax account
 
     Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
-update_type: major
-change_note: First published.
+update_type: minor
+change_note: Updated the wording of the sign-in options (baseline test for Verify).

--- a/lib/service_sign_in/check-update-company-car-tax.en.yaml
+++ b/lib/service_sign_in/check-update-company-car-tax.en.yaml
@@ -1,13 +1,13 @@
 start_page_slug: update-company-car-details
 locale: en
 choose_sign_in:
-  title: Prove your identity to continue
+  title: How do you want to sign in?
   slug: prove-identity
   options:
-    - text: Use Government Gateway
+    - text: Sign in with Government Gateway
       url: https://www.tax.service.gov.uk/paye/company-car/start-government-gateway
       hint_text: You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.
-    - text: Use GOV.UK Verify
+    - text: Sign in with GOV.UK Verify
       url: https://www.tax.service.gov.uk/paye/company-car/start-verify
       hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
     - text: Create an account
@@ -45,5 +45,5 @@ create_new_account:
     ## Personal tax account
 
     Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
-update_type: major
-change_note: First published.
+update_type: minor
+change_note: Updated the wording of the sign-in options (baseline test for Verify).

--- a/lib/service_sign_in/file_self_assessment.en.yaml
+++ b/lib/service_sign_in/file_self_assessment.en.yaml
@@ -1,7 +1,7 @@
 start_page_slug: log-in-file-self-assessment-tax-return
 locale: en
 choose_sign_in:
-  title: Prove your identity to continue
+  title: How do you want to sign in?
   slug: prove-identity
   options:
     - text: Sign in with Government Gateway
@@ -31,4 +31,4 @@ create_new_account:
 
     *[UTR]: Unique Taxpayer Reference
 update_type: minor
-change_note: Corrected the section 'If you're already registered'.
+change_note: Updated the wording of the page title to be sign-in focused (baseline test for Verify).


### PR DESCRIPTION
We're changing the wording on the sign-in pages to make the distinction between sign-in and sign-up more clear to the users.

This change is proposed by the Verify team.

Co-authored-by: Jakub Miarka <jakub.miarka@digital.cabinet-office.gov.uk>
