### PR TITLE
Look for ID in subject field of fact check replies

### DIFF
--- a/app/mailers/noisy_workflow.rb
+++ b/app/mailers/noisy_workflow.rb
@@ -27,7 +27,7 @@ class NoisyWorkflow < ApplicationMailer
       to: recipient_email,
       reply_to: fact_check_address,
       from: "GOV.UK Editorial Team <#{fact_check_address}>",
-      subject: "‘[#{@edition.title}]’ GOV.UK preview of new edition [#{@edition.id}]",
+      subject: "‘[#{@edition.title}]’ GOV.UK preview of new edition [#{Rails.env}-#{@edition.id}]",
     ) do |format|
       format.text { render plain: action.customised_message }
     end

--- a/app/mailers/noisy_workflow.rb
+++ b/app/mailers/noisy_workflow.rb
@@ -27,7 +27,7 @@ class NoisyWorkflow < ApplicationMailer
       to: recipient_email,
       reply_to: fact_check_address,
       from: "GOV.UK Editorial Team <#{fact_check_address}>",
-      subject: "‘[#{@edition.title}]’ GOV.UK preview of new edition",
+      subject: "‘[#{@edition.title}]’ GOV.UK preview of new edition [#{@edition.id}]",
     ) do |format|
       format.text { render plain: action.customised_message }
     end

--- a/config/fact_check.yml
+++ b/config/fact_check.yml
@@ -4,7 +4,7 @@
 # If we ever want to change this format, we'll need to support some notion of
 # legacy formats, so we still pick up emails to old addresses
 address_format: <%=ENV.fetch("FACT_CHECK_ADDRESS_FORMAT", "factcheck+dev-{id}@alphagov.co.uk") %>
-subject_format: <%=ENV.fetch("FACT_CHECK_SUBJECT_FORMAT", "Fact Checked [dev-{id}]") %>
+subject_format: <%=ENV.fetch("FACT_CHECK_SUBJECT_FORMAT", "\\[.+?\\] GOV.UK preview of new edition \\[dev-(?<id>.+?)\\]") %>
 
 fetcher:
   address: <%=ENV.fetch("FACT_CHECK_ADDRESS", "imap.gmail.com") %>

--- a/config/fact_check.yml
+++ b/config/fact_check.yml
@@ -4,6 +4,7 @@
 # If we ever want to change this format, we'll need to support some notion of
 # legacy formats, so we still pick up emails to old addresses
 address_format: <%=ENV.fetch("FACT_CHECK_ADDRESS_FORMAT", "factcheck+dev-{id}@alphagov.co.uk") %>
+subject_format: <%=ENV.fetch("FACT_CHECK_SUBJECT_FORMAT", "Fact Checked [dev-{id}]") %>
 
 fetcher:
   address: <%=ENV.fetch("FACT_CHECK_ADDRESS", "imap.gmail.com") %>

--- a/config/fact_check.yml
+++ b/config/fact_check.yml
@@ -4,7 +4,7 @@
 # If we ever want to change this format, we'll need to support some notion of
 # legacy formats, so we still pick up emails to old addresses
 address_format: <%=ENV.fetch("FACT_CHECK_ADDRESS_FORMAT", "factcheck+dev-{id}@alphagov.co.uk") %>
-subject_format: <%=ENV.fetch("FACT_CHECK_SUBJECT_FORMAT", "\\[.+?\\] GOV.UK preview of new edition \\[dev-(?<id>.+?)\\]") %>
+subject_format: <%=ENV.fetch("FACT_CHECK_SUBJECT_FORMAT", "‘\\[.+?\\]’ GOV.UK preview of new edition \\[dev-(?<id>.+?)\\]") %>
 
 fetcher:
   address: <%=ENV.fetch("FACT_CHECK_ADDRESS", "imap.gmail.com") %>

--- a/config/initializers/fact_check.rb
+++ b/config/initializers/fact_check.rb
@@ -10,6 +10,7 @@ config = YAML.safe_load(
 
 Publisher::Application.fact_check_config = FactCheckConfig.new(
   config.fetch("address_format"),
+  config.fetch("subject_format"),
 )
 
 fetcher_config = config.fetch("fetcher", {})

--- a/lib/fact_check_config.rb
+++ b/lib/fact_check_config.rb
@@ -4,8 +4,8 @@ class FactCheckConfig
       raise ArgumentError, "Expected '#{address_format}' to contain exactly one '{id}'"
     end
 
-    unless subject_format && subject_format.scan("{id}").count == 1
-      raise ArgumentError, "Expected '#{subject_format}' to contain exactly one '{id}'"
+    unless subject_format && subject_format.scan("?<id>").count == 1
+      raise ArgumentError, "Expected '#{subject_format}' to contain exactly one '?<id>'"
     end
 
     @address_prefix, @address_suffix = address_format.split("{id}")
@@ -17,12 +17,9 @@ class FactCheckConfig
       '\Z',
     )
 
-    @subject_prefix, @subject_suffix = subject_format.split("{id}")
     @subject_pattern = Regexp.new(
-      '\A' +
-      Regexp.escape(@subject_prefix) +
-      "(.+?)" +
-      Regexp.escape(@subject_suffix) +
+      '\A.*' +
+      subject_format +
       '\Z',
     )
   end
@@ -49,13 +46,9 @@ class FactCheckConfig
 
   def item_id_from_subject(subject)
     if (match = @subject_pattern.match(subject))
-      match.captures[0]
+      match[:id]
     else
       raise ArgumentError, "'#{subject}' is not a valid fact check address"
     end
-  end
-
-  def subject(item_id)
-    @subject_prefix + item_id.to_s + @subject_suffix
   end
 end

--- a/lib/fact_check_config.rb
+++ b/lib/fact_check_config.rb
@@ -1,25 +1,38 @@
 class FactCheckConfig
-  def initialize(address_format)
+  def initialize(address_format, subject_format)
     unless address_format && address_format.scan("{id}").count == 1
       raise ArgumentError, "Expected '#{address_format}' to contain exactly one '{id}'"
     end
 
-    @prefix, @suffix = address_format.split("{id}")
-    @pattern = Regexp.new(
+    unless subject_format && subject_format.scan("{id}").count == 1
+      raise ArgumentError, "Expected '#{subject_format}' to contain exactly one '{id}'"
+    end
+
+    @address_prefix, @address_suffix = address_format.split("{id}")
+    @address_pattern = Regexp.new(
       '\A' +
-      Regexp.escape(@prefix) +
+      Regexp.escape(@address_prefix) +
       "(.+?)" +
-      Regexp.escape(@suffix) +
+      Regexp.escape(@address_suffix) +
+      '\Z',
+    )
+
+    @subject_prefix, @subject_suffix = subject_format.split("{id}")
+    @subject_pattern = Regexp.new(
+      '\A' +
+      Regexp.escape(@subject_prefix) +
+      "(.+?)" +
+      Regexp.escape(@subject_suffix) +
       '\Z',
     )
   end
 
   def valid_address?(address)
-    @pattern.match(address).present?
+    @address_pattern.match(address).present?
   end
 
-  def item_id(address)
-    if (match = @pattern.match(address))
+  def item_id_from_address(address)
+    if (match = @address_pattern.match(address))
       match.captures[0]
     else
       raise ArgumentError, "'#{address}' is not a valid fact check address"
@@ -27,6 +40,22 @@ class FactCheckConfig
   end
 
   def address(item_id)
-    @prefix + item_id.to_s + @suffix
+    @address_prefix + item_id.to_s + @address_suffix
+  end
+
+  def valid_subject?(subject)
+    @subject_pattern.match(subject).present?
+  end
+
+  def item_id_from_subject(subject)
+    if (match = @subject_pattern.match(subject))
+      match.captures[0]
+    else
+      raise ArgumentError, "'#{subject}' is not a valid fact check address"
+    end
+  end
+
+  def subject(item_id)
+    @subject_prefix + item_id.to_s + @subject_suffix
   end
 end

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -82,7 +82,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
 
     fact_check_email = ActionMailer::Base.deliveries.select { |mail| mail.to.include? "user@example.com" }.last
     assert fact_check_email
-    assert_equal "‘[#{guide.title}]’ GOV.UK preview of new edition", fact_check_email.subject
+    assert_match(/‘\[#{guide.title}\]’ GOV.UK preview of new edition \[[a-z0-9-]+\]/, fact_check_email.subject)
     assert_equal "Blah", fact_check_email.body.to_s
   end
 
@@ -108,8 +108,8 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     assert fact_check_email1
     fact_check_email2 = ActionMailer::Base.deliveries.select { |mail| mail.to.include? "user2@example.com" }.last
     assert fact_check_email2
-    assert_equal "‘[#{guide.title}]’ GOV.UK preview of new edition", fact_check_email1.subject
-    assert_equal "‘[#{guide.title}]’ GOV.UK preview of new edition", fact_check_email2.subject
+    assert_match(/‘\[#{guide.title}\]’ GOV.UK preview of new edition \[[a-z0-9-]+\]/, fact_check_email1.subject)
+    assert_match(/‘\[#{guide.title}\]’ GOV.UK preview of new edition \[[a-z0-9-]+\]/, fact_check_email2.subject)
     assert_equal "Blah", fact_check_email1.body.to_s
     assert_equal "Blah", fact_check_email2.body.to_s
   end
@@ -204,7 +204,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
 
     resent_fact_check_email = ActionMailer::Base.deliveries.select { |mail| mail.to.include? "user-to-ask-for-fact-check@example.com" }.last
     assert resent_fact_check_email
-    assert_equal "‘[#{guide.title}]’ GOV.UK preview of new edition", resent_fact_check_email.subject
+    assert_match(/‘\[#{guide.title}\]’ GOV.UK preview of new edition \[[a-z0-9-]+\]/, resent_fact_check_email.subject)
     assert_equal "Blah blah fact check message", resent_fact_check_email.body.to_s
   end
 

--- a/test/integration/fact_check_email_test.rb
+++ b/test/integration/fact_check_email_test.rb
@@ -138,6 +138,18 @@ class FactCheckEmailTest < ActionDispatch::IntegrationTest
     assert message_bcc.is_marked_for_delete?
   end
 
+  test "should look for fact-check subject field" do
+    edition = FactoryBot.create(:answer_edition, state: "fact_check")
+    message = fact_check_mail_for(edition, subject: "Fact Checked [dev-#{edition.id}]")
+    pp message
+
+    Mail.stubs(:all).yields(message)
+
+    handler = FactCheckEmailHandler.new(fact_check_config)
+
+    assert handler.process_message(message)
+  end
+
   test "should invoke the supplied block after each message" do
     answer1 = FactoryBot.create(:answer_edition, state: "fact_check")
     answer2 = FactoryBot.create(:answer_edition, state: "in_review",

--- a/test/unit/fact_check_config_test.rb
+++ b/test/unit/fact_check_config_test.rb
@@ -4,67 +4,133 @@ require "fact_check_config"
 class FactCheckConfigTest < ActiveSupport::TestCase
   should "fail on a nil address format" do
     assert_raises ArgumentError do
-      FactCheckConfig.new(nil)
+      FactCheckConfig.new(nil, "valid subject [{id}]")
     end
   end
 
   should "fail on an empty address format" do
     assert_raises ArgumentError do
-      FactCheckConfig.new("")
+      FactCheckConfig.new("", "valid subject [{id}]")
     end
   end
 
   should "fail on an address format with no ID marker" do
     assert_raises ArgumentError do
-      FactCheckConfig.new("factcheck@example.com")
+      FactCheckConfig.new("factcheck@example.com", "valid subject [{id}]")
     end
   end
 
   should "accept an address format with an ID marker" do
-    FactCheckConfig.new("factcheck+{id}@example.com")
+    FactCheckConfig.new("factcheck+{id}@example.com", "valid subject [{id}]")
   end
 
   should "fail on an address format with multiple ID markers" do
     assert_raises ArgumentError do
-      FactCheckConfig.new("factcheck+{id}+{id}@example.com")
+      FactCheckConfig.new("factcheck+{id}+{id}@example.com", "valid subject [{id}]")
     end
   end
 
   should "recognise a valid fact check address" do
-    config = FactCheckConfig.new("factcheck+{id}@example.com")
+    config = FactCheckConfig.new("factcheck+{id}@example.com", "valid subject [{id}]")
     assert config.valid_address?("factcheck+123456@example.com")
   end
 
   should "not recognise an invalid fact check address" do
-    config = FactCheckConfig.new("factcheck+{id}@example.com")
+    config = FactCheckConfig.new("factcheck+{id}@example.com", "valid subject [{id}]")
     assert_not config.valid_address?("not-factcheck@example.com")
   end
 
   should "not recognise a fact check address with an empty ID" do
-    config = FactCheckConfig.new("factcheck+{id}@example.com")
+    config = FactCheckConfig.new("factcheck+{id}@example.com", "valid subject [{id}]")
     assert_not config.valid_address?("factcheck+@example.com")
   end
 
   should "extract an item ID from a valid address" do
-    config = FactCheckConfig.new("factcheck+{id}@example.com")
-    assert_equal "1234", config.item_id("factcheck+1234@example.com")
+    config = FactCheckConfig.new("factcheck+{id}@example.com", "valid subject [{id}]")
+    assert_equal "1234", config.item_id_from_address("factcheck+1234@example.com")
   end
 
   should "raise an exception trying to extract an ID from an invalid address" do
-    config = FactCheckConfig.new("factcheck+{id}@example.com")
+    config = FactCheckConfig.new("factcheck+{id}@example.com", "valid subject [{id}]")
     assert_raises ArgumentError do
-      config.item_id("not-factcheck+1234@example.com")
+      config.item_id_from_address("not-factcheck+1234@example.com")
     end
   end
 
   should "construct an address from an item ID" do
-    config = FactCheckConfig.new("factcheck+{id}@example.com")
+    config = FactCheckConfig.new("factcheck+{id}@example.com", "valid subject [{id}]")
     assert_equal "factcheck+1234@example.com", config.address("1234")
   end
 
   should "accept item IDs that aren't strings" do
     # For example, Mongo IDs, but let's not tie this test to Mongo
-    config = FactCheckConfig.new("factcheck+{id}@example.com")
+    config = FactCheckConfig.new("factcheck+{id}@example.com", "valid subject [{id}]")
     assert_equal "factcheck+1234@example.com", config.address(1234)
+  end
+
+  should "fail on a nil subject format" do
+    assert_raises ArgumentError do
+      FactCheckConfig.new("factcheck+{id}@example.com", nil)
+    end
+  end
+
+  should "fail on an empty subject format" do
+    assert_raises ArgumentError do
+      FactCheckConfig.new("factcheck+{id}@example.com", "")
+    end
+  end
+
+  should "fail on an subject format with no ID marker" do
+    assert_raises ArgumentError do
+      FactCheckConfig.new("factcheck+{id}@example.com", "Fact check subject")
+    end
+  end
+
+  should "accept an subject format with an ID marker" do
+    FactCheckConfig.new("factcheck+{id}@example.com", "Fact check subject [{id}]")
+  end
+
+  should "fail on an subject format with multiple ID markers" do
+    assert_raises ArgumentError do
+      FactCheckConfig.new("factcheck+{id}@example.com", "Fact check subject [{id}] [{id}]")
+    end
+  end
+
+  should "recognise a valid fact check subject" do
+    config = FactCheckConfig.new("factcheck+{id}@example.com", "Fact check subject [{id}]")
+    assert config.valid_subject?("Fact check subject [1234]")
+  end
+
+  should "not recognise an invalid fact check subject" do
+    config = FactCheckConfig.new("factcheck+{id}@example.com", "Fact check subject [{id}]")
+    assert_not config.valid_subject?("Not a valid subject")
+  end
+
+  should "not recognise a fact check subject with an empty ID" do
+    config = FactCheckConfig.new("factcheck+{id}@example.com", "Fact check subject [{id}]")
+    assert_not config.valid_subject?("Not a valid subject []")
+  end
+
+  should "extract an item ID from a valid subject" do
+    config = FactCheckConfig.new("factcheck+{id}@example.com", "Fact check subject [{id}]")
+    assert_equal "1234", config.item_id_from_subject("Fact check subject [1234]")
+  end
+
+  should "raise an exception trying to extract an ID from an invalid subject" do
+    config = FactCheckConfig.new("factcheck+{id}@example.com", "Fact check subject [{id}]")
+    assert_raises ArgumentError do
+      config.item_id_from_subject("Not a valid subject [1234]")
+    end
+  end
+
+  should "construct an subject from an item ID" do
+    config = FactCheckConfig.new("factcheck+{id}@example.com", "Fact check subject [{id}]")
+    assert_equal "Fact check subject [1234]", config.subject("1234")
+  end
+
+  should "accept item IDs that aren't strings" do
+    # For example, Mongo IDs, but let's not tie this test to Mongo
+    config = FactCheckConfig.new("factcheck+{id}@example.com", "Fact check subject [{id}]")
+    assert_equal "Fact check subject [1234]", config.subject(1234)
   end
 end

--- a/test/unit/fact_check_config_test.rb
+++ b/test/unit/fact_check_config_test.rb
@@ -2,135 +2,140 @@ require "test_helper"
 require "fact_check_config"
 
 class FactCheckConfigTest < ActiveSupport::TestCase
+  valid_address = "factcheck+1234@example.com"
+  valid_address_pattern = "factcheck+{id}@example.com"
+  valid_subject = "GOV.UK preview of new edition [1234]"
+  valid_subject_pattern = "GOV.UK preview of new edition [{id}]"
+
   should "fail on a nil address format" do
     assert_raises ArgumentError do
-      FactCheckConfig.new(nil, "valid subject [{id}]")
+      FactCheckConfig.new(nil, valid_subject_pattern)
     end
   end
 
   should "fail on an empty address format" do
     assert_raises ArgumentError do
-      FactCheckConfig.new("", "valid subject [{id}]")
+      FactCheckConfig.new("", valid_subject_pattern)
     end
   end
 
   should "fail on an address format with no ID marker" do
     assert_raises ArgumentError do
-      FactCheckConfig.new("factcheck@example.com", "valid subject [{id}]")
+      FactCheckConfig.new("factcheck@example.com", valid_subject_pattern)
     end
   end
 
   should "accept an address format with an ID marker" do
-    FactCheckConfig.new("factcheck+{id}@example.com", "valid subject [{id}]")
+    FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
   end
 
   should "fail on an address format with multiple ID markers" do
     assert_raises ArgumentError do
-      FactCheckConfig.new("factcheck+{id}+{id}@example.com", "valid subject [{id}]")
+      FactCheckConfig.new("factcheck+{id}+{id}@example.com", valid_subject_pattern)
     end
   end
 
   should "recognise a valid fact check address" do
-    config = FactCheckConfig.new("factcheck+{id}@example.com", "valid subject [{id}]")
-    assert config.valid_address?("factcheck+123456@example.com")
+    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    assert config.valid_address?(valid_address)
   end
 
   should "not recognise an invalid fact check address" do
-    config = FactCheckConfig.new("factcheck+{id}@example.com", "valid subject [{id}]")
+    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
     assert_not config.valid_address?("not-factcheck@example.com")
   end
 
   should "not recognise a fact check address with an empty ID" do
-    config = FactCheckConfig.new("factcheck+{id}@example.com", "valid subject [{id}]")
+    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
     assert_not config.valid_address?("factcheck+@example.com")
   end
 
   should "extract an item ID from a valid address" do
-    config = FactCheckConfig.new("factcheck+{id}@example.com", "valid subject [{id}]")
-    assert_equal "1234", config.item_id_from_address("factcheck+1234@example.com")
+    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    assert_equal "1234", config.item_id_from_address(valid_address)
   end
 
   should "raise an exception trying to extract an ID from an invalid address" do
-    config = FactCheckConfig.new("factcheck+{id}@example.com", "valid subject [{id}]")
+    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
     assert_raises ArgumentError do
       config.item_id_from_address("not-factcheck+1234@example.com")
     end
   end
 
   should "construct an address from an item ID" do
-    config = FactCheckConfig.new("factcheck+{id}@example.com", "valid subject [{id}]")
-    assert_equal "factcheck+1234@example.com", config.address("1234")
+    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    assert_equal valid_address, config.address("1234")
   end
 
   should "accept item IDs that aren't strings" do
     # For example, Mongo IDs, but let's not tie this test to Mongo
-    config = FactCheckConfig.new("factcheck+{id}@example.com", "valid subject [{id}]")
-    assert_equal "factcheck+1234@example.com", config.address(1234)
+    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    assert_equal valid_address, config.address(1234)
   end
 
   should "fail on a nil subject format" do
     assert_raises ArgumentError do
-      FactCheckConfig.new("factcheck+{id}@example.com", nil)
+      FactCheckConfig.new(valid_address_pattern, nil)
     end
   end
 
   should "fail on an empty subject format" do
     assert_raises ArgumentError do
-      FactCheckConfig.new("factcheck+{id}@example.com", "")
+      FactCheckConfig.new(valid_address_pattern, "")
     end
   end
 
   should "fail on an subject format with no ID marker" do
     assert_raises ArgumentError do
-      FactCheckConfig.new("factcheck+{id}@example.com", "Fact check subject")
+      FactCheckConfig.new(valid_address_pattern, "Fact check subject")
     end
   end
 
   should "accept an subject format with an ID marker" do
-    FactCheckConfig.new("factcheck+{id}@example.com", "Fact check subject [{id}]")
+    FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
   end
 
   should "fail on an subject format with multiple ID markers" do
     assert_raises ArgumentError do
-      FactCheckConfig.new("factcheck+{id}@example.com", "Fact check subject [{id}] [{id}]")
+      FactCheckConfig.new(valid_address_pattern, "Fact check subject [{id}] [{id}]")
     end
   end
 
   should "recognise a valid fact check subject" do
-    config = FactCheckConfig.new("factcheck+{id}@example.com", "Fact check subject [{id}]")
-    assert config.valid_subject?("Fact check subject [1234]")
+    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    assert config.valid_subject?(valid_subject)
   end
 
   should "not recognise an invalid fact check subject" do
-    config = FactCheckConfig.new("factcheck+{id}@example.com", "Fact check subject [{id}]")
+    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
     assert_not config.valid_subject?("Not a valid subject")
   end
 
   should "not recognise a fact check subject with an empty ID" do
-    config = FactCheckConfig.new("factcheck+{id}@example.com", "Fact check subject [{id}]")
+    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
     assert_not config.valid_subject?("Not a valid subject []")
   end
 
   should "extract an item ID from a valid subject" do
-    config = FactCheckConfig.new("factcheck+{id}@example.com", "Fact check subject [{id}]")
-    assert_equal "1234", config.item_id_from_subject("Fact check subject [1234]")
+    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    assert_equal "1234", config.item_id_from_subject(valid_subject)
   end
 
   should "raise an exception trying to extract an ID from an invalid subject" do
-    config = FactCheckConfig.new("factcheck+{id}@example.com", "Fact check subject [{id}]")
+    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
     assert_raises ArgumentError do
       config.item_id_from_subject("Not a valid subject [1234]")
     end
   end
 
   should "construct an subject from an item ID" do
-    config = FactCheckConfig.new("factcheck+{id}@example.com", "Fact check subject [{id}]")
-    assert_equal "Fact check subject [1234]", config.subject("1234")
+    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    assert_equal valid_subject, config.subject("1234")
   end
 
   should "accept item IDs that aren't strings" do
     # For example, Mongo IDs, but let's not tie this test to Mongo
-    config = FactCheckConfig.new("factcheck+{id}@example.com", "Fact check subject [{id}]")
-    assert_equal "Fact check subject [1234]", config.subject(1234)
+    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    assert_equal valid_subject, config.subject(1234)
   end
 end

--- a/test/unit/fact_check_config_test.rb
+++ b/test/unit/fact_check_config_test.rb
@@ -4,8 +4,8 @@ require "fact_check_config"
 class FactCheckConfigTest < ActiveSupport::TestCase
   valid_address = "factcheck+1234@example.com"
   valid_address_pattern = "factcheck+{id}@example.com"
-  valid_subject = "[Some title] GOV.UK preview of new edition [1234]"
-  valid_subject_pattern = "\\[.+?\\] GOV.UK preview of new edition \\[(?<id>.+?)\\]"
+  valid_subject = "‘[Some title]’ GOV.UK preview of new edition [1234]"
+  valid_subject_pattern = "‘\\[.+?\\]’ GOV.UK preview of new edition \\[(?<id>.+?)\\]"
 
   should "fail on a nil address format" do
     assert_raises ArgumentError do


### PR DESCRIPTION
This is in addition to checking the `to` address and in preference to it, in order to support Notify which doesn't allow setting unique reply-to addresses.

https://trello.com/c/MR3jrlX2/1878-5-publisher-replace-ses-in-email-receipt-workflow-%F0%9F%8D%90