### PR TITLE
Improvements to the auth bypass token

### DIFF
--- a/app/helpers/paths_helper.rb
+++ b/app/helpers/paths_helper.rb
@@ -28,7 +28,12 @@ module PathsHelper
 protected
 
   def jwt_token(sub:)
-    JWT.encode({ "sub" => sub }, jwt_auth_secret, "HS256")
+    payload = {
+      "sub" => sub,
+      "iat" => Time.zone.now.to_i,
+      "exp" => 1.month.from_now.to_i,
+    }
+    JWT.encode(payload, jwt_auth_secret, "HS256")
   end
 
   def jwt_auth_secret

--- a/app/helpers/paths_helper.rb
+++ b/app/helpers/paths_helper.rb
@@ -7,9 +7,9 @@ module PathsHelper
     path = edition_front_end_path(edition)
 
     if should_have_auth_bypass_id?(edition)
-      token = jwt_token(sub: edition.auth_bypass_id)
-      path << "?token=#{token}"
+      path << "?token=#{jwt_token(edition)}"
     end
+
     path
   end
 
@@ -27,9 +27,10 @@ module PathsHelper
 
 protected
 
-  def jwt_token(sub:)
+  def jwt_token(edition)
     payload = {
-      "sub" => sub,
+      "sub" => edition.auth_bypass_id,
+      "content_id" => edition.content_id,
       "iat" => Time.zone.now.to_i,
       "exp" => 1.month.from_now.to_i,
     }

--- a/app/helpers/paths_helper.rb
+++ b/app/helpers/paths_helper.rb
@@ -7,7 +7,7 @@ module PathsHelper
     path = edition_front_end_path(edition)
 
     if should_have_auth_bypass_id?(edition)
-      token = jwt_token(sub: edition.temp_auth_bypass_id)
+      token = jwt_token(sub: edition.auth_bypass_id)
       path << "?token=#{token}"
     end
     path
@@ -46,6 +46,6 @@ protected
 private
 
   def should_have_auth_bypass_id?(edition)
-    %w[published archived].exclude?(edition.state) && edition.temp_auth_bypass_id
+    %w[published archived].exclude?(edition.state) && edition.auth_bypass_id
   end
 end

--- a/app/helpers/paths_helper.rb
+++ b/app/helpers/paths_helper.rb
@@ -46,6 +46,6 @@ protected
 private
 
   def should_have_auth_bypass_id?(edition)
-    %w[published archived].exclude?(edition.state) && edition.auth_bypass_id
+    %w[published archived].exclude?(edition.state)
   end
 end

--- a/app/presenters/formats/edition_format_presenter.rb
+++ b/app/presenters/formats/edition_format_presenter.rb
@@ -14,17 +14,10 @@ module Formats
     attr_reader :edition, :artefact
 
     def optional_fields
-      fields = {}
+      access_limited = { auth_bypass_ids: [edition.auth_bypass_id] }
+      phase = edition.in_beta ? "beta" : nil
 
-      if edition.auth_bypass_id
-        fields[:access_limited] = { auth_bypass_ids: [edition.auth_bypass_id] }
-      end
-
-      if edition.in_beta
-        fields[:phase] = "beta"
-      end
-
-      fields
+      { access_limited: access_limited, phase: phase }.compact
     end
 
     def required_fields(republish)

--- a/app/presenters/formats/edition_format_presenter.rb
+++ b/app/presenters/formats/edition_format_presenter.rb
@@ -16,8 +16,8 @@ module Formats
     def optional_fields
       fields = {}
 
-      if edition.temp_auth_bypass_id
-        fields[:access_limited] = { auth_bypass_ids: [edition.temp_auth_bypass_id] }
+      if edition.auth_bypass_id
+        fields[:access_limited] = { auth_bypass_ids: [edition.auth_bypass_id] }
       end
 
       if edition.in_beta

--- a/lib/tasks/set_auth_bypass_id.rake
+++ b/lib/tasks/set_auth_bypass_id.rake
@@ -1,6 +1,0 @@
-desc "Imports services and removes any old ones"
-task set_auth_bypass_id: :environment do
-  Edition.all.each do |edition|
-    edition.set(auth_bypass_id: edition.temp_auth_bypass_id)
-  end
-end

--- a/test/unit/edition_test.rb
+++ b/test/unit/edition_test.rb
@@ -23,23 +23,12 @@ class EditionTest < ActiveSupport::TestCase
     assert_match "Internal links must start with a forward slash", exception.message
   end
 
-  context "#auth_bypass_id" do
-    should "return a deterministic hex id if edition is in fact-check state" do
-      edition = FactoryBot.create(:edition, state: "fact_check", id: 123)
-      edition.artefact.update(kind: "help_page")
-      assert_equal edition.temp_auth_bypass_id, "a665a459-2042-4f9d-817e-4867efdc4fb8"
-    end
+  should "generate a unique random auth_bypass_id" do
+    edition = FactoryBot.create(:edition)
+    assert edition.auth_bypass_id.is_a?(String)
+    assert_not edition.auth_bypass_id.empty?
 
-    should "return a deterministic hex id if edition is in fact-check-received state" do
-      edition = FactoryBot.create(:edition, state: "fact_check_received", id: 123)
-      edition.artefact.update(kind: "help_page")
-      assert_equal edition.temp_auth_bypass_id, "a665a459-2042-4f9d-817e-4867efdc4fb8"
-    end
-
-    should "return a deterministic hex id if edition is in ready state" do
-      edition = FactoryBot.create(:edition, state: "ready", id: 123)
-      edition.artefact.update(kind: "help_page")
-      assert_equal edition.temp_auth_bypass_id, "a665a459-2042-4f9d-817e-4867efdc4fb8"
-    end
+    second_edition = FactoryBot.create(:edition)
+    assert_not_equal edition.auth_bypass_id, second_edition.auth_bypass_id
   end
 end

--- a/test/unit/helpers/admin/paths_helper_test.rb
+++ b/test/unit/helpers/admin/paths_helper_test.rb
@@ -24,6 +24,8 @@ class PathsHelperTest < ActionView::TestCase
         payload = decoded_token_payload(token)
 
         assert_equal payload["sub"], "123"
+        assert_equal payload["iat"], Time.zone.now.to_i
+        assert_equal payload["exp"], 1.month.from_now.to_i
       end
     end
 

--- a/test/unit/helpers/admin/paths_helper_test.rb
+++ b/test/unit/helpers/admin/paths_helper_test.rb
@@ -14,7 +14,7 @@ class PathsHelperTest < ActionView::TestCase
 
     context "when the edition returns an auth_bypass_id" do
       should "append a valid JWT token to the preview path" do
-        edition = stub(auth_bypass_id: "123", state: "draft", slug: "foo")
+        edition = stub(auth_bypass_id: "123", state: "draft", slug: "foo", content_id: "68134a9a-6146-4925-8472-4e3dd42c055a")
         result = preview_edition_path(edition)
 
         path = result.gsub(/^(.*)\?.*$/, '\1')
@@ -24,6 +24,7 @@ class PathsHelperTest < ActionView::TestCase
         payload = decoded_token_payload(token)
 
         assert_equal payload["sub"], "123"
+        assert_equal payload["content_id"], "68134a9a-6146-4925-8472-4e3dd42c055a"
         assert_equal payload["iat"], Time.zone.now.to_i
         assert_equal payload["exp"], 1.month.from_now.to_i
       end

--- a/test/unit/helpers/admin/paths_helper_test.rb
+++ b/test/unit/helpers/admin/paths_helper_test.rb
@@ -14,7 +14,7 @@ class PathsHelperTest < ActionView::TestCase
 
     context "when the edition returns an auth_bypass_id" do
       should "append a valid JWT token to the preview path" do
-        edition = stub(temp_auth_bypass_id: "123", state: "draft", slug: "foo")
+        edition = stub(auth_bypass_id: "123", state: "draft", slug: "foo")
         result = preview_edition_path(edition)
 
         path = result.gsub(/^(.*)\?.*$/, '\1')

--- a/test/unit/presenters/formats/edition_format_presenter_test.rb
+++ b/test/unit/presenters/formats/edition_format_presenter_test.rb
@@ -155,17 +155,10 @@ class EditionFormatPresenterTest < ActiveSupport::TestCase
       assert_equal "foo", result[:locale]
     end
 
-    context "[:access_limited]" do
-      should "return auth_bypass_ids if present" do
-        edition.expects(:auth_bypass_id).twice.returns("foo")
-        expected = { auth_bypass_ids: %w[foo] }
-        assert_equal expected, result[:access_limited]
-      end
-
-      should "not exist if no auth_bypass_id is present" do
-        edition.expects(:auth_bypass_id).returns(nil)
-        assert_not result.key?(:access_limited)
-      end
+    should "[:access_limited]" do
+      edition.expects(:auth_bypass_id).returns("foo")
+      expected = { auth_bypass_ids: %w[foo] }
+      assert_equal expected, result[:access_limited]
     end
   end
 end

--- a/test/unit/presenters/formats/edition_format_presenter_test.rb
+++ b/test/unit/presenters/formats/edition_format_presenter_test.rb
@@ -27,7 +27,7 @@ class EditionFormatPresenterTest < ActiveSupport::TestCase
       edition.stubs :major_change
       edition.stubs :version_number
       edition.stubs :latest_change_note
-      edition.stubs :temp_auth_bypass_id
+      edition.stubs :auth_bypass_id
       edition.stubs :exact_route?
 
       artefact.stubs :language
@@ -157,13 +157,13 @@ class EditionFormatPresenterTest < ActiveSupport::TestCase
 
     context "[:access_limited]" do
       should "return auth_bypass_ids if present" do
-        edition.expects(:temp_auth_bypass_id).twice.returns("foo")
+        edition.expects(:auth_bypass_id).twice.returns("foo")
         expected = { auth_bypass_ids: %w[foo] }
         assert_equal expected, result[:access_limited]
       end
 
       should "not exist if no auth_bypass_id is present" do
-        edition.expects(:temp_auth_bypass_id).returns(nil)
+        edition.expects(:auth_bypass_id).returns(nil)
         assert_not result.key?(:access_limited)
       end
     end

--- a/test/unit/presenters/formats/generic_edition_presenter_test.rb
+++ b/test/unit/presenters/formats/generic_edition_presenter_test.rb
@@ -45,7 +45,7 @@ class GenericEditionPresenterTest < ActiveSupport::TestCase
         },
         locale: "en",
         access_limited: {
-          auth_bypass_ids: [@edition.temp_auth_bypass_id],
+          auth_bypass_ids: [@edition.auth_bypass_id],
         },
       }
     end


### PR DESCRIPTION
This follows on from #1313 to make various improvements to the auth bypass token. Specifically it adds a `content_id` field to the token for auditing and adds an expiration date of one month to the token. See individual commits for more details.

[Trello Card](https://trello.com/c/oqQD7nOl/2053-5-improve-draft-access-mechanism-for-mainstream-publisher)