### PR TITLE
Add tracking code and name to choose sign in forms

### DIFF
--- a/lib/service_sign_in/check-state-pension.cy.yaml
+++ b/lib/service_sign_in/check-state-pension.cy.yaml
@@ -3,6 +3,8 @@ locale: cy
 choose_sign_in:
   title: Profi pwy ydych er mwyn mynd yn eich blaen
   slug: profi-pwy-ydych
+  tracking_code: UA-43414424-1
+  tracking_name: govspeakButtonTracker
   options:
     - text: Defnyddio Porth y Llywodraeth
       url: https://www.tax.service.gov.uk/gg/sign-in?continue=/personal-account&accountType=individual&origin=PTA-frontend
@@ -32,7 +34,7 @@ create_new_account:
     - eich rhif Yswiriant Gwladol
     - slip cyflog diweddar, P60 neu basbort dilys y DU
 
-    {button}[Creu cyfrif Porth y Llywodraeth](https://www.tax.service.gov.uk/gg/sign-in?continue=/personal-account&accountType=individual&origin=PTA-frontend){/button}
+    {button cross-domain-tracking:UA-43414424-1}[Creu cyfrif Porth y Llywodraeth](https://www.tax.service.gov.uk/gg/sign-in?continue=/personal-account&accountType=individual&origin=PTA-frontend){/button}
 
     ### GOV.UK Verify
 
@@ -41,7 +43,7 @@ create_new_account:
     - cyfeiriad yn y DU
     - pasbort neu drwydded cerdyn-llun dilys
 
-    {button}[Creu cyfrif GOV.UK Verify](https://www.tax.service.gov.uk/personal-account/start-verify){/button}
+    {button cross-domain-tracking:UA-43414424-1}[Creu cyfrif GOV.UK Verify](https://www.tax.service.gov.uk/personal-account/start-verify){/button}
 
     Bydd cwmni ardystiedig bob tro'n gwirio pwy ydych pan fyddwch yn cofrestru gyda GOV.UK Verify. Mae pob un ohonynt yn bodloni safonau diogelwch sydd wedi'u gosod gan y Llywodraeth.
 

--- a/lib/service_sign_in/check-state-pension.en.yaml
+++ b/lib/service_sign_in/check-state-pension.en.yaml
@@ -3,6 +3,8 @@ locale: en
 choose_sign_in:
   title: Prove your identity to continue
   slug: prove-identity
+  tracking_code: UA-43414424-1
+  tracking_name: govspeakButtonTracker
   options:
     - text: Sign in with Government Gateway
       url: https://www.tax.service.gov.uk/gg/sign-in?continue=%2Fcheck-your-state-pension%2Faccount&origin=nisp-frontend&accountType=individual


### PR DESCRIPTION
https://trello.com/c/CbTYssq1/478-enable-cross-domain-tracking-for-cysp-govuk-sign-in-pages

These values are used by forms containing radio groups to enable cross domain tracking.

* Also adds cross domain tracking for buttons in Welsh translation of create-account page
