### PR TITLE
Change link for 'Sign in with Government Gateway' for company car tax

### DIFF
--- a/lib/service_sign_in/check-update-company-car-tax.en.yaml
+++ b/lib/service_sign_in/check-update-company-car-tax.en.yaml
@@ -5,7 +5,7 @@ choose_sign_in:
   slug: prove-identity
   options:
     - text: Sign in with Government Gateway
-      url: https://www.tax.service.gov.uk/paye/company-car/start-government-gateway
+      url: https://www.tax.service.gov.uk/gg/sign-in?continue=/paye/company-car/details&accountType=individual&origin=PERTAX&origin=PTA-companycar
       hint_text: You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.
     - text: Sign in with GOV.UK Verify
       url: https://www.tax.service.gov.uk/paye/company-car/start-verify


### PR DESCRIPTION
- This service is being onboarded to Secure Credentials Platform.
- Change of URL link requested by Sophie Davies, Zendesk ticket #2744164 (https://govuk.zendesk.com/agent/tickets/2744164)