### PR TITLE
Migrate from govuk-lint to rubocop-govuk

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,30 +1,3 @@
-Metrics/BlockLength:
-  Enabled: false
-
-# Not sure what this is, but it doesn't seem to be a big issue.
-Naming/VariableNumber:
-  Enabled: false
-
-# Quite a few cases of this, so not fixing now.
-Style/DateTime:
-  Enabled: false
-
-# Some false positives, and quite a minor issue
-Style/FormatStringToken:
-  Enabled: false
-
-# There are a few cases of this, could be useful to fix at some point
-Style/MethodMissingSuper:
-  Enabled: false
-Style/MissingRespondToMissing:
-  Enabled: false
-
-# (this version of) ActiveRecord/MongoDB does not support `find_each`
-Rails/FindEach:
-  Enabled: false
-
-# `find_by` in (this version of) ActiveRecord/MongoDB behaves
-# differently to normal Rails, raising an exception instead of
-# returning `nil`, so we have to use `where(condition: "value").first` instead
-Rails/FindBy:
-  Enabled: false
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml

--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ group :development do
 end
 
 group :development, :test do
-  gem 'govuk-lint', '~> 4.3'
+  gem 'rubocop-govuk'
   gem 'jasmine', '~> 3.5.0'
   gem 'jasmine-core', '~> 3.5.0'
   gem 'rack', '2.0.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,11 +149,6 @@ GEM
       sanitize (~> 5)
     govuk-content-schema-test-helpers (1.6.1)
       json-schema (~> 2.8.0)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_admin_template (6.7.0)
       bootstrap-sass (= 3.4.1)
       jquery-rails (~> 4.3.1)
@@ -303,7 +298,7 @@ GEM
     omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    parallel (1.18.0)
+    parallel (1.19.1)
     parser (2.6.5.0)
       ast (~> 2.4.0)
     phantomjs (2.1.1.0)
@@ -386,10 +381,14 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
-    rubocop-rspec (1.36.0)
+    rubocop-rspec (1.37.0)
       rubocop (>= 0.68.1)
     ruby-graphviz (1.2.3)
     ruby-progressbar (1.10.1)
@@ -418,8 +417,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     select2-rails (3.5.9.1)
       thor (~> 0.14)
     selectize-rails (0.12.6)
@@ -523,7 +520,6 @@ DEPENDENCIES
   gds-sso (~> 14.2)
   govspeak (~> 6.5.1)
   govuk-content-schema-test-helpers (~> 1.6)
-  govuk-lint (~> 4.3)
   govuk_admin_template (~> 6.7)
   govuk_app_config (~> 2.0.1)
   govuk_sidekiq (~> 3.0.3)
@@ -555,6 +551,7 @@ DEPENDENCIES
   rest-client
   retriable
   reverse_markdown (= 1.3.0)
+  rubocop-govuk
   sass-rails (~> 5.0)
   select2-rails (= 3.5.9.1)
   selectize-rails (= 0.12.6)

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -85,6 +85,10 @@ class EditionsController < InheritedResources::Base
 
     # update! is from the Inherited Resources gem
     # https://github.com/josevalim/inherited_resources/blob/master/lib/inherited_resources/actions.rb#L42
+    # TODO: We should refactor this block as it dates back to 2011 and it grew
+    # quite a bit since then.
+    # For the moment, I'll just disable the Metrics/BlockLength check ¯\_(ツ)_/¯
+    # rubocop:disable Metrics/BlockLength
     update! do |success, failure|
       success.html {
         if attempted_activity
@@ -121,6 +125,7 @@ class EditionsController < InheritedResources::Base
       }
       failure.json { render json: resource.errors, status: 406 }
     end
+    # rubocop:enable Metrics/BlockLength
   end
 
   def linking

--- a/app/decorators/user_search_edition_decorator.rb
+++ b/app/decorators/user_search_edition_decorator.rb
@@ -5,9 +5,15 @@ class UserSearchEditionDecorator
     @user = user
   end
 
+  # rubocop:disable Style/MethodMissingSuper
   def method_missing(method_name, *args)
     @edition.send method_name, *args
   end
+
+  def respond_to_missing?(method_name, *)
+    @edition.respond_to?(method_name)
+  end
+  # rubocop:enable Style/MethodMissingSuper
 
   def user_last_action
     # Note reverse sort

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,8 +20,8 @@ module ApplicationHelper
     link_to title, permitted_params.merge(sort: column, direction: direction), class: css_class
   end
 
-  def diff_html(version_1, version_2)
-    Diffy::Diff.new(version_1, version_2, allow_empty_diff: false).to_s(:html).html_safe
+  def diff_html(version1, version2)
+    Diffy::Diff.new(version1, version2, allow_empty_diff: false).to_s(:html).html_safe
   end
 
   def permitted_params

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -4,6 +4,7 @@ module Workflow
   class CannotDeletePublishedPublication < RuntimeError; end
   extend ActiveSupport::Concern
 
+  # rubocop:disable Metrics/BlockLength
   included do
     validate :not_editing_published_item
     before_destroy :check_can_delete_and_notify
@@ -104,6 +105,7 @@ module Workflow
       end
     end
   end
+  # rubocop:enable Metrics/BlockLength
 
   def can_resend_fact_check?
     fact_check? && latest_status_action&.is_fact_check_request?

--- a/app/traits/attachable.rb
+++ b/app/traits/attachable.rb
@@ -22,6 +22,7 @@ module Attachable
   private
 
     def attaches_with_options(fields, options = {})
+      # rubocop:disable Metrics/BlockLength
       fields.map(&:to_s).each do |field|
         before_save "upload_#{field}".to_sym, if: "#{field}_has_changed?".to_sym
         self.field "#{field}_id".to_sym, type: String
@@ -72,6 +73,7 @@ module Attachable
           end
         end
       end
+      # rubocop:enable Metrics/BlockLength
     end
   end
 

--- a/app/traits/recordable_actions.rb
+++ b/app/traits/recordable_actions.rb
@@ -3,6 +3,7 @@ require "action"
 module RecordableActions
   extend ActiveSupport::Concern
 
+  # rubocop:disable Metrics/BlockLength
   included do
     embeds_many :actions
 
@@ -50,4 +51,5 @@ module RecordableActions
       publication.requester if publication
     end
   end
+  # rubocop:enable Metrics/BlockLength
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -18,15 +18,13 @@ Rails.application.configure do
   config.jwt_auth_secret = "123"
 
   # Enable/disable caching. By default caching is disabled.
+  config.action_controller.perform_caching = false
   if Rails.root.join("tmp/caching-dev.txt").exist?
-    config.action_controller.perform_caching = false
-
     config.cache_store = :memory_store
     config.public_file_server.headers = {
      "Cache-Control" => "public, max-age=172800",
     }
   else
-    config.action_controller.perform_caching = false
     config.cache_store = :null_store
   end
 

--- a/config/initializers/current_release_sha.rb
+++ b/config/initializers/current_release_sha.rb
@@ -2,5 +2,5 @@ if File.exist?("#{Rails.root}/REVISION")
   revision = `cat #{Rails.root}/REVISION`.chomp
   CURRENT_RELEASE_SHA = revision[0..10] # Just get the short SHA
 else
-  CURRENT_RELEASE_SHA = "development"
+  CURRENT_RELEASE_SHA = "development".freeze
 end

--- a/config/initializers/email_groups.rb
+++ b/config/initializers/email_groups.rb
@@ -1,5 +1,5 @@
 EMAIL_GROUPS = {
-    dev: [ENV.fetch("EMAIL_GROUP_DEV", "govuk-dev@digital.cabinet-office.gov.uk")],
-    business: [ENV.fetch("EMAIL_GROUP_BUSINESS", "publisher-alerts-business@digital.cabinet-office.gov.uk")],
-    citizen: [ENV.fetch("EMAIL_GROUP_CITIZEN", "publisher-alerts-citizen@digital.cabinet-office.gov.uk")],
-  }
+  dev: [ENV.fetch("EMAIL_GROUP_DEV", "govuk-dev@digital.cabinet-office.gov.uk")],
+  business: [ENV.fetch("EMAIL_GROUP_BUSINESS", "publisher-alerts-business@digital.cabinet-office.gov.uk")],
+  citizen: [ENV.fetch("EMAIL_GROUP_CITIZEN", "publisher-alerts-citizen@digital.cabinet-office.gov.uk")],
+}.freeze

--- a/config/initializers/fact_check.rb
+++ b/config/initializers/fact_check.rb
@@ -4,7 +4,7 @@ require "fact_check_config"
 
 config_file_path = Rails.root.join("config", "fact_check.yml")
 
-config = YAML.load(
+config = YAML.safe_load(
   ERB.new(File.read(config_file_path)).result,
 )
 

--- a/config/initializers/mapit.rb
+++ b/config/initializers/mapit.rb
@@ -1,1 +1,1 @@
-MAPIT_BASE_URL = "#{Plek.current.find('mapit')}/"
+MAPIT_BASE_URL = "#{Plek.current.find('mapit')}/".freeze

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -18,4 +18,3 @@ ActiveSupport.to_time_preserves_timezone = false
 
 # Require `belongs_to` associations by default. Previous versions had false.
 # Rails.application.config.active_record.belongs_to_required_by_default = false
-

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -4,5 +4,5 @@ Rails.application.config.session_store(
   :cookie_store,
   key: "_publisher_session",
   secure: Rails.env.production? && !ENV["DISABLE_SECURE_COOKIES"],
-  http_only: true
+  http_only: true,
 )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+# Having a long routes file is not a style violation
+# rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
   get "/healthcheck", to: GovukHealthcheck.rack_response(
     GovukHealthcheck::SidekiqRedis,
@@ -10,7 +12,7 @@ Rails.application.routes.draw do
 
   get "downtimes" => "downtimes#index"
 
-  resources :artefacts, only: [:new, :create, :update]
+  resources :artefacts, only: %i[new create update]
 
   resources :editions do
     member do
@@ -36,7 +38,7 @@ Rails.application.routes.draw do
           }
     end
 
-    resource :downtime, only: [:new, :create, :edit, :update, :destroy]
+    resource :downtime, only: %i[new create edit update destroy]
   end
 
   get "reports" => "reports#index", as: :reports
@@ -62,3 +64,4 @@ Rails.application.routes.draw do
 
   mount GovukAdminTemplate::Engine, at: "/style-guide"
 end
+# rubocop:enable Metrics/BlockLength

--- a/lib/fact_check_mail.rb
+++ b/lib/fact_check_mail.rb
@@ -13,9 +13,15 @@ class FactCheckMail
     subject_is_out_of_office? || out_of_office_header_set?
   end
 
+  # rubocop:disable Style/MethodMissingSuper
   def method_missing(method_name, *args, &block)
     @message.public_send(method_name, *args, &block)
   end
+
+  def respond_to_missing?(method_name, *)
+    @message.respond_to?(method_name)
+  end
+  # rubocop:enable Style/MethodMissingSuper
 
 private
 

--- a/lib/tasks/licence_finder.rake
+++ b/lib/tasks/licence_finder.rake
@@ -1,5 +1,19 @@
 require "gds_api/publishing_api_v2"
 
+def create_artefact!
+  artefact = Artefact.new(
+    content_id: "69af22e0-da49-4810-9ee4-22b4666ac627",
+    slug: "licence-finder",
+    name: "Licence finder",
+    owning_app: "publisher",
+    kind: "transaction",
+    state: "draft",
+    language: "en",
+  )
+
+  artefact.save!
+end
+
 namespace :licence_finder do
   desc "Create draft start page for licence finder"
   task licence_finder_draft: :environment do
@@ -18,17 +32,7 @@ namespace :licence_finder do
     end
 
     puts "Creating Artefact matching old content_id: 69af22e0-da49-4810-9ee4-22b4666ac627"
-    artefact = Artefact.new(
-      content_id: "69af22e0-da49-4810-9ee4-22b4666ac627",
-      slug: "licence-finder",
-      name: "Licence finder",
-      owning_app: "publisher",
-      kind: "transaction",
-      state: "draft",
-      language: "en",
-    )
-
-    artefact.save!
+    create_artefact!
     puts "Artefact saved"
     puts "Creating Edition from Artefact"
 

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,4 @@
 desc "Run govuk-lint with similar params to CI"
 task "lint" do
-  sh "bundle exec govuk-lint-ruby --diff --format clang app test lib config"
+  sh "bundle exec rubocop --format clang app test lib config"
 end

--- a/test/unit/content_workflow_presenter_test.rb
+++ b/test/unit/content_workflow_presenter_test.rb
@@ -4,27 +4,27 @@ require "test_helper"
 
 class ContentWorkflowPresenterTest < ActiveSupport::TestCase
   should "provide a CSV export of content workflow" do
-    action_1 = Action.new(
+    action1 = Action.new(
       request_type: "create",
       created_at: "2016-01-07 17:41:57",
     )
 
-    action_2 = Action.new(
+    action2 = Action.new(
       request_type: "request_review",
       created_at: "2016-01-11 10:21:00",
     )
 
-    action_3 = Action.new(
+    action3 = Action.new(
       request_type: "send_fact_check",
       created_at: "2016-01-17 12:11:33",
     )
 
-    action_4 = Action.new(
+    action4 = Action.new(
       request_type: "request_amendments",
       created_at: "2016-01-20 17:41:28",
     )
 
-    action_5 = Action.new(
+    action5 = Action.new(
       request_type: "send_fact_check",
       created_at: "2016-03-07 17:31:44",
     )
@@ -34,7 +34,7 @@ class ContentWorkflowPresenterTest < ActiveSupport::TestCase
       slug: "register-to-vote-armed-forces",
       state: "published",
       assignee: "Ray Khan",
-      actions: [action_1, action_2, action_3, action_4, action_5],
+      actions: [action1, action2, action3, action4, action5],
     )
 
     guide_edition = GuideEdition.new(
@@ -42,7 +42,7 @@ class ContentWorkflowPresenterTest < ActiveSupport::TestCase
       slug: "queens-awards-for-enterprise",
       state: "published",
       assignee: "Constance Cerf",
-      actions: [action_1, action_2, action_3, action_4, action_5],
+      actions: [action1, action2, action3, action4, action5],
     )
 
     Edition.stubs(:published).returns([transaction_edition, guide_edition])

--- a/test/unit/fact_check_message_processor_test.rb
+++ b/test/unit/fact_check_message_processor_test.rb
@@ -73,11 +73,11 @@ class FactCheckMessageProcessorTest < ActiveSupport::TestCase
   end
 
   test "it should turn each paragraph to UTF-8, even if they have different encodings" do
-    utf_8 = "Breatainn Mhòr"
-    iso = utf_8.encode(Encoding::ISO_8859_15)
-    expected = [utf_8, utf_8].join("\n\n")
+    utf8 = "Breatainn Mhòr"
+    iso = utf8.encode(Encoding::ISO_8859_15)
+    expected = [utf8, utf8].join("\n\n")
     body = [
-      utf_8.force_encoding(Encoding::ASCII_8BIT),
+      utf8.force_encoding(Encoding::ASCII_8BIT),
       iso.force_encoding(Encoding::ASCII_8BIT),
     ].join("\n\n")
     message = Mail.new(body: body)


### PR DESCRIPTION
Docs: https://docs.publishing.service.gov.uk/manual/migrate-from-govuk-lint.html

Trello: https://trello.com/c/Z8J455zg/1579-migrate-from-govuk-lint

In some cases, some of the rubocop cops have been disabled, rather than
addressing the issues.

This is not the right time to address these issues more extensively. We
had a conversation about this in the Platform Heath team and we agreed
that refactoring this code is not a priority right now, but there is a
Trello card to capture this:
https://trello.com/c/VNiRPVTP/1385-solve-publisher-linting-issues