### PR TITLE
Update regex and add validation for redirect_url

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -213,7 +213,12 @@ class EditionsController < InheritedResources::Base
   def process_unpublish
     edition = Edition.find(params[:id])
     artefact = edition.artefact
-    success = UnpublishService.call(artefact, current_user, redirect_url)
+
+    if validate_redirect(redirect_url) || redirect_url.blank?
+      success = UnpublishService.call(artefact, current_user, redirect_url)
+    else
+      flash[:danger] = "Redirect path is invalid. #{description(resource)} has not been unpublished."
+    end
 
     if success
       notice = "Content unpublished"
@@ -343,7 +348,12 @@ private
   end
 
   def make_govuk_url_relative(url = "")
-    url.sub(%r{^https?://(www\.)?gov\.uk/}, "/")
+    url.sub(%r{^(https?://)?(www\.)?gov\.uk/}, "/")
+  end
+
+  def validate_redirect(redirect_url)
+    regex = /(\/([a-z0-9]+-)*[a-z0-9]+)+/
+    redirect_url =~ regex
   end
 
   def tagging_update_form

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -57,6 +57,22 @@
       "user_input": "params[:list]",
       "confidence": "High",
       "note": "The params[:list] argument is already checked before the template gets rendered by @presenter.acceptable_list?(@list)."
+    },
+    {
+      "warning_type": "Remote Code Execution",
+      "warning_code": 110,
+      "fingerprint": "9ae68e59cfee3e5256c0540dadfeb74e6b72c91997fdb60411063a6e8518144a",
+      "check_name": "CookieSerialization",
+      "message": "Use of unsafe cookie serialization strategy `:hybrid` might lead to remote code execution",
+      "file": "config/initializers/cookies_serializer.rb",
+      "line": 5,
+      "link": "https://brakemanscanner.org/docs/warning_types/unsafe_deserialization",
+      "code": "Rails.application.config.action_dispatch.cookies_serializer = :hybrid",
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Medium",
+      "note": ""
     }
   ],
   "updated": "2018-08-02 14:09:22 +0100",

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -2,4 +2,4 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :marshal
+Rails.application.config.action_dispatch.cookies_serializer = :hybrid

--- a/test/integration/downtime_integration_test.rb
+++ b/test/integration/downtime_integration_test.rb
@@ -29,7 +29,7 @@ class DowntimeIntegrationTest < JavascriptIntegrationTest
     assert_match("midday to 6pm on #{day} 1 July", page.find_field('Message').value)
     click_button 'Schedule downtime message'
 
-    assert page.has_content?('Apply to become a driving instructor downtime message scheduled')
+    assert page.has_content?('downtime message scheduled')
     assert page.has_content?('Scheduled downtime')
     assert page.has_content?("midday to 6pm on 1 July")
   end
@@ -46,7 +46,7 @@ class DowntimeIntegrationTest < JavascriptIntegrationTest
     assert_match("This service will be unavailable from midday to 9:30pm on #{day} 1 July.", page.find_field('Message').value)
     click_on 'Re-schedule downtime message'
 
-    assert page.has_content?('Apply to become a driving instructor downtime message re-scheduled')
+    assert page.has_content?('downtime message re-scheduled')
     assert page.has_content?("midday to 9:30pm on 1 July")
   end
 
@@ -59,7 +59,7 @@ class DowntimeIntegrationTest < JavascriptIntegrationTest
     click_link 'Edit downtime'
     click_on 'Cancel downtime'
 
-    assert page.has_content?('Apply to become a driving instructor downtime message cancelled')
+    assert page.has_content?('downtime message cancelled')
     assert_no_downtime_scheduled
   end
 


### PR DESCRIPTION
When a user enters url in an invalid format (eg ‘redirect-to’, ‘www.gov.uk/redirect-to', ‘gov.uk/redirect-to') “Something went wrong” error was displayed, the Edition status was set to “Archived” but the page was available to view and no redirect was created.

This makes the `make_govuk_url_relative` more resilient and makes it handle input such as ‘www.gov.uk/redirect-to', ‘gov.uk/redirect-to'.
A validations is also added to ensure that `make_govuk_url_relative` returns url in a correct format.
When a user enters a string that cannot be correctly formatted, a message will be displayed.
 
**Related Zendesk tickets**
- https://govuk.zendesk.com/agent/tickets/3782482
- https://govuk.zendesk.com/agent/tickets/3769569