### PR TITLE
Delete drafts from pub-api on deletion

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -94,7 +94,6 @@ class Artefact
   before_create :record_create_action
   before_update :record_update_action
   after_update :update_editions
-  before_destroy :discard_publishing_api_draft
 
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true, slug: true
@@ -308,14 +307,5 @@ private
     when "archived" then "archived"
     else "draft"
     end
-  end
-
-  def discard_publishing_api_draft
-    Services.publishing_api.discard_draft(self.content_id)
-  rescue GdsApi::HTTPNotFound
-    nil
-  rescue GdsApi::HTTPUnprocessableEntity
-    # This error can also occur when there is no draft to discard
-    nil
   end
 end


### PR DESCRIPTION
Previously Publisher only deleted a draft from publishing-api when it was
the first edition of an Artefact and didn't have any previous editions
as this callback fired when deleting the parent Artefact.

The commit changes the code so whenever a draft is deleted then the
draft is also deleted from publishing-api, this is the correct behaviour
as previously it meant old drafts would linger in publishing-api when
they've been removed from Publisher leading to strange errors when the
new draft and deleted draft didn't match in pub-api. An error seen
recently was due to mismatched URL's between old (deleted)
and new draft. I assume this just works and overwrites the deleted draft
when the url isn't altered for a new draft.

This code also allows the deletion of other publisher specific states,
like "ammends_needed", "ready", "in_review" etc but these appear as
drafts in pub-api and a user can delete these editions from the UI the
same as a plain draft so these should also be deleted from pub-api.

Also added a test for the change, this felt like a slightly odd place as
you're testing specific logic in the model but publisher doesn't test web
requests in models so here it must live.

Trello:
https://trello.com/c/w0VMqd8R/822-deleting-drafts-with-slug-redirects-in-publisher-does-not-remove-slug-redirects