### PR TITLE
Add some documentation on the fact check process

### DIFF
--- a/doc/fact-checking.md
+++ b/doc/fact-checking.md
@@ -1,0 +1,12 @@
+# Fact Checking
+
+Publisher comes with a system to allow editions not yet published to be externally fact checked.
+
+## Process
+
+1. When a content designer clicks the "Fact check" button on an edition, they are presented with a form allowing them to input the email addresses they would like the fact check request to go to.
+1. The fact checker who receives the email then reviews the draft version of the edition, and once happy, replies to the email with the review.
+1. The email arrives in a Gmail inbox. Details of which inbox can be found in secrets under `govuk::apps::publisher::fact_check_username` and `govuk::apps::publisher::fact_check_password`.
+1. Every 10 minutes, the [mail_fetcher](../script/mail_fetcher) script runs which reads any new emails from the inbox, parses the response and adds it to the edition in the database.
+
+**Note:** The ID of the edition is included in the subject line of the fact check email. It's important that this is never removed, otherwise the app would be unable to match the email with the edition.

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -76,7 +76,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
   end
 
   test "fact-check email has reply-to address in it" do
-    guide.update_attribute(:state, "ready")
+    guide.update(state: "ready")
     visit_edition guide
 
     click_link("Fact check")


### PR DESCRIPTION
We've been working in this area recently (and even had an incident) and having this documentation at the beginning would have been very helpful.

It's doesn't go into too much detail in terms of individual lines of code as I wanted to make sure this documentation remains accurate even if the code itself is refactored or changed.

[Trello Card](https://trello.com/c/IspoUGnj/1971-5-enable-fact-check-emails-in-integration-and-staging)