### PR TITLE
Use correct parameter name for reply-to address

### DIFF
--- a/app/mailers/noisy_workflow.rb
+++ b/app/mailers/noisy_workflow.rb
@@ -31,8 +31,7 @@ class NoisyWorkflow < ApplicationMailer
     view_mail(
       template_id,
       to: recipient_email,
-      reply_to: fact_check_address,
-      from: "GOV.UK Editorial Team <#{fact_check_address}>",
+      reply_to_id: fact_check_address,
       subject: "‘[#{@edition.title}]’ GOV.UK preview of new edition",
     )
   end

--- a/test/functional/noisy_workflow_test.rb
+++ b/test/functional/noisy_workflow_test.rb
@@ -71,12 +71,7 @@ class NoisyWorkflowTest < ActionMailer::TestCase
 
   test "fact checking emails should set appropriate reply-to address" do
     guide, email = fact_check_email
-    assert_equal ["factcheck+dev-#{guide.id}@alphagov.co.uk"], email.reply_to
-  end
-
-  test "fact checking emails should go from appropriate email addresses" do
-    guide, email = fact_check_email
-    assert_equal ["factcheck+dev-#{guide.id}@alphagov.co.uk"], email.from
+    assert_equal "factcheck+dev-#{guide.id}@alphagov.co.uk", email["reply_to_id"].value
   end
 
   context ".skip_review" do


### PR DESCRIPTION
Notify doesn't allow setting the from address, and the Notify gem uses a different parameter name for setting the reply-to address, so both of these were being lost when we migrated. Removed the superfluous `from` and renamed `reply_to` to `reply_to_id`.

https://trello.com/c/MR3jrlX2/1878-5-publisher-replace-ses-in-email-receipt-workflow-%F0%9F%8D%90