### PR TITLE
Ensure email body correctly includes message ID

### DIFF
--- a/app/mailers/noisy_workflow.rb
+++ b/app/mailers/noisy_workflow.rb
@@ -26,13 +26,12 @@ class NoisyWorkflow < ApplicationMailer
     @edition = action.edition
     fact_check_prefix = Publisher::Application.fact_check_config.subject_prefix
     reply_to_id = Publisher::Application.fact_check_config.reply_to_id
-    @customised_message = action.customised_message
 
-    @prefixed_edition_id = fact_check_prefix + @edition.id
+    @customised_message = action.customised_message
 
     params = {
       to: recipient_email,
-      subject: "‘[#{@edition.title}]’ GOV.UK preview of new edition [#{@prefixed_edition_id}]",
+      subject: "‘[#{@edition.title}]’ GOV.UK preview of new edition [#{fact_check_prefix}#{@edition.id}]",
     }
     params[:reply_to_id] = reply_to_id if reply_to_id.present?
 

--- a/app/views/noisy_workflow/request_fact_check.text.erb
+++ b/app/views/noisy_workflow/request_fact_check.text.erb
@@ -31,8 +31,7 @@ When fact checking, please:
 
 - only point out factual errors - don’t suggest wording (GDS is responsible for the style)
 - use plain text - GDS systems don’t display text formatting, colours or attachments
-- do not remove [<%= @prefixed_edition_id %>] from the subject
-  line - GDS will not get your fact check response if this is removed
+- do not remove [<%= @edition.id %>] from the subject line - GDS will not get your fact check response if this is removed
 
 To get the content published more quickly:
 

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -57,6 +57,24 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     end
   end
 
+  test "fact-check email has ID in it" do
+    guide.update_attribute(:state, "ready")
+    visit_edition guide
+
+    click_link("Fact check")
+
+    ActionMailer::Base.deliveries.clear
+
+    within "#send_fact_check_form" do
+      fill_in "Email address", with: "user@example.com"
+      click_on "Send"
+    end
+
+    fact_check_email = ActionMailer::Base.deliveries.select { |mail| mail.to.include? "user@example.com" }.last
+    assert fact_check_email
+    assert_match(/do not remove \[.+?\] from the subject line/, fact_check_email.body.to_s)
+  end
+
   test "can send guide to fact-check when in ready state" do
     guide.update_attribute(:state, "ready")
     visit_edition guide


### PR DESCRIPTION
This was failing to be included before due to some odd variable scoping issue (instance variables defined in `noisy_workflow.rb` weren't readable from the template). This way isn't perfect but should be clear enough — there won't be a prefix on the ID in the email body, but this would be in production and it's only intended to be human-readable anyway.

https://trello.com/c/EgwMYcXj/1987-3-update-publisher-interface-and-email-text-to-match-new-fact-check-workflow
