### PR TITLE
Add MultiNoisyWorkflow to loop over addresses and instantiate NoisyWorkflows for each

### DIFF
--- a/app/mailers/multi_noisy_workflow.rb
+++ b/app/mailers/multi_noisy_workflow.rb
@@ -1,0 +1,34 @@
+class MultiNoisyWorkflow < ApplicationMailer
+  def self.make_noise(action, mailer: NoisyWorkflow)
+    recipient_emails = (EMAIL_GROUPS[:citizen] + EMAIL_GROUPS[:business]).uniq
+
+    recipient_emails.map do |recipient_email|
+      mailer.make_noise(action, recipient_email)
+    end
+  end
+
+  def self.skip_review(action, mailer: NoisyWorkflow)
+    recipient_emails = EMAIL_GROUPS[:force_publish_alerts]
+
+    recipient_emails.map do |recipient_email|
+      mailer.skip_review(action, recipient_email)
+    end
+  end
+
+  def self.request_fact_check(action, mailer: NoisyWorkflow)
+    action.email_addresses.split(/,\s*/).map do |recipient_email|
+      mailer.request_fact_check(action, recipient_email)
+    end
+  end
+
+  def self.resend_fact_check(action)
+    edition = action.edition
+    latest_status_action = edition.latest_status_action
+    if latest_status_action.is_fact_check_request? && action.request_type == Action::RESEND_FACT_CHECK
+      self.request_fact_check(latest_status_action)
+    else
+      Rails.logger.info("Asked to resend fact check for #{edition.content_id}, but its most recent status action is not a fact check, it's a #{latest_status_action.request_type}")
+      NoisyWorkflow::NoMail.new
+    end
+  end
+end

--- a/lib/govuk_content_models/action_processors/base_processor.rb
+++ b/lib/govuk_content_models/action_processors/base_processor.rb
@@ -58,10 +58,10 @@ module GovukContentModels
     private
 
       def make_record_action_noises(new_action, action_name)
-        NoisyWorkflow.make_noise(new_action).deliver_now
-        NoisyWorkflow.request_fact_check(new_action).deliver_now if action_name.to_s == "send_fact_check"
-        NoisyWorkflow.resend_fact_check(new_action).deliver_now if action_name.to_s == "resend_fact_check"
-        NoisyWorkflow.skip_review(new_action).deliver_now if action_name.to_s == "skip_review"
+        MultiNoisyWorkflow.make_noise(new_action).map(&:deliver_now)
+        MultiNoisyWorkflow.request_fact_check(new_action).map(&:deliver_now) if action_name.to_s == "send_fact_check"
+        MultiNoisyWorkflow.resend_fact_check(new_action).map(&:deliver_now) if action_name.to_s == "resend_fact_check"
+        MultiNoisyWorkflow.skip_review(new_action).map(&:deliver_now) if action_name.to_s == "skip_review"
       end
     end
   end

--- a/test/functional/multi_noisy_workflow_test.rb
+++ b/test/functional/multi_noisy_workflow_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+
+class MultiNoisyWorkflowTest < ActionMailer::TestCase
+  tests MultiNoisyWorkflow
+
+  def fact_check_email
+    guide = FactoryBot.create(:guide_edition)
+    action = guide.actions.create!(email_addresses: "jys@ketlai.co.uk", customised_message: "Blah")
+    email = MultiNoisyWorkflow.request_fact_check(action)
+    [guide, email]
+  end
+
+  def action_email(action)
+    guide = FactoryBot.create(:guide_edition, title: "Test Guide 2")
+    requester = User.new(name: "Testing Person")
+    action = guide.actions.create(request_type: action, requester: requester)
+    MultiNoisyWorkflow.make_noise(action)
+  end
+
+  context ".resend_fact_check" do
+    setup do
+      @user = User.create(uid: "123", name: "Ben")
+      @other_user = User.create(uid: "321", name: "James")
+
+      @edition = @user.create_edition(:guide, panopticon_id: FactoryBot.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
+      request_review(@user, @edition)
+      approve_review(@other_user, @edition)
+    end
+
+    should "resend the fact check email for an edition in fact check state" do
+      send_fact_check(@user, @edition)
+      stubbed_fact_check_mail = stub("mailer", deliver_now: true)
+      MultiNoisyWorkflow.expects(:request_fact_check).returns(stubbed_fact_check_mail)
+      resend_fact_check_action = @edition.new_action(@user, "resend_fact_check")
+
+      mail = MultiNoisyWorkflow.resend_fact_check(resend_fact_check_action)
+      assert_equal stubbed_fact_check_mail, mail
+    end
+
+    should "return a NoMail instance if the edition is not in fact check state" do
+      MultiNoisyWorkflow.expects(:request_fact_check).never
+      resend_fact_check_action = @edition.new_action(@user, "resend_fact_check")
+
+      mail = MultiNoisyWorkflow.resend_fact_check(resend_fact_check_action)
+      assert mail.is_a? NoisyWorkflow::NoMail
+    end
+
+    should "return a NoMail instance if the supplied action is not a resend fact check one" do
+      MultiNoisyWorkflow.expects(:request_fact_check).never
+
+      mail = MultiNoisyWorkflow.resend_fact_check(@edition.latest_status_action)
+      assert mail.is_a? NoisyWorkflow::NoMail
+    end
+  end
+
+  context "make_noise" do
+    context "Setting the recipients" do
+      should "send to 'publisher-alerts-citizen'" do
+        email = action_email(Action::PUBLISH)
+        assert email.map(&:to).flatten.include?("publisher-alerts-citizen@digital.cabinet-office.gov.uk")
+        email = action_email(Action::REQUEST_REVIEW)
+        assert email.map(&:to).flatten.include?("publisher-alerts-citizen@digital.cabinet-office.gov.uk")
+      end
+    end
+  end
+end

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -104,11 +104,14 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     guide.reload
     assert guide.fact_check?
 
-    fact_check_email = ActionMailer::Base.deliveries.select { |mail| mail.to.include? "user1@example.com" }.last
-    assert fact_check_email
-    assert_includes fact_check_email.to, "user2@example.com"
-    assert_equal "‘[#{guide.title}]’ GOV.UK preview of new edition", fact_check_email.subject
-    assert_equal "Blah", fact_check_email.body.to_s
+    fact_check_email1 = ActionMailer::Base.deliveries.select { |mail| mail.to.include? "user1@example.com" }.last
+    assert fact_check_email1
+    fact_check_email2 = ActionMailer::Base.deliveries.select { |mail| mail.to.include? "user2@example.com" }.last
+    assert fact_check_email2
+    assert_equal "‘[#{guide.title}]’ GOV.UK preview of new edition", fact_check_email1.subject
+    assert_equal "‘[#{guide.title}]’ GOV.UK preview of new edition", fact_check_email2.subject
+    assert_equal "Blah", fact_check_email1.body.to_s
+    assert_equal "Blah", fact_check_email2.body.to_s
   end
 
   test "the fact-check form validates emails and won't send if they are mangled" do

--- a/test/integration/local_transaction_create_edit_test.rb
+++ b/test/integration/local_transaction_create_edit_test.rb
@@ -29,7 +29,7 @@ class LocalTransactionCreateEditTest < JavascriptIntegrationTest
     click_button "Create Local transaction"
     assert page.has_content?(/Foo bar\W#1/)
 
-    assert_equal email_count_before_start + 1, ActionMailer::Base.deliveries.count
+    assert_operator email_count_before_start + 1, :<=, ActionMailer::Base.deliveries.count
     assert_match(
       /Created Local transaction: "Foo bar"/,
       ActionMailer::Base.deliveries.last.subject,


### PR DESCRIPTION
Method based on https://github.com/alphagov/short-url-manager/pull/451

WIP: I still need to add new tests including some to replace those made obsolete by this change.

https://trello.com/c/QYkWTpbv/1889-publisher-send-one-email-per-recipient