### PR TITLE
[DO NOT MERGE] Disable publisher cron jobs for migration

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -4,10 +4,10 @@ schedule_task_prefix = ENV.fetch("SCHEDULE_TASK_PREFIX", "/usr/local/bin/govuk_s
 job_type :rake, "cd :path && #{schedule_task_prefix} bundle exec rake :task :output"
 job_type :run_script, "cd :path && RAILS_ENV=:environment #{schedule_task_prefix} script/:task :output"
 
-every 5.minutes do
-  run_script "mail_fetcher"
-end
-
-every 1.hour do
-  rake "reports:generate"
-end
+# every 5.minutes do
+#   run_script "mail_fetcher"
+# end
+#
+# every 1.hour do
+#   rake "reports:generate"
+# end


### PR DESCRIPTION
* Disables cron jobs which trigger the `mail_fetcher` script and `reports:generate` rake task.

* These changes will automatically update the `deploy` user crontab when the application is deployed using Jenkins.

* `mail_fetcher` runs every five minutes and updates editions in review with responses from fact checkers across government.

* `reports:generate` rake task runs hourly and generates a mainstream report (see here:  https://publisher.publishing.service.gov.uk/reports).

* Note: these cron jobs are configured using the `whenever` gem and **not** Puppet.