### PR TITLE
Remove mention of Winston from skip review emails

### DIFF
--- a/app/views/noisy_workflow/skip_review.text.erb
+++ b/app/views/noisy_workflow/skip_review.text.erb
@@ -5,6 +5,4 @@ Review has been skipped for "<%= @edition.title %>" (<%= @edition.format %>).
 You can view it here:
 <%= edition_url(@edition.id) %>
 
-Regards,
-
-Winston (the GOV.UK Publisher)
+Sent by the GOV.UK Publisher application


### PR DESCRIPTION
Changing who the email is signed off from from Winston to the GOV.UK publisher app to be more clear about where the email has come from.

Trello card: https://trello.com/c/jUuJwRLW