### PR TITLE
HUB-378: Update Verify redirect links

### DIFF
--- a/lib/service_sign_in/check-income-tax.cy.yaml
+++ b/lib/service_sign_in/check-income-tax.cy.yaml
@@ -8,10 +8,10 @@ choose_sign_in:
       url: https://www.tax.service.gov.uk/gg/sign-in?continue=/check-income-tax/what-do-you-want-to-do&accountType=individual&origin=PTA-CYIT-CY
       hint_text: Bydd gennych Ddynodydd Defnyddiwr (ID) os ydych wedi cofrestru i wneud pethau fel cyflwyno'ch Ffurflen Dreth Hunanasesiad ar-lein.
     - text: Defnyddio GOV.UK Verify
-      url: https://www.tax.service.gov.uk/check-income-tax/start-verify?_ga=2.265317837.398886849.1513589676-373904926.1473694521
+      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-tax-estimate?journey_hint=uk_idp_sign_in
       hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Barclays, CitizenSafe, Digidentity, Experian, Swyddfa'r Post, y Post Brenhinol neu SecureIdentity.
     - text: Defnyddiwch hunaniaeth digidol o wlad Ewropeaidd arall
-      url: https://www.tax.service.gov.uk/check-income-tax/start-verify?journey_hint=eidas_sign_in
+      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-tax-estimate?journey_hint=eidas_sign_in
       hint_text: Os ydych yn rhan o gynllun ID mewn gwlad sy'n cymryd rhan, efallai y gallwch ei ddefnyddio yma.
     - text: Creu cyfrif
       slug: creu-cyfrif
@@ -32,7 +32,7 @@ create_new_account:
     - eich rhif Yswiriant Gwladol
     - slip cyflog diweddar, P60 neu basbort y DU sy'n ddilys
 
-    [Creu cyfrif Porth y llywodraeth](https://www.tax.service.gov.uk/gg/sign-in?continue=/paye/company-car/details&accountType=individual&origin=PTA-companycar).
+    {button}[Creu cyfrif Porth y llywodraeth](https://www.tax.service.gov.uk/gg/sign-in?continue=/paye/company-car/details&accountType=individual&origin=PTA-companycar){/button}
 
     ###GOV.UK Verify
 
@@ -41,7 +41,7 @@ create_new_account:
     - cyfeiriad yn y DU
     - pasbort neu drwydded cerdyn-llun dilys
 
-    [Creu cyfrif Porth y Llywodraeth](www.tax.service.gov.uk/paye/company-car/start-verify).
+    {button}[Creu cyfrif Porth y Llywodraeth](https://www.signin.service.gov.uk/initiate-journey/hmrc-tax-estimate?journey_hint=registration){/button}
 
     Bydd cwmni ardystiedig bob tro'n gwirio pwy ydych pan fyddwch yn cofrestru gyda GOV.UK Verify. Mae pob un ohonynt yn bodloni safonau diogelwch sydd wedi'u gosod gan y Llywodraeth.
 
@@ -50,5 +50,5 @@ create_new_account:
     Bydd mewngofnodi am y tro cyntaf, yn cychwyn eich cyfrif treth personol. Gallwch ddefnyddio hwn i wirio'ch cofnodion gyda CThEM a rheoli'ch manylion eraill.
 
 
-update_type: major
-change_note: New Welsh translation for Check your Income Tax for the current year
+update_type: minor
+change_note: Updated Verify links to use correct hints and redirects

--- a/lib/service_sign_in/check-income-tax.en.yaml
+++ b/lib/service_sign_in/check-income-tax.en.yaml
@@ -8,10 +8,10 @@ choose_sign_in:
       url: https://www.tax.service.gov.uk/gg/sign-in?continue=/check-income-tax/what-do-you-want-to-do&accountType=individual&origin=PTA-CYIT-CY
       hint_text: You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.
     - text: Sign in with GOV.UK Verify
-      url: https://www.tax.service.gov.uk/check-income-tax/start-verify?_ga=2.265317837.398886849.1513589676-373904926.1473694521
+      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-tax-estimate?journey_hint=uk_idp_sign_in
       hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
     - text: Sign in with a digital identity from another European country
-      url: https://www.tax.service.gov.uk/check-income-tax/start-verify?journey_hint=eidas_sign_in
+      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-tax-estimate?journey_hint=eidas_sign_in
       hint_text: If you are part of Germany’s Online-Ausweis you can use it here. Identity schemes from other countries will become available later.
     - text: Create an account
       slug: create-account
@@ -42,7 +42,7 @@ create_new_account:
     - a UK address
     - a valid passport or photocard driving licence
 
-    {button}[Create a GOV.UK Verify account](https://www.tax.service.gov.uk/check-income-tax/start-verify?_ga=2.114080007.145612230.1512381177-373904926.1473694521){/button}
+    {button}[Create a GOV.UK Verify account](https://www.signin.service.gov.uk/initiate-journey/hmrc-tax-estimate?journey_hint=registration){/button}
 
     A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.
 
@@ -50,4 +50,4 @@ create_new_account:
 
     Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
 update_type: minor
-change_note: Removed description text for service sign in pages as per results of baseline test.
+change_note: Updated Verify links to use correct hints and redirects

--- a/lib/service_sign_in/check-state-pension.cy.yaml
+++ b/lib/service_sign_in/check-state-pension.cy.yaml
@@ -11,10 +11,10 @@ choose_sign_in:
       url: https://www.tax.service.gov.uk/gg/sign-in?continue=/personal-account&accountType=individual&origin=PTA-frontend
       hint_text: Bydd gennych Ddynodydd Defnyddiwr (ID) os ydych wedi cofrestru i wneud pethau fel cyflwyno'ch Ffurflen Dreth Hunanasesiad ar-lein.
     - text: Defnyddio GOV.UK Verify
-      url: https://www.tax.service.gov.uk/personal-account/start-verify
+      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=uk_idp_sign_in
       hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Barclays, CitizenSafe, Digidentity, Experian, Swyddfa'r Post, y Post Brenhinol neu SecureIdentity.
     - text: Defnyddiwch hunaniaeth digidol o wlad Ewropeaidd arall
-      url: https://www.tax.service.gov.uk/personal-account/start-verify?journey_hint=eidas_sign_in
+      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=eidas_sign_in
       hint_text: Os ydych yn rhan o gynllun ID mewn gwlad sy'n cymryd rhan, efallai y gallwch ei ddefnyddio yma.
     - text: Creu cyfrif
       slug: creu-cyfrif
@@ -44,9 +44,9 @@ create_new_account:
     - cyfeiriad yn y DU
     - pasbort neu drwydded cerdyn-llun dilys
 
-    <a role="button" class="button" href="https://www.tax.service.gov.uk/personal-account/start-verify" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-event="true">Creu cyfrif GOV.UK Verify</a>
+    <a role="button" class="button" href="https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=registration" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-event="true">Creu cyfrif GOV.UK Verify</a>
 
     Bydd cwmni ardystiedig bob tro'n gwirio pwy ydych pan fyddwch yn cofrestru gyda GOV.UK Verify. Mae pob un ohonynt yn bodloni safonau diogelwch sydd wedi'u gosod gan y Llywodraeth.
 
-update_type: major
-change_note: Add hint text to eidas option
+update_type: minor
+change_note: Updated Verify links to use correct hints and redirects

--- a/lib/service_sign_in/check-state-pension.en.yaml
+++ b/lib/service_sign_in/check-state-pension.en.yaml
@@ -11,10 +11,10 @@ choose_sign_in:
       url: https://www.tax.service.gov.uk/gg/sign-in?continue=%2Fcheck-your-state-pension%2Faccount&origin=nisp-frontend&accountType=individual
       hint_text: You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.
     - text: Sign in with GOV.UK Verify
-      url: https://www.tax.service.gov.uk/check-your-state-pension/signin/verify?journey_hint=uk_idp_sign_in
+      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=uk_idp_sign_in
       hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
     - text: Sign in with a digital identity from another European country
-      url: https://www.tax.service.gov.uk/check-your-state-pension/signin/verify?journey_hint=eidas_sign_in
+      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=eidas_sign_in
       hint_text: If you are part of Germany’s Online-Ausweis you can use it here. Identity schemes from other countries will become available later.
     - text: Create an account
       slug: create-account
@@ -45,9 +45,9 @@ create_new_account:
     - a UK address
     - a valid passport or photocard driving licence
 
-    <a role="button" class="button" href="https://www.tax.service.gov.uk/check-your-state-pension/signin/verify?journey_hint=registration" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-event="true">Create a GOV.UK Verify account</a>
+    <a role="button" class="button" href="https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=registration" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-event="true">Create a GOV.UK Verify account</a>
 
     A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.
 
-update_type: major
-change_note: Add eidas option radio button, remove unwanted text regarding personal tax
+update_type: minor
+change_note: Updated Verify links to use correct hints and redirects

--- a/lib/service_sign_in/check-update-company-car-tax.cy.yaml
+++ b/lib/service_sign_in/check-update-company-car-tax.cy.yaml
@@ -8,10 +8,10 @@ choose_sign_in:
       url: https://www.tax.service.gov.uk/gg/sign-in?continue=/paye/company-car/details&accountType=individual&origin=PTA-companycar
       hint_text: Bydd gennych Ddynodydd Defnyddiwr (ID) os ydych wedi cofrestru i wneud pethau fel cyflwyno'ch Ffurflen Dreth Hunanasesiad ar-lein.
     - text: Defnyddio GOV.UK Verify
-      url: https://www.tax.service.gov.uk/paye/company-car/start-verify
+      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-company-car-tax?journey_hint=uk_idp_sign_in
       hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Barclays, CitizenSafe, Digidentity, Experian, Swyddfa'r Post, y Post Brenhinol neu SecureIdentity.
     - text: Defnyddiwch hunaniaeth digidol o wlad Ewropeaidd arall
-      url: https://www.tax.service.gov.uk/paye/company-car/start-verify?journey_hint=eidas_sign_in
+      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-company-car-tax?journey_hint=eidas_sign_in
       hint_text: Os ydych yn rhan o gynllun ID mewn gwlad sy'n cymryd rhan, efallai y gallwch ei ddefnyddio yma.
     - text: Creu cyfrif
       slug: creu-cyfrif
@@ -32,7 +32,7 @@ create_new_account:
     - eich rhif Yswiriant Gwladol
     - slip cyflog diweddar, P60 neu basbort y DU sy'n ddilys
 
-    [Creu cyfrif Porth y llywodraeth](https://www.tax.service.gov.uk/gg/sign-in?continue=/paye/company-car/details&accountType=individual&origin=PTA-companycar).
+    {button}[Creu cyfrif Porth y llywodraeth](https://www.tax.service.gov.uk/gg/sign-in?continue=/paye/company-car/details&accountType=individual&origin=PTA-companycar){/button}
 
     ###GOV.UK Verify
 
@@ -41,7 +41,7 @@ create_new_account:
     - cyfeiriad yn y DU
     - pasbort neu drwydded cerdyn-llun dilys
 
-    [Creu cyfrif Porth y Llywodraeth](www.tax.service.gov.uk/paye/company-car/start-verify).
+    {button}[Creu cyfrif Porth y Llywodraeth](https://www.signin.service.gov.uk/initiate-journey/hmrc-company-car-tax?journey_hint=registration){/button}
 
     Bydd cwmni ardystiedig bob tro'n gwirio pwy ydych pan fyddwch yn cofrestru gyda GOV.UK Verify. Mae pob un ohonynt yn bodloni safonau diogelwch sydd wedi'u gosod gan y Llywodraeth.
 
@@ -50,5 +50,5 @@ create_new_account:
     Bydd mewngofnodi am y tro cyntaf, yn cychwyn eich cyfrif treth personol. Gallwch ddefnyddio hwn i wirio'ch cofnodion gyda CThEM a rheoli'ch manylion eraill.
 
 
-update_type: major
-change_note: Add hint text to eidas option
+update_type: minor
+change_note: Updated Verify links to use correct hints and redirects

--- a/lib/service_sign_in/check-update-company-car-tax.en.yaml
+++ b/lib/service_sign_in/check-update-company-car-tax.en.yaml
@@ -8,10 +8,10 @@ choose_sign_in:
       url: https://www.tax.service.gov.uk/gg/sign-in?continue=/paye/company-car/details&accountType=individual&origin=PTA-companycar
       hint_text: You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.
     - text: Sign in with GOV.UK Verify
-      url: https://www.tax.service.gov.uk/paye/company-car/start-verify
+      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-company-car-tax?journey_hint=uk_idp_sign_in
       hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
     - text: Sign in with a digital identity from another European country
-      url: https://www.tax.service.gov.uk/paye/company-car/start-verify?journey_hint=eidas_sign_in
+      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-company-car-tax?journey_hint=eidas_sign_in
       hint_text: If you are part of Germany’s Online-Ausweis you can use it here. Identity schemes from other countries will become available later.
     - text: Create an account
       slug: create-account
@@ -42,12 +42,12 @@ create_new_account:
     - a UK address
     - a valid passport or photocard driving licence
 
-    {button}[Create a GOV.UK Verify account](https://www.tax.service.gov.uk/paye/company-car/start-verify){/button}
+    {button}[Create a GOV.UK Verify account](https://www.signin.service.gov.uk/initiate-journey/hmrc-company-car-tax?journey_hint=registration){/button}
 
     A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.
 
     ## Personal tax account
 
     Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
-update_type: major
-change_note: Add eidas option radio button.
+update_type: minor
+change_note: Updated Verify links to use correct hints and redirects

--- a/lib/service_sign_in/file_self_assessment.cy.yaml
+++ b/lib/service_sign_in/file_self_assessment.cy.yaml
@@ -8,10 +8,10 @@ choose_sign_in:
       url: https://www.tax.service.gov.uk/account
       hint_text: Bydd gennych chi ID defnyddiwr os ydych chi wedi cofrestru ar gyfer Hunanasesiad neu wedi ffeilio ffurflen dreth ar-lein yn y gorffennol.
     - text: Mewngofnodi gan ddefnyddio GOV.UK Verify
-      url: https://www.tax.service.gov.uk/ida/sa/login
+      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-isa?journey_hint=uk_idp_sign_in
       hint_text: Bydd gennych chi gyfrif os ydych chi wedi profi'n barod pwy ydych chi naill ai gyda Barclays, CitizenSafe, Digidentity, Experian, Swyddfa'r Post, y Post Brenhinol neu SecureIdentity.
     - text: Defnyddiwch hunaniaeth digidol o wlad Ewropeaidd arall
-      url: https://www.tax.service.gov.uk/ida/sa/login?journey_hint=eidas_sign_in
+      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-isa?journey_hint=eidas_sign_in
       hint_text: Os ydych yn rhan o gynllun ID mewn gwlad sy'n cymryd rhan, efallai y gallwch ei ddefnyddio yma.
     - text: Cofrestru ar gyfer Hunanasesiad
       slug: cofrestru-hunan-asesiad
@@ -33,5 +33,5 @@ create_new_account:
     Unwaith eich bod wedi cofrestru, byddwch yn cael llythyr a fydd yn rhoi gwybod i chi beth i'w wneud nesaf. Bydd yn cynnwys eich Cyfeirnod Unigryw y Trethdalwr (UTR).
 
     *[UTR]: Cyfeirnod Trethdalwr Unigryw
-update_type: major
-change_note: Add hint text to eidas option
+update_type: minor
+change_note: Updated Verify links to use correct hints and redirects

--- a/lib/service_sign_in/file_self_assessment.en.yaml
+++ b/lib/service_sign_in/file_self_assessment.en.yaml
@@ -9,10 +9,10 @@ choose_sign_in:
       url: https://www.tax.service.gov.uk/gg/sign-in?continue=/account/&origin=SA-frontend
       hint_text: You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before.
     - text: Sign in with GOV.UK Verify
-      url: https://www.tax.service.gov.uk/ida/sa/login
+      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-isa?journey_hint=uk_idp_sign_in
       hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
     - text: Sign in with a digital identity from another European country
-      url: https://www.tax.service.gov.uk/ida/sa/login?journey_hint=eidas_sign_in
+      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-isa?journey_hint=eidas_sign_in
       hint_text: If you are part of Germany’s Online-Ausweis you can use it here. Identity schemes from other countries will become available later.
     - text: Register for Self Assessment
       slug: register-self-assessment
@@ -34,5 +34,5 @@ create_new_account:
     Once you've registered, you'll get a letter that tells you what to do next. It will include your Unique Taxpayer Reference (UTR).
 
     *[UTR]: Unique Taxpayer Reference
-update_type: major
-change_note: Add eidas option radio button.
+update_type: minor
+change_note: Updated Verify links to use correct hints and redirects

--- a/lib/service_sign_in/personal-tax-account.cy.yaml
+++ b/lib/service_sign_in/personal-tax-account.cy.yaml
@@ -8,10 +8,10 @@ choose_sign_in:
       url: https://www.tax.service.gov.uk/gg/sign-in?continue=/personal-account&accountType=individual&origin=PTA-frontend
       hint_text: Bydd gennych Ddynodydd Defnyddiwr (ID) os ydych wedi cofrestru i wneud pethau fel cyflwyno'ch Ffurflen Dreth Hunanasesiad ar-lein.
     - text: Defnyddio GOV.UK Verify
-      url: https://www.tax.service.gov.uk/personal-account/start-verify
+      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-personal-tax-account?journey_hint=uk_idp_sign_in
       hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Barclays, CitizenSafe, Digidentity, Experian, Swyddfa'r Post, y Post Brenhinol neu SecureIdentity.
     - text: Defnyddiwch hunaniaeth digidol o wlad Ewropeaidd arall
-      url: https://www.tax.service.gov.uk/personal-account/start-verify?journey_hint=eidas_sign_in
+      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-personal-tax-account?journey_hint=eidas_sign_in
       hint_text: Os ydych yn rhan o gynllun ID mewn gwlad sy'n cymryd rhan, efallai y gallwch ei ddefnyddio yma.
     - text: Creu cyfrif
       slug: creu-cyfrif
@@ -40,12 +40,12 @@ create_new_account:
     - cyfeiriad yn y DU
     - pasbort neu drwydded cerdyn-llun dilys
 
-    {button}[Creu cyfrif GOV.UK Verify](https://www.tax.service.gov.uk/personal-account/start-verify){/button}
+    {button}[Creu cyfrif GOV.UK Verify](https://www.signin.service.gov.uk/initiate-journey/hmrc-personal-tax-account?journey_hint=registration){/button}
 
     Bydd cwmni ardystiedig bob tro'n gwirio pwy ydych pan fyddwch yn cofrestru gyda GOV.UK Verify. Mae pob un ohonynt yn bodloni safonau diogelwch sydd wedi'u gosod gan y Llywodraeth.
 
     ## Cyfrif treth personol
 
     Bydd mewngofnodi am y tro cyntaf, yn cychwyn eich cyfrif treth personol. Gallwch ddefnyddio hwn i wirio'ch cofnodion gyda CThEM a rheoli'ch manylion eraill.
-update_type: major
-change_note: Add hint text to eidas option
+update_type: minor
+change_note: Updated Verify links to use correct hints and redirects

--- a/lib/service_sign_in/personal-tax-account.en.yaml
+++ b/lib/service_sign_in/personal-tax-account.en.yaml
@@ -8,10 +8,10 @@ choose_sign_in:
       url: https://www.tax.service.gov.uk/gg/sign-in?continue=/personal-account&accountType=individual&origin=PTA-frontend
       hint_text: You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.
     - text: Sign in with GOV.UK Verify
-      url: https://www.tax.service.gov.uk/personal-account/start-verify
+      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-personal-tax-account?journey_hint=uk_idp_sign_in
       hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
     - text: Sign in with a digital identity from another European country
-      url: https://www.tax.service.gov.uk/personal-account/start-verify?journey_hint=eidas_sign_in
+      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-personal-tax-account?journey_hint=eidas_sign_in
       hint_text: If you are part of Germany’s Online-Ausweis you can use it here. Identity schemes from other countries will become available later.
     - text: Create an account
       slug: create-account
@@ -42,12 +42,12 @@ create_new_account:
     - a UK address
     - a valid passport or photocard driving licence
 
-    {button}[Create a GOV.UK Verify account](https://www.tax.service.gov.uk/personal-account/start-verify){/button}
+    {button}[Create a GOV.UK Verify account](https://www.signin.service.gov.uk/initiate-journey/hmrc-personal-tax-account?journey_hint=registration){/button}
 
     A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.
 
     ## Personal tax account
 
     Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
-update_type: major
-change_note: Add eidas option radio button.
+update_type: minor
+change_note: Updated Verify links to use correct hints and redirects


### PR DESCRIPTION
The Verify Hub supports journey hints to redirect users to the right journey flows
(registration, sign-in or eIDAS). However, the required hints are not being
implemented/passed by the services. We have developed a mechanism which
allows us to record the hint value (the option they selected on the GOV.UK
sign-in pages) by 'bouncing' the user via Verify first.