### PR TITLE
Updated links for Government Gateway replacement

### DIFF
--- a/lib/service_sign_in/check-update-company-car-tax.cy.yaml
+++ b/lib/service_sign_in/check-update-company-car-tax.cy.yaml
@@ -5,7 +5,7 @@ choose_sign_in:
   slug: profi-pwy-ydych
   options:
     - text: Defnyddio Porth y Llywodraeth
-      url: https://www.tax.service.gov.uk/paye/company-car/start-government-gateway
+      url: https://www.tax.service.gov.uk/gg/sign-in?continue=/paye/company-car/details&accountType=individual&origin=PERTAX&origin=PTA-companycar
       hint_text: Bydd gennych Ddynodydd Defnyddiwr (ID) os ydych wedi cofrestru i wneud pethau fel cyflwyno'ch Ffurflen Dreth Hunanasesiad ar-lein.
     - text: Defnyddio GOV.UK Verify
       url: https://www.tax.service.gov.uk/paye/company-car/start-verify
@@ -29,7 +29,7 @@ create_new_account:
     - eich rhif Yswiriant Gwladol
     - slip cyflog diweddar, P60 neu basbort y DU sy'n ddilys
 
-    [Creu cyfrif Porth y llywodraeth.](https://www.tax.service.gov.uk/paye/company-car/start-government-gateway])
+    [Creu cyfrif Porth y llywodraeth](https://www.tax.service.gov.uk/gg/sign-in?continue=/paye/company-car/details&accountType=individual&origin=PERTAX&origin=PTA-companycar).
 
     ###GOV.UK Verify
 


### PR DESCRIPTION
https://trello.com/c/NzkPq091/166-4-content-prs

Replaces #852 

Updated the 'login with' and 'create account' links to Government Gateway so they will work with the Government Gateway replacement when it is added to this service.