### PR TITLE
Add a new done page promo choice for electric vehicles

### DIFF
--- a/app/views/completed_transactions/_fields.html.erb
+++ b/app/views/completed_transactions/_fields.html.erb
@@ -34,6 +34,10 @@
       <%= f.radio_button :promotion_choice, 'mot_reminder',
         { checked: (f.object.promotion_choice == "mot_reminder"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-mot-reminder' } %>
       <%= f.label :promotion_choice, "Promote MOT reminders", value: 'mot_reminder' %>
+      <br />
+      <%= f.radio_button :promotion_choice, 'electric_vehicle',
+        { checked: (f.object.promotion_choice == "electric_vehicle"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-electric-vehicle' } %>
+      <%= f.label :promotion_choice, "Promote electric vehicles", value: 'electric_vehicle' %>
 
       <%= f.input :promotion_choice_url,
           required: false,

--- a/lib/presentation_toggles.rb
+++ b/lib/presentation_toggles.rb
@@ -4,7 +4,7 @@ module PresentationToggles
   included do
     field :presentation_toggles, type: Hash, default: default_presentation_toggles
     validates :promotion_choice_url, presence: true, if: :promotes_something?
-    validates :promotion_choice, inclusion: { in: %w(none organ_donor register_to_vote mot_reminder) }
+    validates :promotion_choice, inclusion: { in: %w(none organ_donor register_to_vote mot_reminder electric_vehicle) }
   end
 
   def promotion_choice=(value)


### PR DESCRIPTION
- The government has a goal to reach zero carbon emissions by 2050, and
  electric cars are part of that.
- Content designers can now select "electric vehicles" as their promo of
  choice.
- While this only needs to be on `/done/vehicle-tax` and
  `/done/check-vehicle-tax` pages, the easiest way given that none of
  these pages are harcoded in `frontend` anymore, is a Publisher
  toggleable promo selection.

TODO:
- [x] Some text for the actual promo. https://github.com/alphagov/frontend/pull/2089

Relevant `govuk-content-schemas` PR: https://github.com/alphagov/govuk-content-schemas/pull/929.

https://trello.com/c/FmE5xU1p/1478-3-add-new-bespoke-message-to-specific-completed-transaction-pages