### PR TITLE
Fix deprecation warnings in tests

### DIFF
--- a/test/functional/link_check_reports_controller_test.rb
+++ b/test/functional/link_check_reports_controller_test.rb
@@ -12,7 +12,7 @@ class LinkCheckReportsControllerTest < ActionController::TestCase
 
   context "#create" do
     setup do
-      @stubbed_api_request = link_checker_api_create_batch(
+      @stubbed_api_request = stub_link_checker_api_create_batch(
         uris: ["https://www.gov.uk"],
         id: "a-batch-id",
         webhook_uri: link_checker_api_callback_url(host: Plek.find("publisher")),

--- a/test/integration/edition_link_check_test.rb
+++ b/test/integration/edition_link_check_test.rb
@@ -10,7 +10,7 @@ class EditionLinkCheckTest < JavascriptIntegrationTest
     stub_linkables
     stub_holidays_used_by_fact_check
 
-    @stubbed_api_request = link_checker_api_create_batch(
+    @stubbed_api_request = stub_link_checker_api_create_batch(
       uris: ["https://www.gov.uk"],
       id: "a-batch-id",
       webhook_uri: link_checker_api_callback_url(host: Plek.find("publisher")),

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -41,7 +41,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
 
   test "the customised message for fact-check is pre-loaded with a 5 working days deadline message" do
     today = Date.parse("2017-04-28")
-    calendars_has_a_bank_holiday_on(Date.parse("2017-05-01"), in_division: "england-and-wales")
+    stub_calendars_has_a_bank_holiday_on(Date.parse("2017-05-01"), in_division: "england-and-wales")
 
     Timecop.freeze(today) do
       guide.update_attribute(:state, "ready")

--- a/test/integration/tagging_test.rb
+++ b/test/integration/tagging_test.rb
@@ -5,7 +5,7 @@ class TaggingTest < JavascriptIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
-    publishing_api_has_lookups({})
+    stub_publishing_api_has_lookups({})
 
     @edition = FactoryBot.create(:guide_edition)
     @artefact = @edition.artefact
@@ -128,7 +128,7 @@ class TaggingTest < JavascriptIntegrationTest
       find(".js-path-field").set("/reclaim-vat")
 
       # Web request that JS makes to check the path is a valid GOV.UK base path
-      publishing_api_has_lookups("/reclaim-vat" => "CONTENT-ID-RECLAIM-VAT")
+      stub_publishing_api_has_lookups("/reclaim-vat" => "CONTENT-ID-RECLAIM-VAT")
       click_on "Add related item"
 
       within :xpath, '//ul[contains(@class,"js-base-path-list")]/li[1]' do
@@ -139,7 +139,7 @@ class TaggingTest < JavascriptIntegrationTest
         assert page.has_field?("tagging_tagging_update_form[ordered_related_items][]", with: "/reclaim-vat")
       end
 
-      publishing_api_has_lookups(
+      stub_publishing_api_has_lookups(
         "/vat-returns" => "CONTENT-ID-VAT-RETURNS",
         "/reclaim-vat" => "CONTENT-ID-RECLAIM-VAT",
       )
@@ -245,7 +245,7 @@ class TaggingTest < JavascriptIntegrationTest
     end
 
     should "User makes a conflicting change" do
-      publishing_api_has_links(
+      stub_publishing_api_has_links(
         "content_id" => @content_id,
         "links" => {
           topics: %w[CONTENT-ID-WELLS],

--- a/test/support/holidays_test_helpers.rb
+++ b/test/support/holidays_test_helpers.rb
@@ -4,6 +4,6 @@ module HolidaysTestHelpers
   include GdsApi::TestHelpers::Calendars
 
   def stub_holidays_used_by_fact_check
-    calendars_has_no_bank_holidays(in_division: "england-and-wales")
+    stub_calendars_has_no_bank_holidays(in_division: "england-and-wales")
   end
 end

--- a/test/support/tag_test_helpers.rb
+++ b/test/support/tag_test_helpers.rb
@@ -7,20 +7,20 @@ module TagTestHelpers
     stub_request(:get, %r{\A#{PUBLISHING_API_V2_ENDPOINT}/expanded-links/.+})
       .to_return(status: 200, body: "{}", headers: {})
 
-    publishing_api_has_linkables([
+    stub_publishing_api_has_linkables([
       { base_path: "/browse/tax/vat", internal_name: "Tax / VAT", publication_state: "published", content_id: "CONTENT-ID-VAT" },
       { base_path: "/browse/tax/capital-gains", internal_name: "Tax / Capital Gains Tax", publication_state: "published", content_id: "CONTENT-ID-CAPITAL" },
       { base_path: "/browse/tax/rti", internal_name: "Tax / RTI", publication_state: "draft", content_id: "CONTENT-ID-RTI" },
       { base_path: "/browse/tax/nil", internal_name: nil, publication_state: "draft", content_id: "CONTENT-ID-NIL" },
     ], document_type: "mainstream_browse_page")
 
-    publishing_api_has_linkables([
+    stub_publishing_api_has_linkables([
       { base_path: "/topic/oil-and-gas/wells", internal_name: "Oil and Gas / Wells", publication_state: "published", content_id: "CONTENT-ID-WELLS" },
       { base_path: "/topic/oil-and-gas/fields", internal_name: "Oil and Gas / Fields", publication_state: "published", content_id: "CONTENT-ID-FIELDS" },
       { base_path: "/topic/oil-and-gas/distillation", internal_name: "Oil and Gas / Distillation", publication_state: "draft", content_id: "CONTENT-ID-DISTILL" },
     ], document_type: "topic")
 
-    publishing_api_has_linkables(
+    stub_publishing_api_has_linkables(
       [
         {
           "public_updated_at" => "2014-10-15 14:35:22",
@@ -34,7 +34,7 @@ module TagTestHelpers
       document_type: "organisation",
     )
 
-    publishing_api_has_linkables([
+    stub_publishing_api_has_linkables([
       { internal_name: "As a user, I need to pay a VAT bill, so that I can pay HMRC what I owe (100550)",
         publication_state: "published", content_id: "CONTENT-ID-USER-NEED" },
     ], document_type: "need")

--- a/test/unit/lib/service_sign_in_yaml_validator_test.rb
+++ b/test/unit/lib/service_sign_in_yaml_validator_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class ServiceSignInYamlValidatorTest < ActiveSupport::TestCase
   def setup
-    publishing_api_has_lookups("/" => nil)
+    stub_publishing_api_has_lookups("/" => nil)
   end
 
   def service_sign_in_yaml_validator(file)
@@ -66,7 +66,7 @@ class ServiceSignInYamlValidatorTest < ActiveSupport::TestCase
       should "return the YAML file as a hash" do
         content = YAML.load_file(valid_yaml_file)
         slug = content["start_page_slug"]
-        publishing_api_has_lookups("/#{slug}" => "a-content-id")
+        stub_publishing_api_has_lookups("/#{slug}" => "a-content-id")
         validator = service_sign_in_yaml_validator(valid_yaml_file)
         assert_equal content, validator.validate
       end
@@ -140,7 +140,7 @@ class ServiceSignInYamlValidatorTest < ActiveSupport::TestCase
     context "when the start_page_slug doesn't exist in the Publishing API" do
       should "log a 'start_page_slug 'slug_name' cannot be found in Publishing API' error" do
         slug = YAML.load_file(invalid_start_page_slug)["start_page_slug"]
-        publishing_api_has_lookups("/#{slug}" => nil)
+        stub_publishing_api_has_lookups("/#{slug}" => nil)
         validator = service_sign_in_yaml_validator(invalid_start_page_slug)
         assert_includes validator.validate, "start_page_slug '#{slug}' cannot be found in Publishing API"
       end

--- a/test/unit/lib/sync_checker_test.rb
+++ b/test/unit/lib/sync_checker_test.rb
@@ -16,7 +16,7 @@ class SyncCheckerTest < ActiveSupport::TestCase
 
     context "for content present in content store" do
       setup do
-        content_store_has_item("/help/cookies", schema_name: "help_page")
+        stub_content_store_has_item("/help/cookies", schema_name: "help_page")
       end
 
       should "succeed for matching expectation" do
@@ -44,7 +44,7 @@ class SyncCheckerTest < ActiveSupport::TestCase
 
     context "for content missing in content store" do
       setup do
-        content_store_does_not_have_item("/help/cookies")
+        stub_content_store_does_not_have_item("/help/cookies")
       end
 
       should "fail" do

--- a/test/unit/lib/working_days_calculator_test.rb
+++ b/test/unit/lib/working_days_calculator_test.rb
@@ -35,7 +35,7 @@ class WorkingDaysCalculatorTest < ActiveSupport::TestCase
   end
 
   setup do
-    calendars_has_no_bank_holidays(in_division: "england-and-wales")
+    stub_calendars_has_no_bank_holidays(in_division: "england-and-wales")
   end
 
   test ".after returns the correct weekday" do
@@ -59,25 +59,25 @@ class WorkingDaysCalculatorTest < ActiveSupport::TestCase
   end
 
   test ".after returns the Tuesday if the next day is a holiday Monday" do
-    calendars_has_a_bank_holiday_on(Date.parse("2017-05-01"), in_division: "england-and-wales")
+    stub_calendars_has_a_bank_holiday_on(Date.parse("2017-05-01"), in_division: "england-and-wales")
     calculator = WorkingDaysCalculator.new(Date.parse("2017-04-21"))
     assert_equal Date.parse("2017-05-2"), calculator.after(6)
   end
 
   test ".after returns the Monday if the next day is a holiday Friday" do
-    calendars_has_a_bank_holiday_on(Date.parse("2016-01-01"), in_division: "england-and-wales")
+    stub_calendars_has_a_bank_holiday_on(Date.parse("2016-01-01"), in_division: "england-and-wales")
     calculator = WorkingDaysCalculator.new(Date.parse("2015-12-31"))
     assert_equal Date.parse("2016-01-4"), calculator.after(1)
   end
 
   test ".after returns the Tuesday if the next day is a holiday on both Friday and Monday" do
-    calendars_has_bank_holidays_on([Date.parse("2017-04-14"), Date.parse("2017-04-17")], in_division: "england-and-wales")
+    stub_calendars_has_bank_holidays_on([Date.parse("2017-04-14"), Date.parse("2017-04-17")], in_division: "england-and-wales")
     calculator = WorkingDaysCalculator.new(Date.parse("2017-04-13"))
     assert_equal Date.parse("2017-04-18"), calculator.after(1)
   end
 
   test ".after accounts for holidays crossed even if they're not the 'next day'" do
-    calendars_has_a_bank_holiday_on(Date.parse("2014-01-01"), in_division: "england-and-wales")
+    stub_calendars_has_a_bank_holiday_on(Date.parse("2014-01-01"), in_division: "england-and-wales")
     calculator = WorkingDaysCalculator.new(Date.parse("2013-12-31"))
     assert_equal Date.parse("2014-01-03"), calculator.after(2)
   end

--- a/test/unit/organisation_content_presenter_test.rb
+++ b/test/unit/organisation_content_presenter_test.rb
@@ -33,7 +33,7 @@ class OrganisationContentPresenterTest < ActiveSupport::TestCase
                                  kind: "answer")
 
     @response["content_id"] = document.content_id
-    publishing_api_has_expanded_links(@response)
+    stub_publishing_api_has_expanded_links(@response)
 
     FactoryBot.create(:edition,
                       panopticon_id: document.id)

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -44,14 +44,14 @@ class ServiceSignInTest < ActiveSupport::TestCase
   context "#content_id" do
     should "create a new content id if we are creating a new content item" do
       SecureRandom.stub :uuid, "random-uuid-string" do
-        publishing_api_has_lookups(base_path => nil)
+        stub_publishing_api_has_lookups(base_path => nil)
         assert_equal "random-uuid-string", subject.content_id
       end
     end
 
     should "use existing content_id if content_item already exists in content-store" do
       content_id = "random-content-id"
-      publishing_api_has_lookups(base_path => content_id)
+      stub_publishing_api_has_lookups(base_path => content_id)
 
       assert_equal content_id, subject.content_id
     end

--- a/test/unit/services/link_check_report_creator_test.rb
+++ b/test/unit/services/link_check_report_creator_test.rb
@@ -10,7 +10,7 @@ class LinkCheckReportCreatorTest < ActiveSupport::TestCase
   end
 
   setup do
-    @stubbed_api_request = link_checker_api_create_batch(
+    @stubbed_api_request = stub_link_checker_api_create_batch(
       uris: ["https://www.gov.uk"],
       id: "a-batch-id",
       webhook_uri: link_checker_api_callback_url(host: Plek.find("publisher")),


### PR DESCRIPTION
Fixing many warnings about deprecated methods including:
- link_checker_api_create_batch
- calendars_has_a_bank_holiday_on
- calendars_has_no_bank_holidays
- publishing_api_has_lookups
- publishing_api_has_linkables
- content_store_has_item
- content_store_does_not_have_item