### PR TITLE
Generate an auth bypass token for each edition

### DIFF
--- a/app/helpers/paths_helper.rb
+++ b/app/helpers/paths_helper.rb
@@ -7,7 +7,7 @@ module PathsHelper
     path = edition_front_end_path(edition)
 
     if should_have_auth_bypass_id?(edition)
-      token = jwt_token(sub: edition.auth_bypass_id)
+      token = jwt_token(sub: edition.temp_auth_bypass_id)
       path << "?token=#{token}"
     end
     path
@@ -46,6 +46,6 @@ protected
 private
 
   def should_have_auth_bypass_id?(edition)
-    %w[published archived].exclude?(edition.state) && edition.auth_bypass_id
+    %w[published archived].exclude?(edition.state) && edition.temp_auth_bypass_id
   end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -120,6 +120,10 @@ class Edition
     destroy_artefact
   end
 
+  after_create do
+    update(auth_bypass_id: temp_auth_bypass_id)
+  end
+
   index assigned_to_id: 1
   index({ panopticon_id: 1, version_number: 1 }, unique: true)
   index state: 1

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -33,6 +33,8 @@ class Edition
   field :change_note,          type: String
   field :review_requested_at,  type: DateTime
 
+  field :auth_bypass_id,       type: String
+
   belongs_to :assigned_to, class_name: "User", optional: true
 
   embeds_many :link_check_reports

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -451,8 +451,8 @@ class Edition
     end
   end
 
-  def auth_bypass_id
-    @auth_bypass_id ||= begin
+  def temp_auth_bypass_id
+    @temp_auth_bypass_id ||= begin
       ary = Digest::SHA256.digest(id.to_s).unpack("NnnnnN")
       ary[2] = (ary[2] & 0x0fff) | 0x4000
       ary[3] = (ary[3] & 0x3fff) | 0x8000

--- a/app/presenters/formats/edition_format_presenter.rb
+++ b/app/presenters/formats/edition_format_presenter.rb
@@ -16,8 +16,8 @@ module Formats
     def optional_fields
       fields = {}
 
-      if edition.auth_bypass_id
-        fields[:access_limited] = { auth_bypass_ids: [edition.auth_bypass_id] }
+      if edition.temp_auth_bypass_id
+        fields[:access_limited] = { auth_bypass_ids: [edition.temp_auth_bypass_id] }
       end
 
       if edition.in_beta

--- a/lib/tasks/set_auth_bypass_id.rake
+++ b/lib/tasks/set_auth_bypass_id.rake
@@ -1,0 +1,6 @@
+desc "Imports services and removes any old ones"
+task set_auth_bypass_id: :environment do
+  Edition.all.each do |edition|
+    edition.update(auth_bypass_id: edition.temp_auth_bypass_id)
+  end
+end

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -27,19 +27,19 @@ class EditionTest < ActiveSupport::TestCase
     should "return a deterministic hex id if edition is in fact-check state" do
       edition = FactoryBot.create(:edition, state: "fact_check", id: 123)
       edition.artefact.update(kind: "help_page")
-      assert_equal edition.auth_bypass_id, "a665a459-2042-4f9d-817e-4867efdc4fb8"
+      assert_equal edition.temp_auth_bypass_id, "a665a459-2042-4f9d-817e-4867efdc4fb8"
     end
 
     should "return a deterministic hex id if edition is in fact-check-received state" do
       edition = FactoryBot.create(:edition, state: "fact_check_received", id: 123)
       edition.artefact.update(kind: "help_page")
-      assert_equal edition.auth_bypass_id, "a665a459-2042-4f9d-817e-4867efdc4fb8"
+      assert_equal edition.temp_auth_bypass_id, "a665a459-2042-4f9d-817e-4867efdc4fb8"
     end
 
     should "return a deterministic hex id if edition is in ready state" do
       edition = FactoryBot.create(:edition, state: "ready", id: 123)
       edition.artefact.update(kind: "help_page")
-      assert_equal edition.auth_bypass_id, "a665a459-2042-4f9d-817e-4867efdc4fb8"
+      assert_equal edition.temp_auth_bypass_id, "a665a459-2042-4f9d-817e-4867efdc4fb8"
     end
   end
 end

--- a/test/unit/helpers/admin/paths_helper_test.rb
+++ b/test/unit/helpers/admin/paths_helper_test.rb
@@ -14,7 +14,7 @@ class PathsHelperTest < ActionView::TestCase
 
     context "when the edition returns an auth_bypass_id" do
       should "append a valid JWT token to the preview path" do
-        edition = stub(auth_bypass_id: "123", state: "draft", slug: "foo")
+        edition = stub(temp_auth_bypass_id: "123", state: "draft", slug: "foo")
         result = preview_edition_path(edition)
 
         path = result.gsub(/^(.*)\?.*$/, '\1')

--- a/test/unit/presenters/formats/edition_format_presenter_test.rb
+++ b/test/unit/presenters/formats/edition_format_presenter_test.rb
@@ -27,7 +27,7 @@ class EditionFormatPresenterTest < ActiveSupport::TestCase
       edition.stubs :major_change
       edition.stubs :version_number
       edition.stubs :latest_change_note
-      edition.stubs :auth_bypass_id
+      edition.stubs :temp_auth_bypass_id
       edition.stubs :exact_route?
 
       artefact.stubs :language
@@ -157,13 +157,13 @@ class EditionFormatPresenterTest < ActiveSupport::TestCase
 
     context "[:access_limited]" do
       should "return auth_bypass_ids if present" do
-        edition.expects(:auth_bypass_id).twice.returns("foo")
+        edition.expects(:temp_auth_bypass_id).twice.returns("foo")
         expected = { auth_bypass_ids: %w[foo] }
         assert_equal expected, result[:access_limited]
       end
 
       should "not exist if no auth_bypass_id is present" do
-        edition.expects(:auth_bypass_id).returns(nil)
+        edition.expects(:temp_auth_bypass_id).returns(nil)
         assert_not result.key?(:access_limited)
       end
     end

--- a/test/unit/presenters/formats/generic_edition_presenter_test.rb
+++ b/test/unit/presenters/formats/generic_edition_presenter_test.rb
@@ -45,7 +45,7 @@ class GenericEditionPresenterTest < ActiveSupport::TestCase
         },
         locale: "en",
         access_limited: {
-          auth_bypass_ids: [@edition.auth_bypass_id],
+          auth_bypass_ids: [@edition.temp_auth_bypass_id],
         },
       }
     end


### PR DESCRIPTION
Currently the auth bypass token is based off the ID of the edition, this means it's not possible to invalidate old tokens, if they were leaked for example. To support this, I've create a Rake task that populates the new field based on the existing method so existing editions will continue to work, but from now onwards, the tokens will be generated from a random UUID. See commits for more details.

[Trello Card](https://trello.com/c/oqQD7nOl/2053-5-improve-draft-access-mechanism-for-mainstream-publisher)