### PR TITLE
Replace button class

### DIFF
--- a/lib/service_sign_in/check-state-pension.cy.yaml
+++ b/lib/service_sign_in/check-state-pension.cy.yaml
@@ -35,7 +35,7 @@ create_new_account:
     - eich rhif Yswiriant Gwladol
     - slip cyflog diweddar, P60 neu basbort dilys y DU
 
-    <a role="button" class="button" href="https://www.tax.service.gov.uk/gg/sign-in?continue=/personal-account&accountType=individual&origin=PTA-frontend" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-event="true">Creu cyfrif Porth y Llywodraeth</a>
+    <a role="button" class="gem-c-button govuk-button" href="https://www.tax.service.gov.uk/gg/sign-in?continue=/personal-account&accountType=individual&origin=PTA-frontend" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-event="true">Creu cyfrif Porth y Llywodraeth</a>
 
     ### GOV.UK Verify
 
@@ -44,7 +44,7 @@ create_new_account:
     - cyfeiriad yn y DU
     - pasbort neu drwydded cerdyn-llun dilys
 
-    <a role="button" class="button" href="https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=registration" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-event="true">Creu cyfrif GOV.UK Verify</a>
+    <a role="button" class="gem-c-button govuk-button" href="https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=registration" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-event="true">Creu cyfrif GOV.UK Verify</a>
 
     Bydd cwmni ardystiedig bob tro'n gwirio pwy ydych pan fyddwch yn cofrestru gyda GOV.UK Verify. Mae pob un ohonynt yn bodloni safonau diogelwch sydd wedi'u gosod gan y Llywodraeth.
 

--- a/lib/service_sign_in/check-state-pension.en.yaml
+++ b/lib/service_sign_in/check-state-pension.en.yaml
@@ -36,7 +36,7 @@ create_new_account:
     * your National Insurance number
     * a recent payslip or P60 or a valid UK passport
 
-    <a role="button" class="button" href="https://www.tax.service.gov.uk/gg/sign-in?continue=/check-your-state-pension&accountType=individual" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-event="true">Create a Government Gateway account</a>
+    <a role="button" class="gem-c-button govuk-button" href="https://www.tax.service.gov.uk/gg/sign-in?continue=/check-your-state-pension&accountType=individual" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-event="true">Create a Government Gateway account</a>
 
     ### GOV.UK Verify
 
@@ -45,7 +45,7 @@ create_new_account:
     - a UK address
     - a valid passport or photocard driving licence
 
-    <a role="button" class="button" href="https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=registration" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-event="true">Create a GOV.UK Verify account</a>
+    <a role="button" class="gem-c-button govuk-button" href="https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=registration" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-event="true">Create a GOV.UK Verify account</a>
 
     A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.
 


### PR DESCRIPTION
- button class (from toolkit via static) is being deprecated)
- a [recent change to the components gem](https://github.com/alphagov/govuk_publishing_components/pull/1282) allows this class swapping to work, otherwise would have left the button with illegible blue text

These buttons are used on e.g. https://www.gov.uk/check-state-pension/sign-in/create-account

Trello card: https://trello.com/c/d8D7JTJE/203-remove-design-patterns-buttons-from-static
