### PR TITLE
Enable updating the language of artefacts

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -41,6 +41,6 @@ private
   end
 
   def updatable_params
-    params.require(:artefact).permit(:id, :slug)
+    params.require(:artefact).permit(:id, :slug, :language)
   end
 end

--- a/app/views/shared/_metadata.html.erb
+++ b/app/views/shared/_metadata.html.erb
@@ -4,6 +4,7 @@
       <div class="col-md-12">
         <%= f.input :id, as: :hidden, input_html: { value: @artefact.id } %>
         <%= f.input :slug, :input_html => { :class => "input-md-6" } %>
+        <%= f.input :language, :input_html => { :class => "input-md-6" } %>
       </div>
     </div>
     <%= f.submit 'Update metadata', class: "btn btn-success btn-large" %>


### PR DESCRIPTION
This should help when content is incorrectly marked as english, but
isn't actually english. I see no reason to restrict this in the
interface, I'm guessing it just wasn't considered when trying to merge
Panopticon in to Publisher.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/publisher), after merging.
