### PR TITLE
Scan for only the edition ID in fact check response subject

### DIFF
--- a/lib/fact_check_config.rb
+++ b/lib/fact_check_config.rb
@@ -14,7 +14,7 @@ class FactCheckConfig
     @reply_to_id = reply_to_id
 
     @subject_prefix = subject_prefix.present? ? subject_prefix + "-" : ""
-    @subject_pattern = /\[#{@subject_prefix}(?<id>[0-9a-f]+)\]/
+    @subject_pattern = /\[#{@subject_prefix}(?<id>[0-9a-f]{24})\]/
 
     @address_prefix, @address_suffix = address_format.split("{id}")
     @address_pattern = Regexp.new(

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -66,6 +66,8 @@ FactoryBot.define do
   end
 
   factory :edition, class: AnswerEdition do
+    id              { SecureRandom.hex(12) }
+
     panopticon_id do
       a = create(:artefact, kind: kind_for_artefact)
       a.id

--- a/test/unit/fact_check_config_test.rb
+++ b/test/unit/fact_check_config_test.rb
@@ -5,11 +5,13 @@ class FactCheckConfigTest < ActiveSupport::TestCase
   valid_address = "factcheck+1234@example.com"
   valid_address_pattern = "factcheck+{id}@example.com"
   reply_to_address = valid_address
-  valid_subjects = ["‘[Some title]’ GOV.UK preview of new edition [1234]",
-                    "‘[Some title]’ GOV.UK preview of new edition [1234] - ticket #5678",
-                    "I've edited the subject but left the ID at the end [1234]",
-                    "I've edited the subject and appended something [1234] - ticket #2468"]
-  valid_prefixed_subjects = valid_subjects.map { |subject| subject.gsub(/\[1234\]/, "[test-1234]") }
+  valid_subjects = ["‘[Some title]’ GOV.UK preview of new edition [5e6bb57b40f0b62656e3e184]",
+                    "‘[Some title]’ GOV.UK preview of new edition [5e6bb57b40f0b62656e3e184] - ticket #5678",
+                    "‘[123456]’ GOV.UK preview of new edition [5e6bb57b40f0b62656e3e184]",
+                    "‘[123456]’ GOV.UK preview of new edition [5e6bb57b40f0b62656e3e184] - ticket #5678",
+                    "I've edited the subject but left the ID at the end [5e6bb57b40f0b62656e3e184]",
+                    "I've edited the subject and appended something [5e6bb57b40f0b62656e3e184] - ticket #2468"]
+  valid_prefixed_subjects = valid_subjects.map { |subject| subject.gsub(/\[5e6bb57b40f0b62656e3e184\]/, "[test-5e6bb57b40f0b62656e3e184]") }
 
   should "fail on a nil address format" do
     assert_raises ArgumentError do
@@ -120,7 +122,7 @@ class FactCheckConfigTest < ActiveSupport::TestCase
   should "extract an item ID from a valid subject" do
     config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
     valid_subjects.each do |valid_subject|
-      assert_equal "1234", config.item_id_from_subject(valid_subject)
+      assert_equal "5e6bb57b40f0b62656e3e184", config.item_id_from_subject(valid_subject)
     end
   end
 
@@ -138,10 +140,10 @@ class FactCheckConfigTest < ActiveSupport::TestCase
   should "raise an exception if there are multiple matches" do
     config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
     valid_subjects.each do |valid_subject|
-      assert_equal false, config.valid_subject?(valid_subject + " [5678]")
+      assert_equal false, config.valid_subject?(valid_subject + " [d682605bec3cf9b8906cf2bc]")
 
       assert_raises ArgumentError do
-        config.item_id_from_subject(valid_subject + " [5678]")
+        config.item_id_from_subject(valid_subject + " [d682605bec3cf9b8906cf2bc]")
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/uTeN3PfS/921-fact-check-emails-not-processed

In 568c72d8c98641977285fc6aa7b7909cfaaa1795, the regex for subject matching was changed. This has an unintended effect of blocking fact check responses being processed where the subject contained any other numbers in square brackets.

Therefore requiring the pattern to be exactly 24 characters, in order to improve matching of the string we are interested in.