### PR TITLE
Stop running update and publish asynchronously

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -93,8 +93,7 @@ class EditionsController < InheritedResources::Base
 
         update_assignment resource, assign_to
 
-        UpdateWorker.perform_async(resource.id.to_s)
-        PublishWorker.perform_async(resource.id.to_s) if update_action_is_publish?
+        UpdateWorker.perform_async(resource.id.to_s, update_action_is_publish?)
 
         return_to = params[:return_to] || edition_path(resource)
         redirect_to return_to
@@ -112,8 +111,7 @@ class EditionsController < InheritedResources::Base
 
         update_assignment resource, assign_to
 
-        UpdateWorker.perform_async(resource.id.to_s)
-        PublishWorker.perform_async(resource.id.to_s) if update_action_is_publish?
+        UpdateWorker.perform_async(resource.id.to_s, update_action_is_publish?)
 
         render json: resource
       }

--- a/app/services/republish_service.rb
+++ b/app/services/republish_service.rb
@@ -1,6 +1,6 @@
 class RepublishService
   def self.call(edition)
-    UpdateService.call(edition, 'republish')
+    UpdateService.call(edition, republish: true)
     PublishService.call(edition, 'republish')
   end
 end

--- a/app/services/update_service.rb
+++ b/app/services/update_service.rb
@@ -1,7 +1,7 @@
 class UpdateService
-  def self.call(edition, update_type = "minor")
+  def self.call(edition, republish: false)
     presenter = EditionPresenterFactory.get_presenter(edition)
-    payload = presenter.render_for_publishing_api(republish: update_type == "republish")
+    payload = presenter.render_for_publishing_api(republish: republish)
     Services.publishing_api.put_content(edition.content_id, payload)
   end
 end

--- a/app/workers/update_worker.rb
+++ b/app/workers/update_worker.rb
@@ -1,8 +1,8 @@
 class UpdateWorker
   include Sidekiq::Worker
 
-  def perform(edition_id, update_type = "minor")
+  def perform(edition_id)
     edition = Edition.find(edition_id)
-    UpdateService.call(edition, update_type)
+    UpdateService.call(edition)
   end
 end

--- a/app/workers/update_worker.rb
+++ b/app/workers/update_worker.rb
@@ -1,8 +1,9 @@
 class UpdateWorker
   include Sidekiq::Worker
 
-  def perform(edition_id)
+  def perform(edition_id, publish = false)
     edition = Edition.find(edition_id)
     UpdateService.call(edition)
+    PublishService.call(edition) if publish
   end
 end

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -245,7 +245,7 @@ class EditionsControllerTest < ActionController::TestCase
     end
 
     should "update the publishing API on successful update" do
-      UpdateWorker.expects(:perform_async).with(@guide.id.to_s)
+      UpdateWorker.expects(:perform_async).with(@guide.id.to_s, false)
 
       post :update,
         params: {

--- a/test/unit/services/republish_service_test.rb
+++ b/test/unit/services/republish_service_test.rb
@@ -8,7 +8,7 @@ class RepublishServiceTest < ActiveSupport::TestCase
 
   context ".call" do
     should "call the UpdateService with the provided edition" do
-      UpdateService.expects(:call).with(edition, 'republish')
+      UpdateService.expects(:call).with(edition, republish: true)
       RepublishService.call(edition)
     end
 

--- a/test/unit/workers/update_worker_test.rb
+++ b/test/unit/workers/update_worker_test.rb
@@ -4,10 +4,9 @@ class UpdateWorkerTest < ActiveSupport::TestCase
   context "#perform" do
     should "call the UpdateService" do
       edition = FactoryBot.create(:edition)
-      update_type = 'foo'
-      UpdateService.expects(:call).with(edition, update_type)
+      UpdateService.expects(:call).with(edition)
 
-      UpdateWorker.new.perform(edition.id, update_type)
+      UpdateWorker.new.perform(edition.id)
     end
   end
 end

--- a/test/unit/workers/update_worker_test.rb
+++ b/test/unit/workers/update_worker_test.rb
@@ -5,8 +5,18 @@ class UpdateWorkerTest < ActiveSupport::TestCase
     should "call the UpdateService" do
       edition = FactoryBot.create(:edition)
       UpdateService.expects(:call).with(edition)
+      PublishService.expects(:call).never
 
       UpdateWorker.new.perform(edition.id)
+    end
+
+    context "when publish is true" do
+      should "call the PublishService" do
+        edition = FactoryBot.create(:edition)
+
+        PublishService.expects(:call).with(edition)
+        UpdateWorker.new.perform(edition.id, true)
+      end
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/bIF8U0cL/184-last-updated-timestamp-not-updating-on-helppage-format-2

We've seen issues with the publishing process from Publisher to Publishing API which can cause the last update to a document to arrive after it has been published - this ends up publishing a document that isn't what the publisher specified and creating an unexpected draft of the full data.

![screen shot 2018-05-24 at 11 26 04](https://user-images.githubusercontent.com/282717/40501087-c4b8e71e-5f7e-11e8-95b0-2e604d96e085.png)

To prevent this we've updated the update and publish process to run a single asynchronous job. This can perform both steps rather than creating two jobs and is no longer vulnerable to ordering issues.