### PR TITLE
Allow govspeak buttons for signin pages to be trackable

### DIFF
--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -2,8 +2,6 @@ module Formats
   class ServiceSignInPresenter
     attr_reader :content
 
-    BUTTON_REGEX = /(\{button\}\[(.*?)\]\((.*?)\)\{\/button\})/
-
     def initialize(content)
       @content = content.deep_symbolize_keys
     end
@@ -149,11 +147,8 @@ module Formats
     end
 
     def content_with_trackable_buttons(content)
-      # Replace all buttons with cross-domain-trackable versions.
-      content.scan(BUTTON_REGEX) do |match|
-        continue unless match.size == 3
-        trackable_button = "{button cross-domain-tracking:#{ga_universal_id}}[#{match[1]}](#{match[2]}){/button}"
-        content = content.gsub(match[0], trackable_button)
+      content.scan(/UA-xxxx/) do |match|
+        content = content.gsub(match, ga_universal_id)
       end
       content
     end

--- a/lib/service_sign_in/check-state-pension.en.yaml
+++ b/lib/service_sign_in/check-state-pension.en.yaml
@@ -34,7 +34,7 @@ create_new_account:
     * your National Insurance number
     * a recent payslip or P60 or a valid UK passport
 
-    {button}[Create a Government Gateway account](https://www.tax.service.gov.uk/gg/sign-in?continue=/check-your-state-pension&accountType=individual){/button}
+    <a role="button" class="button" href="https://www.tax.service.gov.uk/gg/sign-in?continue=/check-your-state-pension&accountType=individual" data-module="cross-domain-tracking" data-tracking-code="UA-xxxx" data-tracking-name="govspeakButtonTracker" data-track-category="ServiceSignIn" data-track-action="Gateway" data-track-label="/check-state-pension/sign-in/create-account">Create a Government Gateway account</a>
 
     ### GOV.UK Verify
 
@@ -43,7 +43,7 @@ create_new_account:
     - a UK address
     - a valid passport or photocard driving licence
 
-    {button}[Create a GOV.UK Verify account](https://www.tax.service.gov.uk/check-your-state-pension/signin/verify?journey_hint=registration){/button}
+    <a role="button" class="button" href="https://www.tax.service.gov.uk/check-your-state-pension/signin/verify?journey_hint=registration" data-module="cross-domain-tracking" data-tracking-code="UA-xxxx" data-tracking-name="govspeakButtonTracker" data-track-category="ServiceSignIn" data-track-action="Verify" data-track-label="/check-state-pension/sign-in/create-account">Create a GOV.UK Verify account</a>
 
     A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.
 

--- a/lib/service_sign_in/example.en.yaml
+++ b/lib/service_sign_in/example.en.yaml
@@ -30,7 +30,7 @@ create_new_account:
     - your National Insurance number
     - a recent payslip or a P60 or valid UK passport
 
-    {button}[Create a Government Gateway account](https://www.tax.service.gov.uk/gg/sign-in?continue=/check-your-state-pension&accountType=individual){/button}
+    <a role="button" class="button" href="https://www.tax.service.gov.uk/gg/sign-in?continue=/check-your-state-pension&accountType=individual" data-module="cross-domain-tracking" data-tracking-code="UA-xxxx" data-tracking-name="govspeakButtonTracker" data-track-category="ServiceSignIn" data-track-action="Gateway" data-track-label="/check-state-pension/sign-in/create-account">Create a Government Gateway account</a>
 
     ###GOV.UK Verify
 
@@ -39,7 +39,7 @@ create_new_account:
     - a UK address
     - a valid passport or photocard driving licence
 
-    {button}[Create a GOV.UK Verify account](https://www.tax.service.gov.uk/check-your-state-pension/signin/verify?journey_hint=registration){/button}
+    <a role="button" class="button" href="https://www.tax.service.gov.uk/check-your-state-pension/signin/verify?journey_hint=registration" data-module="cross-domain-tracking" data-tracking-code="UA-xxxx" data-tracking-name="govspeakButtonTracker" data-track-category="ServiceSignIn" data-track-action="Verify" data-track-label="/check-state-pension/sign-in/create-account">Create a GOV.UK Verify account</a>
 
     A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.
 update_type: major

--- a/lib/service_sign_in/example.en.yaml
+++ b/lib/service_sign_in/example.en.yaml
@@ -30,7 +30,7 @@ create_new_account:
     - your National Insurance number
     - a recent payslip or a P60 or valid UK passport
 
-    [Create a Government Gateway account](#)
+    {button}[Create a Government Gateway account](https://www.tax.service.gov.uk/gg/sign-in?continue=/check-your-state-pension&accountType=individual){/button}
 
     ###GOV.UK Verify
 
@@ -39,7 +39,7 @@ create_new_account:
     - a UK address
     - a valid passport or photocard driving licence
 
-    [Create a GOV.UK Verify account](#)
+    {button}[Create a GOV.UK Verify account](https://www.tax.service.gov.uk/check-your-state-pension/signin/verify?journey_hint=registration){/button}
 
     A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.
 update_type: major

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -244,8 +244,11 @@ class ServiceSignInTest < ActiveSupport::TestCase
           ENV["GA_UNIVERSAL_ID"] = "UA-12345-678"
           @content[:cross_domain_trackable] = true
 
-          assert_match(/\{button cross-domain-tracking:UA-12345-678\}\[.*?\]\(.*?\)\{\/button\}/,
-                       result[:details][:create_new_account][:body].first[:content])
+          govspeak = result[:details][:create_new_account][:body].first[:content]
+
+          assert_match(/data-module="cross-domain-tracking"/, govspeak)
+          assert_match(/data-tracking-code="UA-12345-678"/, govspeak)
+          assert_match(/data-track-category="ServiceSignIn"/, govspeak)
 
           # Restore any previous config
           ENV["GA_UNIVERSAL_ID"] = ga_universal_id

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -238,6 +238,18 @@ class ServiceSignInTest < ActiveSupport::TestCase
 
           assert_equal expected, result[:details][:create_new_account][:body]
         end
+
+        should "[:body] for cross-domain trackable content" do
+          ga_universal_id = ENV["GA_UNIVERSAL_ID"]
+          ENV["GA_UNIVERSAL_ID"] = "UA-12345-678"
+          @content[:cross_domain_trackable] = true
+
+          assert_match(/\{button cross-domain-tracking:UA-12345-678\}\[.*?\]\(.*?\)\{\/button\}/,
+                       result[:details][:create_new_account][:body].first[:content])
+
+          # Restore any previous config
+          ENV["GA_UNIVERSAL_ID"] = ga_universal_id
+        end
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/CbTYssq1/478-enable-cross-domain-tracking-for-cysp-govuk-sign-in-pages

Needed in addition to https://github.com/alphagov/publisher/pull/941 so that buttons in govspeak content are also trackable.