### PR TITLE
Make govspeak sign in buttons trackable

### DIFF
--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -103,8 +103,6 @@ module Formats
           option[:slug] = "#{base_path}/#{option[:slug]}"
           option[:url] = option.delete :slug
         end
-
-        option[:url] = trackable_url(option[:url]) if cross_domain_trackable?
       end
     end
 
@@ -140,12 +138,6 @@ module Formats
 
     def cross_domain_trackable?
       !!content[:cross_domain_trackable]
-    end
-
-    def trackable_url(url)
-      uri = URI(url)
-      url += uri.query.present? ? "&" : "?"
-      url + "clientId=#{ga_universal_id}"
     end
 
     def content_with_trackable_buttons(content)

--- a/lib/service_sign_in/example.en.yaml
+++ b/lib/service_sign_in/example.en.yaml
@@ -30,7 +30,7 @@ create_new_account:
     - your National Insurance number
     - a recent payslip or a P60 or valid UK passport
 
-    [Create a Government Gateway account](#)
+    {button}[Create a Government Gateway account](https://www.tax.service.gov.uk/gg/sign-in?continue=/check-your-state-pension&accountType=individual){/button}
 
     ###GOV.UK Verify
 
@@ -39,7 +39,7 @@ create_new_account:
     - a UK address
     - a valid passport or photocard driving licence
 
-    [Create a GOV.UK Verify account](#)
+    {button}[Create a GOV.UK Verify account](https://www.tax.service.gov.uk/check-your-state-pension/signin/verify?journey_hint=registration){/button}
 
     A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.
 update_type: major

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -187,25 +187,6 @@ class ServiceSignInTest < ActiveSupport::TestCase
 
           assert_includes result[:details][:choose_sign_in][:options], expected
         end
-
-        should "append GA tracking params to specific items" do
-          ga_universal_id = ENV["GA_UNIVERSAL_ID"]
-          ENV["GA_UNIVERSAL_ID"] = "UA-12345-678"
-          @content[:cross_domain_trackable] = true
-
-          option_two = @content[:choose_sign_in][:options][1]
-
-          expected = {
-            text: option_two[:text],
-            url: "#{option_two[:url]}?clientId=UA-12345-678",
-            hint_text: option_two[:hint_text],
-          }
-
-          assert_includes result[:details][:choose_sign_in][:options], expected
-
-          # Restore any previous config
-          ENV["GA_UNIVERSAL_ID"] = ga_universal_id
-        end
       end
     end
 

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -238,6 +238,18 @@ class ServiceSignInTest < ActiveSupport::TestCase
 
           assert_equal expected, result[:details][:create_new_account][:body]
         end
+
+        should "[:body] for cross-domain trackable content" do
+          ga_universal_id = ENV["GA_UNIVERSAL_ID"]
+          ENV["GA_UNIVERSAL_ID"] = "UA-12345-678"
+          @content[:cross_domain_trackable] = true
+
+          assert_match(/\{button cross-domain-tracking:UA-12345-678\}\[.*?\]\(.*?\)\{\/button\}/,
+                       result[:details][:create_new_account][:body].first[:content])
+
+          # Restore any previous config
+          ENV["GA_UNIVERSAL_ID"] = ga_universal_id
+        end
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/CbTYssq1/478-enable-cross-domain-tracking-for-cysp-govuk-sign-in-pages

Uses the `cross-domain-tracking` feature for govspeak buttons on the `/check-state-pension/sign-in/create-account` page.

Removes unnecessary clientId code, this is handled by the cross domain tracking js library.