### PR TITLE
Update create account page content

### DIFF
--- a/lib/service_sign_in/check-income-tax.en.yaml
+++ b/lib/service_sign_in/check-income-tax.en.yaml
@@ -17,37 +17,35 @@ choose_sign_in:
       slug: create-account
       hint_text: If you do not already have one of these accounts, we'll help you choose whether to use Government Gateway or GOV.UK Verify.
 create_new_account:
-  title: Create an account
+  title: Choose a way to prove your identity
   slug: create-account
   body: |
-    To use this service, you need to create either a Government Gateway or GOV.UK Verify account. These are used to help fight identity theft.
+    You need to confirm who you are before you can check your income tax.
 
-    Once you have an account, you can use it to access other government services online.
+    To do this, you can create either a Government Gateway user ID or a GOV.UK Verify identity account.
 
-    ## Choose a way to prove your identity
+    ## Government Gateway
 
-    ### Government Gateway
+    You'll need:
 
-    Registering with Government Gateway usually takes about 10 minutes. It works best if you have:
+    - your National Insurance number or UK address
+    - a recent payslip or P60 or a valid UK passport
+    
+    You can use your user ID for things like your personal or business tax account, Self Assessment, Corporation Tax, PAYE for employers and VAT.
 
-    * your National Insurance number
-    * a recent payslip or P60 or a valid UK passport
+    {button}[Choose Government Gateway](https://www.tax.service.gov.uk/gg/sign-in?continue=/check-income-tax/what-do-you-want-to-do&accountType=individual&origin=PTA-CYIT-CY){/button}
 
-    {button}[Create a Government Gateway account](https://www.tax.service.gov.uk/gg/sign-in?continue=/check-income-tax/what-do-you-want-to-do&accountType=individual&origin=PTA-CYIT-CY){/button}
+    ## GOV.UK Verify
 
-    ### GOV.UK Verify
-
-    Registering with GOV.UK Verify usually takes about 15 minutes. It works best if you have:
+    GOV.UK Verify works best if you're over 20 years old. You'll need:
 
     - a UK address
-    - a valid passport or photocard driving licence
+    - a mobile phone
+    - at least one valid photo ID from any country
+    
+    You can use your identity account for things like Universal Credit, requesting a basic DBS check and Self Assessment. 
 
-    {button}[Create a GOV.UK Verify account](https://www.signin.service.gov.uk/initiate-journey/hmrc-tax-estimate?journey_hint=registration){/button}
+    {button}[Choose GOV.UK Verify](https://www.signin.service.gov.uk/initiate-journey/hmrc-tax-estimate?journey_hint=registration){/button}
 
-    A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.
-
-    ## Personal tax account
-
-    Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
 update_type: minor
-change_note: Updated eIDAS content because more than two countries are connected now.
+change_note: Updated create account page content to be more accurate and help people choose.

--- a/lib/service_sign_in/check-state-pension.en.yaml
+++ b/lib/service_sign_in/check-state-pension.en.yaml
@@ -20,34 +20,35 @@ choose_sign_in:
       slug: create-account
       hint_text: If you do not already have one of these accounts, we'll help you choose whether to use Government Gateway or GOV.UK Verify.
 create_new_account:
-  title: Create an account
+  title: Choose a way to prove your identity
   slug: create-account
   body: |
-    To use this service, you need to create either a Government Gateway or GOV.UK Verify account. These are used to help fight identity theft.
+    You need to confirm who you are before you can check your State Pension.
 
-    Once you have an account, you can use it to access other government services online.
+    To do this, you can create either a Government Gateway user ID or a GOV.UK Verify identity account.
 
-    ## Choose a way to prove your identity
+    ## Government Gateway
 
-    ### Government Gateway
+    You'll need:
 
-    Registering with Government Gateway usually takes about 10 minutes. It works best if you have:
+    - your National Insurance number or UK address
+    - a recent payslip or P60 or a valid UK passport
+    
+    You can use your user ID for things like your personal or business tax account, Self Assessment, Corporation Tax, PAYE for employers and VAT.
 
-    * your National Insurance number
-    * a recent payslip or P60 or a valid UK passport
+    <a role="button" class="gem-c-button govuk-button" href="https://www.tax.service.gov.uk/gg/sign-in?continue=/check-your-state-pension&accountType=individual" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-event="true">Choose Government Gateway</a>
 
-    <a role="button" class="gem-c-button govuk-button" href="https://www.tax.service.gov.uk/gg/sign-in?continue=/check-your-state-pension&accountType=individual" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-event="true">Create a Government Gateway account</a>
+    ## GOV.UK Verify
 
-    ### GOV.UK Verify
-
-    Registering with GOV.UK Verify usually takes about 15 minutes. It works best if you have:
+    GOV.UK Verify works best if you're over 20 years old. You'll need:
 
     - a UK address
-    - a valid passport or photocard driving licence
+    - a mobile phone
+    - at least one valid photo ID from any country
+    
+    You can use your identity account for things like Universal Credit, requesting a basic DBS check and Self Assessment. 
 
-    <a role="button" class="gem-c-button govuk-button" href="https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=registration" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-event="true">Create a GOV.UK Verify account</a>
-
-    A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.
+    <a role="button" class="gem-c-button govuk-button" href="https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=registration" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-event="true">Choose GOV.UK Verify</a>
 
 update_type: minor
-change_note: Updated eIDAS content because more than two countries are connected now.
+change_note: Updated create account page content to be more accurate and help people choose.

--- a/lib/service_sign_in/check-update-company-car-tax.en.yaml
+++ b/lib/service_sign_in/check-update-company-car-tax.en.yaml
@@ -17,37 +17,33 @@ choose_sign_in:
       slug: create-account
       hint_text: If you do not already have one of these accounts, we'll help you choose whether to use Government Gateway or GOV.UK Verify.
 create_new_account:
-  title: Create an account
+  title: Choose a way to prove your identity
   slug: create-account
   body: |
-    To use this service, you need to create either a Government Gateway or GOV.UK Verify account. These are used to help fight identity theft.
+    You need to confirm who you are before you can check or update your company car tax.
 
-    Once you have an account, you can use it to access other government services online.
+    To do this, you can create either a Government Gateway user ID or a GOV.UK Verify identity account.
 
-    ## Choose a way to prove your identity
+    ## Government Gateway
 
-    ### Government Gateway
+    You'll need:
 
-    Registering with Government Gateway usually takes about 10 minutes. It works best if you have:
+    - your National Insurance number or UK address
+    - a recent payslip or P60 or a valid UK passport
+    
+    You can use your user ID for things like your personal or business tax account, Self Assessment, Corporation Tax, PAYE for employers and VAT.
 
-    * your National Insurance number
-    * a recent payslip or P60 or a valid UK passport
+    {button}[Choose Government Gateway](https://www.tax.service.gov.uk/gg/sign-in?continue=/paye/company-car/details&accountType=individual&origin=PTA-companycar){/button}
 
-    {button}[Create a Government Gateway account](https://www.tax.service.gov.uk/gg/sign-in?continue=/paye/company-car/details&accountType=individual&origin=PTA-companycar){/button}
+    ## GOV.UK Verify
 
-    ### GOV.UK Verify
-
-    Registering with GOV.UK Verify usually takes about 15 minutes. It works best if you have:
+    GOV.UK Verify works best if you're over 20 years old. You'll need:
 
     - a UK address
-    - a valid passport or photocard driving licence
+    - a mobile phone
+    - at least one valid photo ID from any country
 
-    {button}[Create a GOV.UK Verify account](https://www.signin.service.gov.uk/initiate-journey/hmrc-company-car-tax?journey_hint=registration){/button}
+    {button}[Choose GOV.UK Verify](https://www.signin.service.gov.uk/initiate-journey/hmrc-company-car-tax?journey_hint=registration){/button}
 
-    A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.
-
-    ## Personal tax account
-
-    Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
 update_type: minor
-change_note: Updated eIDAS content because more than two countries are connected now.
+change_note: Updated create account page content to be more accurate and help people choose.

--- a/lib/service_sign_in/personal-tax-account.en.yaml
+++ b/lib/service_sign_in/personal-tax-account.en.yaml
@@ -17,37 +17,33 @@ choose_sign_in:
       slug: create-account
       hint_text: If you do not already have one of these accounts, we'll help you choose whether to use Government Gateway or GOV.UK Verify.
 create_new_account:
-  title: Create an account
+  title: Choose a way to prove your identity
   slug: create-account
   body: |
-    To use this service, you need to create either a Government Gateway or GOV.UK Verify account. These are used to help fight identity theft.
+    You need to confirm who you are before you can access your personal tax account.
 
-    Once you have an account, you can use it to access other government services online.
+    To do this, you can create either a Government Gateway user ID or a GOV.UK Verify identity account.
 
-    ## Choose a way to prove your identity
+    ## Government Gateway
 
-    ### Government Gateway
+   You'll need:
 
-    Registering with Government Gateway usually takes about 10 minutes. It works best if you have:
-
-    - your National Insurance number
+    - your National Insurance number or UK address
     - a recent payslip or P60 or a valid UK passport
+    
+    You can use your user ID for things like your personal or business tax account, Self Assessment, Corporation Tax, PAYE for employers and VAT.
 
-    {button}[Create a Government Gateway account](https://www.tax.service.gov.uk/gg/sign-in?continue=/personal-account&accountType=individual&origin=PTA-frontend){/button}
+    {button}[Choose Government Gateway](https://www.tax.service.gov.uk/gg/sign-in?continue=/personal-account&accountType=individual&origin=PTA-frontend){/button}
 
-    ### GOV.UK Verify
+    ## GOV.UK Verify
 
-    Registering with GOV.UK Verify usually takes about 15 minutes. It works best if you have:
+    GOV.UK Verify works best if you're over 20 years old. You'll need:
 
     - a UK address
-    - a valid passport or photocard driving licence
+    - a mobile phone
+    - at least one valid photo ID from any country
 
-    {button}[Create a GOV.UK Verify account](https://www.signin.service.gov.uk/initiate-journey/hmrc-personal-tax-account?journey_hint=registration){/button}
+    {button}[Choose GOV.UK Verify](https://www.signin.service.gov.uk/initiate-journey/hmrc-personal-tax-account?journey_hint=registration){/button}
 
-    A certified company will double check your identity when you register with GOV.UK Verify. They’ve all met security standards set by government.
-
-    ## Personal tax account
-
-    Signing in for the first time will activate your personal tax account. You can use this to check your HMRC records and manage your other details.
 update_type: minor
-change_note: Updated eIDAS content because more than two countries are connected now.
+change_note: Updated create account page content to be more accurate and help people choose.


### PR DESCRIPTION
- Updated eligibility criteria for Gateway and Verify 
- Added examples of the most popular other services you can use each account for 
- Edited headings and buttons to make it clearer that users need to choose between two options

This is part of work on GOV.UK Verify user journeys, being done by the hub/eIDAS team. The new page content has been approved by HMRC.

[Jira ticket is here. ](https://govukverify.atlassian.net/browse/HUB-660?atlOrigin=eyJpIjoiMTkxNzU0MzY5YTc1NDc0Yzg5ZGE4NDQ3ZjlkMjAxMjUiLCJwIjoiaiJ9)