### PR TITLE
Add the reply-to address to the body of the fact-check email and test it

### DIFF
--- a/app/views/noisy_workflow/request_fact_check.text.erb
+++ b/app/views/noisy_workflow/request_fact_check.text.erb
@@ -23,6 +23,8 @@ Or, if you spot something that's not correct, reply to this email and tell us:
 - which paragraph or section isn’t right - for example chapter 2, under heading ‘How much it costs’
 - what’s wrong and why - for example the text implies a legal obligation, when there isn't one
 
+Check your reply is being sent to <<%= @edition.fact_check_email_address %>>. Do not remove [<%= @edition.id %>] from the subject line - GDS will not get your fact check response if this is removed.
+
 ---------------------------------------------------
 
 # How to do it
@@ -31,7 +33,6 @@ When fact checking, please:
 
 - only point out factual errors - don’t suggest wording (GDS is responsible for the style)
 - use plain text - GDS systems don’t display text formatting, colours or attachments
-- do not remove [<%= @edition.id %>] from the subject line - GDS will not get your fact check response if this is removed
 
 To get the content published more quickly:
 

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -72,7 +72,25 @@ class EditionWorkflowTest < JavascriptIntegrationTest
 
     fact_check_email = ActionMailer::Base.deliveries.select { |mail| mail.to.include? "user@example.com" }.last
     assert fact_check_email
-    assert_match(/do not remove \[.+?\] from the subject line/, fact_check_email.body.to_s)
+    assert_match(/Do not remove \[.+?\] from the subject line/, fact_check_email.body.to_s)
+  end
+
+  test "fact-check email has reply-to address in it" do
+    guide.update_attribute(:state, "ready")
+    visit_edition guide
+
+    click_link("Fact check")
+
+    ActionMailer::Base.deliveries.clear
+
+    within "#send_fact_check_form" do
+      fill_in "Email address", with: "user@example.com"
+      click_on "Send"
+    end
+
+    fact_check_email = ActionMailer::Base.deliveries.select { |mail| mail.to.include? "user@example.com" }.last
+    assert fact_check_email
+    assert_match(/reply is being sent to <#{Regexp.escape guide.fact_check_email_address}>\./, fact_check_email.body.to_s)
   end
 
   test "can send guide to fact-check when in ready state" do


### PR DESCRIPTION
This is so that HMRC can manually set the reply address, as their system ignores the reply-to header.

https://trello.com/c/jCpYumNF/2009-include-reply-to-address-in-body-of-publisher-fact-check-emails