### PR TITLE
Look for item ID in body as well as subject of factcheck emails

### DIFF
--- a/app/lib/fact_check_config.rb
+++ b/app/lib/fact_check_config.rb
@@ -17,18 +17,30 @@ class FactCheckConfig
     @reply_to_address
   end
 
-  def valid_subject?(subject)
-    subject.scan(@subject_pattern).length == 1
+  def contains_id?(string)
+    string.scan(@subject_pattern).length == 1
   end
 
-  def item_id_from_subject(subject)
-    match = subject.scan(@subject_pattern)
+  def item_id_from_string(string)
+    match = string.scan(@subject_pattern)
     if match.length == 1
       match[0][0]
     elsif match.length > 1
-      raise ArgumentError, "'#{subject}' has too many matches"
+      raise ArgumentError, "'#{string}' has too many matches"
     else
-      raise ArgumentError, "'#{subject}' is not a valid fact check subject"
+      raise ArgumentError, "'#{string}' does not contain any fact check ID"
     end
+  end
+
+  def item_id_from_subject_or_body(subject, body = "")
+    if contains_id?(subject)
+      id = item_id_from_string(subject)
+    elsif contains_id?(body)
+      id = item_id_from_string(body)
+    else
+      raise ArgumentError, "Message does not contain any fact check ID"
+    end
+
+    id
   end
 end

--- a/app/lib/fact_check_config.rb
+++ b/app/lib/fact_check_config.rb
@@ -17,10 +17,6 @@ class FactCheckConfig
     @reply_to_address
   end
 
-  def contains_id?(string)
-    string.scan(@subject_pattern).length == 1
-  end
-
   def item_id_from_string(string)
     match = string.scan(@subject_pattern)
     if match.length == 1

--- a/app/lib/fact_check_config.rb
+++ b/app/lib/fact_check_config.rb
@@ -27,20 +27,14 @@ class FactCheckConfig
       match[0][0]
     elsif match.length > 1
       raise ArgumentError, "'#{string}' has too many matches"
-    else
-      raise ArgumentError, "'#{string}' does not contain any fact check ID"
     end
   end
 
   def item_id_from_subject_or_body(subject, body = "")
-    if contains_id?(subject)
-      id = item_id_from_string(subject)
-    elsif contains_id?(body)
-      id = item_id_from_string(body)
-    else
-      raise ArgumentError, "Message does not contain any fact check ID"
-    end
+    id = (item_id_from_string(subject) || item_id_from_string(body))
 
-    id
+    return id if id
+
+    raise ArgumentError, "Message does not contain any fact check ID"
   end
 end

--- a/app/lib/fact_check_email_handler.rb
+++ b/app/lib/fact_check_email_handler.rb
@@ -20,12 +20,8 @@ class FactCheckEmailHandler
 
     return true if message.out_of_office?
 
-    if @fact_check_config.valid_subject?(message.subject)
-      edition_id = @fact_check_config.item_id_from_subject(message.subject)
-      return FactCheckMessageProcessor.process(message, edition_id)
-    end
-
-    raise "Unable to locate fact check ID from subject"
+    edition_id = @fact_check_config.item_id_from_subject_or_body(message.subject, message.body)
+    FactCheckMessageProcessor.process(message, edition_id)
   rescue StandardError => e
     message = "Failed to process message '#{message.subject}': #{e.message}"
     GovukError.notify(UnableToProcessError.new(message))

--- a/test/unit/fact_check_config_test.rb
+++ b/test/unit/fact_check_config_test.rb
@@ -31,35 +31,35 @@ class FactCheckConfigTest < ActiveSupport::TestCase
   should "recognise a valid fact check subject" do
     config = FactCheckConfig.new(reply_to_address)
     valid_subjects.each do |valid_subject|
-      assert config.contains_id?(valid_subject)
+      assert config.item_id_from_string(valid_subject).present?
     end
   end
 
   should "recognise a valid fact check subject with a prefix" do
     config = FactCheckConfig.new(reply_to_address, subject_prefix)
     valid_prefixed_subjects.each do |valid_prefixed_subject|
-      assert config.contains_id?(valid_prefixed_subject)
+      assert config.item_id_from_string(valid_prefixed_subject).present?
     end
     valid_subjects.each do |valid_subject|
-      assert_not config.contains_id?(valid_subject)
+      assert_nil config.item_id_from_string(valid_subject)
     end
   end
 
   should "not recognise an invalid fact check subject" do
     config = FactCheckConfig.new(reply_to_address)
-    assert_not config.contains_id?("Not a valid subject")
+    assert_nil config.item_id_from_string("Not a valid subject")
   end
 
   should "treat a subject prefixed with Re: as valid" do
     config = FactCheckConfig.new(reply_to_address)
     valid_subjects.each do |valid_subject|
-      assert config.contains_id?("Re: " + valid_subject)
+      assert config.item_id_from_string("Re: " + valid_subject).present?
     end
   end
 
   should "not recognise a fact check subject with an empty ID" do
     config = FactCheckConfig.new(reply_to_address)
-    assert_not config.contains_id?("Not a valid subject []")
+    assert_nil config.item_id_from_string("Not a valid subject []")
   end
 
   should "extract an item ID from a valid subject" do
@@ -79,8 +79,6 @@ class FactCheckConfigTest < ActiveSupport::TestCase
   should "raise an exception if there are multiple matches" do
     config = FactCheckConfig.new(reply_to_address)
     valid_subjects.each do |valid_subject|
-      assert_equal false, config.contains_id?(valid_subject + " [d682605bec3cf9b8906cf2bc]")
-
       assert_raises ArgumentError do
         config.item_id_from_string(valid_subject + " [d682605bec3cf9b8906cf2bc]")
       end

--- a/test/unit/fact_check_config_test.rb
+++ b/test/unit/fact_check_config_test.rb
@@ -31,63 +31,85 @@ class FactCheckConfigTest < ActiveSupport::TestCase
   should "recognise a valid fact check subject" do
     config = FactCheckConfig.new(reply_to_address)
     valid_subjects.each do |valid_subject|
-      assert config.valid_subject?(valid_subject)
+      assert config.contains_id?(valid_subject)
     end
   end
 
   should "recognise a valid fact check subject with a prefix" do
     config = FactCheckConfig.new(reply_to_address, subject_prefix)
     valid_prefixed_subjects.each do |valid_prefixed_subject|
-      assert config.valid_subject?(valid_prefixed_subject)
+      assert config.contains_id?(valid_prefixed_subject)
     end
     valid_subjects.each do |valid_subject|
-      assert_not config.valid_subject?(valid_subject)
+      assert_not config.contains_id?(valid_subject)
     end
   end
 
   should "not recognise an invalid fact check subject" do
     config = FactCheckConfig.new(reply_to_address)
-    assert_not config.valid_subject?("Not a valid subject")
+    assert_not config.contains_id?("Not a valid subject")
   end
 
   should "treat a subject prefixed with Re: as valid" do
     config = FactCheckConfig.new(reply_to_address)
     valid_subjects.each do |valid_subject|
-      assert config.valid_subject?("Re: " + valid_subject)
+      assert config.contains_id?("Re: " + valid_subject)
     end
   end
 
   should "not recognise a fact check subject with an empty ID" do
     config = FactCheckConfig.new(reply_to_address)
-    assert_not config.valid_subject?("Not a valid subject []")
+    assert_not config.contains_id?("Not a valid subject []")
   end
 
   should "extract an item ID from a valid subject" do
     config = FactCheckConfig.new(reply_to_address)
     valid_subjects.each do |valid_subject|
-      assert_equal "5e6bb57b40f0b62656e3e184", config.item_id_from_subject(valid_subject)
+      assert_equal "5e6bb57b40f0b62656e3e184", config.item_id_from_string(valid_subject)
     end
   end
 
   should "raise an exception trying to extract an ID from an invalid subject" do
     config = FactCheckConfig.new(reply_to_address)
     assert_raises ArgumentError do
-      config.item_id_from_subject("Not a valid subject (1234)")
+      config.item_id_from_string("Not a valid subject (1234)")
     end
 
     assert_raises ArgumentError do
-      config.item_id_from_subject("Not a valid subject [notHexadecimal]")
+      config.item_id_from_string("Not a valid subject [notHexadecimal]")
     end
   end
 
   should "raise an exception if there are multiple matches" do
     config = FactCheckConfig.new(reply_to_address)
     valid_subjects.each do |valid_subject|
-      assert_equal false, config.valid_subject?(valid_subject + " [d682605bec3cf9b8906cf2bc]")
+      assert_equal false, config.contains_id?(valid_subject + " [d682605bec3cf9b8906cf2bc]")
 
       assert_raises ArgumentError do
-        config.item_id_from_subject(valid_subject + " [d682605bec3cf9b8906cf2bc]")
+        config.item_id_from_string(valid_subject + " [d682605bec3cf9b8906cf2bc]")
       end
+    end
+  end
+
+  should "fall back to reading ID from body if none in subject" do
+    config = FactCheckConfig.new(reply_to_address)
+    assert_equal config.item_id_from_subject_or_body("subject without id",
+                                                     "random text random text\n\nrandom text [5e6bb57b40f0b62656e3e184] more words\n\nwords words words words"),
+                 "5e6bb57b40f0b62656e3e184"
+  end
+
+  should "ignore ID in body if subject has one" do
+    config = FactCheckConfig.new(reply_to_address)
+    assert_equal config.item_id_from_subject_or_body(valid_subjects.first,
+                                                     "random text random text\n\nrandom text [d682605bec3cf9b8906cf2bc] more words\n\nwords words words words"),
+                 "5e6bb57b40f0b62656e3e184"
+  end
+
+  should "fail if body has multiple IDs" do
+    config = FactCheckConfig.new(reply_to_address)
+    assert_raises ArgumentError do
+      config.item_id_from_subject_or_body("subject without id",
+                                          "random text random text\n\nrandom text [d682605bec3cf9b8906cf2bc] more words\n\nwords words [5e6bb57b40f0b62656e3e184] words words")
     end
   end
 end

--- a/test/unit/fact_check_config_test.rb
+++ b/test/unit/fact_check_config_test.rb
@@ -69,15 +69,11 @@ class FactCheckConfigTest < ActiveSupport::TestCase
     end
   end
 
-  should "raise an exception trying to extract an ID from an invalid subject" do
+  should "return nil if the input contains no valid ID" do
     config = FactCheckConfig.new(reply_to_address)
-    assert_raises ArgumentError do
-      config.item_id_from_string("Not a valid subject (1234)")
-    end
 
-    assert_raises ArgumentError do
-      config.item_id_from_string("Not a valid subject [notHexadecimal]")
-    end
+    assert_nil config.item_id_from_string("Not a valid subject (1234)")
+    assert_nil config.item_id_from_string("Not a valid subject [notHexadecimal]")
   end
 
   should "raise an exception if there are multiple matches" do


### PR DESCRIPTION
https://trello.com/c/R9ZJGaZR/2147-investigate-how-to-reduce-fact-check-email-alerts-caused-by-edition-id-being-manually-removed