### PR TITLE
Add a Rake task for republishing a specific edition

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -25,6 +25,12 @@ namespace :publishing_api do
     KnowledgeApi.new.publish
   end
 
+  desc "Republish an edition"
+  task :republish_edition, %w(slug) => :environment do |_, args|
+    republish Edition.published.where(slug: args[:slug])
+    republish_draft Edition.draft_in_publishing_api.where(slug: args[:slug])
+  end
+
   def republish(editions)
     puts
     puts "Scheduling republishing of #{editions.count} editions"


### PR DESCRIPTION
If there is a problem talking to the publishing-api, it may be necessary to manually republish an edition to the publishing-api.

[Trello Card](https://trello.com/c/gnK6FhQb/828-gather-current-convenience-scripts-rake-tasks-that-might-help-during-brexit-publishing)