### PR TITLE
Include tracking_code and tracking_name in service sign in payload

### DIFF
--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -91,6 +91,11 @@ module Formats
         choose_sign_in[:description] = govspeak_content(description)
       end
 
+      tracking_code = content[:choose_sign_in][:tracking_code]
+      tracking_name = content[:choose_sign_in][:tracking_name]
+      choose_sign_in[:tracking_code] = tracking_code if tracking_code.present?
+      choose_sign_in[:tracking_name] = tracking_name if tracking_name.present?
+
       choose_sign_in
     end
 

--- a/lib/service_sign_in/example.en.yaml
+++ b/lib/service_sign_in/example.en.yaml
@@ -4,6 +4,8 @@ choose_sign_in:
   title: Prove your identity to continue
   slug: choose-sign-in
   description: Your State Pension forecast is provided for your information only and the service does not offer financial advice. When planning for your retirement, you should seek professional advice.
+  tracking_code: UA-xxxxxx
+  tracking_name: somethingClicky
   options:
     - text: Use Government Gateway
       url: https://www.tax.service.gov.uk/gg/sign-in?continue=/account/&origin=SA-frontend

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -156,6 +156,20 @@ class ServiceSignInTest < ActiveSupport::TestCase
         end
       end
 
+      context "[:tracking_code] and [:tracking_name]" do
+        should "be present in the payload when it is present in the YAML file" do
+          assert_equal "UA-xxxxxx", result[:details][:choose_sign_in][:tracking_code]
+          assert_equal "somethingClicky", result[:details][:choose_sign_in][:tracking_name]
+        end
+
+        should "not be present in the payload when it is not present in the YAML file" do
+          @content[:choose_sign_in].delete(:tracking_code)
+          @content[:choose_sign_in].delete(:tracking_name)
+          refute result[:details][:choose_sign_in].has_key?(:tracking_code)
+          refute result[:details][:choose_sign_in].has_key?(:tracking_name)
+        end
+      end
+
       context "[:options]" do
         should "include standard options with an external url" do
           option_one = @content[:choose_sign_in][:options][0]


### PR DESCRIPTION
https://trello.com/c/CbTYssq1/478-enable-cross-domain-tracking-for-cysp-govuk-sign-in-pages

Missed in https://github.com/alphagov/publisher/pull/955 this presents the new fields to the publishing API.