### PR TITLE
Fix type error in fact-check email handling

### DIFF
--- a/app/lib/fact_check_email_handler.rb
+++ b/app/lib/fact_check_email_handler.rb
@@ -19,7 +19,7 @@ class FactCheckEmailHandler
     message = FactCheckMail.new(message)
     return if message.out_of_office?
 
-    edition_id = @fact_check_config.item_id_from_subject_or_body(message.subject, message.body)
+    edition_id = @fact_check_config.item_id_from_subject_or_body(message.subject, message.body.to_s)
     FactCheckMessageProcessor.process(message, edition_id)
   rescue StandardError => e
     raise UnableToProcessError, "Failed to process message '#{message.subject}': #{e.message}"

--- a/test/integration/fact_check_email_test.rb
+++ b/test/integration/fact_check_email_test.rb
@@ -157,6 +157,17 @@ class FactCheckEmailTest < ActionDispatch::IntegrationTest
     assert message.is_marked_for_delete?
   end
 
+  test "should look for fact-check body field" do
+    edition = FactoryBot.create(:answer_edition, state: "fact_check")
+    message = fact_check_mail_for(edition, subject: "Fact Checked", body: "[#{edition.id}]")
+
+    Mail.stubs(:all).yields(message)
+
+    handler = FactCheckEmailHandler.new(fact_check_config)
+
+    assert handler.process_message(message)
+  end
+
   test "should invoke the supplied block after each message" do
     answer1 = FactoryBot.create(:answer_edition, state: "fact_check")
     answer2 = FactoryBot.create(

--- a/test/integration/fact_check_email_test.rb
+++ b/test/integration/fact_check_email_test.rb
@@ -165,7 +165,8 @@ class FactCheckEmailTest < ActionDispatch::IntegrationTest
 
     handler = FactCheckEmailHandler.new(fact_check_config)
 
-    assert handler.process_message(message)
+    handler.process_message(message)
+    assert message.is_marked_for_delete?
   end
 
   test "should invoke the supplied block after each message" do


### PR DESCRIPTION
https://trello.com/c/R9ZJGaZR/2147-investigate-how-to-reduce-fact-check-email-alerts-caused-by-edition-id-being-manually-removed