### PR TITLE
Use update_attribute in Rake task

### DIFF
--- a/lib/tasks/set_auth_bypass_id.rake
+++ b/lib/tasks/set_auth_bypass_id.rake
@@ -1,6 +1,8 @@
 desc "Imports services and removes any old ones"
 task set_auth_bypass_id: :environment do
   Edition.all.each do |edition|
-    edition.update(auth_bypass_id: edition.temp_auth_bypass_id)
+    # rubocop:disable Rails/SkipsModelValidations
+    edition.update_attribute(:auth_bypass_id, edition.temp_auth_bypass_id)
+    # rubocop:enable Rails/SkipsModelValidations
   end
 end


### PR DESCRIPTION
The `update` method performs validation, some editions are failing validation (mostly archived ones where they're not allowed to be edited). Although it shouldn't matter as `auth_bypass_id` only matters for draft editions, I would prefer that all editions have one so we can be confident the value won't ever be `nil`.

This follows on from #1313.

[Trello Card](https://trello.com/c/oqQD7nOl/2053-5-improve-draft-access-mechanism-for-mainstream-publisher)