### PR TITLE
Enable Brakeman

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,5 +4,5 @@ library("govuk")
 
 node('mongodb-2.4') {
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-publisher")
-  govuk.buildProject(sassLint: false, publishingE2ETests: true, rubyLintDiff: false)
+  govuk.buildProject(sassLint: false, publishingE2ETests: true, rubyLintDiff: false, brakeman: true)
 }

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -13,9 +13,12 @@ class PublicationsController < InheritedResources::Base
 protected
 
   def redirect_with_return_to(edition)
-    destination = "/editions/#{edition.id}"
-    destination += '?return_to=' + params[:return_to] if params[:return_to]
-    redirect_to destination
+    redirect_to(
+      controller: "editions",
+      action: "show",
+      id: edition.id,
+      return_to: params.fetch(:return_to, nil)
+    )
   end
 
   def render_new_form(edition)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -59,6 +59,6 @@
       "note": "The params[:list] argument is already checked before the template gets rendered by @presenter.acceptable_list?(@list)."
     }
   ],
-  "updated": "2018-08-02 14:03:50 +0100",
+  "updated": "2018-08-02 14:09:22 +0100",
   "brakeman_version": "4.3.1"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,6 +1,25 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "03561f0c9a2094d474f845a46ecbf4c57a9368c138312384801929b7b6afa4c7",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/root/index.html.erb",
+      "line": 52,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => (\"drafts\" or params[:list]), {})",
+      "render_path": [{"type":"controller","class":"RootController","method":"index","line":20,"file":"app/controllers/root_controller.rb"}],
+      "location": {
+        "type": "template",
+        "template": "root/index"
+      },
+      "user_input": "params[:list]",
+      "confidence": "High",
+      "note": "The params[:list] argument is already checked before the template gets rendered by @presenter.acceptable_list?(@list)."
+    },
+    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "1dd7580ea4eb3c303e870dad82dc5223592fd36c4b44bec6ab6ea0a0c1affbc0",
@@ -19,8 +38,27 @@
       "user_input": "Rails.env",
       "confidence": "Weak",
       "note": "We don't pass any user data to this string."
+    },
+    {
+      "warning_type": "Dangerous Send",
+      "warning_code": 23,
+      "fingerprint": "3f2c31f15778e6b65e944692da7e7a60ce09767a71010060f5237c62d5e0ae41",
+      "check_name": "Send",
+      "message": "User controlled method execution",
+      "file": "app/views/root/index.html.erb",
+      "line": 53,
+      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
+      "code": "@presenter.send((\"drafts\" or params[:list]))",
+      "render_path": [{"type":"controller","class":"RootController","method":"index","line":20,"file":"app/controllers/root_controller.rb"}],
+      "location": {
+        "type": "template",
+        "template": "root/index"
+      },
+      "user_input": "params[:list]",
+      "confidence": "High",
+      "note": "The params[:list] argument is already checked before the template gets rendered by @presenter.acceptable_list?(@list)."
     }
   ],
-  "updated": "2018-08-02 13:57:57 +0100",
+  "updated": "2018-08-02 14:03:50 +0100",
   "brakeman_version": "4.3.1"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,26 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "1dd7580ea4eb3c303e870dad82dc5223592fd36c4b44bec6ab6ea0a0c1affbc0",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "lib/csv_report_generator.rb",
+      "line": 13,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "redis.lock(\"publisher:#{Rails.env}:report_generation_lock\", :life => 15.minutes)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "CsvReportGenerator",
+        "method": "run!"
+      },
+      "user_input": "Rails.env",
+      "confidence": "Weak",
+      "note": "We don't pass any user data to this string."
+    }
+  ],
+  "updated": "2018-08-02 13:57:57 +0100",
+  "brakeman_version": "4.3.1"
+}

--- a/lib/licence_content_importer.rb
+++ b/lib/licence_content_importer.rb
@@ -83,7 +83,7 @@ class LicenceContentImporter
   end
 
   def add_workflow(user, edition)
-    type = Action.const_get(Action::CREATE.to_s.upcase)
+    type = Action::CREATE
     edition.new_action(user, type, {})
     edition.save!
     user.record_note(edition, "Imported via LicenceContentImporter: #{Time.zone.today.to_s(:db)}")

--- a/lib/licence_identifier_migrator.rb
+++ b/lib/licence_identifier_migrator.rb
@@ -25,7 +25,7 @@ class LicenceIdentifierMigrator
     uri = URI.parse(LICENCE_MAPPING_URL)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
-    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     request = Net::HTTP::Get.new(uri.request_uri)
     response = http.request(request)
     YAML.safe_load(response.body)


### PR DESCRIPTION
This enables Brakeman to allow us to automatically check for security vulnerabilities.

It also fixes a few existing warnings, more detail about each one in the respective commit.

[Trello Card](https://trello.com/c/JyrOAef3/363-fix-sql-injection-vulnerabilities-in-govuk-applications)