### PR TITLE
Bump govspeak to 6.5.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,13 +117,13 @@ GEM
       warden-oauth2 (~> 0.0.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govspeak (6.5.5)
+    govspeak (6.5.6)
       actionview (>= 5.0, < 7)
       addressable (>= 2.3.8, < 3)
       govuk_publishing_components (~> 21.4)
       htmlentities (~> 4)
       i18n (~> 0.7)
-      kramdown (~> 1.15.0)
+      kramdown (>= 2.3.0)
       nokogiri (~> 1.5)
       nokogumbo (~> 2)
       rinku (~> 2.0)
@@ -140,7 +140,7 @@ GEM
       sentry-raven (>= 2.7.1, < 3.1.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_publishing_components (21.62.0)
+    govuk_publishing_components (21.63.0)
       govuk_app_config
       kramdown
       plek
@@ -207,14 +207,15 @@ GEM
       kaminari-core (~> 1.0)
       mongoid
     kgio (2.11.3)
-    kramdown (1.15.0)
+    kramdown (2.3.0)
+      rexml
     link_header (0.0.8)
     logstash-event (1.2.02)
     logstasher (1.3.0)
       activesupport (>= 4.0)
       logstash-event (~> 1.2.0)
       request_store
-    loofah (2.6.0)
+    loofah (2.7.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -400,7 +401,7 @@ GEM
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sentry-raven (3.0.2)
+    sentry-raven (3.0.3)
       faraday (>= 1.0)
     shoulda (4.0.0)
       shoulda-context (~> 2.0)


### PR DESCRIPTION
This resolves
[CVE-2020-14001](https://github.com/advisories/GHSA-mqm2-cgpr-p4m6)

[Trello](https://trello.com/c/H49ZOsu1/972-update-all-govspeak-depenendencies-in-govuk-apps)

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/publisher), after merging.
