### PR TITLE
Alert users when skipping review

### DIFF
--- a/app/mailers/noisy_workflow.rb
+++ b/app/mailers/noisy_workflow.rb
@@ -13,6 +13,14 @@ class NoisyWorkflow < ApplicationMailer
     mail(to: recipient_emails.join(", "), subject: subject)
   end
 
+  def skip_review(action)
+    @edition = action.edition
+    mail(
+      to: EMAIL_GROUPS[:force_publish_alerts],
+      subject: "[PUBLISHER] Review has been skipped on #{@edition.title}",
+    )
+  end
+
   def request_fact_check(action)
     @edition = action.edition
     fact_check_address = @edition.fact_check_email_address

--- a/app/views/noisy_workflow/skip_review.text.erb
+++ b/app/views/noisy_workflow/skip_review.text.erb
@@ -1,0 +1,10 @@
+Hello,
+
+Review has been skipped for "<%= @edition.title %>" (<%= @edition.format %>).
+
+You can view it here:
+<%= edition_url(@edition.id) %>
+
+Regards,
+
+Winston (the GOV.UK Publisher)

--- a/app/views/shared/_edition_activity_fields.html.erb
+++ b/app/views/shared/_edition_activity_fields.html.erb
@@ -9,6 +9,10 @@
     <div class="modal-body">
       <%= activity_fields.hidden_field :request_type, value: activity %>
 
+      <% if activity == :skip_review %>
+        <p class="alert alert-warning">You should only skip review in exceptional circumstances, for example if you're the only person responding to an emergency out of hours call.</p>
+      <% end %>
+
       <% if activity == :send_fact_check %>
         <%= activity_fields.input :email_addresses, hint: 'You can enter multiple email addresses if you comma separate them as follows: <code>fact-checker-one@example.com, fact-checker-two@example.com</code>.'.html_safe %>
 

--- a/config/initializers/email_groups.rb
+++ b/config/initializers/email_groups.rb
@@ -2,4 +2,5 @@ EMAIL_GROUPS = {
   dev: [ENV.fetch("EMAIL_GROUP_DEV", "govuk-dev@digital.cabinet-office.gov.uk")],
   business: [ENV.fetch("EMAIL_GROUP_BUSINESS", "publisher-alerts-business@digital.cabinet-office.gov.uk")],
   citizen: [ENV.fetch("EMAIL_GROUP_CITIZEN", "publisher-alerts-citizen@digital.cabinet-office.gov.uk")],
+  force_publish_alerts: [ENV.fetch("EMAIL_GROUP_FORCE_PUBLISH_ALERTS", "mainstream-force-publishing-alerts@digital.cabinet-office.gov.uk")],
 }.freeze

--- a/lib/govuk_content_models/action_processors/base_processor.rb
+++ b/lib/govuk_content_models/action_processors/base_processor.rb
@@ -61,6 +61,7 @@ module GovukContentModels
         NoisyWorkflow.make_noise(new_action).deliver_now
         NoisyWorkflow.request_fact_check(new_action).deliver_now if action_name.to_s == "send_fact_check"
         NoisyWorkflow.resend_fact_check(new_action).deliver_now if action_name.to_s == "resend_fact_check"
+        NoisyWorkflow.skip_review(new_action).deliver_now if action_name.to_s == "skip_review"
       end
     end
   end

--- a/test/functional/noisy_workflow_test.rb
+++ b/test/functional/noisy_workflow_test.rb
@@ -110,6 +110,16 @@ class NoisyWorkflowTest < ActionMailer::TestCase
     end
   end
 
+  context ".skip_review" do
+    should "should send an email on skipping review" do
+      user = FactoryBot.create(:user, name: "Ben", permissions: %w[skip_review])
+      guide = user.create_edition(:guide, panopticon_id: FactoryBot.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
+      request_review(user, guide)
+      NoisyWorkflow.expects(:skip_review).returns(mock("noise maker", deliver_now: nil))
+      skip_review(user, guide)
+    end
+  end
+
   context "make_noise" do
     context "Setting the subject" do
       should "set a subject containing the description" do


### PR DESCRIPTION
To reduce the possibility of force publishing without anyone noticing we have added:
- Warning text to the skip review dialog box
- An email to be sent out when review is skipped

Trello card: Trello card: https://trello.com/c/d8D7JTJE/203-remove-design-patterns-buttons-from-static