### PR TITLE
Remove support for email fact check reading edition ID from address

### DIFF
--- a/config/fact_check.yml
+++ b/config/fact_check.yml
@@ -3,7 +3,6 @@
 # The main address pattern sent out as the From address on fact check emails
 # If we ever want to change this format, we'll need to support some notion of
 # legacy formats, so we still pick up emails to old addresses
-address_format: <%=ENV.fetch("FACT_CHECK_ADDRESS_FORMAT", "factcheck+dev-{id}@alphagov.co.uk") %>
 subject_prefix: <%=ENV.fetch("FACT_CHECK_SUBJECT_PREFIX", "") %>
 reply_to_address: <%=ENV.fetch("FACT_CHECK_REPLY_TO_ADDRESS", "factcheck+dev@alphagov.co.uk") %>
 reply_to_id: <%=ENV.fetch("FACT_CHECK_REPLY_TO_ID", nil) %>

--- a/config/initializers/fact_check.rb
+++ b/config/initializers/fact_check.rb
@@ -9,7 +9,6 @@ config = YAML.safe_load(
 )
 
 Publisher::Application.fact_check_config = FactCheckConfig.new(
-  config.fetch("address_format"),
   config.fetch("reply_to_address"),
   config.fetch("subject_prefix"),
   config.fetch("reply_to_id"),

--- a/lib/fact_check_config.rb
+++ b/lib/fact_check_config.rb
@@ -1,11 +1,7 @@
 class FactCheckConfig
   attr_reader :subject_prefix, :reply_to_id
 
-  def initialize(address_format, reply_to_address, subject_prefix = "", reply_to_id = nil)
-    unless address_format && address_format.scan("{id}").count == 1
-      raise ArgumentError, "Expected '#{address_format}' to contain exactly one '{id}'"
-    end
-
+  def initialize(reply_to_address, subject_prefix = "", reply_to_id = nil)
     if reply_to_address.blank?
       raise ArgumentError, "Expected reply_to_address not to be nil"
     end
@@ -15,27 +11,6 @@ class FactCheckConfig
 
     @subject_prefix = subject_prefix.present? ? subject_prefix + "-" : ""
     @subject_pattern = /\[#{@subject_prefix}(?<id>[0-9a-f]{24})\]/
-
-    @address_prefix, @address_suffix = address_format.split("{id}")
-    @address_pattern = Regexp.new(
-      '\A' +
-      Regexp.escape(@address_prefix) +
-      "(.+?)" +
-      Regexp.escape(@address_suffix) +
-      '\Z',
-    )
-  end
-
-  def valid_address?(address)
-    @address_pattern.match(address).present?
-  end
-
-  def item_id_from_address(address)
-    if (match = @address_pattern.match(address))
-      match.captures[0]
-    else
-      raise ArgumentError, "'#{address}' is not a valid fact check address"
-    end
   end
 
   def address

--- a/lib/fact_check_email_handler.rb
+++ b/lib/fact_check_email_handler.rb
@@ -25,14 +25,7 @@ class FactCheckEmailHandler
       return FactCheckMessageProcessor.process(message, edition_id)
     end
 
-    message.recipients.each do |recipient|
-      if @fact_check_config.valid_address?(recipient.to_s)
-        edition_id = @fact_check_config.item_id_from_address(recipient.to_s)
-        return FactCheckMessageProcessor.process(message, edition_id)
-      end
-    end
-
-    raise "Unable to locate fact check ID from address or subject"
+    raise "Unable to locate fact check ID from subject"
   rescue StandardError => e
     message = "Failed to process message '#{message.subject}': #{e.message}"
     GovukError.notify(UnableToProcessError.new(message))

--- a/test/unit/fact_check_config_test.rb
+++ b/test/unit/fact_check_config_test.rb
@@ -1,10 +1,8 @@
 require "test_helper"
-require "fact_check_config"
 
 class FactCheckConfigTest < ActiveSupport::TestCase
-  valid_address = "factcheck+1234@example.com"
-  valid_address_pattern = "factcheck+{id}@example.com"
-  reply_to_address = valid_address
+  subject_prefix = "test"
+  reply_to_address = "factcheck+1234@example.com"
   valid_subjects = ["‘[Some title]’ GOV.UK preview of new edition [5e6bb57b40f0b62656e3e184]",
                     "‘[Some title]’ GOV.UK preview of new edition [5e6bb57b40f0b62656e3e184] - ticket #5678",
                     "‘[123456]’ GOV.UK preview of new edition [5e6bb57b40f0b62656e3e184]",
@@ -13,87 +11,32 @@ class FactCheckConfigTest < ActiveSupport::TestCase
                     "I've edited the subject and appended something [5e6bb57b40f0b62656e3e184] - ticket #2468"]
   valid_prefixed_subjects = valid_subjects.map { |subject| subject.gsub(/\[5e6bb57b40f0b62656e3e184\]/, "[test-5e6bb57b40f0b62656e3e184]") }
 
-  should "fail on a nil address format" do
-    assert_raises ArgumentError do
-      FactCheckConfig.new(nil, reply_to_address)
-    end
-  end
-
   should "fail on a nil reply-to address" do
     assert_raises ArgumentError do
-      FactCheckConfig.new(valid_address_pattern, nil)
-    end
-  end
-
-  should "fail on an empty address format" do
-    assert_raises ArgumentError do
-      FactCheckConfig.new("", reply_to_address)
+      FactCheckConfig.new(nil)
     end
   end
 
   should "fail on an empty reply-to address" do
     assert_raises ArgumentError do
-      FactCheckConfig.new(valid_address_pattern, "")
-    end
-  end
-
-  should "fail on an address format with no ID marker" do
-    assert_raises ArgumentError do
-      FactCheckConfig.new("factcheck@example.com", reply_to_address)
-    end
-  end
-
-  should "accept an address format with an ID marker" do
-    FactCheckConfig.new(valid_address_pattern, reply_to_address)
-  end
-
-  should "fail on an address format with multiple ID markers" do
-    assert_raises ArgumentError do
-      FactCheckConfig.new("factcheck+{id}+{id}@example.com", reply_to_address)
-    end
-  end
-
-  should "recognise a valid fact check address" do
-    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
-    assert config.valid_address?(valid_address)
-  end
-
-  should "not recognise an invalid fact check address" do
-    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
-    assert_not config.valid_address?("not-factcheck@example.com")
-  end
-
-  should "not recognise a fact check address with an empty ID" do
-    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
-    assert_not config.valid_address?("factcheck+@example.com")
-  end
-
-  should "extract an item ID from a valid address" do
-    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
-    assert_equal "1234", config.item_id_from_address(valid_address)
-  end
-
-  should "raise an exception trying to extract an ID from an invalid address" do
-    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
-    assert_raises ArgumentError do
-      config.item_id_from_address("not-factcheck+1234@example.com")
+      FactCheckConfig.new("")
     end
   end
 
   should "return a static reply-to address regardless of id" do
-    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
+    config = FactCheckConfig.new(reply_to_address)
     assert_equal reply_to_address, config.address
   end
 
   should "recognise a valid fact check subject" do
-    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
+    config = FactCheckConfig.new(reply_to_address)
     valid_subjects.each do |valid_subject|
       assert config.valid_subject?(valid_subject)
     end
   end
 
   should "recognise a valid fact check subject with a prefix" do
-    config = FactCheckConfig.new(valid_address_pattern, reply_to_address, "test")
+    config = FactCheckConfig.new(reply_to_address, subject_prefix)
     valid_prefixed_subjects.each do |valid_prefixed_subject|
       assert config.valid_subject?(valid_prefixed_subject)
     end
@@ -103,31 +46,31 @@ class FactCheckConfigTest < ActiveSupport::TestCase
   end
 
   should "not recognise an invalid fact check subject" do
-    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
+    config = FactCheckConfig.new(reply_to_address)
     assert_not config.valid_subject?("Not a valid subject")
   end
 
   should "treat a subject prefixed with Re: as valid" do
-    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
+    config = FactCheckConfig.new(reply_to_address)
     valid_subjects.each do |valid_subject|
       assert config.valid_subject?("Re: " + valid_subject)
     end
   end
 
   should "not recognise a fact check subject with an empty ID" do
-    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
+    config = FactCheckConfig.new(reply_to_address)
     assert_not config.valid_subject?("Not a valid subject []")
   end
 
   should "extract an item ID from a valid subject" do
-    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
+    config = FactCheckConfig.new(reply_to_address)
     valid_subjects.each do |valid_subject|
       assert_equal "5e6bb57b40f0b62656e3e184", config.item_id_from_subject(valid_subject)
     end
   end
 
   should "raise an exception trying to extract an ID from an invalid subject" do
-    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
+    config = FactCheckConfig.new(reply_to_address)
     assert_raises ArgumentError do
       config.item_id_from_subject("Not a valid subject (1234)")
     end
@@ -138,7 +81,7 @@ class FactCheckConfigTest < ActiveSupport::TestCase
   end
 
   should "raise an exception if there are multiple matches" do
-    config = FactCheckConfig.new(valid_address_pattern, reply_to_address)
+    config = FactCheckConfig.new(reply_to_address)
     valid_subjects.each do |valid_subject|
       assert_equal false, config.valid_subject?(valid_subject + " [d682605bec3cf9b8906cf2bc]")
 


### PR DESCRIPTION
Publisher used to link an email fact check to an edition via an edition
ID provided in the email address.

[This was replaced by instead preferring to match the edition ID from the subject
line](https://github.com/alphagov/publisher/pull/1256), which was a requirement of moving to GOVUK Notify as our e-mail service

Now that this preferred solution is in use, the old code can now be removed.

[trello](https://trello.com/c/D8NuPoX8/2078-2-remove-support-for-edition-ids-in-address-in-publisher)