### PR TITLE
Create experimental "knowledge API"

### DIFF
--- a/app/services/knowledge_api.rb
+++ b/app/services/knowledge_api.rb
@@ -1,0 +1,27 @@
+class KnowledgeApi
+  CONTENT_ID = "4dbbc2d1-a0db-441b-96c9-a743d067f724".freeze
+  KNOWLEDGE_ENTRIES = YAML.load_file(Rails.root.join("app", "services", "knowledge_api.yml")).freeze
+
+  def publish
+    Services.publishing_api.put_content(CONTENT_ID, payload)
+    Services.publishing_api.publish(CONTENT_ID, "major")
+  end
+
+  def payload
+    {
+      base_path: "/knowledge-alpha",
+      title: "Experimental knowledge API",
+      document_type: "knowledge_alpha",
+      phase: "alpha",
+      publishing_app: "publisher",
+      rendering_app: "frontend",
+      schema_name: "knowledge_alpha",
+      details: {
+        entries: KNOWLEDGE_ENTRIES,
+      },
+      routes: [
+        { path: "/knowledge-alpha", type: "exact" }
+      ],
+    }
+  end
+end

--- a/app/services/knowledge_api.yml
+++ b/app/services/knowledge_api.yml
@@ -1,0 +1,48 @@
+- id: minimum-wage
+  title: Minimum wage rates
+  source: https://www.gov.uk/national-minimum-wage-rates
+  data:
+    - age_range: 25 and over
+      minimum_wage: 7.83
+    - age_range: 21 to 24
+      minimum_wage: 7.38
+    - age_range: 18 to 20
+      minimum_wage: 5.90
+    - age_range: Under 18
+      minimum_wage: 4.20
+    - age_range: Apprentice
+      minimum_wage: 3.70
+
+- id: income-tax
+  title: Income Tax rates and bands
+  source: https://www.gov.uk/income-tax-rates
+  data:
+    - band: Personal Allowance
+      taxable_income: Up to £11,850
+      tax_rate: 0%
+    - band: Basic rate
+      taxable_income: £11,851 to £46,350
+      tax_rate: 20%
+    - band: Higher rate
+      taxable_income: £46,351 to £150,000
+      tax_rate: 40%
+    - band: Additional rate
+      taxable_income: over £150,000
+      tax_rate: 45%
+
+- id: tax-return-deadlines
+  title: Self Assessment tax return deadlines
+  source: https://www.gov.uk/self-assessment-tax-returns/deadlines
+  data:
+    - event: Register for Self Assessment
+      deadline: 2018-10-05
+      description: Register for Self Assessment if you’re self-employed or a sole trader, not self-employed, or registering a partner or partnership
+    - event: Paper tax returns
+      deadline: 2018-10-31
+      description: Midnight 31 October 2018
+    - event: Online tax returns
+      deadline: 2019-01-31
+      description: Midnight 31 January 2019
+    - event: Pay the tax you owe
+      deadline: 2019-01-31
+      description: Midnight 31 January 2019

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -20,6 +20,11 @@ namespace :publishing_api do
     republish_draft format_editions.draft_in_publishing_api
   end
 
+  desc 'Publish the experimental knowledge API'
+  task :publish_knowledge do
+    KnowledgeApi.new.publish
+  end
+
   def republish(editions)
     puts
     puts "Scheduling republishing of #{editions.count} editions"

--- a/test/unit/services/knowledge_api_test.rb
+++ b/test/unit/services/knowledge_api_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class KnowledgeApiTest < ActiveSupport::TestCase
+  include GovukContentSchemaTestHelpers::TestUnit
+
+  should "tell the publishing API" do
+    Services.publishing_api.expects(:put_content)
+    Services.publishing_api.expects(:publish)
+
+    KnowledgeApi.new.publish
+  end
+
+  should "send valid content" do
+    assert_valid_against_schema(KnowledgeApi.new.payload, "knowledge_alpha")
+  end
+end


### PR DESCRIPTION
Running this rake task creates a new content item at https://www.gov.uk/api/content/knowledge-alpha. It is currently populated with the content of a number of high-profile guides in a structured format.

- Minimum wage rates from https://www.gov.uk/national-minimum-wage-rates
- Income Tax rates and bands from https://www.gov.uk/income-tax-rates
- Self Assessment tax return deadlines from https://www.gov.uk/self-assessment-tax-returns/deadlines

This is part of an experiment. We're currently working with one of the voice providers (starts with an A) to see if we can get GOV.UK facts directly into the knowledge engine that underpins the service. We've checked this data format with them, and they said that they would be able to consume this.

Obviously this isn't a very scalable solution - the information from the guides is currently duplicated. Once the data changes we'll have to update these numbers as well (a process for this will be set up).

A better idea might be to either 1) extract the data from the content, 2) manage the data elsewhere and inject it into the content. This would require a lot of initial development however, so this initial "API" serves as a test case. If we find that the voice provider won't be able to use it, we can remove this content item easily.

This commit requires https://github.com/alphagov/govuk-content-schemas/pull/772 to be deployed.

https://trello.com/c/4mRr4Mzi