### PR TITLE
HUB-91: https://govukverify.atlassian.net/browse/HUB-91

### DIFF
--- a/lib/service_sign_in/check-income-tax.en.yaml
+++ b/lib/service_sign_in/check-income-tax.en.yaml
@@ -29,7 +29,7 @@ create_new_account:
     * your National Insurance number
     * a recent payslip or P60 or a valid UK passport
 
-    [Create a Government Gateway account](https://www.tax.service.gov.uk/check-income-tax/start-government-gateway?_ga=2.114080007.145612230.1512381177-373904926.1473694521).
+    {button}[Create a Government Gateway account](https://www.tax.service.gov.uk/check-income-tax/start-government-gateway?_ga=2.114080007.145612230.1512381177-373904926.1473694521){/button}
 
     ### GOV.UK Verify
 
@@ -38,7 +38,7 @@ create_new_account:
     - a UK address
     - a valid passport or photocard driving licence
 
-    [Create a GOV.UK Verify account](https://www.tax.service.gov.uk/check-income-tax/start-verify?_ga=2.114080007.145612230.1512381177-373904926.1473694521).
+    {button}[Create a GOV.UK Verify account](https://www.tax.service.gov.uk/check-income-tax/start-verify?_ga=2.114080007.145612230.1512381177-373904926.1473694521){/button}
 
     A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.
 
@@ -46,4 +46,4 @@ create_new_account:
 
     Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
 update_type: minor
-change_note: Updated the wording of the sign-in options (baseline test for Verify).
+change_note: added a button instead of the links to gov gateway and verify.

--- a/lib/service_sign_in/check-update-company-car-tax.en.yaml
+++ b/lib/service_sign_in/check-update-company-car-tax.en.yaml
@@ -29,7 +29,7 @@ create_new_account:
     * your National Insurance number
     * a recent payslip or P60 or a valid UK passport
 
-    [Create a Government Gateway account](https://www.tax.service.gov.uk/paye/company-car/start-government-gateway).
+    {button}[Create a Government Gateway account](https://www.tax.service.gov.uk/paye/company-car/start-government-gateway){/button}
 
     ### GOV.UK Verify
 
@@ -38,7 +38,7 @@ create_new_account:
     - a UK address
     - a valid passport or photocard driving licence
 
-    [Create a GOV.UK Verify account](https://www.tax.service.gov.uk/paye/company-car/start-verify).
+    {button}[Create a GOV.UK Verify account](https://www.tax.service.gov.uk/paye/company-car/start-verify){/button}
 
     A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.
 
@@ -46,4 +46,4 @@ create_new_account:
 
     Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
 update_type: minor
-change_note: Updated the wording of the sign-in options (baseline test for Verify).
+change_note: added a button instead of the links to gov gateway and verify.

--- a/lib/service_sign_in/personal-tax-account.en.yaml
+++ b/lib/service_sign_in/personal-tax-account.en.yaml
@@ -29,7 +29,7 @@ create_new_account:
     * your National Insurance number
     * a recent payslip or P60 or a valid UK passport
 
-    [Create a Government Gateway account](https://www.tax.service.gov.uk/personal-account/start-government-gateway).
+    {button}[Create a Government Gateway account](https://www.tax.service.gov.uk/personal-account/start-government-gateway){/button}
 
     ### GOV.UK Verify
 
@@ -38,12 +38,12 @@ create_new_account:
     - a UK address
     - a valid passport or photocard driving licence
 
-    [Create a GOV.UK Verify account](https://www.tax.service.gov.uk/personal-account/start-verify).
+    {button}[Create a GOV.UK Verify account](https://www.tax.service.gov.uk/personal-account/start-verify){/button}
 
     A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.
 
     ## Personal tax account
 
     Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
-update_type: major
-change_note: First published.
+update_type: minor
+change_note: added a button instead of the links to gov gateway and verify.


### PR DESCRIPTION
Clearer call to actions on the Create Account page

Small change to the create account pages for Personal Tax account, Company Car tax and Check Income tax pages in the service sigin in pages to turn the links to gateway and verify services into buttons in the hopes of making them stand out more to users.

Due to Verify devs not having the same dev set up as govUK devs I have not been able to run this locally but will add the design page to the PR. There should be no copy change or functional changes, just the links representing as buttons.

![screen shot 2018-03-22 at 12 25 14](https://user-images.githubusercontent.com/15333080/37847170-d0eb7e9e-2ec7-11e8-8e76-19c69ba7bfb7.png)


Solo: @rachelthecodesmith