### PR TITLE
Read reply-to address from a separate environment variable

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -436,7 +436,7 @@ class Edition
   end
 
   def fact_check_email_address
-    Publisher::Application.fact_check_config.address(id)
+    Publisher::Application.fact_check_config.address
   end
 
   def check_if_archived

--- a/app/views/shared/_history.html.erb
+++ b/app/views/shared/_history.html.erb
@@ -73,7 +73,7 @@
     <% else %>
       This edition can’t be previewed.<br />
     <% end %>
-    Send fact check responses to <%= mail_to resource.fact_check_email_address %>
+    Send fact check responses to <%= mail_to resource.fact_check_email_address %> and include [<%= resource.id %>] in the subject line.
   </p>
 
   <div class="panel-group">

--- a/config/fact_check.yml
+++ b/config/fact_check.yml
@@ -5,6 +5,7 @@
 # legacy formats, so we still pick up emails to old addresses
 address_format: <%=ENV.fetch("FACT_CHECK_ADDRESS_FORMAT", "factcheck+dev-{id}@alphagov.co.uk") %>
 subject_prefix: <%=ENV.fetch("FACT_CHECK_SUBJECT_PREFIX", "") %>
+reply_to_address: <%=ENV.fetch("FACT_CHECK_REPLY_TO_ID", "factcheck+dev@alphagov.co.uk") %>
 reply_to_id: <%=ENV.fetch("FACT_CHECK_REPLY_TO_ID", nil) %>
 
 fetcher:

--- a/config/fact_check.yml
+++ b/config/fact_check.yml
@@ -5,7 +5,7 @@
 # legacy formats, so we still pick up emails to old addresses
 address_format: <%=ENV.fetch("FACT_CHECK_ADDRESS_FORMAT", "factcheck+dev-{id}@alphagov.co.uk") %>
 subject_prefix: <%=ENV.fetch("FACT_CHECK_SUBJECT_PREFIX", "") %>
-reply_to_address: <%=ENV.fetch("FACT_CHECK_REPLY_TO_ID", "factcheck+dev@alphagov.co.uk") %>
+reply_to_address: <%=ENV.fetch("FACT_CHECK_REPLY_TO_ADDRESS", "factcheck+dev@alphagov.co.uk") %>
 reply_to_id: <%=ENV.fetch("FACT_CHECK_REPLY_TO_ID", nil) %>
 
 fetcher:

--- a/config/initializers/fact_check.rb
+++ b/config/initializers/fact_check.rb
@@ -10,6 +10,7 @@ config = YAML.safe_load(
 
 Publisher::Application.fact_check_config = FactCheckConfig.new(
   config.fetch("address_format"),
+  config.fetch("reply_to_address"),
   config.fetch("subject_prefix"),
   config.fetch("reply_to_id"),
 )

--- a/lib/fact_check_config.rb
+++ b/lib/fact_check_config.rb
@@ -1,11 +1,16 @@
 class FactCheckConfig
   attr_reader :subject_prefix, :reply_to_id
 
-  def initialize(address_format, subject_prefix = "", reply_to_id = nil)
+  def initialize(address_format, reply_to_address, subject_prefix = "", reply_to_id = nil)
     unless address_format && address_format.scan("{id}").count == 1
       raise ArgumentError, "Expected '#{address_format}' to contain exactly one '{id}'"
     end
 
+    if reply_to_address.blank?
+      raise ArgumentError, "Expected reply_to_address not to be nil"
+    end
+
+    @reply_to_address = reply_to_address
     @reply_to_id = reply_to_id
 
     @subject_prefix = subject_prefix.present? ? subject_prefix + "-" : ""
@@ -33,8 +38,8 @@ class FactCheckConfig
     end
   end
 
-  def address(item_id)
-    @address_prefix + item_id.to_s + @address_suffix
+  def address
+    @reply_to_address
   end
 
   def valid_subject?(subject)

--- a/test/integration/fact_check_email_test.rb
+++ b/test/integration/fact_check_email_test.rb
@@ -16,7 +16,7 @@ class FactCheckEmailTest < ActionDispatch::IntegrationTest
       to      attrs.fetch(:to,      edition && edition.fact_check_email_address)
       cc      attrs.fetch(:cc,      nil)
       bcc     attrs.fetch(:bcc,     nil)
-      subject attrs.fetch(:subject, "This is a fact check response")
+      subject attrs.fetch(:subject, "This is a fact check response [#{edition.present? ? edition.id : ''}]")
       body    attrs.fetch(:body,    "I like it. Good work!")
     end
 
@@ -140,8 +140,7 @@ class FactCheckEmailTest < ActionDispatch::IntegrationTest
 
   test "should look for fact-check subject field" do
     edition = FactoryBot.create(:answer_edition, state: "fact_check")
-    message = fact_check_mail_for(edition, subject: "Fact Checked [dev-#{edition.id}]")
-    pp message
+    message = fact_check_mail_for(edition, subject: "Fact Checked [#{edition.id}]")
 
     Mail.stubs(:all).yields(message)
 

--- a/test/unit/fact_check_config_test.rb
+++ b/test/unit/fact_check_config_test.rb
@@ -4,6 +4,7 @@ require "fact_check_config"
 class FactCheckConfigTest < ActiveSupport::TestCase
   valid_address = "factcheck+1234@example.com"
   valid_address_pattern = "factcheck+{id}@example.com"
+  reply_to_address = valid_address
   valid_subjects = ["‘[Some title]’ GOV.UK preview of new edition [1234]",
                     "‘[Some title]’ GOV.UK preview of new edition [1234] - ticket #5678",
                     "I've edited the subject but left the ID at the end [1234]",
@@ -12,79 +13,85 @@ class FactCheckConfigTest < ActiveSupport::TestCase
 
   should "fail on a nil address format" do
     assert_raises ArgumentError do
-      FactCheckConfig.new(nil)
+      FactCheckConfig.new(nil, reply_to_address)
+    end
+  end
+
+  should "fail on a nil reply-to address" do
+    assert_raises ArgumentError do
+      FactCheckConfig.new(valid_address_pattern, nil)
     end
   end
 
   should "fail on an empty address format" do
     assert_raises ArgumentError do
-      FactCheckConfig.new("")
+      FactCheckConfig.new("", reply_to_address)
+    end
+  end
+
+  should "fail on an empty reply-to address" do
+    assert_raises ArgumentError do
+      FactCheckConfig.new(valid_address_pattern, "")
     end
   end
 
   should "fail on an address format with no ID marker" do
     assert_raises ArgumentError do
-      FactCheckConfig.new("factcheck@example.com")
+      FactCheckConfig.new("factcheck@example.com", reply_to_address)
     end
   end
 
   should "accept an address format with an ID marker" do
-    FactCheckConfig.new(valid_address_pattern)
+    FactCheckConfig.new(valid_address_pattern, reply_to_address)
   end
 
   should "fail on an address format with multiple ID markers" do
     assert_raises ArgumentError do
-      FactCheckConfig.new("factcheck+{id}+{id}@example.com")
+      FactCheckConfig.new("factcheck+{id}+{id}@example.com", reply_to_address)
     end
   end
 
   should "recognise a valid fact check address" do
-    config = FactCheckConfig.new(valid_address_pattern)
+    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
     assert config.valid_address?(valid_address)
   end
 
   should "not recognise an invalid fact check address" do
-    config = FactCheckConfig.new(valid_address_pattern)
+    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
     assert_not config.valid_address?("not-factcheck@example.com")
   end
 
   should "not recognise a fact check address with an empty ID" do
-    config = FactCheckConfig.new(valid_address_pattern)
+    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
     assert_not config.valid_address?("factcheck+@example.com")
   end
 
   should "extract an item ID from a valid address" do
-    config = FactCheckConfig.new(valid_address_pattern)
+    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
     assert_equal "1234", config.item_id_from_address(valid_address)
   end
 
   should "raise an exception trying to extract an ID from an invalid address" do
-    config = FactCheckConfig.new(valid_address_pattern)
+    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
     assert_raises ArgumentError do
       config.item_id_from_address("not-factcheck+1234@example.com")
     end
   end
 
-  should "construct an address from an item ID" do
-    config = FactCheckConfig.new(valid_address_pattern)
-    assert_equal valid_address, config.address("1234")
-  end
-
-  should "accept item IDs that aren't strings" do
-    # For example, Mongo IDs, but let's not tie this test to Mongo
-    config = FactCheckConfig.new(valid_address_pattern)
-    assert_equal valid_address, config.address(1234)
+  should "return a static reply-to address regardless of id" do
+    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
+    assert_equal reply_to_address, config.address
   end
 
   should "recognise a valid fact check subject" do
-    config = FactCheckConfig.new(valid_address_pattern)
+    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
     valid_subjects.each do |valid_subject|
       assert config.valid_subject?(valid_subject)
     end
   end
 
   should "recognise a valid fact check subject with a prefix" do
-    config = FactCheckConfig.new(valid_address_pattern, "test")
+    config = FactCheckConfig.new(valid_address_pattern, reply_to_address, "test")
     valid_prefixed_subjects.each do |valid_prefixed_subject|
       assert config.valid_subject?(valid_prefixed_subject)
     end
@@ -94,31 +101,31 @@ class FactCheckConfigTest < ActiveSupport::TestCase
   end
 
   should "not recognise an invalid fact check subject" do
-    config = FactCheckConfig.new(valid_address_pattern)
+    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
     assert_not config.valid_subject?("Not a valid subject")
   end
 
   should "treat a subject prefixed with Re: as valid" do
-    config = FactCheckConfig.new(valid_address_pattern)
+    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
     valid_subjects.each do |valid_subject|
       assert config.valid_subject?("Re: " + valid_subject)
     end
   end
 
   should "not recognise a fact check subject with an empty ID" do
-    config = FactCheckConfig.new(valid_address_pattern)
+    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
     assert_not config.valid_subject?("Not a valid subject []")
   end
 
   should "extract an item ID from a valid subject" do
-    config = FactCheckConfig.new(valid_address_pattern)
+    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
     valid_subjects.each do |valid_subject|
       assert_equal "1234", config.item_id_from_subject(valid_subject)
     end
   end
 
   should "raise an exception trying to extract an ID from an invalid subject" do
-    config = FactCheckConfig.new(valid_address_pattern)
+    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
     assert_raises ArgumentError do
       config.item_id_from_subject("Not a valid subject (1234)")
     end
@@ -129,7 +136,7 @@ class FactCheckConfigTest < ActiveSupport::TestCase
   end
 
   should "raise an exception if there are multiple matches" do
-    config = FactCheckConfig.new(valid_address_pattern)
+    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
     valid_subjects.each do |valid_subject|
       assert_equal false, config.valid_subject?(valid_subject + " [5678]")
 


### PR DESCRIPTION
This allows us to stop showing the ID in the reply-to address we're giving to users, without actually yet disabling it for incoming messages.

The caveat is, though, that it should be compatible with both the `address_format` (at least, compatible with the existing gmail filters that assume that address format) and matching the address that the `reply_to_id` refers to. Neither of these is guaranteed to break things if they're different, but inconsistency is likely to complicate things and it's difficult or impossible to reliably ensure that they're compatible.

https://trello.com/c/EgwMYcXj/1987-3-update-publisher-interface-and-email-text-to-match-new-fact-check-workflow
