### PR TITLE
Use set in a Rake task

### DIFF
--- a/lib/tasks/set_auth_bypass_id.rake
+++ b/lib/tasks/set_auth_bypass_id.rake
@@ -1,8 +1,6 @@
 desc "Imports services and removes any old ones"
 task set_auth_bypass_id: :environment do
   Edition.all.each do |edition|
-    # rubocop:disable Rails/SkipsModelValidations
-    edition.update_attribute(:auth_bypass_id, edition.temp_auth_bypass_id)
-    # rubocop:enable Rails/SkipsModelValidations
+    edition.set(auth_bypass_id: edition.temp_auth_bypass_id)
   end
 end


### PR DESCRIPTION
In #1315 I changed the code to use `update_attribute` so it ignores the validation, but still runs the callback. Unfortunately there's a callback set up which performs validation which means this solution
doesn't work: https://github.com/alphagov/publisher/blob/35c2756693990798de7a6e3b0d15721c682a5b30/app/models/edition.rb#L391-L403

Instead we can use `set` which performs a single atomic operation on the database. See https://docs.mongodb.com/mongoid/current/tutorials/mongoid-persistence/#atomic for more details.

The task also takes only 2 minutes to run using `set` compared to 10 minutes with `update`.