### PR TITLE
HUB-143: Add description to service sign in pages

### DIFF
--- a/lib/service_sign_in/check-income-tax.en.yaml
+++ b/lib/service_sign_in/check-income-tax.en.yaml
@@ -2,6 +2,7 @@ start_page_slug: check-income-tax-current-year
 locale: en
 choose_sign_in:
   title: Prove your identity to continue
+  description: You’ll need an account to prove your identity and check your income tax for the current year.
   slug: prove-identity
   options:
     - text: Sign in with Government Gateway
@@ -47,4 +48,4 @@ create_new_account:
 
     Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
 update_type: minor
-change_note: Update title and added hint text for service sign in page for consistency.
+change_note: Added description text for service sign in page including service name.

--- a/lib/service_sign_in/check-update-company-car-tax.en.yaml
+++ b/lib/service_sign_in/check-update-company-car-tax.en.yaml
@@ -2,6 +2,7 @@ start_page_slug: update-company-car-details
 locale: en
 choose_sign_in:
   title: Prove your identity to continue
+  description: You’ll need an account to prove your identity and check or update your company car tax.
   slug: prove-identity
   options:
     - text: Sign in with Government Gateway
@@ -47,4 +48,4 @@ create_new_account:
 
     Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
 update_type: minor
-change_note: Update title and added hint text for service sign in page for consistency.
+change_note: Added description text for service sign in page including service name.

--- a/lib/service_sign_in/file_self_assessment.en.yaml
+++ b/lib/service_sign_in/file_self_assessment.en.yaml
@@ -2,6 +2,7 @@ start_page_slug: log-in-file-self-assessment-tax-return
 locale: en
 choose_sign_in:
   title: How do you want to sign in?
+  description: You’ll need an account to prove your identity and complete your Self Assessment.
   slug: prove-identity
   options:
     - text: Sign in with Government Gateway
@@ -31,4 +32,4 @@ create_new_account:
 
     *[UTR]: Unique Taxpayer Reference
 update_type: minor
-change_note: Updated the wording of the page title to be sign-in focused (baseline test for Verify).
+change_note: Added description text for service sign in page including service name.

--- a/lib/service_sign_in/personal-tax-account.en.yaml
+++ b/lib/service_sign_in/personal-tax-account.en.yaml
@@ -2,6 +2,7 @@ start_page_slug: personal-tax-account
 locale: en
 choose_sign_in:
   title: Prove your identity to continue
+  description: You’ll need an account to prove your identity and sign in to your personal tax account.
   slug: prove-identity
   options:
     - text: Sign in with Government Gateway
@@ -47,4 +48,4 @@ create_new_account:
 
     Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
 update_type: minor
-change_note: Update title and added hint text for service sign in page for consistency.
+change_note: Added description text for service sign in page including service name.


### PR DESCRIPTION
Add a description paragraph that will be displayed under the title on each of the 4 services using the service sign in pattern, each description includes the service specific text. This "description" is already present in the example yaml, the schema and on the page template on government-frontend but was hitherto unused. Should this prove to be a good pattern according to the base line test we will add a description to the welsh pages as well.

https://govukverify.atlassian.net/browse/HUB-143

<img width="760" alt="hub_143" src="https://user-images.githubusercontent.com/15333080/40302277-809358c0-5ce6-11e8-8bc9-76e47fec60ab.png">


solo: @rachelthecodesmith