### PR TITLE
Alert when fact check emails cannot be processed

### DIFF
--- a/app/mailers/noisy_workflow.rb
+++ b/app/mailers/noisy_workflow.rb
@@ -58,11 +58,6 @@ class NoisyWorkflow < ApplicationMailer
     end
   end
 
-  def report_errors(error_list)
-    @errors = error_list
-    mail(to: EMAIL_GROUPS[:dev], subject: "Errors in fact check email processing")
-  end
-
 protected
 
   def describe_action(action)

--- a/config/initializers/email_groups.rb
+++ b/config/initializers/email_groups.rb
@@ -1,5 +1,4 @@
 EMAIL_GROUPS = {
-  dev: [ENV.fetch("EMAIL_GROUP_DEV", "govuk-dev@digital.cabinet-office.gov.uk")],
   business: [ENV.fetch("EMAIL_GROUP_BUSINESS", "publisher-alerts-business@digital.cabinet-office.gov.uk")],
   citizen: [ENV.fetch("EMAIL_GROUP_CITIZEN", "publisher-alerts-citizen@digital.cabinet-office.gov.uk")],
   force_publish_alerts: [ENV.fetch("EMAIL_GROUP_FORCE_PUBLISH_ALERTS", "mainstream-force-publishing-alerts@digital.cabinet-office.gov.uk")],

--- a/script/mail_fetcher
+++ b/script/mail_fetcher
@@ -51,9 +51,4 @@ rescue StandardError => e
   raise
 end
 
-if handler.errors.any?
-  Rails.logger.error(handler.errors.join("\n"))
-  NoisyWorkflow.report_errors(handler.errors).deliver
-end
-
 Rails.logger.info "Finished running MailFetcher in #{Rails.env} mode - #{Time.now.utc}"


### PR DESCRIPTION
https://trello.com/c/uTeN3PfS/921-fact-check-emails-not-processed

Previously we used to collect fact check processing errors and send
them to an email address. The code for this appeared to be broken
(it wasn't sending an email), and in any case, we should be sending
all errors to Sentry, so they're in one place.