### PR TITLE
Adds link to relevant alert documentation

### DIFF
--- a/doc/fact-checking.md
+++ b/doc/fact-checking.md
@@ -9,4 +9,4 @@ Publisher comes with a system to allow editions not yet published to be external
 1. The email arrives in a Gmail inbox. Details of which inbox can be found in secrets under `govuk::apps::publisher::fact_check_username` and `govuk::apps::publisher::fact_check_password`.
 1. Every 5 minutes, the [mail_fetcher](../script/mail_fetcher) script runs which reads any new emails from the inbox, parses the response and adds it to the edition in the database.
 
-**Note:** The ID of the edition is included in the subject line of the fact check email. It's important that this is never removed, otherwise the app would be unable to match the email with the edition.
+**Note:** The ID of the edition is included in the subject line of the fact check email. It's important that this is never removed, otherwise the app will be [unable to match the email with the edition](https://docs.publishing.service.gov.uk/manual/alerts/publisher-unprocessed-fact-check-emails.html).


### PR DESCRIPTION
Adds a link to the documentation for the relevant alert, to tie the documentation together.


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/publisher), after merging.
