### PR TITLE
Configure tracking domain for check-state-pension

### DIFF
--- a/lib/service_sign_in/check-state-pension.cy.yaml
+++ b/lib/service_sign_in/check-state-pension.cy.yaml
@@ -4,6 +4,7 @@ choose_sign_in:
   title: Profi pwy ydych er mwyn mynd yn eich blaen
   slug: profi-pwy-ydych
   tracking_code: UA-43414424-1
+  tracking_domain: www.tax.service.gov.uk
   tracking_name: govspeakButtonTracker
   options:
     - text: Defnyddio Porth y Llywodraeth

--- a/lib/service_sign_in/check-state-pension.en.yaml
+++ b/lib/service_sign_in/check-state-pension.en.yaml
@@ -4,6 +4,7 @@ choose_sign_in:
   title: Prove your identity to continue
   slug: prove-identity
   tracking_code: UA-43414424-1
+  tracking_domain: www.tax.service.gov.uk
   tracking_name: govspeakButtonTracker
   options:
     - text: Sign in with Government Gateway


### PR DESCRIPTION
... via newly added property. (See https://github.com/alphagov/govuk-content-schemas/pull/823)
Instead of using the tracking domain from the option url, we'll set it directly on the tracking form.

