### PR TITLE
Add new Completed Transaction "promotion" option

### DIFF
--- a/app/presenters/formats/completed_transaction_presenter.rb
+++ b/app/presenters/formats/completed_transaction_presenter.rb
@@ -2,7 +2,7 @@ module Formats
   class CompletedTransactionPresenter < EditionFormatPresenter
   private
 
-    PROMOTIONS = %w(organ_donor register_to_vote)
+    PROMOTIONS = %w(organ_donor register_to_vote mot_reminder)
 
     def schema_name
       'completed_transaction'

--- a/app/presenters/formats/completed_transaction_presenter.rb
+++ b/app/presenters/formats/completed_transaction_presenter.rb
@@ -2,7 +2,7 @@ module Formats
   class CompletedTransactionPresenter < EditionFormatPresenter
   private
 
-    PROMOTIONS = %w(organ_donor register_to_vote mot_reminder)
+    PROMOTIONS = %w(organ_donor register_to_vote mot_reminder).freeze
 
     def schema_name
       'completed_transaction'

--- a/app/views/completed_transactions/_fields.html.erb
+++ b/app/views/completed_transactions/_fields.html.erb
@@ -33,7 +33,7 @@
       <br />
       <%= f.radio_button :promotion_choice, 'mot_reminder',
         { checked: (f.object.promotion_choice == "mot_reminder"), disabled: @resource.locked_for_edits? } %>
-      <%= f.label :promotion_choice, "Promote MOT Reminders", value: 'mot_reminder' %>
+      <%= f.label :promotion_choice, "Promote MOT reminders", value: 'mot_reminder' %>
 
       <%= f.input :promotion_choice_url,
           required: false,

--- a/app/views/completed_transactions/_fields.html.erb
+++ b/app/views/completed_transactions/_fields.html.erb
@@ -30,6 +30,10 @@
       <%= f.radio_button :promotion_choice, 'register_to_vote',
         { checked: (f.object.promotion_choice == "register_to_vote"), disabled: @resource.locked_for_edits? } %>
       <%= f.label :promotion_choice, "Promote register to vote", value: 'register_to_vote' %>
+      <br />
+      <%= f.radio_button :promotion_choice, 'mot_reminder',
+        { checked: (f.object.promotion_choice == "mot_reminder"), disabled: @resource.locked_for_edits? } %>
+      <%= f.label :promotion_choice, "Promote MOT Reminders", value: 'mot_reminder' %>
 
       <%= f.input :promotion_choice_url,
           required: false,

--- a/lib/presentation_toggles.rb
+++ b/lib/presentation_toggles.rb
@@ -4,7 +4,7 @@ module PresentationToggles
   included do
     field :presentation_toggles, type: Hash, default: default_presentation_toggles
     validates :promotion_choice_url, presence: true, if: :promotes_something?
-    validates :promotion_choice, inclusion: { in: %w(none organ_donor register_to_vote) }
+    validates :promotion_choice, inclusion: { in: %w(none organ_donor register_to_vote mot_reminder) }
   end
 
   def promotion_choice=(value)

--- a/test/integration/completed_transactions_create_edit_test.rb
+++ b/test/integration/completed_transactions_create_edit_test.rb
@@ -98,4 +98,15 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
     assert page.has_field? "Promotion choice URL", with: register_to_vote_promotion_url
     assert page.has_unchecked_field? "Promote organ donation"
   end
+
+  should "show list of promotion options" do
+    edition = FactoryBot.create(:completed_transaction_edition, panopticon_id: @artefact.id)
+
+    visit_edition edition
+
+    assert page.has_content? "Don't promote anything on this page"
+    assert page.has_content? "Promote organ donation"
+    assert page.has_content? "Promote register to vote"
+    assert page.has_content? "Promote MOT Reminders"
+  end
 end

--- a/test/integration/completed_transactions_create_edit_test.rb
+++ b/test/integration/completed_transactions_create_edit_test.rb
@@ -107,6 +107,6 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
     assert page.has_content? "Don't promote anything on this page"
     assert page.has_content? "Promote organ donation"
     assert page.has_content? "Promote register to vote"
-    assert page.has_content? "Promote MOT Reminders"
+    assert page.has_content? "Promote MOT reminders"
   end
 end

--- a/test/models/completed_transaction_edition_test.rb
+++ b/test/models/completed_transaction_edition_test.rb
@@ -52,5 +52,12 @@ class CompletedTransactionEditionTest < ActiveSupport::TestCase
 
     assert_equal "register_to_vote", completed_transaction_edition.reload.promotion_choice
     assert_equal "https://www.gov.uk/register-to-vote", completed_transaction_edition.promotion_choice_url
+
+    completed_transaction_edition.promotion_choice = "mot_reminder"
+    completed_transaction_edition.promotion_choice_url = "https://www.gov.uk/mot-reminder"
+    completed_transaction_edition.save!
+
+    assert_equal "mot_reminder", completed_transaction_edition.reload.promotion_choice
+    assert_equal "https://www.gov.uk/mot-reminder", completed_transaction_edition.promotion_choice_url
   end
 end


### PR DESCRIPTION
There is a department request to add another promotion option 'MOT reminders' to the `completed transaction` format.

It works in the same way as the `organ_donor` option, where you can select it to be the promotion for any `completed transaction` done page (for example https://www.gov.uk/done/vehicle-tax)

Available `promotion_choice` options:
- none
- organ_donor
- register_to_vote
- mot_reminder

Related PRs:
https://github.com/alphagov/govuk-content-schemas/pull/747
https://github.com/alphagov/frontend/pull/1488

Trello card: [Request for new option in Completed Transaction 'promotion' slot](https://trello.com/c/fQQYxNIK/70-request-for-new-option-in-completed-transaction-promotion-slot)

Before:
![publisher_promotion_options_before](https://user-images.githubusercontent.com/19667619/38877293-4791f838-4256-11e8-8b26-6c1e65a13a36.png)
After:
![publisher_promotion_options__after](https://user-images.githubusercontent.com/19667619/39477605-a5b8ac48-4d57-11e8-956d-e36bd4834f0c.png)

