### PR TITLE
Improve regex for parsing an edition ID from a subject header

### DIFF
--- a/lib/fact_check_config.rb
+++ b/lib/fact_check_config.rb
@@ -9,7 +9,7 @@ class FactCheckConfig
     @reply_to_id = reply_to_id
 
     @subject_prefix = subject_prefix.present? ? subject_prefix + "-" : ""
-    subject_format = "‘\\[.+?\\]’ GOV.UK preview of new edition \\[#{@subject_prefix}(?<id>.+?)\\]"
+    subject_format = "\\[#{@subject_prefix}(?<id>[0-9a-f]+)\\]"
 
     @address_prefix, @address_suffix = address_format.split("{id}")
     @address_pattern = Regexp.new(
@@ -21,9 +21,7 @@ class FactCheckConfig
     )
 
     @subject_pattern = Regexp.new(
-      '\A.*' +
-      subject_format +
-      '\Z',
+      subject_format,
     )
   end
 
@@ -48,10 +46,13 @@ class FactCheckConfig
   end
 
   def item_id_from_subject(subject)
-    if (match = @subject_pattern.match(subject))
-      match[:id]
+    match = subject.scan(@subject_pattern)
+    if match.length == 1
+      match[0][0]
+    elsif match.length > 1
+      raise ArgumentError, "'#{subject}' has too many matches"
     else
-      raise ArgumentError, "'#{subject}' is not a valid fact check address"
+      raise ArgumentError, "'#{subject}' is not a valid fact check subject"
     end
   end
 end

--- a/lib/fact_check_config.rb
+++ b/lib/fact_check_config.rb
@@ -9,7 +9,7 @@ class FactCheckConfig
     @reply_to_id = reply_to_id
 
     @subject_prefix = subject_prefix.present? ? subject_prefix + "-" : ""
-    subject_format = "\\[#{@subject_prefix}(?<id>[0-9a-f]+)\\]"
+    @subject_pattern = /\[#{@subject_prefix}(?<id>[0-9a-f]+)\]/
 
     @address_prefix, @address_suffix = address_format.split("{id}")
     @address_pattern = Regexp.new(
@@ -18,10 +18,6 @@ class FactCheckConfig
       "(.+?)" +
       Regexp.escape(@address_suffix) +
       '\Z',
-    )
-
-    @subject_pattern = Regexp.new(
-      subject_format,
     )
   end
 

--- a/lib/fact_check_config.rb
+++ b/lib/fact_check_config.rb
@@ -38,7 +38,7 @@ class FactCheckConfig
   end
 
   def valid_subject?(subject)
-    @subject_pattern.match(subject).present?
+    subject.scan(@subject_pattern).length == 1
   end
 
   def item_id_from_subject(subject)

--- a/test/unit/fact_check_config_test.rb
+++ b/test/unit/fact_check_config_test.rb
@@ -131,6 +131,8 @@ class FactCheckConfigTest < ActiveSupport::TestCase
   should "raise an exception if there are multiple matches" do
     config = FactCheckConfig.new(valid_address_pattern)
     valid_subjects.each do |valid_subject|
+      assert_equal false, config.valid_subject?(valid_subject + " [5678]")
+
       assert_raises ArgumentError do
         config.item_id_from_subject(valid_subject + " [5678]")
       end

--- a/test/unit/fact_check_config_test.rb
+++ b/test/unit/fact_check_config_test.rb
@@ -4,8 +4,11 @@ require "fact_check_config"
 class FactCheckConfigTest < ActiveSupport::TestCase
   valid_address = "factcheck+1234@example.com"
   valid_address_pattern = "factcheck+{id}@example.com"
-  valid_subject = "‘[Some title]’ GOV.UK preview of new edition [1234]"
-  valid_prefixed_subject = "‘[Some title]’ GOV.UK preview of new edition [test-1234]"
+  valid_subjects = ["‘[Some title]’ GOV.UK preview of new edition [1234]",
+                    "‘[Some title]’ GOV.UK preview of new edition [1234] - ticket #5678",
+                    "I've edited the subject but left the ID at the end [1234]",
+                    "I've edited the subject and appended something [1234] - ticket #2468"]
+  valid_prefixed_subjects = valid_subjects.map { |subject| subject.gsub(/\[1234\]/, "[test-1234]") }
 
   should "fail on a nil address format" do
     assert_raises ArgumentError do
@@ -75,13 +78,19 @@ class FactCheckConfigTest < ActiveSupport::TestCase
 
   should "recognise a valid fact check subject" do
     config = FactCheckConfig.new(valid_address_pattern)
-    assert config.valid_subject?(valid_subject)
+    valid_subjects.each do |valid_subject|
+      assert config.valid_subject?(valid_subject)
+    end
   end
 
   should "recognise a valid fact check subject with a prefix" do
     config = FactCheckConfig.new(valid_address_pattern, "test")
-    assert config.valid_subject?(valid_prefixed_subject)
-    assert_not config.valid_subject?(valid_subject)
+    valid_prefixed_subjects.each do |valid_prefixed_subject|
+      assert config.valid_subject?(valid_prefixed_subject)
+    end
+    valid_subjects.each do |valid_subject|
+      assert_not config.valid_subject?(valid_subject)
+    end
   end
 
   should "not recognise an invalid fact check subject" do
@@ -91,7 +100,9 @@ class FactCheckConfigTest < ActiveSupport::TestCase
 
   should "treat a subject prefixed with Re: as valid" do
     config = FactCheckConfig.new(valid_address_pattern)
-    assert config.valid_subject?("Re: " + valid_subject)
+    valid_subjects.each do |valid_subject|
+      assert config.valid_subject?("Re: " + valid_subject)
+    end
   end
 
   should "not recognise a fact check subject with an empty ID" do
@@ -101,13 +112,28 @@ class FactCheckConfigTest < ActiveSupport::TestCase
 
   should "extract an item ID from a valid subject" do
     config = FactCheckConfig.new(valid_address_pattern)
-    assert_equal "1234", config.item_id_from_subject(valid_subject)
+    valid_subjects.each do |valid_subject|
+      assert_equal "1234", config.item_id_from_subject(valid_subject)
+    end
   end
 
   should "raise an exception trying to extract an ID from an invalid subject" do
     config = FactCheckConfig.new(valid_address_pattern)
     assert_raises ArgumentError do
-      config.item_id_from_subject("Not a valid subject [1234]")
+      config.item_id_from_subject("Not a valid subject (1234)")
+    end
+
+    assert_raises ArgumentError do
+      config.item_id_from_subject("Not a valid subject [notHexadecimal]")
+    end
+  end
+
+  should "raise an exception if there are multiple matches" do
+    config = FactCheckConfig.new(valid_address_pattern)
+    valid_subjects.each do |valid_subject|
+      assert_raises ArgumentError do
+        config.item_id_from_subject(valid_subject + " [5678]")
+      end
     end
   end
 end


### PR DESCRIPTION
Previously the regex would look for an exact match based on what was sent, pinned to the end of the string but not the start (to allow for 'Re:' and similar prefixes). However, it seems that in some cases there can also be text added to the end of the string (e.g., an ID added by the other party's own ticketing system) or even a complete modification of the subject, in which case all we can do is ask the user not to remove the ID.

I've made a few guesses as to what is an appropriate level of cautiousness: for example, this looks for any hexadecimal string surrounded by square brackes (and prefixed with an environment, if one is set); however, I've considered it to be an error if there's more than one match (because we can't be sure we'll pick the right one).

We could also try multiple ways of matching (e.g., look for a more exact match with the subject we sent, and if it fails then any hex string; or look for any hex string and if there are multiple matches then pick the one that seems to be immediately prefixed by our subject, if any). But since we don't know enough about the ways this could fail, it seemed like a premature optimisation; it would be better to revisit this if we start to see a common kind of failure in the future.

https://trello.com/c/KHVxF6ry/1969-3-update-publisher-interface-and-email-text-to-match-new-fact-check-workflow
