### PR TITLE
Relax authorized host domains in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,6 +15,9 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
+  # Allow requests for all domains e.g. <app>.dev.gov.uk
+  config.hosts.clear
+
   config.jwt_auth_secret = "123"
 
   # Enable/disable caching. By default caching is disabled.


### PR DESCRIPTION
This changes the development configuration to allow requests from
any domain. While this will include *.dev.gov.uk, this reduces the
coupling to that specific domain without any extra effort, thus
supporting more use cases like Docker training.

Rails 6.0 adds a host authentication middleware that limits access by
default to 0.0.0.0/0, ::/0 and localhost. This commit adds the dev.gov.uk
hosts for the application to that list. There's no need to add the hosts
in production since the middleware is primarily to prevent DNS rebinding
attacks against a Rails application running locally.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/publisher), after merging.
