### PR TITLE
Speed up tests

### DIFF
--- a/test/integration/adding_parts_to_guides_test.rb
+++ b/test/integration/adding_parts_to_guides_test.rb
@@ -87,35 +87,6 @@ class AddingPartsToGuidesTest < JavascriptIntegrationTest
       assert_correct_parts
     end
 
-    context 'removing parts' do
-      setup do
-        save_edition_and_assert_success
-        visit current_path
-      end
-
-      should 'remove the appropriate part' do
-        within :css, '#parts div.fields:nth-of-type(3)' do
-          click_on 'Remove this part'
-        end
-
-        save_edition_and_assert_success
-        assert_correct_parts(2)
-
-        visit current_path
-        assert_correct_parts(2)
-
-        within :css, '#parts div.fields:nth-of-type(2)' do
-          click_on 'Remove this part'
-        end
-
-        save_edition_and_assert_success
-        assert_correct_parts(1)
-
-        visit current_path
-        assert_correct_parts(1)
-      end
-    end
-
     context 'when removing parts' do
       setup do
         save_edition_and_assert_success

--- a/test/integration/adding_variants_to_transactions_test.rb
+++ b/test/integration/adding_variants_to_transactions_test.rb
@@ -90,35 +90,6 @@ class AddingVariantsToTransactionsTest < JavascriptIntegrationTest
       assert_correct_variants
     end
 
-    context 'removing variants' do
-      setup do
-        save_edition_and_assert_success
-        visit current_path
-      end
-
-      should 'remove the appropriate variant' do
-        within :css, '#parts div.fields:nth-of-type(3)' do
-          click_on 'Remove this variant'
-        end
-
-        save_edition_and_assert_success
-        assert_correct_variants(2)
-
-        visit current_path
-        assert_correct_variants(2)
-
-        within :css, '#parts div.fields:nth-of-type(2)' do
-          click_on 'Remove this variant'
-        end
-
-        save_edition_and_assert_success
-        assert_correct_variants(1)
-
-        visit current_path
-        assert_correct_variants(1)
-      end
-    end
-
     context 'when removing variants' do
       setup do
         save_edition_and_assert_success

--- a/test/integration/edition_history_test.rb
+++ b/test/integration/edition_history_test.rb
@@ -42,8 +42,8 @@ class EditionHistoryTest < JavascriptIntegrationTest
       visit_edition @answer
       click_on "History and notes"
 
-      refute page.has_css?('#edition-history p.add-bottom-margin', text: "Preview edition at")
-      refute page.has_css?('#edition-history p.add-bottom-margin', text: "View this on the GOV.UK website")
+      assert page.has_no_css?('#edition-history p.add-bottom-margin', text: "Preview edition at")
+      assert page.has_no_css?('#edition-history p.add-bottom-margin', text: "View this on the GOV.UK website")
     end
 
     should "have the first history actions visible" do
@@ -67,7 +67,7 @@ class EditionHistoryTest < JavascriptIntegrationTest
       click_on "History and notes"
 
       assert page.has_css?('p', text: 'email reply')
-      refute page.has_css?('p', text: 'original email request')
+      assert page.has_no_css?('p', text: 'original email request')
       assert page.has_css?('.panel a', text: 'Toggle earlier messages')
 
       click_on "Toggle earlier messages"

--- a/test/integration/edition_major_change_test.rb
+++ b/test/integration/edition_major_change_test.rb
@@ -14,8 +14,8 @@ class EditionMajorChangeTest < JavascriptIntegrationTest
   test "doesn't show change note until an edition has been published" do
     edition = FactoryBot.create(:answer_edition)
     visit_edition edition
-    refute page.has_field?("edition_change_note")
-    refute page.has_field?("edition_major_change")
+    assert page.has_no_field?("edition_change_note")
+    assert page.has_no_field?("edition_major_change")
   end
 
   with_and_without_javascript do

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -36,7 +36,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
 
     visit_edition guide
 
-    refute page.has_xpath?("//select[@id='edition_assigned_to_id']/option[text() = '#{disabled_user.name}']")
+    assert page.has_no_xpath?("//select[@id='edition_assigned_to_id']/option[text() = '#{disabled_user.name}']")
   end
 
   test "the customised message for fact-check is pre-loaded with a 5 working days deadline message" do
@@ -223,7 +223,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     send_action guide, "2nd pair of eyes", "Send to 2nd pair of eyes", "I think this is done"
 
     assert page.has_selector?(".alert-info")
-    refute has_link? "OK for publication"
+    assert has_no_link? "OK for publication"
   end
 
   test "cannot be the guide reviewer and assignee" do
@@ -376,7 +376,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     filter_for_all_users
     view_filtered_list "Archived"
 
-    assert_not page.has_content? "Create new edition"
+    assert page.has_no_content? "Create new edition"
   end
 
   test "cannot preview an archived article" do

--- a/test/integration/mark_edition_in_beta_test.rb
+++ b/test/integration/mark_edition_in_beta_test.rb
@@ -35,7 +35,7 @@ class MarkEditionInBetaTest < JavascriptIntegrationTest
       refute find('#edition_in_beta').checked?
 
       visit "/?user_filter=all"
-      refute page.has_text?("#{edition.title} beta")
+      assert page.has_no_text?("#{edition.title} beta")
     end
   end
 end

--- a/test/integration/root_overview_test.rb
+++ b/test/integration/root_overview_test.rb
@@ -120,7 +120,7 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
 
     visit "/"
     select_box = find_field('Assignee')
-    refute page.has_xpath?(select_box.path + "/option[text() = '#{disabled_user.name}']")
+    assert page.has_no_xpath?(select_box.path + "/option[text() = '#{disabled_user.name}']")
   end
 
   test "Publications in review are ordered correctly" do

--- a/test/integration/user_search_test.rb
+++ b/test/integration/user_search_test.rb
@@ -22,7 +22,7 @@ class UserSearchTest < ActionDispatch::IntegrationTest
 
     visit "/user_search"
 
-    refute page.has_content? @guide.title
+    assert page.has_no_content? @guide.title
   end
 
   test "filtering by format" do
@@ -45,18 +45,18 @@ class UserSearchTest < ActionDispatch::IntegrationTest
 
     assert page.has_content?("Vehicle insurance")
     assert page.has_content?("Growing your business")
-    refute page.has_content?("Vehicle answer")
+    assert page.has_no_content?("Vehicle answer")
 
     filter_by_content("Vehicle")
 
     assert page.has_content?("Vehicle insurance")
-    refute page.has_content?("Growing your business")
-    refute page.has_content?("Vehicle answer")
+    assert page.has_no_content?("Growing your business")
+    assert page.has_no_content?("Vehicle answer")
 
     filter_by_format("Answer")
 
-    refute page.has_content?("Vehicle insurance")
-    refute page.has_content?("Growing your business")
+    assert page.has_no_content?("Vehicle insurance")
+    assert page.has_no_content?("Growing your business")
     assert page.has_content?("Vehicle answer")
   end
 
@@ -75,7 +75,7 @@ class UserSearchTest < ActionDispatch::IntegrationTest
     filter_by_content "insurance"
 
     assert page.has_content?("Vehicle insurance")
-    refute page.has_content?("Growing your business")
+    assert page.has_no_content?("Growing your business")
   end
 
 
@@ -88,7 +88,7 @@ class UserSearchTest < ActionDispatch::IntegrationTest
 
     filter_by_content "insurance"
 
-    refute page.has_content?("Vehicle insurance")
+    assert page.has_no_content?("Vehicle insurance")
   end
 
   test "selecting another user" do
@@ -106,7 +106,7 @@ class UserSearchTest < ActionDispatch::IntegrationTest
     assert page.has_content?("Search by user")
 
     assert page.has_content?(guides[0].title)
-    refute page.has_content?(guides[1].title)
+    assert page.has_no_content?(guides[1].title)
   end
 
   test "doesn't show disabled users in 'Filter by user' select box" do
@@ -115,6 +115,6 @@ class UserSearchTest < ActionDispatch::IntegrationTest
     visit "/user_search"
 
     select_box = find_field('User')
-    refute page.has_xpath?(select_box.path + "/option[text() = '#{disabled_user.name}']")
+    assert page.has_no_xpath?(select_box.path + "/option[text() = '#{disabled_user.name}']")
   end
 end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -120,13 +120,13 @@ class JavascriptIntegrationTest < ActionDispatch::IntegrationTest
   def fill_in_parts(guide)
     visit_edition guide
 
-    unless page.has_css?('#parts div.part:first-of-type input')
+    if page.has_no_css?('#parts div.part:first-of-type input')
       add_new_part
     end
 
     # Toggle the first part to be open, presuming the first part
     # is called 'Untitled part'
-    unless page.has_css?('#parts div.part:first-of-type input')
+    if page.has_no_css?('#parts div.part:first-of-type input')
       scroll_to_bottom
       click_on 'Untitled part'
     end
@@ -146,13 +146,13 @@ class JavascriptIntegrationTest < ActionDispatch::IntegrationTest
   def fill_in_variants(transaction)
     visit_edition transaction
 
-    unless page.has_css?('#parts div.part:first-of-type input')
+    if page.has_no_css?('#parts div.part:first-of-type input')
       add_new_variant
     end
 
     # Toggle the first variant to be open, presuming the first variant
     # is called 'Untitled variant'
-    unless page.has_css?('#parts div.part:first-of-type input')
+    if page.has_no_css?('#parts div.part:first-of-type input')
       scroll_to_bottom
       click_on 'Untitled variant'
     end
@@ -201,10 +201,7 @@ class JavascriptIntegrationTest < ActionDispatch::IntegrationTest
 
   def assert_all_edition_fields_disabled(page)
     selector = '#edit input:not(#link-check-report):not([disabled]):not([type="hidden"]), #edit select:not([disabled]), #edit textarea:not([disabled])'
-    inputs = page.all(selector)
-    input_description = ""
-    inputs.each { |i| input_description = "#{input_description}\n##{i['id']}" }
-    assert_same(0, inputs.length, "#{inputs.length} field(s) on this edition need(s) disabling: #{input_description}")
+    assert page.has_no_selector?(selector)
   end
 
   def save_edition(with_javascript = using_javascript?)

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -204,14 +204,11 @@ class JavascriptIntegrationTest < ActionDispatch::IntegrationTest
     assert page.has_no_selector?(selector)
   end
 
-  def save_edition(with_javascript = using_javascript?)
-    # It is possible for workflow messages to obscure the workflow buttons.
-    # Trigger a click on the save button for these cases.
-    if with_javascript && page.has_css?(".workflow-message", visible: true)
-      page.execute_script("$('#save-edition').trigger('click');")
-    else
-      click_on('Save')
-    end
+  def save_edition
+    # Ensure that there are no workflow messages as they may obscure the
+    # workflow buttons.
+    page.has_no_css?(".workflow-message", visible: true)
+    click_on('Save')
   end
 
   def save_tags


### PR DESCRIPTION
Swaps the intent of tests so that we don't invoke capybara's wait time unless it's desired.  

For example, if we don't want to see a selector, then we should use `assert page.has_no_css?` rather than `refute page.has_css?`.  The latter will cause capybara to wait until the `default_max_wait_time`.

Also removes a couple of duplicate tests

Should speed builds up from ~13 mins to ~8 mins

https://ci.integration.publishing.service.gov.uk/job/publisher/job/speed-up-tests/buildTimeTrend