### PR TITLE
Revert to send emails using SES

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem "inherited_resources"
 gem "jquery-ui-rails", "~> 6.0"
 gem "kaminari", "~> 1.2"
 gem "kaminari-mongoid", "1.0.1"
-gem "mail-notify"
 gem "mlanett-redis-lock", "0.2.7" # Only used in some importers
 gem "momentjs-rails", "2.20.1"
 gem "mongo", "2.4.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,9 +242,6 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    mail-notify (1.0.2)
-      actionmailer (>= 5.2.4.2, < 6.1)
-      notifications-ruby-client (~> 5.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     metaclass (0.0.4)
@@ -284,8 +281,6 @@ GEM
       mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.2)
       nokogiri (~> 1.8, >= 1.8.4)
-    notifications-ruby-client (5.1.2)
-      jwt (>= 1.5, < 3)
     null_logger (0.0.1)
     oauth2 (1.4.4)
       faraday (>= 0.8, < 2.0)
@@ -539,7 +534,6 @@ DEPENDENCIES
   jquery-ui-rails (~> 6.0)
   kaminari (~> 1.2)
   kaminari-mongoid (= 1.0.1)
-  mail-notify
   minitest-reporters
   mlanett-redis-lock (= 0.2.7)
   mocha (= 1.9.0)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,2 @@
-class ApplicationMailer < Mail::Notify::Mailer
-  def template_id
-    @template_id ||= ENV.fetch("GOVUK_NOTIFY_TEMPLATE_ID", "fake-test-template-id")
-  end
+class ApplicationMailer < ActionMailer::Base
 end

--- a/app/mailers/noisy_workflow.rb
+++ b/app/mailers/noisy_workflow.rb
@@ -31,7 +31,8 @@ class NoisyWorkflow < ApplicationMailer
     view_mail(
       template_id,
       to: recipient_email,
-      reply_to_id: fact_check_address,
+      reply_to: fact_check_address,
+      from: "GOV.UK Editorial Team <#{fact_check_address}>",
       subject: "‘[#{@edition.title}]’ GOV.UK preview of new edition",
     )
   end

--- a/app/mailers/noisy_workflow.rb
+++ b/app/mailers/noisy_workflow.rb
@@ -2,23 +2,19 @@
 
 class NoisyWorkflow < ApplicationMailer
   include PathsHelper
-
-  add_template_helper(PathsHelper)
-  add_template_helper(WorkingDaysHelper)
   default from: "Winston (GOV.UK Publisher) <winston@alphagov.co.uk>"
 
   def make_noise(action, recipient_email)
     @action = action
     @preview_url = preview_edition_path(@action.edition)
     subject = "[PUBLISHER] #{describe_action(@action)}"
-    view_mail(template_id, to: recipient_email, subject: subject)
+    mail(to: recipient_email, subject: subject)
   end
 
   def skip_review(action, recipient_email)
     @edition = action.edition
     @edition_url = edition_url(@edition.id, host: Plek.find("publisher"), external: true)
-    view_mail(
-      template_id,
+    mail(
       to: recipient_email,
       subject: "[PUBLISHER] Review has been skipped on #{@edition.title}",
     )
@@ -27,14 +23,14 @@ class NoisyWorkflow < ApplicationMailer
   def request_fact_check(action, recipient_email)
     @edition = action.edition
     fact_check_address = @edition.fact_check_email_address
-    @customised_message = action.customised_message
-    view_mail(
-      template_id,
+    mail(
       to: recipient_email,
       reply_to: fact_check_address,
       from: "GOV.UK Editorial Team <#{fact_check_address}>",
       subject: "‘[#{@edition.title}]’ GOV.UK preview of new edition",
-    )
+    ) do |format|
+      format.text { render plain: action.customised_message }
+    end
   end
 
   class NoMail

--- a/app/views/noisy_workflow/request_fact_check.text.erb
+++ b/app/views/noisy_workflow/request_fact_check.text.erb
@@ -1,6 +1,3 @@
-<%- if @customised_message -%>
-<%= @customised_message -%>
-<%- else -%>
 Hi,
 
 We need you to check the factual accuracy of changes made to ‘<%= @edition.title%>’ before it’s published on GOV.UK.
@@ -49,4 +46,4 @@ Ask your GOV.UK lead if:
 
 Thank you.
 
-<% end %>
+

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,11 +32,6 @@ module Publisher
     # Custom directories with classes and modules you want to be autoloadable.
     config.eager_load_paths += %W(#{config.root}/lib #{config.root}/app/presenters #{config.root}/app/decorators)
 
-
-    config.action_mailer.notify_settings = {
-      api_key: Rails.application.secrets.notify_api_key || "fake-test-api-key",
-    }
-
     config.generators do |g|
       g.orm :mongoid
       g.template_engine :erb # this could be :haml or whatever

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,7 +75,6 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
 
   config.action_mailer.default_url_options = { host: "www.gov.uk" }
-  config.action_mailer.delivery_method = :notify
 
   # Generate digests for assets URLs.
   config.assets.digest = true

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -23,4 +23,3 @@ test:
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   link_checker_api_secret_token: <%= ENV["LINK_CHECKER_API_SECRET_TOKEN"] %>
-  notify_api_key: <%= ENV["GOVUK_NOTIFY_API_KEY"] %>

--- a/test/functional/multi_noisy_workflow_test.rb
+++ b/test/functional/multi_noisy_workflow_test.rb
@@ -28,8 +28,6 @@ class MultiNoisyWorkflowTest < ActionMailer::TestCase
     end
 
     should "resend the fact check email for an edition in fact check state" do
-      stub_calendars_has_no_bank_holidays(in_division: "england-and-wales")
-
       send_fact_check(@user, @edition)
       stubbed_fact_check_mail = stub("mailer", deliver_now: true)
       MultiNoisyWorkflow.expects(:request_fact_check).returns(stubbed_fact_check_mail)

--- a/test/functional/noisy_workflow_test.rb
+++ b/test/functional/noisy_workflow_test.rb
@@ -3,10 +3,6 @@ require "test_helper"
 class NoisyWorkflowTest < ActionMailer::TestCase
   tests NoisyWorkflow
 
-  setup do
-    stub_calendars_has_no_bank_holidays(in_division: "england-and-wales")
-  end
-
   def fact_check_email
     guide = FactoryBot.create(:guide_edition)
     action = guide.actions.create!(email_addresses: "jys@ketlai.co.uk", customised_message: "Blah")

--- a/test/functional/noisy_workflow_test.rb
+++ b/test/functional/noisy_workflow_test.rb
@@ -71,7 +71,12 @@ class NoisyWorkflowTest < ActionMailer::TestCase
 
   test "fact checking emails should set appropriate reply-to address" do
     guide, email = fact_check_email
-    assert_equal "factcheck+dev-#{guide.id}@alphagov.co.uk", email["reply_to_id"].value
+    assert_equal ["factcheck+dev-#{guide.id}@alphagov.co.uk"], email.reply_to
+  end
+
+  test "fact checking emails should go from appropriate email addresses" do
+    guide, email = fact_check_email
+    assert_equal ["factcheck+dev-#{guide.id}@alphagov.co.uk"], email.from
   end
 
   context ".skip_review" do

--- a/test/unit/edition_clone_test.rb
+++ b/test/unit/edition_clone_test.rb
@@ -6,7 +6,6 @@ class EditionCloneTest < ActiveSupport::TestCase
     @other_user = User.create uid: "321", name: "Furious Five"
 
     @artefact = FactoryBot.create(:artefact, name: "Childcare", slug: "childcare")
-    stub_calendars_has_no_bank_holidays(in_division: "england-and-wales")
   end
 
   def fact_check_and_publish(edition = nil)

--- a/test/unit/guide_edition_test.rb
+++ b/test/unit/guide_edition_test.rb
@@ -3,7 +3,6 @@ require "test_helper"
 class GuideEditionTest < ActiveSupport::TestCase
   setup do
     @artefact = FactoryBot.create(:artefact, name: "Childcare", slug: "childcare")
-    stub_calendars_has_no_bank_holidays(in_division: "england-and-wales")
   end
 
   def template_guide


### PR DESCRIPTION
We've spotted a problem where the reply-to address sent via Notify isn't working correctly, so we have to revert this for now until we decide how best to proceed.