### PR TITLE
Remove contractions from interface

### DIFF
--- a/app/views/shared/_common_edition_attributes.html.erb
+++ b/app/views/shared/_common_edition_attributes.html.erb
@@ -18,5 +18,5 @@
 <%= f.input :overview,
       :as => :text,
       :label => 'Meta tag description',
-      :hint => 'Some search engines will display this if they can&rsquo;t find what they need in the main text',
+      :hint => 'Some search engines will display this if they cannot find what they need in the main text',
       :input_html => { :rows => 4, :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,6 @@ en:
   formtastic:
     hints:
       guide:
-        slug: "eg ‘title-of-part’ (no spaces, apostrophes, etc)"
+        slug: "for example, title-of-part (no spaces, apostrophes or acronyms)"
       part:
-        slug: "eg ‘title-of-part’ (no spaces, apostrophes, etc)"
+        slug: "for example, title-of-part (no spaces, apostrophes or acronyms)"


### PR DESCRIPTION
Remove elements that come up in searches for `'t` in the interface so it's easier for content designers to find negative contractions in body text.