### PR TITLE
Use event tracking data attr for check-state-pension

### DIFF
--- a/lib/service_sign_in/check-state-pension.cy.yaml
+++ b/lib/service_sign_in/check-state-pension.cy.yaml
@@ -34,7 +34,7 @@ create_new_account:
     - eich rhif Yswiriant Gwladol
     - slip cyflog diweddar, P60 neu basbort dilys y DU
 
-    <a role="button" class="button" href="https://www.tax.service.gov.uk/gg/sign-in?continue=/personal-account&accountType=individual&origin=PTA-frontend" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-page-view="false">Creu cyfrif Porth y Llywodraeth</a>
+    <a role="button" class="button" href="https://www.tax.service.gov.uk/gg/sign-in?continue=/personal-account&accountType=individual&origin=PTA-frontend" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-event="true">Creu cyfrif Porth y Llywodraeth</a>
 
     ### GOV.UK Verify
 
@@ -43,7 +43,7 @@ create_new_account:
     - cyfeiriad yn y DU
     - pasbort neu drwydded cerdyn-llun dilys
 
-    <a role="button" class="button" href="https://www.tax.service.gov.uk/personal-account/start-verify" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-page-view="false">Creu cyfrif GOV.UK Verify</a>
+    <a role="button" class="button" href="https://www.tax.service.gov.uk/personal-account/start-verify" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-event="true">Creu cyfrif GOV.UK Verify</a>
 
     Bydd cwmni ardystiedig bob tro'n gwirio pwy ydych pan fyddwch yn cofrestru gyda GOV.UK Verify. Mae pob un ohonynt yn bodloni safonau diogelwch sydd wedi'u gosod gan y Llywodraeth.
 

--- a/lib/service_sign_in/check-state-pension.en.yaml
+++ b/lib/service_sign_in/check-state-pension.en.yaml
@@ -35,7 +35,7 @@ create_new_account:
     * your National Insurance number
     * a recent payslip or P60 or a valid UK passport
 
-    <a role="button" class="button" href="https://www.tax.service.gov.uk/gg/sign-in?continue=/check-your-state-pension&accountType=individual" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-page-view="false">Create a Government Gateway account</a>
+    <a role="button" class="button" href="https://www.tax.service.gov.uk/gg/sign-in?continue=/check-your-state-pension&accountType=individual" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-event="true">Create a Government Gateway account</a>
 
     ### GOV.UK Verify
 
@@ -44,7 +44,7 @@ create_new_account:
     - a UK address
     - a valid passport or photocard driving licence
 
-    <a role="button" class="button" href="https://www.tax.service.gov.uk/check-your-state-pension/signin/verify?journey_hint=registration" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-page-view="false">Create a GOV.UK Verify account</a>
+    <a role="button" class="button" href="https://www.tax.service.gov.uk/check-your-state-pension/signin/verify?journey_hint=registration" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-event="true">Create a GOV.UK Verify account</a>
 
     A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.
 


### PR DESCRIPTION
https://trello.com/c/CbTYssq1/478-enable-cross-domain-tracking-for-cysp-govuk-sign-in-pages

Depends on https://github.com/alphagov/static/pull/1554

Instead of being explicit about sending page views, use an updated data attribute name to be explicit about sending an event (for cross domain tracking).