### PR TITLE
[DO NOT MERGE] Add hide chapter navigation option for guides

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -233,7 +233,7 @@ protected
     case subtype
     when :guide_edition
       [
-        parts_attributes: %i[title body slug order id _destroy]
+        parts_attributes: %i[title body slug order hide_chapter_navigation id _destroy]
       ]
     when :licence_edition
       %i[
@@ -263,7 +263,7 @@ protected
         :body,
         :start_button_text,
         nodes_attributes: [
-          :slug, :title, :body, :order, :kind, :id, :_destroy,
+          :slug, :title, :body, :order, :hide_chapter_navigation, :kind, :id, :_destroy,
           options_attributes: %i[label next_node id _destroy]
         ],
       ]

--- a/app/models/part.rb
+++ b/app/models/part.rb
@@ -12,6 +12,7 @@ class Part
   field :title,      type: String
   field :body,       type: String
   field :slug,       type: String
+  field :hide_chapter_navigation, type: Boolean
   field :created_at, type: DateTime, default: lambda { Time.zone.now }
 
   GOVSPEAK_FIELDS = [:body].freeze

--- a/app/presenters/formats/guide_presenter.rb
+++ b/app/presenters/formats/guide_presenter.rb
@@ -31,7 +31,8 @@ module Formats
               content_type: "text/govspeak",
               content: part.body.to_s,
             }
-          ]
+          ],
+          hide_chapter_navigation: part.hide_chapter_navigation
         }
       end
     end

--- a/app/views/shared/_part.html.erb
+++ b/app/views/shared/_part.html.erb
@@ -32,6 +32,12 @@
                       :required => true,
                       :input_html => {:rows => '25', :disabled => @resource.locked_for_edits? } %>
 
+          <%= f.input :hide_chapter_navigation,
+                      as: :boolean,
+                      label: 'Hide chapter navigation',
+                      :hint => 'If this guide part is in a step by step navigation, hide the guide chapter links and next/previous navigation arrows.',
+                      wrapper_html: { class: "emphasised-field form-group" } %>
+
           <%= f.input :order, :as => :hidden, :input_html => { :class => 'order', :disabled => !editable } %>
 
           <% unless @resource.locked_for_edits? %>

--- a/test/unit/presenters/formats/guide_presenter_test.rb
+++ b/test/unit/presenters/formats/guide_presenter_test.rb
@@ -20,6 +20,7 @@ class GuidePresenterTest < ActiveSupport::TestCase
       title: "title-#{num}",
       slug: "slug-#{num}",
       body: "body-#{num}",
+      hide_chapter_navigation: true,
       order: num,
       guide_edition: edition
     )
@@ -51,7 +52,8 @@ class GuidePresenterTest < ActiveSupport::TestCase
               content_type: 'text/govspeak',
               content: 'body-1'
             }
-          ]
+          ],
+          hide_chapter_navigation: true
         },
         {
           title: 'title-2',
@@ -61,7 +63,8 @@ class GuidePresenterTest < ActiveSupport::TestCase
               content_type: 'text/govspeak',
               content: 'body-2'
             }
-          ]
+          ],
+          hide_chapter_navigation: true
         }
       ]
 
@@ -77,7 +80,8 @@ class GuidePresenterTest < ActiveSupport::TestCase
         body: [{
           content_type: 'text/govspeak',
           content: ""
-        }]
+        }],
+        hide_chapter_navigation: nil
       }]
 
       assert_equal expected, result[:details][:parts]


### PR DESCRIPTION
Superceded by #917.

On some guides that occur within a step by step navigation, the guide navigation elements are conflicting with the step navigation, or needlessly duplicating them. This adds an option to publisher to allow content managers the ability to hide the guide navigation elements if that part is inside a step by step navigation.

Example of a guide part currently:

<img width="1108" alt="screen shot 2018-07-31 at 14 10 07" src="https://user-images.githubusercontent.com/861310/43640019-11918748-9716-11e8-9fd3-51e23f299f7d.png">

The same page but with this option turned on:

<img width="1100" alt="screen shot 2018-07-31 at 14 10 22" src="https://user-images.githubusercontent.com/861310/43640033-1cf6041a-9716-11e8-9ed6-c9b645d5cb04.png">

What this looks like in publisher:

<img width="829" alt="screen shot 2018-08-03 at 12 11 43" src="https://user-images.githubusercontent.com/861310/43640097-700c4c36-9716-11e8-967a-42f6c2de5c63.png">


**This PR is a work in progress**. Also I've not made a change to publisher before, so any suggestions welcome.

Related change to content schemas: https://github.com/alphagov/govuk-content-schemas/pull/802

Trello card: https://trello.com/c/RNsA7E4Q/763-hide-chapter-navigation-on-mainstream-guides
