### PR TITLE
Upgrade Jasmine 2.5.2 => 3.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,8 +61,8 @@ end
 
 group :development, :test do
   gem 'govuk-lint', '~> 3.8.0'
-  gem 'jasmine', '2.5.2'
-  gem 'jasmine-core', '2.5.2'
+  gem 'jasmine', '~> 3.3.0'
+  gem 'jasmine-core', '~> 3.3.0'
   gem 'rack', '2.0.6'
   gem 'pry-byebug'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,12 +202,12 @@ GEM
       railties (>= 4.2, < 5.3)
       responders
     io-like (0.3.0)
-    jasmine (2.5.2)
-      jasmine-core (>= 2.5.1, < 3.0.0)
+    jasmine (3.3.0)
+      jasmine-core (~> 3.3.0)
       phantomjs
       rack (>= 1.2.1)
       rake
-    jasmine-core (2.5.2)
+    jasmine-core (3.3.0)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -513,8 +513,8 @@ DEPENDENCIES
   govuk_test
   has_scope
   inherited_resources
-  jasmine (= 2.5.2)
-  jasmine-core (= 2.5.2)
+  jasmine (~> 3.3.0)
+  jasmine-core (~> 3.3.0)
   jquery-ui-rails (~> 6.0)
   kaminari (~> 1.1)
   kaminari-mongoid (= 1.0.1)

--- a/app/assets/javascripts/modules/ajax_save.js
+++ b/app/assets/javascripts/modules/ajax_save.js
@@ -110,7 +110,7 @@
         // Save errored, form still has unsaved changes
         GOVUKAdmin.Data.editionFormDirty = true;
 
-        element.trigger('error.ajaxsave.admin', response);
+        element.trigger('errors.ajaxsave.admin', response);
       }
 
       function showErrors(errors) {

--- a/app/assets/javascripts/modules/ajax_save_with_parts.js
+++ b/app/assets/javascripts/modules/ajax_save_with_parts.js
@@ -5,7 +5,7 @@
       var ajaxSave = new GOVUKAdmin.Modules.AjaxSave();
 
       element.on('success.ajaxsave.admin', success);
-      element.on('error.ajaxsave.admin', error);
+      element.on('errors.ajaxsave.admin', error);
       ajaxSave.start(element);
 
       function success(evt, response) {

--- a/spec/javascripts/spec/ajax_save.spec.js
+++ b/spec/javascripts/spec/ajax_save.spec.js
@@ -227,7 +227,7 @@ describe('An ajax save module', function() {
 
     it('triggers an error.ajaxsave.admin dom event', function() {
       var errorResponse = false;
-      element.on('error.ajaxsave.admin', function(evt, response) {
+      element.on('errors.ajaxsave.admin', function(evt, response) {
         errorResponse = response;
       });
       ajaxError({not_a_field: ['nonsense']});

--- a/spec/javascripts/spec/ajax_save.spec.js
+++ b/spec/javascripts/spec/ajax_save.spec.js
@@ -22,6 +22,10 @@ describe('An ajax save module', function() {
     $('body').append(element);
     ajaxSave = new GOVUKAdmin.Modules.AjaxSave();
     ajaxSave.start(element);
+
+    var submitCallbackSpy = jasmine.createSpy('some/url').and.returnValue(false);
+    element.submit(submitCallbackSpy);
+
   });
 
   afterEach(function() {

--- a/spec/javascripts/spec/ajax_save_with_parts.spec.js
+++ b/spec/javascripts/spec/ajax_save_with_parts.spec.js
@@ -124,7 +124,7 @@ describe('An ajax save with parts module', function() {
 
   describe('when the form save errors', function() {
     beforeEach(function() {
-      element.trigger('error.ajaxsave.admin', {responseJSON: {"parts":
+      element.trigger('errors.ajaxsave.admin', {responseJSON: {"parts":
         [
           {
             "5f00000001:1":{"slug":["can't be blank","is invalid"]},

--- a/spec/javascripts/spec/ajax_save_with_parts.spec.js
+++ b/spec/javascripts/spec/ajax_save_with_parts.spec.js
@@ -4,8 +4,20 @@ describe('An ajax save with parts module', function() {
   var ajaxSaveWithParts,
       element;
 
-  beforeEach(function() {
+  beforeAll(function() {
+    // Stub a bootstrap collapse method on jQuery
+    $.fn.collapse = function (str) {
+      if (str === "show") {
+        $(this).addClass('in');
+        element.trigger('shown.bs.collapse');
+      } else if (str === "hide") {
+        $(this).removeClass('in');
+        element.trigger('hidden.bs.collapse');
+      }
+    }
+  })
 
+  beforeEach(function() {
     element = $('<form action="some/url">\
       <div class="js-status-message"></div>\
       <div class="fields">\
@@ -63,6 +75,11 @@ describe('An ajax save with parts module', function() {
   afterEach(function() {
     element.remove();
   });
+
+  afterAll(function(){
+    // Delete bootstrap stub
+    delete $.fn.collapse;
+  })
 
   describe('it does everything ajax save does', function() {
     describe('ie when clicking a save link', function() {


### PR DESCRIPTION
This upgrades Jasmine to the latest version, requiring a few changes to the specs.

-  a new callback spy to prevent a form submission from attempting to navigate to a non-exsistant path.

- stubs jQuery with a `collapse` function from Bootstrap, to prevent order-dependent failures if Bootstrap has not already been loaded by Jasmine.

- renames a custom jQuery `error` event to `errors`. This mitigates an issue where jQuery does not correctly resolve the handler by not setting `event.result` to `false` and therefore not calling `preventDefault`. 

```
handle = ontype && cur[ ontype ];
			if ( handle && handle.apply && acceptData( cur ) ) {
				event.result = handle.apply( cur, data );
				if ( event.result === false ) {
					event.preventDefault();
...
```

This ultimately results in Jasmine presenting the unresolved error events as `message += error.toString() + ' thrown';` => `[object Object] thrown`.

Preferably we would be able to handle this within the specs, or call `stopPropagation` on the events ourselves, but this does not seem to work. Suggestions welcome!


[Trello card](https://trello.com/c/iIjAEF2k/265-upgrade-jasmine-for-publisher)