### PR TITLE
Add link to Collections Publisher for step by step reviews

### DIFF
--- a/app/presenters/primary_listing_presenter.rb
+++ b/app/presenters/primary_listing_presenter.rb
@@ -52,6 +52,10 @@ class PrimaryListingPresenter
     @scope = @scope.internal_search(string)
   end
 
+  def step_by_step_review_url
+    "#{Plek.current.find('collections-publisher', external: true)}/step-by-step-pages?status=submitted_for_2i&order_by=updated_at"
+  end
+
   alias_method :drafts, :draft
   alias_method :out_for_fact_check, :fact_check
 

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -48,6 +48,14 @@
         </div>
       </div>
 
+      <% if params[:list] == "in_review" %>
+        <div class="col-md-10">
+          <p>
+            <%= link_to "Check Collections publisher", @presenter.step_by_step_review_url %> for step by steps that are waiting for review
+          </p>
+        </div>
+      <% end %>
+
       <div id="publication-list-container" class="col-md-10">
         <%= render @list %>
         <%= paginate @presenter.send(@list), theme: 'twitter-bootstrap-3' %>

--- a/test/integration/root_overview_test.rb
+++ b/test/integration/root_overview_test.rb
@@ -147,6 +147,16 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
     assert page.has_css?("#publication-list-container table tbody tr:nth-child(3) td:nth-child(5)", text: "4 days")
   end
 
+  test "Shows link to Collections Publisher when reviewing in review documents" do
+    FactoryBot.create(:user)
+
+    visit "/"
+    filter_by_user("All")
+    click_on "In review"
+
+    assert page.has_link?("Check Collections publisher", href: "#{Plek.current.find('collections-publisher', external: true)}/step-by-step-pages?status=submitted_for_2i&order_by=updated_at")
+  end
+
   test "allows a user to claim 2i" do
     stub_linkables
 


### PR DESCRIPTION
This adds a link above the list of publications informing content designers that step by steps awaiting review can be found in Collections Publisher.

<img width="1218" alt="Screen Shot 2019-09-24 at 15 09 50" src="https://user-images.githubusercontent.com/6329861/65520606-c07cfa00-dedf-11e9-85a2-4464e4e2d8d2.png">

Not to be merged until the 2i process is fully implemented in Collections Publisher.

Trello card: https://trello.com/c/4TBohVzN/34-add-link-for-sbs-review-queue-to-mainstream-publisher