### PR TITLE
Add opt in and opt out URLs for completed transactions

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -21,6 +21,12 @@
   left: -9999em;
 }
 
+.promotion-choice-register-to-vote:checked ~ .promotion-choice-opt-in-out-url,
+.promotion-choice-mot-reminder:checked ~ .promotion-choice-opt-in-out-url {
+  position: absolute;
+  left: -9999em;
+}
+
 .related-external-links {
   input[type=text] {
     margin-bottom: 0px;

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -289,6 +289,8 @@ protected
         body
         promotion_choice
         promotion_choice_url
+        promotion_choice_opt_in_url
+        promotion_choice_opt_out_url
       ]
     else # answer_edition, help_page_edition
       [

--- a/app/presenters/formats/completed_transaction_presenter.rb
+++ b/app/presenters/formats/completed_transaction_presenter.rb
@@ -5,32 +5,30 @@ module Formats
     PROMOTIONS = %w(organ_donor register_to_vote mot_reminder).freeze
 
     def schema_name
-      'completed_transaction'
+      "completed_transaction"
     end
 
     def document_type
-      'completed_transaction'
+      "completed_transaction"
     end
 
     def details
-      return optional_details.merge(required_details) if PROMOTIONS.include?(promotion_choice["choice"])
-
-      required_details
+      optional_details.merge(required_details)
     end
 
     def required_details
-      {
-        external_related_links: external_related_links
-      }
+      { external_related_links: external_related_links }
     end
 
     def optional_details
-      {
-        promotion: {
-          category: promotion_choice.fetch("choice"),
-          url: promotion_choice.fetch("url", '')
-        }
-      }
+      { promotion: promotion_details }.compact
+    end
+
+    def promotion_details
+      return unless PROMOTIONS.include?(promotion_choice["choice"])
+
+      { category: promotion_choice.fetch("choice") }
+        .merge(promotion_choice.slice("url").symbolize_keys.compact)
     end
 
     def promotion_choice

--- a/app/presenters/formats/completed_transaction_presenter.rb
+++ b/app/presenters/formats/completed_transaction_presenter.rb
@@ -28,7 +28,12 @@ module Formats
       return unless PROMOTIONS.include?(promotion_choice["choice"])
 
       { category: promotion_choice.fetch("choice") }
-        .merge(promotion_choice.slice("url").symbolize_keys.compact)
+        .merge(
+          promotion_choice
+            .slice("url", "opt_in_url", "opt_out_url")
+            .symbolize_keys
+            .compact
+        )
     end
 
     def promotion_choice

--- a/app/views/completed_transactions/_fields.html.erb
+++ b/app/views/completed_transactions/_fields.html.erb
@@ -24,21 +24,31 @@
       <%= f.label :promotion_choice, "Don't promote anything on this page", value: 'none' %>
       <br />
       <%= f.radio_button :promotion_choice, 'organ_donor',
-        { checked: (f.object.promotion_choice == "organ_donor"), disabled: @resource.locked_for_edits? } %>
+        { checked: (f.object.promotion_choice == "organ_donor"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-organ-donor' } %>
       <%= f.label :promotion_choice, "Promote organ donation", value: 'organ_donor' %>
       <br />
       <%= f.radio_button :promotion_choice, 'register_to_vote',
-        { checked: (f.object.promotion_choice == "register_to_vote"), disabled: @resource.locked_for_edits? } %>
+        { checked: (f.object.promotion_choice == "register_to_vote"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-register-to-vote' } %>
       <%= f.label :promotion_choice, "Promote register to vote", value: 'register_to_vote' %>
       <br />
       <%= f.radio_button :promotion_choice, 'mot_reminder',
-        { checked: (f.object.promotion_choice == "mot_reminder"), disabled: @resource.locked_for_edits? } %>
+        { checked: (f.object.promotion_choice == "mot_reminder"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-mot-reminder' } %>
       <%= f.label :promotion_choice, "Promote MOT reminders", value: 'mot_reminder' %>
 
       <%= f.input :promotion_choice_url,
           required: false,
           input_html: { disabled: @resource.locked_for_edits? },
           wrapper_html: { class: "form-group input-md-8 promotion-choice-url", id: 'promotion-choice-url' } %>
+
+      <%= f.input :promotion_choice_opt_in_url,
+          required: false,
+          input_html: { disabled: @resource.locked_for_edits? },
+          wrapper_html: { class: "form-group input-md-8 promotion-choice-url promotion-choice-opt-in-out-url", id: 'promotion-choice-opt-in-url' } %>
+
+      <%= f.input :promotion_choice_opt_out_url,
+          required: false,
+          input_html: { disabled: @resource.locked_for_edits? },
+          wrapper_html: { class: "form-group input-md-8 promotion-choice-url promotion-choice-opt-in-out-url", id: 'promotion-choice-opt-out-url' } %>
     </div>
 
   </div>

--- a/lib/presentation_toggles.rb
+++ b/lib/presentation_toggles.rb
@@ -15,6 +15,14 @@ module PresentationToggles
     promotion_choice_key['url'] = value
   end
 
+  def promotion_choice_opt_in_url=(value)
+    promotion_choice_key["opt_in_url"] = value
+  end
+
+  def promotion_choice_opt_out_url=(value)
+    promotion_choice_key["opt_out_url"] = value
+  end
+
   def promotion_choice
     choice = promotion_choice_key["choice"]
     choice.empty? ? "none" : choice
@@ -28,10 +36,19 @@ module PresentationToggles
     promotion_choice_key["url"]
   end
 
+  def promotion_choice_opt_in_url
+    promotion_choice_key["opt_in_url"]
+  end
+
+  def promotion_choice_opt_out_url
+    promotion_choice_key["opt_out_url"]
+  end
+
   def promotion_choice_key
     unless presentation_toggles.key? 'promotion_choice'
       presentation_toggles['promotion_choice'] = self.class.default_presentation_toggles['promotion_choice']
     end
+
     presentation_toggles['promotion_choice']
   end
 

--- a/test/models/completed_transaction_edition_test.rb
+++ b/test/models/completed_transaction_edition_test.rb
@@ -41,10 +41,14 @@ class CompletedTransactionEditionTest < ActiveSupport::TestCase
 
     completed_transaction_edition.promotion_choice = "organ_donor"
     completed_transaction_edition.promotion_choice_url = "https://www.organdonation.nhs.uk/registration/"
+    completed_transaction_edition.promotion_choice_opt_in_url = "https://www.organdonation.nhs.uk/registration/in/"
+    completed_transaction_edition.promotion_choice_opt_out_url = "https://www.organdonation.nhs.uk/registration/out/"
     completed_transaction_edition.save!
 
     assert_equal "organ_donor", completed_transaction_edition.reload.promotion_choice
     assert_equal "https://www.organdonation.nhs.uk/registration/", completed_transaction_edition.promotion_choice_url
+    assert_equal "https://www.organdonation.nhs.uk/registration/in/", completed_transaction_edition.promotion_choice_opt_in_url
+    assert_equal "https://www.organdonation.nhs.uk/registration/out/", completed_transaction_edition.promotion_choice_opt_out_url
 
     completed_transaction_edition.promotion_choice = "register_to_vote"
     completed_transaction_edition.promotion_choice_url = "https://www.gov.uk/register-to-vote"

--- a/test/unit/presenters/formats/completed_transaction_presenter_test.rb
+++ b/test/unit/presenters/formats/completed_transaction_presenter_test.rb
@@ -36,13 +36,31 @@ class CompletedTransactionPresenterTest < ActiveSupport::TestCase
   context "[:details]" do
     should "[:promotion]" do
       edition.presentation_toggles["promotion_choice"] = {
-        'choice' => 'organ_donor',
+        'choice' => 'mot_reminder',
         'url' => 'http://www.foo.com'
       }
 
       expected = {
-        category: 'organ_donor',
+        category: 'mot_reminder',
         url: 'http://www.foo.com'
+      }
+
+      assert_equal expected, result[:details][:promotion]
+    end
+
+    should "opt in and opt out [:promotion]" do
+      edition.presentation_toggles["promotion_choice"] = {
+        'choice' => 'organ_donor',
+        'url' => 'http://www.foo.com',
+        'opt_in_url' => 'http://www.bar.com',
+        'opt_out_url' => 'http://www.baz.com',
+      }
+
+      expected = {
+        category: 'organ_donor',
+        url: 'http://www.foo.com',
+        opt_in_url: 'http://www.bar.com',
+        opt_out_url: 'http://www.baz.com',
       }
 
       assert_equal expected, result[:details][:promotion]


### PR DESCRIPTION
The content of this promotion page will be changing to include two URLs, an opt in and an opt out URL.

At the moment the old URL is still allowed as a parameter until all the pages have converted to use only the opt in and opt out URLs.

This depends on alphagov/govuk-content-schemas#910.

[Trello Card](https://trello.com/c/HFsNGxTy/1088-investigate-organ-donation-promos-on-done-pages)