### PR TITLE
Allow editing artefact slugs

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -2,14 +2,6 @@ require "plek"
 require "artefact_action" # Require this when running outside Rails
 require_dependency "safe_html"
 
-class CannotEditSlugIfEverPublished < ActiveModel::Validator
-  def validate(record)
-    if record.changes.keys.include?("slug") && record.state_was == "live"
-      record.errors[:slug] << "Cannot edit slug for live artefacts"
-    end
-  end
-end
-
 class Artefact
   include Mongoid::Document
   include Mongoid::Timestamps
@@ -115,7 +107,6 @@ class Artefact
   validates :state, inclusion: { in: %w(draft live archived) }
   validates :owning_app, presence: true
   validates :language, inclusion: { in: %w(en cy) }
-  validates_with CannotEditSlugIfEverPublished
   validate :validate_prefixes_and_paths
   validate :format_of_new_need_ids, if: :need_ids_changed?
 

--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -156,16 +156,12 @@ class Artefact
   end
 
   def update_editions
-    case state
-    when 'draft'
-      if self.slug_changed?
-        Edition.where(:state.nin => ["archived"],
-                      panopticon_id: self.id).each do |edition| # rubocop:disable Rails/FindEach
-          edition.update_slug_from_artefact(self)
-        end
+    return archive_editions if state == 'archived'
+
+    if self.slug_changed?
+      Edition.draft_in_publishing_api.where(panopticon_id: self.id).each do |edition| # rubocop:disable Rails/FindEach
+        edition.update_slug_from_artefact(self)
       end
-    when 'archived'
-      archive_editions
     end
   end
 

--- a/app/views/shared/_metadata.html.erb
+++ b/app/views/shared/_metadata.html.erb
@@ -1,4 +1,4 @@
-<% if publication.draft? %>
+<% if Edition::PUBLISHING_API_DRAFT_STATES.include? publication.state %>
   <%= semantic_bootstrap_nested_form_for(@artefact, :html => { :class => 'artefact', :id => 'edit_artefact'}) do |f| %>
     <div class="row">
       <div class="col-md-12">

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -298,6 +298,44 @@ class ArtefactTest < ActiveSupport::TestCase
     assert_not_equal artefact.name, edition.title
   end
 
+  test "should not change the slug of published editions when the artefact slug is changed" do
+    artefact = FactoryBot.create(:artefact,
+        slug: "too-late-to-edit",
+        kind: "answer",
+        name: "Foo bar",
+        owning_app: "publisher",
+        state: "live")
+
+    user1 = FactoryBot.create(:user)
+    edition = AnswerEdition.find_or_create_from_panopticon_data(artefact.id, user1)
+    edition.state = "published"
+    edition.save!
+
+    artefact.slug = "belated-correction"
+    artefact.save!
+
+    assert_equal "too-late-to-edit", edition.reload.slug
+  end
+
+  test "should change the slug of draft editions when the artefact slug is changed" do
+    artefact = FactoryBot.create(:artefact,
+        slug: "too-late-to-edit",
+        kind: "answer",
+        name: "Foo bar",
+        owning_app: "publisher",
+        state: "live")
+
+    user1 = FactoryBot.create(:user)
+    edition = AnswerEdition.find_or_create_from_panopticon_data(artefact.id, user1)
+    edition.state = "draft"
+    edition.save!
+
+    artefact.slug = "belated-correction"
+    artefact.save!
+
+    assert_equal "belated-correction", edition.reload.slug
+  end
+
   test "should indicate when any editions have been published for this artefact" do
     artefact = FactoryBot.create(:artefact,
         slug: "foo-bar",

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -275,20 +275,6 @@ class ArtefactTest < ActiveSupport::TestCase
     assert_equal "something-else", edition.slug
   end
 
-  test "should not let you edit the slug if the artefact is live" do
-    artefact = FactoryBot.create(:artefact,
-        slug: "too-late-to-edit",
-        kind: "answer",
-        name: "Foo bar",
-        owning_app: "publisher",
-        state: "live")
-
-    artefact.slug = "belated-correction"
-    refute artefact.save
-
-    assert_equal "too-late-to-edit", artefact.reload.slug
-  end
-
   # should continue to work in the way it has been:
   # i.e. you can edit everything but the name/title for published content in panop
   test "on save title should not be applied to already published content" do


### PR DESCRIPTION
This restriction on editing slugs comes from https://github.com/alphagov/govuk_content_models/commit/2f82275027300fc78924f5227ae1dce6fb3e0a5c, copied into this repository when that was retired, and the original commit message from 2012 justifies the change by reference to Panopticon, which has since been retired.

I tried it on integration, and it seemed to work with a guide, even the subpages.  I suspect there's no reason to keep the restriction any more.

This will allow publishers to self-serve on slug changes in publisher from now on.

---

Related to this [Trello card](https://trello.com/c/6ZHEUpB9/228-change-slug-of-uk-residence-for-eu-citizens-guide)