### PR TITLE
Process mail based on env var

### DIFF
--- a/lib/fact_check_email_handler.rb
+++ b/lib/fact_check_email_handler.rb
@@ -34,12 +34,14 @@ class FactCheckEmailHandler
 
   # &after_each_message: an optional block to call after processing each message
   def process(&after_each_message)
-    Mail.all(read_only: false, delete_after_find: true) do |message|
-      message.skip_deletion unless process_message(message)
-      begin
-        after_each_message.call(message) if after_each_message
-      rescue => e
-        GovukError.notify(e)
+    if ENV.include?("RUN_FACT_CHECK_FETCHER")
+      Mail.all(read_only: false, delete_after_find: true) do |message|
+        message.skip_deletion unless process_message(message)
+        begin
+          yield(message) if block_given?
+        rescue StandardError => e
+          GovukError.notify(e)
+        end
       end
     end
   end

--- a/lib/mail_fetcher_config.rb
+++ b/lib/mail_fetcher_config.rb
@@ -6,9 +6,7 @@ class MailFetcherConfig
       raise ArgumentError, "Non-symbolic keys: #{keys_string}"
     end
 
-    @imap_details = if ENV["RUN_FACT_CHECK_FETCHER"] && config_hash.present?
-                      config_hash.dup
-                    end
+    @imap_details = config_hash.dup if config_hash.present?
   end
 
   def configure(mail_module = Mail)

--- a/test/unit/mail_fetcher_config_test.rb
+++ b/test/unit/mail_fetcher_config_test.rb
@@ -12,15 +12,6 @@ class MailFetcherConfigTest < ActiveSupport::TestCase
     end
   end
 
-  setup do
-    @env_run_fact_check_fetcher = ENV["RUN_FACT_CHECK_FETCHER"]
-    ENV["RUN_FACT_CHECK_FETCHER"] = "1"
-  end
-
-  teardown do
-    ENV["RUN_FACT_CHECK_FETCHER"] = @env_run_fact_check_fetcher
-  end
-
   should "raise an error if given strings as keys" do
     assert_raises ArgumentError do
       MailFetcherConfig.new("user_name" => "bob@example.com")
@@ -42,12 +33,5 @@ class MailFetcherConfigTest < ActiveSupport::TestCase
     mail = StubMail.new
     mail.expects(:defaults).never
     MailFetcherConfig.new({}).configure(mail)
-  end
-
-  should "not configure email settings if RUN_FACT_CHECKER_FETCHER is not set" do
-    mail = StubMail.new
-    mail.expects(:defaults).never
-    ENV.delete("RUN_FACT_CHECK_FETCHER")
-    MailFetcherConfig.new(user_name: "bob@example.com").configure(mail)
   end
 end


### PR DESCRIPTION
https://trello.com/c/MjhoqAug/168-investigate-how-mainstream-publisher-should-be-checking-for-emails-on-integration-2

The environment var `RUN_FACT_CHECK_FETCHER` is set per environment to control processing of fact check emails.

The [previous implementation used this var to determine whether or not to set the
imap details](https://github.com/alphagov/publisher/blob/master/lib/mail_fetcher_config.rb#L9) but not to prevent attempts to process the emails on the server.

So `Mail#all` would attempt to retrieve mail based on defaults and this would result in a [connection refused error on localhost:110](https://sentry.io/govuk/app-publisher/issues/523285917/?query=environment:integration-blue-aws).

The PR alters the behaviour to a no-op if the env var is not set.