### PR TITLE
Use visibility modifier to reveal modal forms

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.scss
@@ -69,10 +69,24 @@ select.date {
  * required to apply correct display attributes to .tab-pane
  * elements wrapped inside the edition form in .tab-content.
  * See: edition/show.html.erb
+ *
+ * Uses visibility: rather than display: modifiers so that modal forms
+ * embedded in hidden tabs can be displayed.
  */
 .tab-content .tab-pane {
-  display: none;
+  overflow: hidden;
+  position: absolute;
+  visibility: hidden;
+  width: 0px;
 }
 .tab-content .active {
-  display: block;
+  visibility: visible;
+  position: relative;
+  width: 100%;
+}
+.tab-content>.tab-pane {
+  display: inline-block;
+}
+.modal.in {
+  visibility: visible;
 }


### PR DESCRIPTION
https://trello.com/c/KIZW45MY/191-modals-on-the-edition-form-in-publisher-only-work-on-the-edit-tab

![screenshot from 2018-05-30 17-18-54](https://user-images.githubusercontent.com/93511/40733452-9a2b18ce-642d-11e8-9d56-2a0126d0e49e.png)

Modal forms are embedded in the edit tab, when this tab is hidden with
`display: none`  they can't be displayed as any child elements cannot override this rule.

Using visibility modifier instead allows a parent to be hidden and a child to be shown.