### PR TITLE
Allow variants of transaction pages

### DIFF
--- a/app/assets/javascripts/modules/ajax_save_with_parts.js
+++ b/app/assets/javascripts/modules/ajax_save_with_parts.js
@@ -9,7 +9,7 @@
       ajaxSave.start(element);
 
       function success(evt, response) {
-        var parts = response.parts;
+        var parts = response.parts || response.variants;
         if (parts) {
           for (var i = 0, l = parts.length; i < l; i++) {
             updatePart(parts[i]);
@@ -19,7 +19,7 @@
 
       function error(evt, response) {
         var responseJSON = response.responseJSON,
-            partErrors = typeof responseJSON === "object" && responseJSON.parts;
+            partErrors = typeof responseJSON === "object" && (responseJSON.parts || responseJSON.variants);
 
         if (partErrors) {
           $.each(partErrors[0], showPartErrors);

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -18,6 +18,10 @@ class EditionsController < InheritedResources::Base
       @ordered_parts = @resource.parts.in_order
     end
 
+    if @resource.is_a?(Varianted)
+      @ordered_variants = @resource.variants.in_order
+    end
+
     @tagging_update = tagging_update_form
     @artefact = @resource.artefact
 
@@ -269,15 +273,16 @@ protected
         ],
       ]
     when :transaction_edition
-      %i[
-        introduction
-        start_button_text
-        will_continue_on
-        link
-        more_information
-        alternate_methods
-        need_to_know
-        department_analytics_profile
+      [
+        :introduction,
+        :start_button_text,
+        :will_continue_on,
+        :link,
+        :more_information,
+        :alternate_methods,
+        :need_to_know,
+        :department_analytics_profile,
+        variants_attributes: %i[title slug introduction link more_information alternate_methods order id _destroy]
       ]
     when :completed_transaction_edition
       %i[

--- a/app/helpers/editions_helper.rb
+++ b/app/helpers/editions_helper.rb
@@ -9,7 +9,7 @@ module EditionsHelper
   def resource_form(&form_definition)
     html_options = { id: 'edition-form' }
     unless @resource.locked_for_edits? || @resource.archived?
-      if @resource.is_a?(Parted)
+      if @resource.is_a?(Parted) || @resource.is_a?(Varianted)
         html_options['data-module'] = 'ajax-save-with-parts'
       elsif @resource.format != 'SimpleSmartAnswer'
         html_options['data-module'] = 'ajax-save'

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -97,7 +97,6 @@ class Edition
   EXACT_ROUTE_EDITION_CLASSES = %w[
     CampaignEdition
     HelpPageEdition
-    TransactionEdition
   ].freeze
 
   validates :title, presence: true

--- a/app/models/transaction_edition.rb
+++ b/app/models/transaction_edition.rb
@@ -1,6 +1,9 @@
 require "edition"
+require "varianted"
 
 class TransactionEdition < Edition
+  include Varianted
+
   field :introduction, type: String
   field :will_continue_on, type: String
   field :link, type: String

--- a/app/models/variant.rb
+++ b/app/models/variant.rb
@@ -1,0 +1,27 @@
+require_dependency "safe_html"
+
+class Variant
+  include Mongoid::Document
+
+  embedded_in :transaction_edition
+
+  scope :in_order, lambda { order_by(order: :asc) }
+
+  field :order,             type: Integer
+  field :title,             type: String
+  field :slug,              type: String
+  field :introduction,      type: String
+  field :link,              type: String
+  field :more_information,  type: String
+  field :alternate_methods, type: String
+  field :created_at,        type: DateTime, default: lambda { Time.zone.now }
+
+  GOVSPEAK_FIELDS = %i[introduction more_information alternate_methods].freeze
+
+  validates_presence_of :title
+  validates_presence_of :slug
+  validates_exclusion_of :slug, in: ["video"], message: "Can not be video"
+  validates_format_of :slug, with: /\A[a-z0-9\-]+\Z/i
+  validates_with SafeHtml
+  validates_with LinkValidator
+end

--- a/app/models/varianted.rb
+++ b/app/models/varianted.rb
@@ -1,0 +1,43 @@
+require_dependency "variant"
+
+module Varianted
+  def self.included(klass)
+    klass.embeds_many :variants
+    klass.accepts_nested_attributes_for :variants, allow_destroy: true,
+      reject_if: proc { |attrs| attrs["title"].blank? && attrs["slug"].blank? }
+    klass.after_validation :merge_embedded_variants_errors
+  end
+
+  def build_clone(target_class = nil)
+    new_edition = super
+
+    # If the new edition is of the same type or another type that has variants,
+    # copy over the variants from this edition
+    if target_class.nil? || target_class.include?(Varianted)
+      new_edition.variants = self.variants.map(&:dup)
+    end
+
+    new_edition
+  end
+
+  def order_variants
+    ordered_variants = variants.sort_by { |p| p.order ? p.order : 99999 }
+    ordered_variants.each_with_index do |obj, i|
+      obj.order = i + 1
+    end
+  end
+
+private
+
+  def merge_embedded_variants_errors
+    return if variants.empty?
+
+    if errors.delete(:variants) == ["is invalid"]
+      variants_errors = variants.inject({}) do |result, variant|
+        result["#{variant._id}:#{variant.order}"] = variant.errors.messages if variant.errors.present?
+        result
+      end
+      errors.add(:variants, variants_errors)
+    end
+  end
+end

--- a/app/presenters/formats/transaction_presenter.rb
+++ b/app/presenters/formats/transaction_presenter.rb
@@ -12,25 +12,39 @@ module Formats
 
     def details
       {
-        introductory_paragraph: govspeak(:introduction),
+        variants: variants,
+        introductory_paragraph: govspeak(edition.introduction),
         start_button_text: edition.start_button_text,
         will_continue_on: edition.will_continue_on,
         transaction_start_link: edition.link,
-        more_information: govspeak(:more_information),
-        other_ways_to_apply: govspeak(:alternate_methods),
-        what_you_need_to_know: govspeak(:need_to_know),
+        more_information: govspeak(edition.more_information),
+        other_ways_to_apply: govspeak(edition.alternate_methods),
+        what_you_need_to_know: govspeak(edition.need_to_know),
         external_related_links: external_related_links,
         department_analytics_profile: edition.department_analytics_profile,
         downtime_message: downtime_message
       }.delete_if { |_, value| value.nil? }
     end
 
+    def variants
+      edition.variants.in_order.map do |variant|
+        {
+          title: variant.title.to_s,
+          slug: variant.slug.to_s,
+          introductory_paragraph: govspeak(variant.introduction),
+          transaction_start_link: variant.link.to_s,
+          more_information: govspeak(variant.more_information),
+          other_ways_to_apply: govspeak(variant.alternate_methods)
+        }.delete_if { |_, value| value.nil? }
+      end
+    end
+
     def govspeak(field)
-      if edition.send(field).present?
+      if field.present?
         [
           {
             content_type: "text/govspeak",
-            content: edition.send(field).to_s
+            content: field.to_s
           }
         ]
       end

--- a/app/views/shared/_transaction_variant.html.erb
+++ b/app/views/shared/_transaction_variant.html.erb
@@ -1,0 +1,61 @@
+<div class="panel panel-part part">
+  <div class="panel-heading js-sort-handle">
+    <h4 class="panel-title">
+      <a class="js-part-toggle" data-toggle="collapse" data-parent="#parts" href="#<%= f.object.slug || 'untitled-part' %>">
+        <i class="glyphicon glyphicon-chevron-down pull-left add-right-margin"></i>
+        <span class="js-part-title"><%= f.object.title.present? ? f.object.title : 'Untitled variant' %></span>
+      </a>
+    </h4>
+  </div>
+  <div id="<%= f.object.slug || 'untitled-part' %>" class="js-part-toggle-target panel-collapse collapse in" aria-expanded="true">
+    <div class="panel-body">
+        <%= f.inputs do %>
+          <%= f.input :title,
+                      :input_html => { :class => 'title', :disabled => @resource.locked_for_edits? },
+                      :hint => false,
+                      :required => true %>
+
+          <%
+            slug_input_html = { :class => 'slug', :disabled => ! editable }
+            if @resource.version_number == 1
+              slug_input_html['data-accepts-generated-value'] = true
+            end
+          %>
+
+          <%= f.input :slug,
+                      :input_html => slug_input_html,
+                      :hint => true,
+                      :required => true %>
+
+          <%= f.input :introduction,
+                      :as => :text,
+                      :label => 'Introductory paragraph',
+                      :hint => 'Set the scene for the user. What is about to happen? (eg. "you will need to fill in a form, print it out and take it to the post office")',
+                      :input_html => { :rows => 8, :disabled => @resource.locked_for_edits?, :class => 'input-md-7' } %>
+
+          <%= f.input :link,
+                      :label => 'Link to start of transaction',
+                      :hint => 'Link as deep as possible.',
+                      :input_html => { :disabled => @resource.locked_for_edits?, :class => 'input-md-7' } %>
+
+          <%= f.input :more_information,
+                      :as => :text,
+                      :input_html => { :disabled => @resource.locked_for_edits?, :class => 'input-md-10' } %>
+
+          <%= f.input :alternate_methods,
+                      :as => :text,
+                      :label => "Other ways to apply",
+                      :hint => "Alternative ways of completing this transaction. Not displayed on front end if left blank.",
+                      :input_html => { :disabled => @resource.locked_for_edits?, :class => 'input-md-10' } %>
+
+          <%= f.input :order, :as => :hidden, :input_html => { :class => 'order', :disabled => !editable } %>
+
+          <% unless @resource.locked_for_edits? %>
+            <%= f.link_to_remove class: 'btn btn-default btn-sm' do %>
+              <i class="glyphicon glyphicon-remove glyphicon-smaller-than-text"></i> Remove this variant
+            <% end %>
+          <% end %>
+        <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/transactions/_fields.html.erb
+++ b/app/views/transactions/_fields.html.erb
@@ -53,4 +53,30 @@
   </div>
 </div>
 
+<div class="row">
+
+  <div class="col-md-8"
+    data-module="collapsible-group"
+    data-expand-text="Expand all variants"
+    data-collapse-text="Collapse all variants"
+  >
+    <h3 class="remove-top-margin">Variants</h3>
+    <p class="add-bottom-margin if-no-js-hide">
+      <a href="#" class="js-toggle-all">Collapse all variants</a>
+    </p>
+
+    <section class="panel-group" id="parts" data-module="parts">
+      <%= f.semantic_fields_for :variants, @ordered_variants do |variant| %>
+        <%= render :partial => '/shared/transaction_variant', :locals => {:f => variant, :editable => ! @resource.locked_for_edits? } %>
+      <% end %>
+    </section>
+
+    <%= f.link_to_add :variants, :data => { :target => "#parts" }, :class => 'btn btn-default' do %>
+      <i class="glyphicon glyphicon-plus add-right-margin"></i>Add new variant
+    <% end %>
+
+  </div>
+
+</div>
+
 <%= render partial: 'shared/workflow_buttons', locals: { f: f } %>

--- a/test/integration/adding_variants_to_transactions_test.rb
+++ b/test/integration/adding_variants_to_transactions_test.rb
@@ -1,0 +1,242 @@
+require 'integration_test_helper'
+
+class AddingVariantsToTransactionsTest < JavascriptIntegrationTest
+  setup do
+    setup_users
+    stub_linkables
+    stub_holidays_used_by_fact_check
+  end
+
+  context 'creating a transaction with variants' do
+    setup do
+      @random_name = (0...8).map { rand(65..89).chr }.join + " TRANSACTION"
+
+      transaction = FactoryBot.create(:transaction_edition, title: @random_name, slug: 'test-transaction')
+      transaction.save!
+      transaction.update_attribute(:state, 'draft')
+
+      visit_edition transaction
+
+      add_new_variant
+      within :css, '#parts div.fields:first-of-type' do
+        fill_in 'Title', with: 'Variant One'
+        fill_in 'Introductory paragraph', with: 'Body text'
+        fill_in 'Slug', with: 'variant-one'
+        fill_in 'Link to start of transaction', with: 'http://www.example.com/one'
+      end
+
+      assert page.has_css?('#parts div.fields', count: 1)
+
+      add_new_variant
+      within :css, '#parts div.fields:nth-of-type(2)' do
+        fill_in 'Title', with: 'Variant Two'
+        fill_in 'Introductory paragraph', with: 'Body text'
+        fill_in 'Slug', with: 'variant-two'
+        fill_in 'Link to start of transaction', with: 'http://www.example.com/two'
+      end
+
+      assert page.has_css?('#parts div.fields', count: 2)
+
+      add_new_variant
+      within :css, '#parts div.fields:nth-of-type(3)' do
+        fill_in 'Title', with: 'Variant Three'
+        fill_in 'Introductory paragraph', with: 'Body text'
+        fill_in 'Slug', with: 'variant-three'
+        fill_in 'Link to start of transaction', with: 'http://www.example.com/three'
+      end
+    end
+
+    should "save the transaction and variants using ajax" do
+      save_edition_and_assert_success
+      visit current_path
+      assert_correct_variants
+
+      visit "/?user_filter=all&list=drafts"
+      assert page.has_content? @random_name
+    end
+
+    should "be able to hide and show edited variant after saving" do
+      save_edition_and_assert_success
+      visit current_path
+      assert page.has_css?('#variant-one[aria-expanded="true"]')
+      within :css, '#parts div.fields:nth-of-type(1)' do
+        fill_in 'Title', with: 'Variant One (edited)'
+        fill_in 'Introductory paragraph', with: 'Body text'
+        fill_in 'Slug', with: 'variant-one-edited'
+        fill_in 'Link to start of transaction', with: 'http://www.example.com/one-new'
+      end
+      save_edition_and_assert_success
+
+      assert page.has_css?('#variant-one-edited[aria-expanded="true"]')
+
+      # collapse variant
+      click_on 'Variant One (edited)'
+      assert page.has_css?('#variant-one-edited[aria-expanded="false"]')
+    end
+
+    should "add the new variants only once" do
+      save_edition_and_assert_success
+      save_edition_and_assert_success
+      save_edition_and_assert_success
+
+      visit current_path
+      assert_correct_variants
+
+      save_edition_and_assert_success
+      save_edition_and_assert_success
+      assert_correct_variants
+
+      visit current_path
+      assert_correct_variants
+    end
+
+    context 'removing variants' do
+      setup do
+        save_edition_and_assert_success
+        visit current_path
+      end
+
+      should 'remove the appropriate variant' do
+        within :css, '#parts div.fields:nth-of-type(3)' do
+          click_on 'Remove this variant'
+        end
+
+        save_edition_and_assert_success
+        assert_correct_variants(2)
+
+        visit current_path
+        assert_correct_variants(2)
+
+        within :css, '#parts div.fields:nth-of-type(2)' do
+          click_on 'Remove this variant'
+        end
+
+        save_edition_and_assert_success
+        assert_correct_variants(1)
+
+        visit current_path
+        assert_correct_variants(1)
+      end
+    end
+
+    context 'when removing variants' do
+      setup do
+        save_edition_and_assert_success
+        visit current_path
+      end
+
+      should 'remove the appropriate variant' do
+        within :css, '#parts div.fields:nth-of-type(3)' do
+          click_on 'Remove this variant'
+        end
+
+        save_edition_and_assert_success
+        assert_correct_variants(2)
+
+        visit current_path
+        assert_correct_variants(2)
+
+        within :css, '#parts div.fields:nth-of-type(2)' do
+          click_on 'Remove this variant'
+        end
+
+        save_edition_and_assert_success
+        assert_correct_variants(1)
+
+        visit current_path
+        assert_correct_variants(1)
+      end
+    end
+
+    context 'when entering invalid variants' do
+      setup do
+        save_edition_and_assert_success
+        visit current_path
+      end
+
+      should 'not save when a variant is invalid' do
+        within :css, '#parts div.fields:nth-of-type(2)' do
+          fill_in 'Slug', with: ''
+        end
+
+        within :css, '#parts div.fields:nth-of-type(3)' do
+          fill_in 'Title', with: ''
+          fill_in 'Slug', with: 'variant-three'
+        end
+
+        save_edition_and_assert_error
+
+        assert page.has_css?('#parts .has-error', count: 2)
+
+        within :css, '#parts div.fields:nth-of-type(2)' do
+          assert page.has_css?('.has-error[id*="slug"]')
+          assert page.has_css?('.js-error li', count: 2)
+          assert page.has_css?('.js-error li', text: 'can\'t be blank')
+          assert page.has_css?('.js-error li', text: 'is invalid')
+        end
+
+        within :css, '#parts div.fields:nth-of-type(3)' do
+          assert page.has_css?('.has-error[id*="title"]')
+          assert page.has_css?('.js-error li', count: 1)
+          assert page.has_css?('.js-error li', text: 'can\'t be blank')
+        end
+      end
+    end
+  end
+
+  test "slug for new variants should be automatically generated" do
+    random_name = (0...8).map { rand(65..89).chr }.join + " TRANSACTION"
+
+    transaction = FactoryBot.create(:transaction_edition, title: random_name, slug: 'test-transaction')
+    transaction.save!
+    transaction.update_attribute(:state, 'draft')
+
+    visit_edition transaction
+
+    add_new_variant
+    within :css, '#parts .fields:first-of-type .part' do
+      fill_in 'Title', with: 'Variant One'
+      fill_in 'Introductory paragraph', with: 'Body text'
+      assert_equal 'variant-one', find(:css, ".slug").value
+
+      fill_in 'Title', with: 'Variant One changed'
+      fill_in 'Introductory paragraph', with: 'Body text'
+      assert_equal 'variant-one-changed', find(:css, ".slug").value
+    end
+  end
+
+  test "slug for edition which has been previously published shouldn't be generated" do
+    transaction = FactoryBot.create(:transaction_edition_with_two_variants, state: 'published', title: "Foo bar")
+    transaction.save!
+    visit_edition transaction
+    click_on "Create new edition"
+
+    within :css, '#parts .fields:first-of-type .part' do
+      assert_equal 'variant-one', find(:css, ".slug").value
+      fill_in 'Title', with: 'Variant One changed'
+      fill_in 'Introductory paragraph', with: 'Body text'
+      assert_equal 'variant-one', find(:css, ".slug").value
+    end
+  end
+
+  def assert_correct_variants(count = 3)
+    assert page.has_css?('#parts .panel-part', count: count)
+    assert page.has_css?('#parts .panel-title', count: count)
+    assert page.has_css?('#parts .panel-body', count: count)
+
+    if count > 0 # rubocop:disable Style/NumericPredicate
+      assert page.has_css?('#variant-one', count: 1)
+      assert_equal page.find('#variant-one input.title').value, 'Variant One'
+    end
+
+    if count > 1
+      assert page.has_css?('#variant-two', count: 1)
+      assert_equal page.find('#variant-two input.title').value, 'Variant Two'
+    end
+
+    if count > 2
+      assert page.has_css?('#variant-three', count: 1)
+      assert_equal page.find('#variant-three input.title').value, 'Variant Three'
+    end
+  end
+end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -133,13 +133,39 @@ class JavascriptIntegrationTest < ActionDispatch::IntegrationTest
 
     within :css, '#parts div.part:first-of-type' do
       fill_in 'Title', with: 'Part One'
-      fill_in 'Body',  with: 'Body text'
-      fill_in 'Slug',  with: 'part-one'
+      fill_in 'Body', with: 'Body text'
+      fill_in 'Slug', with: 'part-one'
     end
 
     save_edition_and_assert_success
 
     guide.reload
+  end
+
+  # Fill in some sample variants for a transaction
+  def fill_in_variants(transaction)
+    visit_edition transaction
+
+    unless page.has_css?('#parts div.part:first-of-type input')
+      add_new_variant
+    end
+
+    # Toggle the first variant to be open, presuming the first variant
+    # is called 'Untitled variant'
+    unless page.has_css?('#parts div.part:first-of-type input')
+      scroll_to_bottom
+      click_on 'Untitled variant'
+    end
+
+    within :css, '#parts div.part:first-of-type' do
+      fill_in 'Title', with: 'Variant One'
+      fill_in 'Introductory paragraph', with: 'Body text'
+      fill_in 'Slug', with: 'variant-one'
+    end
+
+    save_edition_and_assert_success
+
+    transaction.reload
   end
 
   def select2(value, scope)
@@ -229,6 +255,11 @@ class JavascriptIntegrationTest < ActionDispatch::IntegrationTest
   def add_new_part
     scroll_to_bottom
     click_on 'Add new part'
+  end
+
+  def add_new_variant
+    scroll_to_bottom
+    click_on 'Add new variant'
   end
 
   def scroll_to_bottom

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -382,12 +382,10 @@ class ArtefactTest < ActiveSupport::TestCase
       should 'be true if its owning_app is publisher and its kind is that of an exact route edition' do
         assert FactoryBot.build(:artefact, kind: 'campaign', prefixes: []).exact_route?
         assert FactoryBot.build(:artefact, kind: 'help_page', prefixes: []).exact_route?
-        assert FactoryBot.build(:artefact, kind: 'transaction', prefixes: []).exact_route?
 
         # regardless of prefixes
         assert FactoryBot.build(:artefact, kind: 'campaign', prefixes: ['/hats']).exact_route?
         assert FactoryBot.build(:artefact, kind: 'help_page', prefixes: ['/shoes']).exact_route?
-        assert FactoryBot.build(:artefact, kind: 'transaction', prefixes: ['/scarves']).exact_route?
       end
 
       should 'be false if its owning_app is not publisher and its kind is not that of an exact route edition' do
@@ -399,6 +397,7 @@ class ArtefactTest < ActiveSupport::TestCase
         refute FactoryBot.build(:artefact, kind: 'place', prefixes: []).exact_route?
         refute FactoryBot.build(:artefact, kind: 'programme', prefixes: []).exact_route?
         refute FactoryBot.build(:artefact, kind: 'simple_smart_answer', prefixes: []).exact_route?
+        refute FactoryBot.build(:artefact, kind: 'transaction', prefixes: []).exact_route?
         refute FactoryBot.build(:artefact, kind: 'video', prefixes: []).exact_route?
 
         # regardless of prefixes
@@ -410,6 +409,7 @@ class ArtefactTest < ActiveSupport::TestCase
         refute FactoryBot.build(:artefact, kind: 'place', prefixes: ['/belts']).exact_route?
         refute FactoryBot.build(:artefact, kind: 'programme', prefixes: ['/socks']).exact_route?
         refute FactoryBot.build(:artefact, kind: 'simple_smart_answer', prefixes: ['/onesies']).exact_route?
+        refute FactoryBot.build(:artefact, kind: 'transaction', prefixes: ['/scarves']).exact_route?
         refute FactoryBot.build(:artefact, kind: 'video', prefixes: ['/all-other-clothing']).exact_route?
       end
     end

--- a/test/models/varianted_test.rb
+++ b/test/models/varianted_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+# require "edition"
+# require "varianted"
+
+class VariantedTest < ActiveSupport::TestCase
+  test "should merge variant validation errors with parent document's errors" do
+    edition = FactoryBot.create(:transaction_edition)
+    edition.variants.build(_id: '54c10d4d759b743528000010', order: '1', title: "", slug: "overview")
+    edition.variants.build(_id: '54c10d4d759b743528000011', order: '2', title: "Prepare for your appointment", slug: "")
+    edition.variants.build(_id: '54c10d4d759b743528000012', order: '3', title: "Valid", slug: "valid")
+
+    refute edition.valid?
+
+    assert_equal({ title: ["can't be blank"] }, edition.errors[:variants][0]['54c10d4d759b743528000010:1'])
+    assert_equal({ slug: ["can't be blank", "is invalid"] }, edition.errors[:variants][0]['54c10d4d759b743528000011:2'])
+    assert_equal 2, edition.errors[:variants][0].length
+  end
+end

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -192,6 +192,17 @@ FactoryBot.define do
     alternate_methods { "Method A or Method B" }
   end
 
+  factory :transaction_edition_with_two_variants, parent: :transaction_edition do
+    after :create do |getp|
+      getp.variants.build(title: "VARIANT !",
+                          introduction: "This is some version text.",
+                          slug: "variant-one")
+      getp.variants.build(title: "VARIANT !!",
+                          introduction: "This is some more version text.",
+                          slug: "variant-two")
+    end
+  end
+
   factory :licence_edition, parent: :edition, class: "LicenceEdition" do
     licence_identifier { "AB1234" }
     licence_short_description { "This is a licence short description." }

--- a/test/unit/presenters/formats/transaction_presenter_test.rb
+++ b/test/unit/presenters/formats/transaction_presenter_test.rb
@@ -24,6 +24,17 @@ class TransactionPresenterTest < ActiveSupport::TestCase
     )
   end
 
+  def add_variant(num)
+    Variant.create(
+      title: "title-#{num}",
+      slug: "slug-#{num}",
+      introduction: "introduction-#{num}",
+      link: "http://www.example.com/#{num}",
+      order: num,
+      transaction_edition: edition
+    )
+  end
+
   def result
     subject.render_for_publishing_api
   end
@@ -37,6 +48,50 @@ class TransactionPresenterTest < ActiveSupport::TestCase
   end
 
   context "[:details]" do
+    should "[:variants]" do
+      add_variant(2)
+      add_variant(1)
+
+      expected = [
+        {
+          title: 'title-1',
+          slug: 'slug-1',
+          introductory_paragraph: [
+            {
+              content_type: 'text/govspeak',
+              content: 'introduction-1'
+            }
+          ],
+          transaction_start_link: 'http://www.example.com/1'
+        },
+        {
+          title: 'title-2',
+          slug: 'slug-2',
+          introductory_paragraph: [
+            {
+              content_type: 'text/govspeak',
+              content: 'introduction-2'
+            }
+          ],
+          transaction_start_link: 'http://www.example.com/2'
+        }
+      ]
+
+      assert_equal expected, result[:details][:variants]
+    end
+
+    should "handle nil parts of variants" do
+      Variant.create(transaction_edition: edition)
+
+      expected = [{
+        title: "",
+        slug: "",
+        transaction_start_link: ""
+      }]
+
+      assert_equal expected, result[:details][:variants]
+    end
+
     should "[:introductory_paragraph]" do
       edition.update_attribute(:introduction, 'foo')
       expected = [
@@ -139,7 +194,7 @@ class TransactionPresenterTest < ActiveSupport::TestCase
   should "[:routes]" do
     edition.update_attribute(:slug, 'foo')
     expected = [
-      { path: '/foo', type: 'exact' },
+      { path: '/foo', type: 'prefix' },
     ]
     assert_equal expected, result[:routes]
   end


### PR DESCRIPTION
This commit adds a new concept named "variants" to transaction pages. Variants are technically similar to "parts", which are used for guides and other document types.

For transaction pages, variants allow transaction pages to respond to URLs of the form www.gov.uk/transaction/variant and display different page text and button targets based on the slug.

The primary use of this will initially be to allow GOV.UK Verify journeys which lead directly to a single IDP.

RFC: https://github.com/alphagov/govuk-rfcs/pull/97