### PR TITLE
Remove all instances of the unicode sequence \u2028

### DIFF
--- a/db/migrate/20180508125107_remove_unicode_2028.rb
+++ b/db/migrate/20180508125107_remove_unicode_2028.rb
@@ -1,0 +1,29 @@
+class RemoveUnicode2028 < Mongoid::Migration
+  def self.up
+    unicode = "\u2028"
+    unicode_re = Regexp.new(unicode)
+    updated = []
+
+    Edition.where(:body => { '$regex' => unicode }, :state => { '$ne' => 'archived' }).each do |edition|
+      edition.body = edition.body.gsub(unicode, '')
+      updated << edition if edition.save(validate: false) # These are published editions and we don't want to go via workflow.
+    end
+
+    Edition.where(:parts => { '$elemMatch' => { :body => { '$regex' => unicode } } },
+                  :state => { '$ne' => 'archived' }).each do |edition|
+      edition.parts.each do |part|
+        if part.body =~ unicode_re
+          part.body = part.body.gsub(unicode, '')
+        end
+      end
+      updated << edition if edition.save(validate: false)
+    end
+
+    puts "#{updated.size} editions updated."
+    puts "Ids: #{updated.map(&:id).uniq.join(', ')}"
+    puts "Slugs: #{updated.map(&:slug).uniq.join(', ')}"
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
https://trello.com/c/6uVjBZUj/124-validation-issue-in-publisher-2

This unicode sequence is identified as a change due to recent
updates to the sanitize gem. The knock on effect of this is that
govspeak validation fails and the edition cannot be saved.
Removing the offending sequence should have no effect on the presentation
of the markdown as it's an artefact from particular text editors.