### PR TITLE
Include archived editions in major updates query

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -178,7 +178,7 @@ class Edition
   end
 
   def major_updates_in_series
-    history.published.major_updates
+    history.archived_or_published.major_updates
   end
 
   def latest_major_update


### PR DESCRIPTION
To determine the `public_updated_at` of an edition, we find the latest major update of the artefact and use the `updated_at` of that date. Unfortunately, the query is missing editions in the archived state, meaning that they were once published but have since been superseeded. We need to include these in the query to make sure that we find the most recently `updated_at`, at the moment it will miss any archived editions (which will be all the previous editions) and always get the `updated_at` from the first published edition.