### PR TITLE
Update link for Government Gateway replacement

### DIFF
--- a/lib/service_sign_in/personal-tax-account.en.yaml
+++ b/lib/service_sign_in/personal-tax-account.en.yaml
@@ -29,7 +29,7 @@ create_new_account:
     - your National Insurance number
     - a recent payslip or P60 or a valid UK passport
 
-    {button}[Create a Government Gateway account](https://www.tax.service.gov.uk/personal-account/start-government-gateway){/button}
+    {button}[Create a Government Gateway account](https://www.tax.service.gov.uk/gg/sign-in?continue=/personal-account&accountType=individual&origin=PERTAX&origin=PTA-frontend){/button}
 
     ### GOV.UK Verify
 


### PR DESCRIPTION
Update 'create account' link for the Government gateway replacement so it will work when it's added to this service. 
(NOTE: the link to sign in to the service has already been updated).