### PR TITLE
Updated link for Government Gateway replacement

### DIFF
--- a/lib/service_sign_in/personal-tax-account.en.yaml
+++ b/lib/service_sign_in/personal-tax-account.en.yaml
@@ -5,7 +5,7 @@ choose_sign_in:
   slug: prove-identity
   options:
     - text: Use Government Gateway
-      url: https://www.tax.service.gov.uk/personal-account/start-government-gateway
+      url: https://www.tax.service.gov.uk/gg/sign-in?continue=/personal-account&accountType=individual&origin=PERTAX&origin=PTA-frontend
       hint_text: You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.
     - text: Use GOV.UK Verify
       url: https://www.tax.service.gov.uk/personal-account/start-verify


### PR DESCRIPTION
Updated the Government Gateway service link so that it will work when this service is onboarded to the Government Gateway replacement.
Zen request: https://govuk.zendesk.com/agent/tickets/2744528
Trello: https://trello.com/c/KgGmOFJU/1516-11-may-government-gateway-replacement-update-links-to-services-for-pta-tax-credits-change-address