### PR TITLE
Add a migration to remove travel advice editions

### DIFF
--- a/db/migrate/20190924072449_remove_travel_advice_editions.rb
+++ b/db/migrate/20190924072449_remove_travel_advice_editions.rb
@@ -1,0 +1,10 @@
+class RemoveTravelAdviceEditions < Mongoid::Migration
+  def self.up
+    TravelAdviceEdition.delete_all
+    Artefact.where(kind: "travel-advice").delete_all
+  end
+
+  def self.down
+    raise Mongoid::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
Publisher is no longer responsible for these documents so we can remove them.

Prerequisite to #1126.