### PR TITLE
Make the ID prefix in the subject configurable

### DIFF
--- a/app/mailers/noisy_workflow.rb
+++ b/app/mailers/noisy_workflow.rb
@@ -23,11 +23,12 @@ class NoisyWorkflow < ApplicationMailer
   def request_fact_check(action, recipient_email)
     @edition = action.edition
     fact_check_address = @edition.fact_check_email_address
+    fact_check_prefix = ENV.fetch("FACT_CHECK_SUBJECT_PREFIX", "")
     mail(
       to: recipient_email,
       reply_to: fact_check_address,
       from: "GOV.UK Editorial Team <#{fact_check_address}>",
-      subject: "‘[#{@edition.title}]’ GOV.UK preview of new edition [#{Rails.env}-#{@edition.id}]",
+      subject: "‘[#{@edition.title}]’ GOV.UK preview of new edition [#{fact_check_prefix.present? ? fact_check_prefix + '-' : ''}#{@edition.id}]",
     ) do |format|
       format.text { render plain: action.customised_message }
     end

--- a/app/mailers/noisy_workflow.rb
+++ b/app/mailers/noisy_workflow.rb
@@ -23,12 +23,12 @@ class NoisyWorkflow < ApplicationMailer
   def request_fact_check(action, recipient_email)
     @edition = action.edition
     fact_check_address = @edition.fact_check_email_address
-    fact_check_prefix = ENV.fetch("FACT_CHECK_SUBJECT_PREFIX", "")
+    fact_check_prefix = Publisher::Application.fact_check_config.subject_prefix
     mail(
       to: recipient_email,
       reply_to: fact_check_address,
       from: "GOV.UK Editorial Team <#{fact_check_address}>",
-      subject: "‘[#{@edition.title}]’ GOV.UK preview of new edition [#{fact_check_prefix.present? ? fact_check_prefix + '-' : ''}#{@edition.id}]",
+      subject: "‘[#{@edition.title}]’ GOV.UK preview of new edition [#{fact_check_prefix}#{@edition.id}]",
     ) do |format|
       format.text { render plain: action.customised_message }
     end

--- a/config/fact_check.yml
+++ b/config/fact_check.yml
@@ -4,7 +4,7 @@
 # If we ever want to change this format, we'll need to support some notion of
 # legacy formats, so we still pick up emails to old addresses
 address_format: <%=ENV.fetch("FACT_CHECK_ADDRESS_FORMAT", "factcheck+dev-{id}@alphagov.co.uk") %>
-subject_format: <%=ENV.fetch("FACT_CHECK_SUBJECT_FORMAT", "‘\\[.+?\\]’ GOV.UK preview of new edition \\[dev-(?<id>.+?)\\]") %>
+subject_prefix: <%=ENV.fetch("FACT_CHECK_SUBJECT_PREFIX", "") %>
 
 fetcher:
   address: <%=ENV.fetch("FACT_CHECK_ADDRESS", "imap.gmail.com") %>

--- a/config/initializers/fact_check.rb
+++ b/config/initializers/fact_check.rb
@@ -10,7 +10,7 @@ config = YAML.safe_load(
 
 Publisher::Application.fact_check_config = FactCheckConfig.new(
   config.fetch("address_format"),
-  config.fetch("subject_format"),
+  config.fetch("subject_prefix"),
 )
 
 fetcher_config = config.fetch("fetcher", {})

--- a/lib/fact_check_config.rb
+++ b/lib/fact_check_config.rb
@@ -1,12 +1,10 @@
 class FactCheckConfig
-  def initialize(address_format, subject_format)
+  def initialize(address_format, subject_prefix = "")
     unless address_format && address_format.scan("{id}").count == 1
       raise ArgumentError, "Expected '#{address_format}' to contain exactly one '{id}'"
     end
 
-    unless subject_format && subject_format.scan("?<id>").count == 1
-      raise ArgumentError, "Expected '#{subject_format}' to contain exactly one '?<id>'"
-    end
+    subject_format = "‘\\[.+?\\]’ GOV.UK preview of new edition \\[#{subject_prefix.present? ? subject_prefix + '-' : ''}(?<id>.+?)\\]"
 
     @address_prefix, @address_suffix = address_format.split("{id}")
     @address_pattern = Regexp.new(

--- a/lib/fact_check_config.rb
+++ b/lib/fact_check_config.rb
@@ -1,10 +1,13 @@
 class FactCheckConfig
+  attr_reader :subject_prefix
+
   def initialize(address_format, subject_prefix = "")
     unless address_format && address_format.scan("{id}").count == 1
       raise ArgumentError, "Expected '#{address_format}' to contain exactly one '{id}'"
     end
 
-    subject_format = "‘\\[.+?\\]’ GOV.UK preview of new edition \\[#{subject_prefix.present? ? subject_prefix + '-' : ''}(?<id>.+?)\\]"
+    @subject_prefix = subject_prefix.present? ? subject_prefix + "-" : ""
+    subject_format = "‘\\[.+?\\]’ GOV.UK preview of new edition \\[#{@subject_prefix}(?<id>.+?)\\]"
 
     @address_prefix, @address_suffix = address_format.split("{id}")
     @address_pattern = Regexp.new(

--- a/test/unit/fact_check_config_test.rb
+++ b/test/unit/fact_check_config_test.rb
@@ -5,129 +5,107 @@ class FactCheckConfigTest < ActiveSupport::TestCase
   valid_address = "factcheck+1234@example.com"
   valid_address_pattern = "factcheck+{id}@example.com"
   valid_subject = "‘[Some title]’ GOV.UK preview of new edition [1234]"
-  valid_subject_pattern = "‘\\[.+?\\]’ GOV.UK preview of new edition \\[(?<id>.+?)\\]"
+  valid_prefixed_subject = "‘[Some title]’ GOV.UK preview of new edition [test-1234]"
 
   should "fail on a nil address format" do
     assert_raises ArgumentError do
-      FactCheckConfig.new(nil, valid_subject_pattern)
+      FactCheckConfig.new(nil)
     end
   end
 
   should "fail on an empty address format" do
     assert_raises ArgumentError do
-      FactCheckConfig.new("", valid_subject_pattern)
+      FactCheckConfig.new("")
     end
   end
 
   should "fail on an address format with no ID marker" do
     assert_raises ArgumentError do
-      FactCheckConfig.new("factcheck@example.com", valid_subject_pattern)
+      FactCheckConfig.new("factcheck@example.com")
     end
   end
 
   should "accept an address format with an ID marker" do
-    FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    FactCheckConfig.new(valid_address_pattern)
   end
 
   should "fail on an address format with multiple ID markers" do
     assert_raises ArgumentError do
-      FactCheckConfig.new("factcheck+{id}+{id}@example.com", valid_subject_pattern)
+      FactCheckConfig.new("factcheck+{id}+{id}@example.com")
     end
   end
 
   should "recognise a valid fact check address" do
-    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    config = FactCheckConfig.new(valid_address_pattern)
     assert config.valid_address?(valid_address)
   end
 
   should "not recognise an invalid fact check address" do
-    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    config = FactCheckConfig.new(valid_address_pattern)
     assert_not config.valid_address?("not-factcheck@example.com")
   end
 
   should "not recognise a fact check address with an empty ID" do
-    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    config = FactCheckConfig.new(valid_address_pattern)
     assert_not config.valid_address?("factcheck+@example.com")
   end
 
   should "extract an item ID from a valid address" do
-    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    config = FactCheckConfig.new(valid_address_pattern)
     assert_equal "1234", config.item_id_from_address(valid_address)
   end
 
   should "raise an exception trying to extract an ID from an invalid address" do
-    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    config = FactCheckConfig.new(valid_address_pattern)
     assert_raises ArgumentError do
       config.item_id_from_address("not-factcheck+1234@example.com")
     end
   end
 
   should "construct an address from an item ID" do
-    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    config = FactCheckConfig.new(valid_address_pattern)
     assert_equal valid_address, config.address("1234")
   end
 
   should "accept item IDs that aren't strings" do
     # For example, Mongo IDs, but let's not tie this test to Mongo
-    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    config = FactCheckConfig.new(valid_address_pattern)
     assert_equal valid_address, config.address(1234)
   end
 
-  should "fail on a nil subject format" do
-    assert_raises ArgumentError do
-      FactCheckConfig.new(valid_address_pattern, nil)
-    end
-  end
-
-  should "fail on an empty subject format" do
-    assert_raises ArgumentError do
-      FactCheckConfig.new(valid_address_pattern, "")
-    end
-  end
-
-  should "fail on an subject format with no ID marker" do
-    assert_raises ArgumentError do
-      FactCheckConfig.new(valid_address_pattern, "Fact check subject")
-    end
-  end
-
-  should "accept an subject format with an ID marker" do
-    FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
-  end
-
-  should "fail on an subject format with multiple ID markers" do
-    assert_raises ArgumentError do
-      FactCheckConfig.new(valid_address_pattern, "Fact check subject [(?<id>.+?)] [(?<id>.+?)]")
-    end
-  end
-
   should "recognise a valid fact check subject" do
-    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    config = FactCheckConfig.new(valid_address_pattern)
     assert config.valid_subject?(valid_subject)
   end
 
+  should "recognise a valid fact check subject with a prefix" do
+    config = FactCheckConfig.new(valid_address_pattern, "test")
+    assert config.valid_subject?(valid_prefixed_subject)
+    assert_not config.valid_subject?(valid_subject)
+  end
+
   should "not recognise an invalid fact check subject" do
-    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    config = FactCheckConfig.new(valid_address_pattern)
     assert_not config.valid_subject?("Not a valid subject")
   end
 
   should "treat a subject prefixed with Re: as valid" do
-    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    config = FactCheckConfig.new(valid_address_pattern)
     assert config.valid_subject?("Re: " + valid_subject)
   end
 
   should "not recognise a fact check subject with an empty ID" do
-    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    config = FactCheckConfig.new(valid_address_pattern)
     assert_not config.valid_subject?("Not a valid subject []")
   end
 
   should "extract an item ID from a valid subject" do
-    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    config = FactCheckConfig.new(valid_address_pattern)
     assert_equal "1234", config.item_id_from_subject(valid_subject)
   end
 
   should "raise an exception trying to extract an ID from an invalid subject" do
-    config = FactCheckConfig.new(valid_address_pattern, valid_subject_pattern)
+    config = FactCheckConfig.new(valid_address_pattern)
     assert_raises ArgumentError do
       config.item_id_from_subject("Not a valid subject [1234]")
     end


### PR DESCRIPTION
This is expected to be configured by Puppet.

The current code uses an email address pattern in which the environment    (production/staging/integration) is embedded, and uses this both to    parse incoming emails and generate outgoing emails (the environment is    part of an opaque string as far as the app is concerned).

However, here I've made the prefix configurable but not the subject as a    whole: partly because the subject was already defined in code and not    configurable through Puppet, and partly because trying to both parse and    generate from the same string is needlessly complex.

The prefix can be left blank (e.g., in production).

https://trello.com/c/MR3jrlX2/1878-5-publisher-replace-ses-in-email-receipt-workflow-%F0%9F%8D%90