### PR TITLE
Configure dwp xdomain params

### DIFF
--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -101,8 +101,6 @@ module Formats
           option[:slug] = "#{base_path}/#{option[:slug]}"
           option[:url] = option.delete :slug
         end
-
-        option[:url] = trackable_url(option[:url]) if cross_domain_trackable?
       end
     end
 
@@ -133,16 +131,6 @@ module Formats
 
     def existing_content_id
       Services.publishing_api.lookup_content_id(base_path: base_path)
-    end
-
-    def cross_domain_trackable?
-      !!content[:cross_domain_trackable]
-    end
-
-    def trackable_url(url)
-      uri = URI(url)
-      url += uri.query.present? ? "&" : "?"
-      url + "clientId=#{ENV['GA_UNIVERSAL_ID']}"
     end
   end
 end

--- a/lib/service_sign_in/check-state-pension.en.yaml
+++ b/lib/service_sign_in/check-state-pension.en.yaml
@@ -33,7 +33,7 @@ create_new_account:
     * your National Insurance number
     * a recent payslip or P60 or a valid UK passport
 
-    {button}[Create a Government Gateway account](https://www.tax.service.gov.uk/gg/sign-in?continue=/check-your-state-pension&accountType=individual){/button}
+    {button cross-domain-tracking:UA-43414424-1}[Create a Government Gateway account](https://www.tax.service.gov.uk/gg/sign-in?continue=/check-your-state-pension&accountType=individual){/button}
 
     ### GOV.UK Verify
 
@@ -42,7 +42,7 @@ create_new_account:
     - a UK address
     - a valid passport or photocard driving licence
 
-    {button}[Create a GOV.UK Verify account](https://www.tax.service.gov.uk/check-your-state-pension/signin/verify?journey_hint=registration){/button}
+    {button cross-domain-tracking:UA-43414424-1}[Create a GOV.UK Verify account](https://www.tax.service.gov.uk/check-your-state-pension/signin/verify?journey_hint=registration){/button}
 
     A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.
 

--- a/lib/service_sign_in/check-state-pension.en.yaml
+++ b/lib/service_sign_in/check-state-pension.en.yaml
@@ -1,5 +1,4 @@
 start_page_slug: check-state-pension
-cross_domain_trackable: true
 locale: en
 choose_sign_in:
   title: Prove your identity to continue

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -187,25 +187,6 @@ class ServiceSignInTest < ActiveSupport::TestCase
 
           assert_includes result[:details][:choose_sign_in][:options], expected
         end
-
-        should "append GA tracking params to specific items" do
-          ga_universal_id = ENV["GA_UNIVERSAL_ID"]
-          ENV["GA_UNIVERSAL_ID"] = "UA-12345-678"
-          @content[:cross_domain_trackable] = true
-
-          option_two = @content[:choose_sign_in][:options][1]
-
-          expected = {
-            text: option_two[:text],
-            url: "#{option_two[:url]}?clientId=UA-12345-678",
-            hint_text: option_two[:hint_text],
-          }
-
-          assert_includes result[:details][:choose_sign_in][:options], expected
-
-          # Restore any previous config
-          ENV["GA_UNIVERSAL_ID"] = ga_universal_id
-        end
       end
     end
 


### PR DESCRIPTION
https://trello.com/c/CbTYssq1/478-enable-cross-domain-tracking-for-cysp-govuk-sign-in-pages

Enable cross domain tracking for DWP's GA property from CySP pages.