### PR TITLE
Add Coronavirus Service

### DIFF
--- a/data/local_services.csv
+++ b/data/local_services.csv
@@ -117,6 +117,7 @@ LGSL,Description,Providing Tier
 1135,Find out about transport for 16-19 year olds in education,county/unitary
 1140,Find out about emergency school closures,county/unitary
 1145,Find your local 14-19 prospectus,county/unitary
+1287,Find out about coronavirus,all
 1307,Get information on services disrupted by severe weather,all
 1579,Find out about family information services,county/unitary
 1580,Find out how to hold a street party,all


### PR DESCRIPTION
Trello: [Set up new service in local links manager for local authority covid pages](https://trello.com/c/n5l5Ahwp/356-set-up-new-service-in-llm-for-local-authority-covid-pages)

Allow Covid-19 outbreak related local links to be added.
Coronavirus has been coded as "Current emergency situation - health".

See https://standards.esd.org.uk/?uri=service%2F1287 for more details.