### PR TITLE
Copy in_beta field when cloning editions

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -467,6 +467,7 @@ private
   def base_field_keys
     %i[
       title
+      in_beta
       panopticon_id
       overview
       slug

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -154,9 +154,11 @@ class EditionTest < ActiveSupport::TestCase
                                 state: "published",
                                 panopticon_id: @artefact.id,
                                 version_number: 1,
-                                overview: "I am a test overview")
+                                overview: "I am a test overview",
+                                in_beta: true)
     clone_edition = edition.build_clone
     assert_equal "I am a test overview", clone_edition.overview
+    assert_equal true, clone_edition.in_beta
     assert_equal 2, clone_edition.version_number
   end
 


### PR DESCRIPTION
A pain point we experienced with publisher was that the in_beta flag is
not persisted onto new editions. This meant that it was easy to lose the
beta status.

I'm assuming that the omission of this field just represents a simple
oversight rather than any concious decision to exclude this.