### PR TITLE
Trim whitespace from URLs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'select2-rails', '3.5.9.1' # Updating this will mean updating the styling as
 gem 'selectize-rails', '0.12.6'
 gem 'state_machines', '~> 0.4'
 gem 'state_machines-mongoid', '~> 0.1'
+gem "strip_attributes", "~> 1.9"
 gem 'uglifier', '4.1.20'
 gem 'whenever', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -472,6 +472,8 @@ GEM
       mongoid (>= 4.0.0)
       state_machines-activemodel (>= 0.5.0)
     statsd-ruby (1.4.0)
+    strip_attributes (1.9.0)
+      activemodel (>= 3.0, < 7.0)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -564,6 +566,7 @@ DEPENDENCIES
   state_machines (~> 0.4)
   state_machines-graphviz
   state_machines-mongoid (~> 0.1)
+  strip_attributes (~> 1.9)
   timecop (= 0.9.1)
   uglifier (= 4.1.20)
   webmock (~> 3.7.4)

--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -6,6 +6,8 @@ class Artefact
   include Mongoid::Document
   include Mongoid::Timestamps
 
+  strip_attributes only: :redirect_url
+
   field "name",                 type: String
   field "slug",                 type: String
   field "paths",                type: Array, default: []

--- a/app/models/artefact_external_link.rb
+++ b/app/models/artefact_external_link.rb
@@ -1,6 +1,8 @@
 class ArtefactExternalLink
   include Mongoid::Document
 
+  strip_attributes only: :url
+
   field "title", type: String
   field "url", type: String
 

--- a/app/models/campaign_edition.rb
+++ b/app/models/campaign_edition.rb
@@ -4,6 +4,8 @@ require 'edition'
 class CampaignEdition < Edition
   include Attachable
 
+  strip_attributes only: :organisation_url
+
   field :body, type: String
   field :organisation_formatted_name, type: String
   field :organisation_url, type: String

--- a/app/models/guide_edition.rb
+++ b/app/models/guide_edition.rb
@@ -4,6 +4,8 @@ require "parted"
 class GuideEdition < Edition
   include Parted
 
+  strip_attributes only: :video_url
+
   field :video_url,     type: String
   field :video_summary, type: String
   field :hide_chapter_navigation, type: Boolean

--- a/app/models/transaction_edition.rb
+++ b/app/models/transaction_edition.rb
@@ -4,6 +4,8 @@ require "varianted"
 class TransactionEdition < Edition
   include Varianted
 
+  strip_attributes only: :link
+
   field :introduction, type: String
   field :will_continue_on, type: String
   field :link, type: String

--- a/app/models/variant.rb
+++ b/app/models/variant.rb
@@ -3,6 +3,8 @@ require_dependency "safe_html"
 class Variant
   include Mongoid::Document
 
+  strip_attributes only: :link
+
   embedded_in :transaction_edition
 
   scope :in_order, lambda { order_by(order: :asc) }

--- a/app/models/video_edition.rb
+++ b/app/models/video_edition.rb
@@ -4,6 +4,8 @@ require "attachable"
 class VideoEdition < Edition
   include Attachable
 
+  strip_attributes only: :video_url
+
   field :video_url,     type: String
   field :video_summary, type: String
   field :body,          type: String

--- a/test/models/artefact_external_link_test.rb
+++ b/test/models/artefact_external_link_test.rb
@@ -28,5 +28,11 @@ class ArtefactExternalLinkTest < ActiveSupport::TestCase
       link = ArtefactExternalLink.new(title: "Foo", url: "https://bar.com")
       assert link.valid?
     end
+
+    should "trim whitespace from URLs" do
+      link = ArtefactExternalLink.new(title: "Test", url: " http://example.org ")
+      assert link.valid?
+      assert link.url == "http://example.org"
+    end
   end
 end

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -70,6 +70,12 @@ class ArtefactTest < ActiveSupport::TestCase
         assert_equal 1, a.errors[:slug].count
       end
     end
+
+    should "trim whitespace from URLs" do
+      artefact = FactoryBot.build(:artefact, redirect_url: " https://www.gov.uk ")
+      assert artefact.valid?
+      assert artefact.redirect_url == "https://www.gov.uk"
+    end
   end
 
   context "validating paths and prefixes" do

--- a/test/models/campaign_edition_test.rb
+++ b/test/models/campaign_edition_test.rb
@@ -64,4 +64,10 @@ class CampaignEditionTest < ActiveSupport::TestCase
 
     assert campaign.valid?
   end
+
+  should "trim whitespace from URLs" do
+    campaign = FactoryBot.build(:campaign_edition, organisation_url: " https://www.gov.uk ")
+    assert campaign.valid?
+    assert campaign.organisation_url == "https://www.gov.uk"
+  end
 end

--- a/test/models/transaction_edition_test.rb
+++ b/test/models/transaction_edition_test.rb
@@ -32,4 +32,10 @@ class TransactionEditionTest < ActiveSupport::TestCase
       assert_equal "more info", transaction.indexable_content
     end
   end
+
+  should "trim whitespace from URLs" do
+    transaction = FactoryBot.build(:transaction_edition, link: " https://www.gov.uk ")
+    assert transaction.valid?
+    assert transaction.link == "https://www.gov.uk"
+  end
 end

--- a/test/models/video_edition_test.rb
+++ b/test/models/video_edition_test.rb
@@ -46,4 +46,10 @@ class VideoEditionTest < ActiveSupport::TestCase
       assert_equal expected, v.whole_body
     end
   end
+
+  should "trim whitespace from URLs" do
+    video = FactoryBot.build(:video_edition, video_url: " https://youtube.com ")
+    assert video.valid?
+    assert video.video_url == "https://youtube.com"
+  end
 end

--- a/test/unit/guide_edition_test.rb
+++ b/test/unit/guide_edition_test.rb
@@ -54,4 +54,10 @@ class GuideEditionTest < ActiveSupport::TestCase
     new_edition = user.new_version(edition)
     assert_equal edition.overview, new_edition.overview
   end
+
+  test "it should trim whitespace from URLs" do
+    guide = FactoryBot.create(:guide_edition, video_url: " https://youtube.com ")
+    assert guide.valid?
+    assert guide.video_url == "https://youtube.com"
+  end
 end


### PR DESCRIPTION
If a content designer enters a URL with whitespace, this gets sent to the Publishing API, which refuses the request. Publisher doesn't surface this error to the content designer, so it appears as though the document has published correctly when actually it hasn't.

[Trello Card](https://trello.com/c/vZXmbYWH/1290-3-remove-trailing-space-from-urls-in-publisher)