### PR TITLE
EID-1753 Be more generic when refering to European identity schemes.

### DIFF
--- a/lib/service_sign_in/check-income-tax.en.yaml
+++ b/lib/service_sign_in/check-income-tax.en.yaml
@@ -12,7 +12,7 @@ choose_sign_in:
       hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
     - text: Sign in with a digital identity from another European country
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-tax-estimate?journey_hint=eidas_sign_in
-      hint_text: If you’re part of an ID scheme in Germany or Italy you may be able to use it here.
+      hint_text: If you’re part of an ID scheme in a participating country, you may be able to use it here.
     - text: Create an account
       slug: create-account
       hint_text: If you do not already have one of these accounts, we'll help you choose whether to use Government Gateway or GOV.UK Verify.
@@ -50,4 +50,4 @@ create_new_account:
 
     Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
 update_type: minor
-change_note: Updated Verify links to use correct hints and redirects
+change_note: Updated eIDAS content because more than two countries are connected now.

--- a/lib/service_sign_in/check-state-pension.en.yaml
+++ b/lib/service_sign_in/check-state-pension.en.yaml
@@ -15,7 +15,7 @@ choose_sign_in:
       hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
     - text: Sign in with a digital identity from another European country
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=eidas_sign_in
-      hint_text: If you’re part of an ID scheme in Germany or Italy you may be able to use it here.
+      hint_text: If you’re part of an ID scheme in a participating country, you may be able to use it here.
     - text: Create an account
       slug: create-account
       hint_text: If you do not already have one of these accounts, we'll help you choose whether to use Government Gateway or GOV.UK Verify.
@@ -50,4 +50,4 @@ create_new_account:
     A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.
 
 update_type: minor
-change_note: Updated Verify links to use correct hints and redirects
+change_note: Updated eIDAS content because more than two countries are connected now.

--- a/lib/service_sign_in/check-update-company-car-tax.en.yaml
+++ b/lib/service_sign_in/check-update-company-car-tax.en.yaml
@@ -12,7 +12,7 @@ choose_sign_in:
       hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
     - text: Sign in with a digital identity from another European country
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-company-car-tax?journey_hint=eidas_sign_in
-      hint_text: If you’re part of an ID scheme in Germany or Italy you may be able to use it here.
+      hint_text: If you’re part of an ID scheme in a participating country, you may be able to use it here.
     - text: Create an account
       slug: create-account
       hint_text: If you do not already have one of these accounts, we'll help you choose whether to use Government Gateway or GOV.UK Verify.
@@ -50,4 +50,4 @@ create_new_account:
 
     Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
 update_type: minor
-change_note: Updated Verify links to use correct hints and redirects
+change_note: Updated eIDAS content because more than two countries are connected now.

--- a/lib/service_sign_in/file_self_assessment.en.yaml
+++ b/lib/service_sign_in/file_self_assessment.en.yaml
@@ -13,7 +13,7 @@ choose_sign_in:
       hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
     - text: Sign in with a digital identity from another European country
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-isa?journey_hint=eidas_sign_in
-      hint_text: If you’re part of an ID scheme in Germany or Italy you may be able to use it here.
+      hint_text: If you’re part of an ID scheme in a participating country, you may be able to use it here.
     - text: Register for Self Assessment
       slug: register-self-assessment
       hint_text: You must register before you can file your first tax return.
@@ -35,4 +35,4 @@ create_new_account:
 
     *[UTR]: Unique Taxpayer Reference
 update_type: minor
-change_note: Updated Verify links to use correct hints and redirects
+change_note: Updated eIDAS content because more than two countries are connected now.

--- a/lib/service_sign_in/personal-tax-account.en.yaml
+++ b/lib/service_sign_in/personal-tax-account.en.yaml
@@ -12,7 +12,7 @@ choose_sign_in:
       hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
     - text: Sign in with a digital identity from another European country
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-personal-tax-account?journey_hint=eidas_sign_in
-      hint_text: If you’re part of an ID scheme in Germany or Italy you may be able to use it here.
+      hint_text: If you’re part of an ID scheme in a participating country, you may be able to use it here.
     - text: Create an account
       slug: create-account
       hint_text: If you do not already have one of these accounts, we'll help you choose whether to use Government Gateway or GOV.UK Verify.
@@ -50,4 +50,4 @@ create_new_account:
 
     Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
 update_type: minor
-change_note: Updated Verify links to use correct hints and redirects
+change_note: Updated eIDAS content because more than two countries are connected now.


### PR DESCRIPTION
Once there was only Germany connected, then there was Italy too.  Now there are many countries and the message needs to be more generic.

The existing Welsh translation is the generic message we're using so no change is required there.