### PR TITLE
Extend default rake task with rubocop linting

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,4 +10,4 @@ Rake.application.options.trace = true
 
 Rails.application.load_tasks
 
-task default: ["db:mongoid:create_indexes", :test, "jasmine:ci"]
+task default: ["db:mongoid:create_indexes", :test, "jasmine:ci", :lint]

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Lint Ruby"
+task lint: :environment do
+  sh "bundle exec rubocop"
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/5Gob6WUL/147-for-everyone-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks)