### PR TITLE
HUB-209: Remove description text from service sign in pages

### DIFF
--- a/lib/service_sign_in/check-income-tax.en.yaml
+++ b/lib/service_sign_in/check-income-tax.en.yaml
@@ -2,7 +2,6 @@ start_page_slug: check-income-tax-current-year
 locale: en
 choose_sign_in:
   title: Prove your identity to continue
-  description: You’ll need an account to prove your identity and check your income tax for the current year.
   slug: prove-identity
   options:
     - text: Sign in with Government Gateway
@@ -48,4 +47,4 @@ create_new_account:
 
     Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
 update_type: minor
-change_note: Added description text for service sign in page including service name.
+change_note: Removed description text for service sign in pages as per results of baseline test.

--- a/lib/service_sign_in/check-update-company-car-tax.en.yaml
+++ b/lib/service_sign_in/check-update-company-car-tax.en.yaml
@@ -2,7 +2,6 @@ start_page_slug: update-company-car-details
 locale: en
 choose_sign_in:
   title: Prove your identity to continue
-  description: You’ll need an account to prove your identity and check or update your company car tax.
   slug: prove-identity
   options:
     - text: Sign in with Government Gateway
@@ -48,4 +47,4 @@ create_new_account:
 
     Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
 update_type: minor
-change_note: Added description text for service sign in page including service name.
+change_note: Removed description text for service sign in pages as per results of baseline test.

--- a/lib/service_sign_in/personal-tax-account.en.yaml
+++ b/lib/service_sign_in/personal-tax-account.en.yaml
@@ -2,7 +2,6 @@ start_page_slug: personal-tax-account
 locale: en
 choose_sign_in:
   title: Prove your identity to continue
-  description: You’ll need an account to prove your identity and sign in to your personal tax account.
   slug: prove-identity
   options:
     - text: Sign in with Government Gateway
@@ -48,4 +47,4 @@ create_new_account:
 
     Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
 update_type: minor
-change_note: Added description text for service sign in page including service name.
+change_note: Removed description text for service sign in pages as per results of baseline test.


### PR DESCRIPTION
Remove description text from personal tax account, update company car
tax and check income tax pages. This text was added as part of a
baseline test (HUB-143) and has made no improvement. This commit removes
the text. Note, no changes have been made to the self assessment page as
this page has always had description text and follows a slightly
different pattern.

solo: @rachelthecodesmith