### PR TITLE
Amend review skipped email content

### DIFF
--- a/app/mailers/noisy_workflow.rb
+++ b/app/mailers/noisy_workflow.rb
@@ -13,6 +13,7 @@ class NoisyWorkflow < ApplicationMailer
   end
 
   def skip_review(action, recipient_email)
+    @action = action
     @edition = action.edition
     @edition_url = edition_url(@edition.id, host: Plek.find("publisher"), external: true)
     view_mail(

--- a/app/views/noisy_workflow/skip_review.text.erb
+++ b/app/views/noisy_workflow/skip_review.text.erb
@@ -1,6 +1,8 @@
 Hello,
 
-Review has been skipped for "<%= @edition.title %>" (<%= @edition.format %>).
+<%= @action.requester.name %> has skipped review for "<%= @edition.title %>" (<%= @edition.format %>).
+
+The reason given was: <%= @action.comment %>
 
 You can view it here:
 <%= @edition_url %>


### PR DESCRIPTION
Inserts name of the user who skipped review, and their reason, into the body of the email that is sent to admins.

[Trello](https://trello.com/c/IjmdeY7H/2002-2-iterate-skipreview-alert-email-in-publisher)