### PR TITLE
Update link for Government Gateway replacement

### DIFF
--- a/lib/service_sign_in/personal-tax-account.cy.yaml
+++ b/lib/service_sign_in/personal-tax-account.cy.yaml
@@ -28,7 +28,7 @@ create_new_account:
     - eich rhif Yswiriant Gwladol
     - slip cyflog diweddar, P60 neu basbort dilys y DU
 
-    {button}[Creu cyfrif Porth y Llywodraeth](https://www.tax.service.gov.uk/personal-account/start-government-gateway){/button}
+    {button}[Creu cyfrif Porth y Llywodraeth](https://www.tax.service.gov.uk/gg/sign-in?continue=/personal-account&accountType=individual&origin=PERTAX&origin=PTA-frontend){/button}
 
     ### GOV.UK Verify
 


### PR DESCRIPTION
https://trello.com/c/NzkPq091/166-4-content-prs

Replaces https://github.com/alphagov/publisher/pull/854

Update 'create account' link for the Government gateway replacement so it will work when it's added to this service. 
(NOTE: the link to sign in to the service has already been updated).