### PR TITLE
Update link for Government Gateway replacement

### DIFF
--- a/lib/service_sign_in/check-update-company-car-tax.en.yaml
+++ b/lib/service_sign_in/check-update-company-car-tax.en.yaml
@@ -29,7 +29,7 @@ create_new_account:
     * your National Insurance number
     * a recent payslip or P60 or a valid UK passport
 
-    {button}[Create a Government Gateway account](https://www.tax.service.gov.uk/paye/company-car/start-government-gateway){/button}
+    {button}[Create a Government Gateway account](https://www.tax.service.gov.uk/gg/sign-in?continue=/paye/company-car/details&accountType=individual&origin=PERTAX&origin=PTA-companycar){/button}
 
     ### GOV.UK Verify
 


### PR DESCRIPTION
Update link to 'create account' so it will work with the Government Gateway replacement when it's added to this service.
(Note: the link to the sign in to this service has already been updated.)