### PR TITLE
Fix favicon not showing

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,10 +1,8 @@
 <% content_for :page_title, ' | GOV.UK Publisher' %>
 <% content_for :favicon do %>
   <% environment_style = GovukAdminTemplate.environment_style %>
-  <%= favicon_link_tag(
-    environment_style ? "favicon-#{environment_style}.png" : "favicon.png",
-    skip_pipeline: true
-  ) %>
+  <% favicon = environment_style ? "favicon-#{environment_style}.png" : "favicon.png" %>
+  <%= favicon_link_tag "govuk_admin_template/#{favicon}" %>
 <% end %>
 <% content_for :head do %>
   <%= stylesheet_link_tag "application", :media => "all" %>


### PR DESCRIPTION
I previously broke this by responding a bit too aggressively to a
warning emitted from many of the tests:

```
DEPRECATION WARNING: The asset "favicon.png" is not present in the asset pipeline.Falling back to an asset that may be in the public folder.
This behavior is deprecated and will be removed.
To bypass the asset pipeline and preserve this behavior,
use the `skip_pipeline: true` option.
```

Turns out the asset was in the pipeline but it couldn't be found easily.
This can be resolved by amending the path to include
`govuk_admin_template/`.