### PR TITLE
Remove deleted parts from the DOM after successful AJAX requests

### DIFF
--- a/app/assets/javascripts/modules/ajax_save_with_parts.js
+++ b/app/assets/javascripts/modules/ajax_save_with_parts.js
@@ -15,6 +15,7 @@
             updatePart(parts[i]);
           }
         }
+        removeDeletedParts();
       }
 
       function error(evt, response) {
@@ -24,6 +25,11 @@
         if (partErrors) {
           $.each(partErrors[0], showPartErrors);
         }
+      }
+
+      function removeDeletedParts() {
+        var deletedParts = $("[id*='__destroy'][value='1']")
+        deletedParts.parents(".fields").remove();
       }
 
       function showPartErrors(partKey, partErrors) {

--- a/spec/javascripts/spec/ajax_save_with_parts.spec.js
+++ b/spec/javascripts/spec/ajax_save_with_parts.spec.js
@@ -48,6 +48,7 @@ describe('An ajax save with parts module', function() {
             <input class="slug" type="text" id="edition_part_101_slug" name="edition[part][101][slug]" value="slug-2">\
           </div>\
           <input type="hidden" id="edition_part_101_id" name="edition[part][101][id]" value="5f00000002">\
+          <input id="edition_parts_attributes_101__destroy" type="hidden" name="edition[parts_attributes][deleted][__destroy]" value="false">\
         </div>\
       </div>\
       <div class="fields">\
@@ -61,6 +62,20 @@ describe('An ajax save with parts module', function() {
           <input class="order" type="hidden" id="edition_part_4535667_order" name="edition[part][4535667][order]" value="3">\
           <div id="edition_parts_attributes_4535667_slug_input">\
             <input class="slug" type="text" id="edition_part_4535667_slug" name="edition[part][4535667][slug]" value="">\
+          </div>\
+        </div>\
+      </div>\
+      <div class="fields">\
+        <a href="#" class="js-part-toggle">\
+          <span class="js-part-title">Deleted part</span>\
+        </a>\
+        <div class="js-part-toggle-target" id="deleted-part">\
+          <div id="edition_parts_attributes_deleted_title_input">\
+            <input class="title" type="text" id="edition_part_deleted_title" name="edition[part][deleted][title]" value="Deleted Part">\
+          </div>\
+          <input class="order" type="hidden" id="edition_part_deleted_order" name="edition[part][deleted][order]" value="4">\
+          <div id="edition_parts_attributes_deleted_slug_input">\
+            <input id="edition_parts_attributes_deleted__destroy" type="hidden" name="edition[parts_attributes][deleted][__destroy]" value="1">\
           </div>\
         </div>\
       </div>\
@@ -110,6 +125,11 @@ describe('An ajax save with parts module', function() {
       expect(element.find('.js-part-toggle').eq(0).attr('href')).toBe('#updated-title-1');
       expect(element.find('.js-part-toggle').eq(1).attr('href')).toBe('#updated-title-2');
     });
+
+    it('removes deleted parts from the DOM to prevent inclusion in subsequent posts', function(){
+      expect(element.find('#edition_parts_attributes_101_title_input').length).toBe(1);
+      expect(element.find('#edition_parts_attributes_deleted_title_input').length).toBe(0);
+    })
   });
 
   describe('when a new part is added and the form is saved', function() {


### PR DESCRIPTION
When editing an edition, updates are made via an ajax request. Upon deleting a part, the part is hidden in the DOM. Although marked as "destroyed" in the DOM and successfully deleted from the database, subsequent update requests include the part details in the params. This caused a database error as the part no longer exists, resulting in a "Something gone's wrong" message. The user would have to refresh their page and lose any edits made since a deletion.

This PR ensures that, after a successful update, any deleted parts are not just hidden but removed from the DOM, to prevent their details being included in request params.

[trello](https://trello.com/c/ibsbiyZ4/1716-5-investigate-and-fix-the-bug-that-deletes-parts-in-publisher)

