### PR TITLE
Print coverage after running tests

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,5 +1,0 @@
-require "simplecov-rcov"
-
-SimpleCov.start "rails" do
-end
-SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,6 @@ group :test do
   gem "rails-controller-testing"
   gem "shoulda"
   gem "simplecov", require: false
-  gem "simplecov-rcov", require: false
   gem "timecop"
   gem "webdrivers"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -445,8 +445,6 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
-    simplecov-rcov (0.2.3)
-      simplecov (>= 0.4.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -557,7 +555,6 @@ DEPENDENCIES
   selectize-rails
   shoulda
   simplecov
-  simplecov-rcov
   state_machines
   state_machines-graphviz
   state_machines-mongoid

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,9 +1,8 @@
-# TODO: Enable simplecov again, once the encoding issue is fixed
-# https://github.com/fguillen/simplecov-rcov/issues/20
-#
-# require 'simplecov'
-
 ENV["RAILS_ENV"] = "test"
+
+# Must go at top of file
+require "simplecov"
+SimpleCov.start
 
 require File.expand_path("../config/environment", __dir__)
 


### PR DESCRIPTION
https://trello.com/c/epNWudCR/176-write-an-rfc-for-continuous-deployment-and-seek-review

Previously this used to require visiting the generated, static
webpage, and was surprisingly configured in a '.simplecov' file.


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/publisher), after merging.