### PR TITLE
Fix GSS codes for two councils in Scotland with recent border changes

### DIFF
--- a/db/migrate/20180712141700_fix_gss_codes_for_some_councils_in_existing_support_schemes.rb
+++ b/db/migrate/20180712141700_fix_gss_codes_for_some_councils_in_existing_support_schemes.rb
@@ -1,0 +1,22 @@
+class FixGssCodesForScottishCouncilsInExistingSupportSchemes < Mongoid::Migration
+  def self.up
+    Edition.skip_callback(:save, :before, :check_for_archived_artefact)
+
+    fife_schemes = BusinessSupportEdition.where(area_gss_codes: "S12000015")
+    fife_schemes.each do |fi|
+      fi.area_gss_codes.delete("S12000015")
+      fi.area_gss_codes.push("S12000047")
+      fi.save!(validate: false)
+    end
+
+    perth_kinross_schemes = BusinessSupportEdition.where(area_gss_codes: "S12000024")
+    perth_kinross_schemes.each do |pk|
+      pk.area_gss_codes.delete("S12000024")
+      pk.area_gss_codes.push("S12000048")
+      pk.save!(validate: false)
+    end
+  end
+
+  def self.down
+  end
+end


### PR DESCRIPTION
Following on from https://github.com/alphagov/mapit/commit/6df21ef1632ab11e29a5188d0591602137c06db9, two councils (Fife and Perth & Kinross) have recently changed their borders.

As well as updating in MapIt, the data also need updating here in Publisher to reflect the new codes.

https://trello.com/c/dql5PCnX/283-update-mapit-data