### PR TITLE
Add Welsh sign in page

### DIFF
--- a/lib/service_sign_in/check-income-tax.cy.yaml
+++ b/lib/service_sign_in/check-income-tax.cy.yaml
@@ -1,0 +1,54 @@
+start_page_slug: gwirioch-treth-incwm-ar-gyfer-y-flwyddyn-bresennol
+locale: cy
+choose_sign_in:
+  title: Profi pwy ydych er mwyn mynd yn eich blaen
+  slug: profi-pwy-ydych
+  options:
+    - text: Defnyddio Porth y Llywodraeth
+      url: https://www.tax.service.gov.uk/gg/sign-in?continue=/check-income-tax/what-do-you-want-to-do&accountType=individual&origin=PTA-CYIT-CY
+      hint_text: Bydd gennych Ddynodydd Defnyddiwr (ID) os ydych wedi cofrestru i wneud pethau fel cyflwyno'ch Ffurflen Dreth Hunanasesiad ar-lein.
+    - text: Defnyddio GOV.UK Verify
+      url: https://www.tax.service.gov.uk/check-income-tax/start-verify?_ga=2.265317837.398886849.1513589676-373904926.1473694521
+      hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Barclays, CitizenSafe, Digidentity, Experian, Swyddfa'r Post, y Post Brenhinol neu SecureIdentity.
+    - text: Defnyddiwch hunaniaeth digidol o wlad Ewropeaidd arall
+      url: https://www.tax.service.gov.uk/check-income-tax/start-verify?journey_hint=eidas_sign_in
+      hint_text: Os ydych yn rhan o gynllun ID mewn gwlad sy'n cymryd rhan, efallai y gallwch ei ddefnyddio yma.
+    - text: Creu cyfrif
+      slug: creu-cyfrif
+create_new_account:
+  title: Creu cyfrif
+  slug: creu-cyfrif
+  body: |
+    I ddefnyddio'r gwasanaeth hwn, bydd angen i chi greu naill ai cyfrif Porth y Llywodraeth neu gyfrif GOV.UK Verify. Caiff y rhain eu defnyddio i helpu i ddiogelu rhag twyll dwyn hunaniaeth.
+
+    Unwaith y bydd cyfrif gennych, gallwch ei ddefnyddio i gyrchu gwasanaethau ar-lein eraill y Llywodraeth.
+
+    ##Dewiswch ffordd o brofi pwy ydych
+
+    ###Porth y Llywodraeth
+
+    Fel arfer mae'n cymryd tua 10 munud i greu cyfrif Porth y Llywodraeth. Bydd yn gweithio orau os oes gennych y canlynol:
+
+    - eich rhif Yswiriant Gwladol
+    - slip cyflog diweddar, P60 neu basbort y DU sy'n ddilys
+
+    [Creu cyfrif Porth y llywodraeth](https://www.tax.service.gov.uk/gg/sign-in?continue=/paye/company-car/details&accountType=individual&origin=PTA-companycar).
+
+    ###GOV.UK Verify
+
+    Fel arfer mae'n cymryd tua 15 munud i gofrestru gyda GOV.UK Verify. Bydd yn gweithio orau os oes gennych y canlynol:
+
+    - cyfeiriad yn y DU
+    - pasbort neu drwydded cerdyn-llun dilys
+
+    [Creu cyfrif Porth y Llywodraeth](www.tax.service.gov.uk/paye/company-car/start-verify).
+
+    Bydd cwmni ardystiedig bob tro'n gwirio pwy ydych pan fyddwch yn cofrestru gyda GOV.UK Verify. Mae pob un ohonynt yn bodloni safonau diogelwch sydd wedi'u gosod gan y Llywodraeth.
+
+    ##Cyfrif treth personol
+
+    Bydd mewngofnodi am y tro cyntaf, yn cychwyn eich cyfrif treth personol. Gallwch ddefnyddio hwn i wirio'ch cofnodion gyda CThEM a rheoli'ch manylion eraill.
+
+
+update_type: major
+change_note: New Welsh translation for Check your Income Tax for the current year


### PR DESCRIPTION
This adds a new sign in page in Welsh to support a translated version
of https://www.gov.uk/check-income-tax-current-year that will appear
at https://www.gov.uk/gwirioch-treth-incwm-ar-gyfer-y-flwyddyn-bresennol

https://govuk.zendesk.com/agent/tickets/3423986