### PR TITLE
Add hide chapter navigation option to guides

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -233,6 +233,7 @@ protected
     case subtype
     when :guide_edition
       [
+        :hide_chapter_navigation,
         parts_attributes: %i[title body slug order id _destroy]
       ]
     when :licence_edition

--- a/app/models/guide_edition.rb
+++ b/app/models/guide_edition.rb
@@ -6,6 +6,7 @@ class GuideEdition < Edition
 
   field :video_url,     type: String
   field :video_summary, type: String
+  field :hide_chapter_navigation, type: Boolean
 
   GOVSPEAK_FIELDS = [].freeze
 

--- a/app/presenters/formats/guide_presenter.rb
+++ b/app/presenters/formats/guide_presenter.rb
@@ -18,6 +18,7 @@ module Formats
       {
         parts: parts,
         external_related_links: external_related_links,
+        hide_chapter_navigation: !!edition.hide_chapter_navigation
       }
     end
 

--- a/app/views/guides/_fields.html.erb
+++ b/app/views/guides/_fields.html.erb
@@ -7,6 +7,13 @@
   </div>
 </div>
 
+<%= f.input :hide_chapter_navigation,
+            as: :boolean,
+            label: 'Hide chapter navigation and arrows',
+            input_html: { disabled: @resource.locked_for_edits? },
+            :hint => 'Only do this when every chapter is included in a step by step navigation.',
+            wrapper_html: { class: "emphasised-field form-group" } %>
+
 <hr>
 
 <div class="row">

--- a/test/integration/guide_create_edit_test.rb
+++ b/test/integration/guide_create_edit_test.rb
@@ -27,6 +27,37 @@ class GuideCreateEditTest < JavascriptIntegrationTest
     assert_equal "Foo bar", g.title
   end
 
+  should "editing a GuideEdition, and hiding chapter navigation" do
+    guide = FactoryBot.create(:guide_edition,
+                               panopticon_id: @artefact.id,
+                               state: 'draft',
+                               title: "Foo bar #0")
+
+    visit_edition guide
+    refute find('#edition_hide_chapter_navigation').checked?
+
+    # using 'check' and similar capybara approaches does not work here for some reason
+    page.execute_script("$('#edition_hide_chapter_navigation').attr('checked', 'checked')")
+
+    assert find('#edition_hide_chapter_navigation').checked?
+    save_edition_and_assert_success
+
+    visit_edition guide
+    assert find('#edition_hide_chapter_navigation').checked?
+  end
+
+  should "show hide_chapter_navigation as selected" do
+    guide = FactoryBot.build(:guide_edition,
+                               panopticon_id: @artefact.id,
+                               state: 'draft',
+                               title: "Foo bar #0")
+    guide.hide_chapter_navigation = true
+    guide.save!
+
+    visit_edition guide
+    assert find('#edition_hide_chapter_navigation').checked?
+  end
+
   should "editing a GuideEdition, and adding some parts" do
     guide = FactoryBot.build(:guide_edition,
                                panopticon_id: @artefact.id,

--- a/test/unit/presenters/formats/guide_presenter_test.rb
+++ b/test/unit/presenters/formats/guide_presenter_test.rb
@@ -95,6 +95,12 @@ class GuidePresenterTest < ActiveSupport::TestCase
 
       assert_equal expected, result[:details][:external_related_links]
     end
+
+    should "[:hide_chapter_navigation]" do
+      edition.update_attribute(:hide_chapter_navigation, true)
+
+      assert_equal true, result[:details][:hide_chapter_navigation]
+    end
   end
 
   should "[:routes]" do


### PR DESCRIPTION
Supercedes #914.

On some guides that occur within a step by step navigation, the guide navigation elements are conflicting with the step navigation, or needlessly duplicating them. This adds an option to publisher to allow content managers the ability to hide the guide navigation elements if that part is inside a step by step navigation.

Example of a guide part currently:

<img width="1108" alt="screen shot 2018-07-31 at 14 10 07" src="https://user-images.githubusercontent.com/861310/43640019-11918748-9716-11e8-9fd3-51e23f299f7d.png">

The same page but with this option turned on:

<img width="1100" alt="screen shot 2018-07-31 at 14 10 22" src="https://user-images.githubusercontent.com/861310/43640033-1cf6041a-9716-11e8-9ed6-c9b645d5cb04.png">

What this looks like in publisher:

![screen shot 2018-08-07 at 14 17 58](https://user-images.githubusercontent.com/861310/43778103-b985bff8-9a4c-11e8-8663-54780d785386.png)

**This PR is a work in progress**. Also I've not made a change to publisher before, so any suggestions welcome.

Related change to content schemas: https://github.com/alphagov/govuk-content-schemas/pull/802

Trello card: https://trello.com/c/RNsA7E4Q/763-hide-chapter-navigation-on-mainstream-guides
