### PR TITLE
Set primary publishing organisation on publish

### DIFF
--- a/app/services/publish_service.rb
+++ b/app/services/publish_service.rb
@@ -1,4 +1,6 @@
 class PublishService
+  GDS_ORGANISATION_ID = "af07d5a5-df63-4ddc-9383-6a666845ebe9".freeze
+
   class << self
     def call(edition, update_type = nil)
       publish_current_draft(edition, update_type)
@@ -13,6 +15,13 @@ class PublishService
         content_id,
         update_type,
         locale: edition.artefact.language
+      )
+
+      Services.publishing_api.patch_links(
+        content_id,
+        links: {
+          "primary_publishing_organisation" => [GDS_ORGANISATION_ID]
+        }
       )
     end
   end

--- a/test/unit/services/publish_service_test.rb
+++ b/test/unit/services/publish_service_test.rb
@@ -15,6 +15,11 @@ class PublishServiceTest < ActiveSupport::TestCase
     PublishService.call(edition, update_type)
   end
 
+  should "set links" do
+    Services.publishing_api.expects(:patch_links)
+    PublishService.call(edition, update_type)
+  end
+
   def edition
     @_edition ||= stub(
       id: 123,


### PR DESCRIPTION
GDS is responsible for everything published through publisher.

This uses link-set links for consistency with other publishing
apps (https://docs.publishing.service.gov.uk/apis/publishing-api/link-expansion.html#patch-link-set---link-set-links)

In publisher, other kinds of links are set through a separate form, so we need
to add in another call to make sure the primary org gets set.

Trello: https://trello.com/c/Z6nv4TjA/313-set-primary-org-in-mainstream-publisher