### PR TITLE
HUB-131: Amend copy on service sign in pages for consistency.

### DIFF
--- a/lib/service_sign_in/check-income-tax.en.yaml
+++ b/lib/service_sign_in/check-income-tax.en.yaml
@@ -1,7 +1,7 @@
 start_page_slug: check-income-tax-current-year
 locale: en
 choose_sign_in:
-  title: How do you want to sign in?
+  title: Prove your identity to continue
   slug: prove-identity
   options:
     - text: Sign in with Government Gateway
@@ -12,6 +12,7 @@ choose_sign_in:
       hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
     - text: Create an account
       slug: create-account
+      hint_text: If you do not already have one of these accounts, we'll help you choose whether to use Government Gateway or GOV.UK Verify.
 create_new_account:
   title: Create an account
   slug: create-account
@@ -46,4 +47,4 @@ create_new_account:
 
     Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
 update_type: minor
-change_note: added a button instead of the links to gov gateway and verify.
+change_note: Update title and added hint text for service sign in page for consistency.

--- a/lib/service_sign_in/check-update-company-car-tax.en.yaml
+++ b/lib/service_sign_in/check-update-company-car-tax.en.yaml
@@ -1,7 +1,7 @@
 start_page_slug: update-company-car-details
 locale: en
 choose_sign_in:
-  title: How do you want to sign in?
+  title: Prove your identity to continue
   slug: prove-identity
   options:
     - text: Sign in with Government Gateway
@@ -12,6 +12,7 @@ choose_sign_in:
       hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
     - text: Create an account
       slug: create-account
+      hint_text: If you do not already have one of these accounts, we'll help you choose whether to use Government Gateway or GOV.UK Verify.
 create_new_account:
   title: Create an account
   slug: create-account
@@ -46,4 +47,4 @@ create_new_account:
 
     Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
 update_type: minor
-change_note: added a button instead of the links to gov gateway and verify.
+change_note: Update title and added hint text for service sign in page for consistency.

--- a/lib/service_sign_in/personal-tax-account.en.yaml
+++ b/lib/service_sign_in/personal-tax-account.en.yaml
@@ -4,14 +4,15 @@ choose_sign_in:
   title: Prove your identity to continue
   slug: prove-identity
   options:
-    - text: Use Government Gateway
+    - text: Sign in with Government Gateway
       url: https://www.tax.service.gov.uk/gg/sign-in?continue=/personal-account&accountType=individual&origin=PERTAX&origin=PTA-frontend
       hint_text: You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.
-    - text: Use GOV.UK Verify
+    - text: Sign in with GOV.UK Verify
       url: https://www.tax.service.gov.uk/personal-account/start-verify
       hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
     - text: Create an account
       slug: create-account
+      hint_text: If you do not already have one of these accounts, we'll help you choose whether to use Government Gateway or GOV.UK Verify.
 create_new_account:
   title: Create an account
   slug: create-account
@@ -46,4 +47,4 @@ create_new_account:
 
     Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
 update_type: minor
-change_note: added a button instead of the links to gov gateway and verify.
+change_note: Update title and added hint text for service sign in page for consistency.


### PR DESCRIPTION
Change text on service sign in pages for company-car-tax, personal-tax-account and check-income-tax.
No changes made to the file-self-assessment service sign in page due to the difference in user journey options.
No change to layout or functionality of the page, just content changes to make the journey consistent.

https://govukverify.atlassian.net/browse/HUB-131

The change required is to update the copy on the following service interstitial pages:

Personal Tax Account - https://www.gov.uk/personal-tax-account/sign-in/prove-identity
Check This Year’s Tax Estimate - https://www.gov.uk/check-income-tax-current-year/sign-in/prove-identity
Check Company Car Tax - https://www.gov.uk/update-company-car-details/sign-in/prove-identity

No change to self-assessment due to the difference in user journey options, i.e. only being able to create an account with government gateway. (confirmed with content designer).
Self-Assessment - https://www.gov.uk/log-in-file-self-assessment-tax-return/sign-in/prove-identity

Copy

Prove your identity to continue
Sign in with Government Gateway
You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.

Sign in with GOV.UK Verify
You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.

Create Account
If you do not already have one of these accounts, we'll help you choose whether to use Government Gateway or GOV.UK Verify

NB: there is no change to copy for the create account page.
NB: Welsh translations are out of scope for this story - we will see if further changes are needed after HUB-143 - baseline test (https://govukverify.atlassian.net/browse/HUB-143) is completed and get the correct translation for the winning copy as this may require further changes to this page at a later date.

The paragraph of text shown on the image below after the title is not part of this card but will be done as part of a baseline test in HUB-143 (separate jira ticket). Other than that new sign in pages should appear as per the below image.

<img width="760" alt="hub_131" src="https://user-images.githubusercontent.com/15333080/40007888-dacf6de8-5795-11e8-9920-cabc852addf2.png">


Co-Authored-by: Callum Knights <callum.knights@digital.cabinet-office.gov.uk>