### PR TITLE
Add support for alpha phase

### DIFF
--- a/app/assets/stylesheets/colors.scss
+++ b/app/assets/stylesheets/colors.scss
@@ -1,1 +1,1 @@
-$beta-color: #f47738; // orange
+$govuk-brand-colour: #1d70b8; // GOV.UK blue

--- a/app/assets/stylesheets/sortable_table.scss
+++ b/app/assets/stylesheets/sortable_table.scss
@@ -6,14 +6,14 @@
   line-height: 1.3;
   font-size: 16px;
 
-  .badge-beta {
+  .badge-phase {
     position: relative;
     top: -2px;
   }
 }
 
-.badge-beta {
-  background-color: $beta-color;
+.badge-phase {
+  background-color: $govuk-brand-colour;
 }
 
 .publication-table-date {

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -317,8 +317,8 @@ protected
        change_note
        major_change
        title
-       in_beta
        overview
+       phase
      ]
   end
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -17,7 +17,8 @@ class Edition
   field :sibling_in_progress,  type: Integer,  default: nil
 
   field :title,                type: String
-  field :in_beta,              type: Boolean,  default: false
+  field :in_beta,              type: Boolean, default: false
+  field :phase,                type: String, default: "live"
   field :created_at,           type: DateTime, default: lambda { Time.zone.now }
   field :publish_at,           type: DateTime
   field :overview,             type: String
@@ -133,6 +134,10 @@ class Edition
 
   def self.convertible_formats
     Artefact::FORMATS_BY_DEFAULT_OWNING_APP["publisher"] - %w[local_transaction] - Artefact::RETIRED_FORMATS
+  end
+
+  def phase_names
+    %w[live alpha beta].freeze
   end
 
   def series
@@ -458,6 +463,18 @@ class Edition
 
   def latest_link_check_report
     link_check_reports.last
+  end
+
+  def live?
+    phase == "live"
+  end
+
+  def in_alpha?
+    phase == "alpha"
+  end
+
+  def in_beta?
+    in_beta || phase == "beta"
   end
 
 private

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -474,7 +474,7 @@ class Edition
   end
 
   def in_beta?
-    in_beta || phase == "beta"
+    phase == "beta"
   end
 
 private
@@ -482,7 +482,7 @@ private
   def base_field_keys
     %i[
       title
-      in_beta
+      phase
       panopticon_id
       overview
       slug

--- a/app/presenters/formats/edition_format_presenter.rb
+++ b/app/presenters/formats/edition_format_presenter.rb
@@ -14,17 +14,10 @@ module Formats
     attr_reader :edition, :artefact
 
     def optional_fields
-      fields = {}
-
-      if edition.auth_bypass_id
-        fields[:access_limited] = { auth_bypass_ids: [edition.auth_bypass_id] }
-      end
-
-      if edition.in_beta
-        fields[:phase] = "beta"
-      end
-
-      fields
+      {
+        access_limited: access_limited,
+        phase: phase,
+      }.compact
     end
 
     def required_fields(republish)
@@ -43,6 +36,7 @@ module Formats
         change_note: edition.latest_change_note,
         details: details,
         locale: artefact.language,
+        phase: edition.phase,
       }
     end
 
@@ -56,6 +50,14 @@ module Formats
 
     def details
       {}
+    end
+
+    def phase
+      edition.phase if !edition.live?
+    end
+
+    def access_limited
+      { auth_bypass_ids: [edition.auth_bypass_id] } if edition.auth_bypass_id
     end
 
     def rendering_app

--- a/app/views/root/_publication.html.erb
+++ b/app/views/root/_publication.html.erb
@@ -6,7 +6,7 @@
     <h4 class="publication-table-title">
       <%= link_to publication.admin_list_title, edition_path(publication) %>
       <% if !publication.live? %>
-        <span class="badge badge-beta"><%= publication.phase %></span>
+        <span class="badge badge-phase"><%= publication.phase %></span>
       <% end %>
     </h4>
 

--- a/app/views/root/_publication.html.erb
+++ b/app/views/root/_publication.html.erb
@@ -5,8 +5,8 @@
   <td class="title">
     <h4 class="publication-table-title">
       <%= link_to publication.admin_list_title, edition_path(publication) %>
-      <% if publication.in_beta? %>
-        <span class="badge badge-beta">beta</span>
+      <% if !publication.live? %>
+        <span class="badge badge-beta"><%= publication.phase %></span>
       <% end %>
     </h4>
 

--- a/app/views/shared/_common_edition_attributes.html.erb
+++ b/app/views/shared/_common_edition_attributes.html.erb
@@ -1,22 +1,27 @@
 <%= hidden_field_tag "return_to", params[:return_to] if params[:return_to] %>
+
 <div class="form-group">
   <label for="edition_assigned_to_id">Assigned to</label>
   <%= f.select :assigned_to_id, enabled_users_select_options, {}, {:class => 'form-control input-md-3', :disabled => @resource.locked_for_edits?, "data-module" => 'assignee-select'} %>
 </div>
+
 <%= render partial: 'reviewer_field', locals: { f: f } if @resource.in_review? %>
 <%= render partial: 'major_change_fields', locals: { f: f } if @resource.published_edition %>
 
 <%= f.input :title,
-      :input_html => { :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>
+  :input_html => { :disabled => @resource.locked_for_edits?, :class => 'input-md-7' } %>
 
-<%= f.input :in_beta,
-      as: :boolean,
-      label: 'Content is in beta',
-      input_html: { disabled: @resource.locked_for_edits? },
-      wrapper_html: { class: "emphasised-field form-group add-bottom-margin input-md-7" } %>
+<div class="form-group">
+  <%= f.label :phase, "Content phase" %>
+  <%= f.select :phase, @resource.phase_names, {},
+    :class => "form-control input-md-3",
+    :disabled => @resource.locked_for_edits? %>
+</div>
 
-<%= f.input :overview,
-      :as => :text,
-      :label => 'Meta tag description',
-      :hint => 'Some search engines will display this if they cannot find what they need in the main text',
-      :input_html => { :rows => 4, :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>
+<div class="form-group">
+  <%= f.input :overview,
+    :as => :text,
+    :label => 'Meta tag description',
+    :hint => 'Some search engines will display this if they cannot find what they need in the main text',
+    :input_html => { :rows => 4, :disabled => @resource.locked_for_edits?, class: 'input-md-7' } %>
+</div>

--- a/db/migrate/20200427085013_update_beta_boolean_to_phase_string.rb
+++ b/db/migrate/20200427085013_update_beta_boolean_to_phase_string.rb
@@ -1,0 +1,9 @@
+class UpdateBetaBooleanToPhaseString < Mongoid::Migration
+  def self.up
+    Edition.where(in_beta: true).update_all(phase: "beta")
+  end
+
+  def self.down
+    Edition.where(phase: "beta").update_all(in_beta: true)
+  end
+end

--- a/test/integration/mark_edition_in_beta_test.rb
+++ b/test/integration/mark_edition_in_beta_test.rb
@@ -8,34 +8,45 @@ class MarkEditionInBetaTest < JavascriptIntegrationTest
   end
 
   with_and_without_javascript do
+    should "allow marking an edition as in alpha" do
+      edition = FactoryBot.create(:edition)
+      visit_edition edition
+
+      select("alpha")
+
+      save_edition_and_assert_success
+
+      visit "/?user_filter=all"
+
+      assert page.has_text?("alpha")
+    end
+
     should "allow marking an edition as in beta" do
       edition = FactoryBot.create(:edition)
       visit_edition edition
 
-      assert_not find("#edition_in_beta").checked?
-      check "Content is in beta"
+      select("beta")
 
       save_edition_and_assert_success
 
-      assert find("#edition_in_beta").checked?
-
       visit "/?user_filter=all"
-      assert page.has_text?("#{edition.title} beta")
+
+      assert page.has_text?("beta")
     end
 
-    should "allow marking an edition as not in beta" do
-      edition = FactoryBot.create(:edition, in_beta: true)
+    should "allow marking an edition as live" do
+      edition = FactoryBot.create(:edition, phase: "beta")
       visit_edition edition
 
-      assert find("#edition_in_beta").checked?
-      uncheck "Content is in beta"
+      select("live")
 
       save_edition_and_assert_success
 
-      assert_not find("#edition_in_beta").checked?
-
       visit "/?user_filter=all"
-      assert page.has_no_text?("#{edition.title} beta")
+
+      assert page.has_text?(edition.title)
+      assert page.has_no_text?("alpha")
+      assert page.has_no_text?("beta")
     end
   end
 end

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -159,10 +159,10 @@ class EditionTest < ActiveSupport::TestCase
                                 panopticon_id: @artefact.id,
                                 version_number: 1,
                                 overview: "I am a test overview",
-                                in_beta: true)
+                                phase: "phase name")
     clone_edition = edition.build_clone
     assert_equal "I am a test overview", clone_edition.overview
-    assert_equal true, clone_edition.in_beta
+    assert_equal "phase name", clone_edition.phase
     assert_equal 2, clone_edition.version_number
   end
 

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -45,12 +45,16 @@ class EditionTest < ActiveSupport::TestCase
     assert a.errors[:title].any?
   end
 
-  test "it is not in beta by default" do
-    assert_not FactoryBot.build(:guide_edition).in_beta?
+  test "it is live by default" do
+    assert FactoryBot.build(:guide_edition).live?
+  end
+
+  test "it can be in alpha" do
+    assert FactoryBot.build(:guide_edition, phase: "alpha").in_alpha?
   end
 
   test "it can be in beta" do
-    assert FactoryBot.build(:guide_edition, in_beta: true).in_beta?
+    assert FactoryBot.build(:guide_edition, phase: "beta").in_beta?
   end
 
   test "it should give a friendly (legacy supporting) description of its format" do

--- a/test/unit/presenters/formats/edition_format_presenter_test.rb
+++ b/test/unit/presenters/formats/edition_format_presenter_test.rb
@@ -6,7 +6,7 @@ class EditionFormatPresenterTest < ActiveSupport::TestCase
   end
 
   def edition
-    @edition ||= stub(artefact: artefact, in_beta: false)
+    @edition ||= stub(artefact: artefact)
   end
 
   def artefact
@@ -29,6 +29,8 @@ class EditionFormatPresenterTest < ActiveSupport::TestCase
       edition.stubs :latest_change_note
       edition.stubs :auth_bypass_id
       edition.stubs :exact_route?
+      edition.stubs :live?
+      edition.stubs :phase
 
       artefact.stubs :language
     end
@@ -62,17 +64,18 @@ class EditionFormatPresenterTest < ActiveSupport::TestCase
       assert_equal "override me", result[:document_type]
     end
 
-    context "when in beta" do
-      should "include phase" do
-        edition.expects(:in_beta).returns(true)
-        assert_equal "beta", result[:phase]
+    context "when not live" do
+      should "include phase name" do
+        edition.expects(:live?).returns(false)
+        edition.expects(:phase).returns("phase name")
+        assert_equal "phase name", result[:phase]
       end
     end
 
-    context "when not in beta" do
-      should "not include phase" do
-        edition.expects(:in_beta).returns(false)
-        assert_not_includes result.keys, :phase
+    context "when live" do
+      should "not include phase name" do
+        edition.expects(:live?).returns(true)
+        assert_equal nil, result[:phase]
       end
     end
 

--- a/test/unit/presenters/formats/generic_edition_presenter_test.rb
+++ b/test/unit/presenters/formats/generic_edition_presenter_test.rb
@@ -44,6 +44,7 @@ class GenericEditionPresenterTest < ActiveSupport::TestCase
           external_related_links: expected_external_related_links,
         },
         locale: "en",
+        phase: "live",
         access_limited: {
           auth_bypass_ids: [@edition.auth_bypass_id],
         },


### PR DESCRIPTION
<img width="697" alt="Screenshot 2020-05-01 at 15 15 31" src="https://user-images.githubusercontent.com/3141541/80811838-b1210600-8bbe-11ea-9a30-cd9ad64fbb19.png">

<img width="727" alt="Screenshot 2020-05-01 at 15 16 36" src="https://user-images.githubusercontent.com/3141541/80811877-c4cc6c80-8bbe-11ea-9bae-0ade913ab296.png">

https://trello.com/c/ZITqImYk/109-change-publisher-app-to-allow-publisher-to-show-which-phase-the-product-is-in