### PR TITLE
Update knowledge api minimum wage rates

### DIFF
--- a/app/services/knowledge_api.yml
+++ b/app/services/knowledge_api.yml
@@ -3,15 +3,15 @@
   source: https://www.gov.uk/national-minimum-wage-rates
   data:
     - age_range: 25 and over
-      minimum_wage: 7.83
+      minimum_wage: 8.21
     - age_range: 21 to 24
-      minimum_wage: 7.38
+      minimum_wage: 7.70
     - age_range: 18 to 20
-      minimum_wage: 5.90
+      minimum_wage: 6.15
     - age_range: Under 18
-      minimum_wage: 4.20
+      minimum_wage: 4.35
     - age_range: Apprentice
-      minimum_wage: 3.70
+      minimum_wage: 3.90
 
 - id: income-tax
   title: Income Tax rates and bands


### PR DESCRIPTION
These values have been updated to match the content here: https://www.gov.uk/national-minimum-wage-rates#current-rates

The knowledge_api is used to tell Alexa about important values on GOV.UK so we should keep this up to date. (Check it out at https://www.gov.uk/api/content/knowledge-alpha)

We'll need to republish the content item on 1st April by running:
```
  rake publishing_api:publish_knowledge
```
against publisher on a backend box.