### PR TITLE
EID-942 - Create GOV.UK sign-in interstitial page for Check your State Pension

### DIFF
--- a/lib/service_sign_in/check-state-pension.en.yaml
+++ b/lib/service_sign_in/check-state-pension.en.yaml
@@ -1,0 +1,53 @@
+start_page_slug: check-state-pension
+locale: en
+choose_sign_in:
+  title: Prove your identity to continue
+  slug: prove-identity
+  options:
+    - text: Sign in with Government Gateway
+      url: https://www.tax.service.gov.uk/gg/sign-in?continue=%2Fcheck-your-state-pension%2Faccount&origin=nisp-frontend&accountType=individual
+      hint_text: You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.
+    - text: Sign in with GOV.UK Verify
+      url: https://www.tax.service.gov.uk/check-your-state-pension/signin/verify?journey_hint=uk_idp_sign_in
+      hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
+    - text: Sign in with a digital identity from another European country
+      url: https://www.tax.service.gov.uk/check-your-state-pension/signin/verify?journey_hint=eidas_sign_in
+      hint_text: If you are part of Germany’s Online-Ausweis you can use it here. Identity schemes from other countries will become available later.
+    - text: Create an account
+      slug: create-account
+      hint_text: If you do not already have one of these accounts, we'll help you choose whether to use Government Gateway or GOV.UK Verify.
+create_new_account:
+  title: Create an account
+  slug: create-account
+  body: |
+    To use this service, you need to create either a Government Gateway or GOV.UK Verify account. These are used to help fight identity theft.
+
+    Once you have an account, you can use it to access other government services online.
+
+    ## Choose a way to prove your identity
+
+    ### Government Gateway
+
+    Registering with Government Gateway usually takes about 10 minutes. It works best if you have:
+
+    * your National Insurance number
+    * a recent payslip or P60 or a valid UK passport
+
+    {button}[Create a Government Gateway account](https://www.tax.service.gov.uk/gg/sign-in?continue=/check-your-state-pension&accountType=individual){/button}
+
+    ### GOV.UK Verify
+
+    Registering with GOV.UK Verify usually takes about 15 minutes. It works best if you have:
+
+    - a UK address
+    - a valid passport or photocard driving licence
+
+    {button}[Create a GOV.UK Verify account](https://www.tax.service.gov.uk/check-your-state-pension/signin/verify?journey_hint=registration){/button}
+
+    A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.
+
+    ## Personal tax account
+
+    Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
+update_type: major
+change_note: First published.


### PR DESCRIPTION
- Create service sign in page for Check your State Pension, to make
the introduction to eIDAS option easier
- Include option on the sign in page so user can select to confirm
their identiy with another european country. For now until eIDAS is enabled
on verify, this will take them to the usual verify sign in page.
- Radio button grouping for the sign in page is situated within the choose_sign_in_presenter.rb
within the government-frontend repo. Where the last option in the order will be after the or.
- For now, this will not be linked to the current check-state-pension start page.