### PR TITLE
Remove Royal Mail and Citizensafe

### DIFF
--- a/lib/service_sign_in/check-income-tax.cy.yaml
+++ b/lib/service_sign_in/check-income-tax.cy.yaml
@@ -9,7 +9,7 @@ choose_sign_in:
       hint_text: Bydd gennych Ddynodydd Defnyddiwr (ID) os ydych wedi cofrestru i wneud pethau fel cyflwyno'ch Ffurflen Dreth Hunanasesiad ar-lein.
     - text: Defnyddio GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-tax-estimate?journey_hint=uk_idp_sign_in
-      hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Barclays, CitizenSafe, Digidentity, Experian, Swyddfa'r Post, y Post Brenhinol neu SecureIdentity.
+      hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Barclays, Digidentity, Experian, Swyddfa'r Post neu SecureIdentity.
     - text: Defnyddiwch hunaniaeth digidol o wlad Ewropeaidd arall
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-tax-estimate?journey_hint=eidas_sign_in
       hint_text: Os ydych yn rhan o gynllun ID mewn gwlad sy'n cymryd rhan, efallai y gallwch ei ddefnyddio yma.

--- a/lib/service_sign_in/check-income-tax.en.yaml
+++ b/lib/service_sign_in/check-income-tax.en.yaml
@@ -9,7 +9,7 @@ choose_sign_in:
       hint_text: You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.
     - text: Sign in with GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-tax-estimate?journey_hint=uk_idp_sign_in
-      hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
+      hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
     - text: Sign in with a digital identity from another European country
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-tax-estimate?journey_hint=eidas_sign_in
       hint_text: If you are part of Germany’s Online-Ausweis you can use it here. Identity schemes from other countries will become available later.

--- a/lib/service_sign_in/check-state-pension.cy.yaml
+++ b/lib/service_sign_in/check-state-pension.cy.yaml
@@ -12,7 +12,7 @@ choose_sign_in:
       hint_text: Bydd gennych Ddynodydd Defnyddiwr (ID) os ydych wedi cofrestru i wneud pethau fel cyflwyno'ch Ffurflen Dreth Hunanasesiad ar-lein.
     - text: Defnyddio GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=uk_idp_sign_in
-      hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Barclays, CitizenSafe, Digidentity, Experian, Swyddfa'r Post, y Post Brenhinol neu SecureIdentity.
+      hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Barclays, Digidentity, Experian, Swyddfa'r Post neu SecureIdentity.
     - text: Defnyddiwch hunaniaeth digidol o wlad Ewropeaidd arall
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=eidas_sign_in
       hint_text: Os ydych yn rhan o gynllun ID mewn gwlad sy'n cymryd rhan, efallai y gallwch ei ddefnyddio yma.

--- a/lib/service_sign_in/check-state-pension.en.yaml
+++ b/lib/service_sign_in/check-state-pension.en.yaml
@@ -12,7 +12,7 @@ choose_sign_in:
       hint_text: You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.
     - text: Sign in with GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=uk_idp_sign_in
-      hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
+      hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
     - text: Sign in with a digital identity from another European country
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=eidas_sign_in
       hint_text: If you are part of Germany’s Online-Ausweis you can use it here. Identity schemes from other countries will become available later.

--- a/lib/service_sign_in/check-update-company-car-tax.cy.yaml
+++ b/lib/service_sign_in/check-update-company-car-tax.cy.yaml
@@ -9,7 +9,7 @@ choose_sign_in:
       hint_text: Bydd gennych Ddynodydd Defnyddiwr (ID) os ydych wedi cofrestru i wneud pethau fel cyflwyno'ch Ffurflen Dreth Hunanasesiad ar-lein.
     - text: Defnyddio GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-company-car-tax?journey_hint=uk_idp_sign_in
-      hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Barclays, CitizenSafe, Digidentity, Experian, Swyddfa'r Post, y Post Brenhinol neu SecureIdentity.
+      hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Barclays, Digidentity, Experian, Swyddfa'r Post neu SecureIdentity.
     - text: Defnyddiwch hunaniaeth digidol o wlad Ewropeaidd arall
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-company-car-tax?journey_hint=eidas_sign_in
       hint_text: Os ydych yn rhan o gynllun ID mewn gwlad sy'n cymryd rhan, efallai y gallwch ei ddefnyddio yma.

--- a/lib/service_sign_in/check-update-company-car-tax.en.yaml
+++ b/lib/service_sign_in/check-update-company-car-tax.en.yaml
@@ -9,7 +9,7 @@ choose_sign_in:
       hint_text: You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.
     - text: Sign in with GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-company-car-tax?journey_hint=uk_idp_sign_in
-      hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
+      hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
     - text: Sign in with a digital identity from another European country
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-company-car-tax?journey_hint=eidas_sign_in
       hint_text: If you are part of Germany’s Online-Ausweis you can use it here. Identity schemes from other countries will become available later.

--- a/lib/service_sign_in/claim-rural-payments.en.yaml
+++ b/lib/service_sign_in/claim-rural-payments.en.yaml
@@ -10,7 +10,7 @@ choose_sign_in:
       hint_text: You'll have a CRN and password if you've already registered for the Rural Payments service.
     - text: Sign in with GOV.UK Verify
       url: https://www.ruralpayments.service.gov.uk/auth/ida/request
-      hint_text: You'll have an account if you've already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
+      hint_text: You'll have an account if you've already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
     - text: Register for the Rural Payments service
       url: https://www.gov.uk/guidance/register-for-rural-payments
       hint_text: You must register before you can make a rural payment claim.

--- a/lib/service_sign_in/file_self_assessment.cy.yaml
+++ b/lib/service_sign_in/file_self_assessment.cy.yaml
@@ -9,7 +9,7 @@ choose_sign_in:
       hint_text: Bydd gennych chi ID defnyddiwr os ydych chi wedi cofrestru ar gyfer Hunanasesiad neu wedi ffeilio ffurflen dreth ar-lein yn y gorffennol.
     - text: Mewngofnodi gan ddefnyddio GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-isa?journey_hint=uk_idp_sign_in
-      hint_text: Bydd gennych chi gyfrif os ydych chi wedi profi'n barod pwy ydych chi naill ai gyda Barclays, CitizenSafe, Digidentity, Experian, Swyddfa'r Post, y Post Brenhinol neu SecureIdentity.
+      hint_text: Bydd gennych chi gyfrif os ydych chi wedi profi'n barod pwy ydych chi naill ai gyda Barclays, Digidentity, Experian, Swyddfa'r Post neu SecureIdentity.
     - text: Defnyddiwch hunaniaeth digidol o wlad Ewropeaidd arall
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-isa?journey_hint=eidas_sign_in
       hint_text: Os ydych yn rhan o gynllun ID mewn gwlad sy'n cymryd rhan, efallai y gallwch ei ddefnyddio yma.

--- a/lib/service_sign_in/file_self_assessment.en.yaml
+++ b/lib/service_sign_in/file_self_assessment.en.yaml
@@ -10,7 +10,7 @@ choose_sign_in:
       hint_text: You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before.
     - text: Sign in with GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-isa?journey_hint=uk_idp_sign_in
-      hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
+      hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
     - text: Sign in with a digital identity from another European country
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-isa?journey_hint=eidas_sign_in
       hint_text: If you are part of Germany’s Online-Ausweis you can use it here. Identity schemes from other countries will become available later.

--- a/lib/service_sign_in/personal-tax-account.cy.yaml
+++ b/lib/service_sign_in/personal-tax-account.cy.yaml
@@ -9,7 +9,7 @@ choose_sign_in:
       hint_text: Bydd gennych Ddynodydd Defnyddiwr (ID) os ydych wedi cofrestru i wneud pethau fel cyflwyno'ch Ffurflen Dreth Hunanasesiad ar-lein.
     - text: Defnyddio GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-personal-tax-account?journey_hint=uk_idp_sign_in
-      hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Barclays, CitizenSafe, Digidentity, Experian, Swyddfa'r Post, y Post Brenhinol neu SecureIdentity.
+      hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Barclays, Digidentity, Experian, Swyddfa'r Post neu SecureIdentity.
     - text: Defnyddiwch hunaniaeth digidol o wlad Ewropeaidd arall
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-personal-tax-account?journey_hint=eidas_sign_in
       hint_text: Os ydych yn rhan o gynllun ID mewn gwlad sy'n cymryd rhan, efallai y gallwch ei ddefnyddio yma.

--- a/lib/service_sign_in/personal-tax-account.en.yaml
+++ b/lib/service_sign_in/personal-tax-account.en.yaml
@@ -9,7 +9,7 @@ choose_sign_in:
       hint_text: You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.
     - text: Sign in with GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-personal-tax-account?journey_hint=uk_idp_sign_in
-      hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
+      hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
     - text: Sign in with a digital identity from another European country
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-personal-tax-account?journey_hint=eidas_sign_in
       hint_text: If you are part of Germany’s Online-Ausweis you can use it here. Identity schemes from other countries will become available later.


### PR DESCRIPTION
As of 1st March, they will no longer be acting as identity providers for Verify.

See https://trello.com/c/vi7RV11M