### PR TITLE
Fix formatting

### DIFF
--- a/lib/service_sign_in/personal-tax-account.en.yaml
+++ b/lib/service_sign_in/personal-tax-account.en.yaml
@@ -26,7 +26,7 @@ create_new_account:
 
     ## Government Gateway
 
-   You'll need:
+    You'll need:
 
     - your National Insurance number or UK address
     - a recent payslip or P60 or a valid UK passport


### PR DESCRIPTION
'You'll need:' was being treated as a new YAML property instead
of part of the 'body:' YAML property.

Follow-on from #1300. 

Trello: https://trello.com/c/nP2Y2ztz/2043-content-pr-update-content-on-the-service-sign-in-pages