### PR TITLE
Require govuk_editor to progress editions

### DIFF
--- a/app/lib/govuk_content_models/action_processors/approve_fact_check_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/approve_fact_check_processor.rb
@@ -1,6 +1,9 @@
 module GovukContentModels
   module ActionProcessors
     class ApproveFactCheckProcessor < BaseProcessor
+      def process?
+        actor.govuk_editor?
+      end
     end
   end
 end

--- a/app/lib/govuk_content_models/action_processors/approve_review_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/approve_review_processor.rb
@@ -2,7 +2,7 @@ module GovukContentModels
   module ActionProcessors
     class ApproveReviewProcessor < BaseProcessor
       def process?
-        requester_different?
+        actor.govuk_editor? && requester_different?
       end
     end
   end

--- a/app/lib/govuk_content_models/action_processors/archive_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/archive_processor.rb
@@ -1,6 +1,9 @@
 module GovukContentModels
   module ActionProcessors
     class ArchiveProcessor < BaseProcessor
+      def process?
+        actor.govuk_editor?
+      end
     end
   end
 end

--- a/app/lib/govuk_content_models/action_processors/assign_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/assign_processor.rb
@@ -1,6 +1,10 @@
 module GovukContentModels
   module ActionProcessors
     class AssignProcessor < BaseProcessor
+      def process?
+        actor.govuk_editor?
+      end
+
       def process
         edition.set(assigned_to_id: action_attributes[:recipient_id])
         edition.reload

--- a/app/lib/govuk_content_models/action_processors/cancel_scheduled_publishing_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/cancel_scheduled_publishing_processor.rb
@@ -1,6 +1,9 @@
 module GovukContentModels
   module ActionProcessors
     class CancelScheduledPublishingProcessor < BaseProcessor
+      def process?
+        actor.govuk_editor?
+      end
     end
   end
 end

--- a/app/lib/govuk_content_models/action_processors/create_edition_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/create_edition_processor.rb
@@ -5,6 +5,10 @@ module GovukContentModels
         Action::CREATE
       end
 
+      def process?
+        actor.govuk_editor?
+      end
+
       # Return value is used in caller chain to show errors
       # rubocop:disable Rails/SaveBang
       def process

--- a/app/lib/govuk_content_models/action_processors/emergency_publish_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/emergency_publish_processor.rb
@@ -1,6 +1,0 @@
-module GovukContentModels
-  module ActionProcessors
-    class EmergencyPublishProcessor < BaseProcessor
-    end
-  end
-end

--- a/app/lib/govuk_content_models/action_processors/new_version_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/new_version_processor.rb
@@ -2,7 +2,7 @@ module GovukContentModels
   module ActionProcessors
     class NewVersionProcessor < BaseProcessor
       def process?
-        edition.published?
+        actor.govuk_editor? && edition.published?
       end
 
       def process

--- a/app/lib/govuk_content_models/action_processors/publish_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/publish_processor.rb
@@ -1,6 +1,9 @@
 module GovukContentModels
   module ActionProcessors
     class PublishProcessor < BaseProcessor
+      def process?
+        actor.govuk_editor?
+      end
     end
   end
 end

--- a/app/lib/govuk_content_models/action_processors/request_amendments_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/request_amendments_processor.rb
@@ -2,6 +2,8 @@ module GovukContentModels
   module ActionProcessors
     class RequestAmendmentsProcessor < BaseProcessor
       def process?
+        return false unless actor.govuk_editor?
+
         if edition.in_review?
           requester_different?
         else

--- a/app/lib/govuk_content_models/action_processors/request_review_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/request_review_processor.rb
@@ -1,6 +1,9 @@
 module GovukContentModels
   module ActionProcessors
     class RequestReviewProcessor < BaseProcessor
+      def process?
+        actor.govuk_editor?
+      end
     end
   end
 end

--- a/app/lib/govuk_content_models/action_processors/resend_fact_check_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/resend_fact_check_processor.rb
@@ -1,6 +1,10 @@
 module GovukContentModels
   module ActionProcessors
     class ResendFactCheckProcessor < BaseProcessor
+      def process?
+        actor.govuk_editor?
+      end
+
       def process
         return false unless edition.latest_status_action.is_fact_check_request?
 

--- a/app/lib/govuk_content_models/action_processors/schedule_for_publishing_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/schedule_for_publishing_processor.rb
@@ -1,6 +1,10 @@
 module GovukContentModels
   module ActionProcessors
     class ScheduleForPublishingProcessor < BaseProcessor
+      def process?
+        actor.govuk_editor?
+      end
+
       def process
         publish_at = action_attributes.delete(:publish_at).to_time.utc
         action_attributes[:request_details] = { scheduled_time: publish_at }

--- a/app/lib/govuk_content_models/action_processors/send_fact_check_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/send_fact_check_processor.rb
@@ -1,6 +1,10 @@
 module GovukContentModels
   module ActionProcessors
     class SendFactCheckProcessor < BaseProcessor
+      def process?
+        actor.govuk_editor?
+      end
+
       def process
         return false if action_attributes[:email_addresses].blank?
 

--- a/app/lib/govuk_content_models/action_processors/skip_fact_check_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/skip_fact_check_processor.rb
@@ -1,6 +1,9 @@
 module GovukContentModels
   module ActionProcessors
     class SkipFactCheckProcessor < BaseProcessor
+      def process?
+        actor.govuk_editor?
+      end
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,4 +73,8 @@ class User
   def unassign(edition)
     GovukContentModels::ActionProcessors::AssignProcessor.new(self, edition).processed_edition
   end
+
+  def govuk_editor?
+    permissions.include?("govuk_editor")
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,7 @@ class User
   field "uid",                     type: String
   field "version",                 type: Integer
   field "email",                   type: String
-  field "permissions",             type: Array
+  field "permissions",             type: Array, default: []
   field "remotely_signed_out",     type: Boolean, default: false
   field "organisation_slug",       type: String
   field "disabled",                type: Boolean, default: false

--- a/db/seeds/user.rb
+++ b/db/seeds/user.rb
@@ -5,7 +5,7 @@ if User.where(name: "Test user").blank?
   User.create!(
     name: "Test user",
     uid: user_id,
-    permissions: %w[signin editor skip_review],
+    permissions: %w[signin govuk_editor skip_review],
     organisation_content_id: gds_organisation_id,
   )
 end

--- a/test/functional/event_mailer_test.rb
+++ b/test/functional/event_mailer_test.rb
@@ -22,8 +22,8 @@ class EventMailerTest < ActionMailer::TestCase
   end
 
   def publisher_and_guide
-    user = User.create!(uid: "123", name: "Ben")
-    other_user = User.create!(uid: "321", name: "James")
+    user = FactoryBot.create(:user, :govuk_editor, uid: "123", name: "Ben")
+    other_user = FactoryBot.create(:user, :govuk_editor, uid: "321", name: "James")
 
     guide = user.create_edition(:guide, panopticon_id: FactoryBot.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
     edition = guide
@@ -40,7 +40,7 @@ class EventMailerTest < ActionMailer::TestCase
   test "user should be able to have an email sent for fact checking" do
     stub_mailer = stub("mailer", deliver_now: true)
     EventMailer.expects(:request_fact_check).returns(stub_mailer)
-    user = User.create!(name: "Ben")
+    user = FactoryBot.create(:user, :govuk_editor, name: "Ben")
     artefact = FactoryBot.create(:artefact)
     guide = user.create_edition(:guide, title: "My Title", slug: "my-title", panopticon_id: artefact.id)
     edition = guide
@@ -58,7 +58,7 @@ class EventMailerTest < ActionMailer::TestCase
   end
 
   test "should send an email on fact check received" do
-    user = User.create!(name: "Ben")
+    user = FactoryBot.create(:user, :govuk_editor, name: "Ben")
     guide = user.create_edition(
       :guide,
       panopticon_id: FactoryBot.create(:artefact).id,
@@ -74,7 +74,7 @@ class EventMailerTest < ActionMailer::TestCase
 
   context ".skip_review" do
     should "should send an email on skipping review" do
-      user = FactoryBot.create(:user, name: "Ben", permissions: %w[skip_review])
+      user = FactoryBot.create(:user, name: "Ben", permissions: %w[govuk_editor skip_review])
       guide = user.create_edition(:guide, panopticon_id: FactoryBot.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
       request_review(user, guide)
       EventMailer.expects(:skip_review).returns(mock("event email", deliver_now: nil))

--- a/test/functional/event_notifications_test.rb
+++ b/test/functional/event_notifications_test.rb
@@ -17,8 +17,8 @@ class EventNotificationsTest < ActiveSupport::TestCase
 
   context ".resend_fact_check" do
     setup do
-      @user = User.create!(uid: "123", name: "Ben")
-      @other_user = User.create!(uid: "321", name: "James")
+      @user = FactoryBot.create(:user, :govuk_editor, uid: "123", name: "Ben")
+      @other_user = FactoryBot.create(:user, :govuk_editor, uid: "321", name: "James")
 
       @edition = @user.create_edition(:guide, panopticon_id: FactoryBot.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
       request_review(@user, @edition)

--- a/test/integration/change_edition_type_test.rb
+++ b/test/integration/change_edition_type_test.rb
@@ -6,7 +6,7 @@ class ChangeEditionTypeTest < JavascriptIntegrationTest
 
   setup do
     stub_linkables
-    FactoryBot.create(:user)
+    FactoryBot.create(:user, :govuk_editor)
     stub_mapit_areas_requests(Plek.current.find("imminence"))
     stub_holidays_used_by_fact_check
   end

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -9,8 +9,8 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     stub_linkables
     stub_holidays_used_by_fact_check
 
-    @alice = FactoryBot.create(:user, name: "Alice")
-    @bob = FactoryBot.create(:user, name: "Bob")
+    @alice = FactoryBot.create(:user, :govuk_editor, name: "Alice")
+    @bob = FactoryBot.create(:user, :govuk_editor, name: "Bob")
 
     @guide = FactoryBot.create(:guide_edition)
     login_as "Alice"

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -383,6 +383,17 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     assert page.has_content? guide.title
   end
 
+  test "can't approve review if not govuk_editor" do
+    guide.state = "in_review"
+    guide.save!(validate: false)
+
+    login_as FactoryBot.create(:user)
+
+    visit_edition guide
+    send_action guide, "OK for publication", "OK for publication", "Yup, looks good"
+    assert page.has_content? "Couldn't approve review"
+  end
+
   test "can skip fact-check" do
     guide.update!(state: "fact_check")
 

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -196,6 +196,8 @@ class EditionWorkflowTest < JavascriptIntegrationTest
 
     visit_edition guide
     send_action guide, "Needs more work", "Request amendments", "You need to fix some stuff"
+    assert page.has_content?("updated")
+
     filter_for_all_users
     view_filtered_list "Amends needed"
 
@@ -207,6 +209,8 @@ class EditionWorkflowTest < JavascriptIntegrationTest
 
     visit_edition guide
     send_action guide, "Needs more work", "Request amendments", "You need to fix some stuff"
+    assert page.has_content?("updated")
+
     filter_for_all_users
     view_filtered_list "Amends needed"
 
@@ -233,6 +237,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
       assert page.has_content? "user-to-ask-for-fact-check@example.com"
       click_on "Resend"
     end
+    assert page.has_content?("updated")
 
     visit_edition guide
     click_on "History and notes"
@@ -273,6 +278,8 @@ class EditionWorkflowTest < JavascriptIntegrationTest
 
     visit_edition guide
     send_action guide, "2nd pair of eyes", "Send to 2nd pair of eyes", "I think this is done"
+    assert page.has_content?("updated")
+
     filter_for_all_users
     view_filtered_list "In review"
 
@@ -284,6 +291,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
 
     visit_edition guide
     send_action guide, "2nd pair of eyes", "Send to 2nd pair of eyes", "I think this is done"
+    assert page.has_content?("updated")
 
     assert page.has_selector?(".alert-info")
     assert has_no_link? "OK for publication"
@@ -306,6 +314,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
 
     visit_edition guide
     send_action guide, "2nd pair of eyes", "Send to 2nd pair of eyes", "I think this is done"
+    assert page.has_content?("updated")
 
     select("", from: "Reviewer")
     save_edition_and_assert_success
@@ -327,6 +336,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     guide.assigned_to = bob
 
     send_action guide, "2nd pair of eyes", "Send to 2nd pair of eyes", "I think this is done"
+    assert page.has_content?("updated")
 
     visit_edition guide
 
@@ -352,6 +362,8 @@ class EditionWorkflowTest < JavascriptIntegrationTest
 
     visit_edition guide
     send_action guide, "Needs more work", "Request amendments", "You need to fix some stuff"
+    assert page.has_content?("updated")
+
     filter_for_all_users
     view_filtered_list "Amends needed"
 
@@ -364,6 +376,8 @@ class EditionWorkflowTest < JavascriptIntegrationTest
 
     visit_edition guide
     send_action guide, "OK for publication", "OK for publication", "Yup, looks good"
+    assert page.has_content?("updated")
+
     filter_for_all_users
     view_filtered_list "Ready"
     assert page.has_content? guide.title
@@ -394,6 +408,8 @@ class EditionWorkflowTest < JavascriptIntegrationTest
 
     visit_edition guide
     send_action guide, "Minor or no changes required", "Approve fact check", "Hurrah!"
+    assert page.has_content?("updated")
+
     filter_for_all_users
     view_filtered_list "Ready"
 
@@ -522,7 +538,6 @@ class EditionWorkflowTest < JavascriptIntegrationTest
 
     within :css, action_element_id, &block
 
-    assert page.has_content?("updated"), "new page doesn't show 'updated' message"
     guide.reload
   end
 
@@ -536,6 +551,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
       fill_in "Customised message", with: message
       click_on "Send"
     end
+    assert page.has_content?("updated")
   end
 
   def send_action(guide, button_text, modal_button_text, message)

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -416,6 +416,16 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     assert page.has_content? guide.title
   end
 
+  test "can't progress from fact-check if not govuk_editor" do
+    guide.update!(state: "fact_check_received")
+
+    login_as FactoryBot.create(:user)
+
+    visit_edition guide
+    send_action guide, "Minor or no changes required", "Approve fact check", "Hurrah!"
+    assert page.has_content? "Couldn't approve fact check"
+  end
+
   test "can go back to fact-check from fact-check received" do
     guide.update!(state: "fact_check_received")
 

--- a/test/integration/root_overview_test.rb
+++ b/test/integration/root_overview_test.rb
@@ -9,10 +9,10 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
     # This isn't right, really need a way to run actions when
     # logged in as particular users without having Signonotron running.
     #
-    alice = FactoryBot.create(:user, name: "Alice", uid: "alice")
+    alice = FactoryBot.create(:user, :govuk_editor, name: "Alice", uid: "alice")
 
-    bob     = FactoryBot.create(:user, name: "Bob", uid: "bob")
-    charlie = FactoryBot.create(:user, name: "Charlie", uid: "charlie")
+    bob     = FactoryBot.create(:user, :govuk_editor, name: "Bob", uid: "bob")
+    charlie = FactoryBot.create(:user, :govuk_editor, name: "Charlie", uid: "charlie")
 
     x = FactoryBot.create(:guide_edition, title: "XXX", slug: "xxx")
     y = FactoryBot.create(:guide_edition, title: "YYY", slug: "yyy")
@@ -53,7 +53,7 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
   end
 
   test "filtering by title content" do
-    FactoryBot.create(:user)
+    FactoryBot.create(:user, :govuk_editor)
     FactoryBot.create(:guide_edition, title: "XXX")
     FactoryBot.create(:guide_edition, title: "YYY")
 
@@ -67,7 +67,7 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
   end
 
   test "filtering by title content should not lose the active section" do
-    FactoryBot.create(:user)
+    FactoryBot.create(:user, :govuk_editor)
 
     visit "/"
     click_on "Amends needed"
@@ -78,7 +78,7 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
   end
 
   test "filtering by format" do
-    FactoryBot.create(:user)
+    FactoryBot.create(:user, :govuk_editor)
     FactoryBot.create(:guide_edition, title: "Draft guide")
     FactoryBot.create(:transaction_edition, title: "Draft transaction")
     FactoryBot.create(:guide_edition, title: "Amends needed guide", state: "amends_needed")
@@ -105,7 +105,7 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
   end
 
   test "invalid sibling_in_progress should not break archived view" do
-    FactoryBot.create(:user)
+    FactoryBot.create(:user, :govuk_editor)
     FactoryBot.create(:guide_edition, title: "XXX", state: "archived", sibling_in_progress: 2)
 
     visit "/"
@@ -124,7 +124,7 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
   end
 
   test "Publications in review are ordered correctly" do
-    FactoryBot.create(:user)
+    FactoryBot.create(:user, :govuk_editor)
     FactoryBot.create(
       :guide_edition,
       title: "XXX",
@@ -163,7 +163,7 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
   end
 
   test "Shows link to Collections Publisher when reviewing in review documents" do
-    FactoryBot.create(:user)
+    FactoryBot.create(:user, :govuk_editor)
 
     visit "/"
     filter_by_user("All")
@@ -175,8 +175,8 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
   test "allows a user to claim 2i" do
     stub_linkables
 
-    user = FactoryBot.create(:user)
-    assignee = FactoryBot.create(:user)
+    user = FactoryBot.create(:user, :govuk_editor)
+    assignee = FactoryBot.create(:user, :govuk_editor)
     edition = FactoryBot.create(
       :guide_edition,
       title: "XXX",
@@ -203,10 +203,10 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
   test "prevents claiming 2i when someone else has" do
     stub_linkables
 
-    FactoryBot.create(:user)
+    FactoryBot.create(:user, :govuk_editor)
 
-    assignee = FactoryBot.create(:user)
-    another_user = FactoryBot.create(:user, name: "Another McPerson")
+    assignee = FactoryBot.create(:user, :govuk_editor)
+    another_user = FactoryBot.create(:user, :govuk_editor, name: "Another McPerson")
     edition = FactoryBot.create(
       :guide_edition,
       title: "XXX",
@@ -246,7 +246,7 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
   end
 
   test "prevents the assignee claiming 2i" do
-    user = FactoryBot.create(:user)
+    user = FactoryBot.create(:user, :govuk_editor)
     FactoryBot.create(
       :guide_edition,
       title: "XXX",
@@ -264,7 +264,7 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
   end
 
   test "filtering by published should show a table with an edition with a slug as a link" do
-    FactoryBot.create(:user)
+    FactoryBot.create(:user, :govuk_editor)
     FactoryBot.create(:guide_edition, state: "published", title: "Test", slug: "test-slug")
 
     visit "/"

--- a/test/integration/skip_review_test.rb
+++ b/test/integration/skip_review_test.rb
@@ -37,7 +37,7 @@ class SkipReviewTest < JavascriptIntegrationTest
     GDS::SSO.test_user = nil
   end
 
-  should "allow a user with the correct permissions to force publish" do
+  should "allow a user with the correct permissions to skip review" do
     login_as @permitted_user
 
     visit "/publications/#{@artefact.id}"
@@ -60,7 +60,7 @@ class SkipReviewTest < JavascriptIntegrationTest
     end
   end
 
-  should "not allow a user without permissions to force publish" do
+  should "not allow a user without permissions to skip review" do
     editor = FactoryBot.create(
       :user,
       name: "Editor",

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -16,8 +16,8 @@ class ActionDispatch::IntegrationTest
     # This may not be the right way to do things. We rely on the gds-sso
     # having a strategy that uses the first user. We probably want some
     # tests that cover the oauth interaction properly
-    @author   = FactoryBot.create(:user, name: "Author",   email: "test@example.com")
-    @reviewer = FactoryBot.create(:user, name: "Reviewer", email: "test@example.com")
+    @author   = FactoryBot.create(:user, :govuk_editor, name: "Author",   email: "test@example.com")
+    @reviewer = FactoryBot.create(:user, :govuk_editor, name: "Reviewer", email: "test@example.com")
   end
 
   def login_as(user)

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -198,7 +198,7 @@ class ArtefactTest < ActiveSupport::TestCase
       owning_app: "publisher",
     )
 
-    user1 = FactoryBot.create(:user)
+    user1 = FactoryBot.create(:user, :govuk_editor)
     edition = AnswerEdition.find_or_create_from_panopticon_data(artefact.id, user1)
     edition.state = "published"
     edition.save!
@@ -222,7 +222,7 @@ class ArtefactTest < ActiveSupport::TestCase
       state: "live",
     )
 
-    user1 = FactoryBot.create(:user)
+    user1 = FactoryBot.create(:user, :govuk_editor)
     edition = AnswerEdition.find_or_create_from_panopticon_data(artefact.id, user1)
     edition.state = "published"
     edition.save!
@@ -243,7 +243,7 @@ class ArtefactTest < ActiveSupport::TestCase
       state: "live",
     )
 
-    user1 = FactoryBot.create(:user)
+    user1 = FactoryBot.create(:user, :govuk_editor)
     edition = AnswerEdition.find_or_create_from_panopticon_data(artefact.id, user1)
     edition.state = "draft"
     edition.save!
@@ -262,7 +262,7 @@ class ArtefactTest < ActiveSupport::TestCase
       name: "Foo bar",
       owning_app: "publisher",
     )
-    user1 = FactoryBot.create(:user)
+    user1 = FactoryBot.create(:user, :govuk_editor)
     edition = AnswerEdition.find_or_create_from_panopticon_data(artefact.id, user1)
 
     assert_not artefact.any_editions_published?

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -441,7 +441,7 @@ class EditionTest < ActiveSupport::TestCase
     artefact.save!
 
     Artefact.find(artefact.id)
-    user = User.create!
+    user = FactoryBot.create(:user, :govuk_editor)
 
     publication = Edition.find_or_create_from_panopticon_data(artefact.id, user)
 
@@ -479,7 +479,7 @@ class EditionTest < ActiveSupport::TestCase
     a, b = 2.times.map { FactoryBot.create(:guide_edition, panopticon_id: @artefact.id) }
 
     alice, bob, charlie = %w[alice bob charlie].map do |s|
-      FactoryBot.create(:user, name: s)
+      FactoryBot.create(:user, :govuk_editor, name: s)
     end
     alice.assign(a, bob)
     alice.assign(a, charlie)
@@ -520,7 +520,7 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test "deleting a newer draft of a published edition removes sibling information" do
-    user1 = FactoryBot.create(:user)
+    user1 = FactoryBot.create(:user, :govuk_editor)
     edition = AnswerEdition.find_or_create_from_panopticon_data(@artefact.id, user1)
     edition.update!(state: "published")
     second_edition = edition.build_clone
@@ -536,7 +536,7 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test "the latest edition should remove sibling_in_progress details if it is present" do
-    user1 = FactoryBot.create(:user)
+    user1 = FactoryBot.create(:user, :govuk_editor)
     edition = AnswerEdition.find_or_create_from_panopticon_data(@artefact.id, user1)
     edition.update!(state: "published")
 
@@ -548,7 +548,7 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test "should also delete associated artefact" do
-    user1 = FactoryBot.create(:user)
+    user1 = FactoryBot.create(:user, :govuk_editor)
     edition = AnswerEdition.find_or_create_from_panopticon_data(@artefact.id, user1)
 
     assert_difference "Artefact.count", -1 do
@@ -557,7 +557,7 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test "should not delete associated artefact if there are other editions of this publication" do
-    user1 = FactoryBot.create(:user)
+    user1 = FactoryBot.create(:user, :govuk_editor)
     edition = AnswerEdition.find_or_create_from_panopticon_data(@artefact.id, user1)
     edition.update!(state: "published")
 
@@ -577,7 +577,7 @@ class EditionTest < ActiveSupport::TestCase
     a, b = 2.times.map { |_i| FactoryBot.create(:guide_edition, panopticon_id: @artefact.id) }
 
     alice, bob, charlie = %w[alice bob charlie].map do |s|
-      FactoryBot.create(:user, name: s)
+      FactoryBot.create(:user, :govuk_editor, name: s)
     end
 
     alice.assign(a, bob)
@@ -633,8 +633,8 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test "should be assigned to the last assigned recipient" do
-    alice = FactoryBot.create(:user, name: "alice")
-    bob = FactoryBot.create(:user, name: "bob")
+    alice = FactoryBot.create(:user, :govuk_editor, name: "alice")
+    bob = FactoryBot.create(:user, :govuk_editor, name: "bob")
     edition = FactoryBot.create(:guide_edition, panopticon_id: @artefact.id, state: "ready")
     alice.assign(edition, bob)
     assert_equal bob, edition.assigned_to
@@ -683,7 +683,7 @@ class EditionTest < ActiveSupport::TestCase
   test "should archive older editions, even if there are validation errors, when a new edition is published" do
     edition = FactoryBot.create(:guide_edition_with_two_parts, panopticon_id: @artefact.id, state: "ready")
 
-    user = User.create! name: "bob"
+    user = FactoryBot.create(:user, :govuk_editor, name: "bob")
     publish(user, edition, "First publication")
 
     second_edition = edition.build_clone
@@ -714,7 +714,7 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test "when an edition is published, publish_at is cleared" do
-    user = FactoryBot.create(:user)
+    user = FactoryBot.create(:user, :govuk_editor)
     edition = FactoryBot.create(:edition, :scheduled_for_publishing)
 
     publish(user, edition, "First publication")
@@ -724,7 +724,7 @@ class EditionTest < ActiveSupport::TestCase
 
   test "edition can return latest status action of a specified request type" do
     edition = FactoryBot.create(:guide_edition, panopticon_id: @artefact.id, state: "draft")
-    user = User.create!(name: "George")
+    user = FactoryBot.create(:user, :govuk_editor, name: "George")
     request_review(user, edition)
 
     assert_equal edition.actions.size, 1
@@ -742,7 +742,7 @@ class EditionTest < ActiveSupport::TestCase
   test "edition's publish history is recorded" do
     edition = FactoryBot.create(:guide_edition, panopticon_id: @artefact.id, state: "ready")
 
-    user = User.create! name: "bob"
+    user = FactoryBot.create(:user, :govuk_editor, name: "bob")
     publish(user, edition, "First publication")
 
     second_edition = edition.build_clone
@@ -769,7 +769,7 @@ class EditionTest < ActiveSupport::TestCase
   test "a series with all editions published should not have siblings in progress" do
     edition = FactoryBot.create(:guide_edition, panopticon_id: @artefact.id, state: "ready")
 
-    user = User.create! name: "bob"
+    user = FactoryBot.create(:user, :govuk_editor, name: "bob")
     publish(user, edition, "First publication")
 
     new_edition = edition.build_clone
@@ -786,7 +786,7 @@ class EditionTest < ActiveSupport::TestCase
     edition = FactoryBot.create(:guide_edition, panopticon_id: @artefact.id, state: "ready")
     edition.save!
 
-    user = User.create! name: "bob"
+    user = FactoryBot.create(:user, :govuk_editor, name: "bob")
     publish(user, edition, "First publication")
 
     new_edition = edition.build_clone
@@ -867,8 +867,8 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test "should denormalise an assignee's name when an edition is assigned" do
-    user1 = FactoryBot.create(:user)
-    user2 = FactoryBot.create(:user)
+    user1 = FactoryBot.create(:user, :govuk_editor)
+    user2 = FactoryBot.create(:user, :govuk_editor)
 
     edition = FactoryBot.create(:guide_edition, panopticon_id: @artefact.id, state: "draft")
     user1.assign edition, user2
@@ -878,7 +878,7 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test "should denormalise a creator's name when an edition is created" do
-    user = FactoryBot.create(:user)
+    user = FactoryBot.create(:user, :govuk_editor)
     artefact = FactoryBot.create(
       :artefact,
       slug: "foo-bar",
@@ -893,7 +893,7 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test "should denormalise a publishing user's name when an edition is published" do
-    user = FactoryBot.create(:user)
+    user = FactoryBot.create(:user, :govuk_editor)
 
     edition = FactoryBot.create(:guide_edition, panopticon_id: @artefact.id, state: "ready")
     publish(user, edition, "First publication")
@@ -902,7 +902,7 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test "should set siblings in progress to nil for new editions" do
-    FactoryBot.create(:user)
+    FactoryBot.create(:user, :govuk_editor)
     edition = FactoryBot.create(:guide_edition, panopticon_id: @artefact.id, state: "ready")
     FactoryBot.create(:guide_edition, panopticon_id: @artefact.id, state: "published")
     assert_equal 1, edition.version_number
@@ -922,7 +922,7 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test "should update previous editions when new edition is published" do
-    user = FactoryBot.create(:user)
+    user = FactoryBot.create(:user, :govuk_editor)
     FactoryBot.create(:guide_edition, panopticon_id: @artefact.id, state: "archived")
     published_edition = FactoryBot.create(:guide_edition, panopticon_id: @artefact.id, state: "published")
 

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -730,6 +730,13 @@ class EditionTest < ActiveSupport::TestCase
     assert_nil edition.reload.publish_at
   end
 
+  test "cannot request review if not govuk_editor" do
+    edition = FactoryBot.create(:guide_edition, panopticon_id: @artefact.id, state: "draft")
+    user = User.create!(name: "George")
+    request_review(user, edition)
+    assert_equal edition.actions.size, 0
+  end
+
   test "edition can return latest status action of a specified request type" do
     edition = FactoryBot.create(:guide_edition, panopticon_id: @artefact.id, state: "draft")
     user = FactoryBot.create(:user, :govuk_editor, name: "George")

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -640,6 +640,14 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal bob, edition.assigned_to
   end
 
+  test "cannot assign if user is not govuk_editor" do
+    alice = FactoryBot.create(:user, name: "alice")
+    bob = FactoryBot.create(:user, :govuk_editor, name: "bob")
+    edition = FactoryBot.create(:guide_edition, panopticon_id: @artefact.id, state: "ready")
+    alice.assign(edition, bob)
+    assert_nil edition.assigned_to
+  end
+
   test "new edition should have an incremented version number" do
     edition = FactoryBot.create(:guide_edition, panopticon_id: @artefact.id, state: "published")
     new_edition = edition.build_clone

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -89,22 +89,21 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "creating a transaction with the initial details creates a valid transaction" do
-    user = User.create!(name: "bob")
+    user = FactoryBot.create(:user, :govuk_editor, name: "bob")
     trans = user.create_edition(:transaction, title: "test", slug: "test", panopticon_id: @artefact.id)
     assert trans.valid?
   end
 
   test "user can't okay a publication they've sent for review" do
-    user = User.create!(name: "bob")
-
+    user = FactoryBot.create(:user, :govuk_editor, name: "bob")
     trans = user.create_edition(:transaction, title: "test answer", slug: "test", panopticon_id: @artefact.id)
     request_review(user, trans)
     assert_not approve_review(user, trans)
   end
 
   test "Edition becomes assigned to user when user is assigned an edition" do
-    boss_user = FactoryBot.create(:user, name: "Mat")
-    worker_user = FactoryBot.create(:user, name: "Grunt")
+    boss_user = FactoryBot.create(:user, :govuk_editor, name: "Mat")
+    worker_user = FactoryBot.create(:user, :govuk_editor, name: "Grunt")
 
     publication = boss_user.create_edition(:answer, title: "test answer", slug: "test", panopticon_id: @artefact.id)
     boss_user.assign(publication, worker_user)
@@ -115,8 +114,8 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "Edition can be unassigned" do
-    boss_user = FactoryBot.create(:user, name: "Mat")
-    worker_user = FactoryBot.create(:user, name: "Grunt")
+    boss_user = FactoryBot.create(:user, :govuk_editor, name: "Mat")
+    worker_user = FactoryBot.create(:user, :govuk_editor, name: "Grunt")
 
     publication = boss_user.create_edition(:answer, title: "test answer", slug: "test", panopticon_id: @artefact.id)
     boss_user.assign(publication, worker_user)

--- a/test/models/workflow_test.rb
+++ b/test/models/workflow_test.rb
@@ -510,6 +510,12 @@ class WorkflowTest < ActiveSupport::TestCase
 
     should "schedule an edition for publishing if it is ready" do
       edition = FactoryBot.create(:edition, state: "ready")
+      schedule_for_publishing(FactoryBot.create(:user), edition, @activity_details)
+      assert_not edition.reload.scheduled_for_publishing?
+    end
+
+    should "not schedule an edition for publishing if user is not govuk_editor" do
+      edition = FactoryBot.create(:edition, state: "ready")
 
       schedule_for_publishing(@user, edition, @activity_details)
 

--- a/test/models/workflow_test.rb
+++ b/test/models/workflow_test.rb
@@ -7,8 +7,8 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   def template_users
-    user = FactoryBot.create(:user, name: "Bob")
-    other_user = FactoryBot.create(:user, name: "James")
+    user = FactoryBot.create(:user, :govuk_editor, name: "Bob")
+    other_user = FactoryBot.create(:user, :govuk_editor, name: "James")
     [user, other_user]
   end
 
@@ -25,8 +25,8 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   def publisher_and_guide
-    user = FactoryBot.create(:user, name: "Ben")
-    other_user = FactoryBot.create(:user, name: "James")
+    user = FactoryBot.create(:user, :govuk_editor, name: "Ben")
+    other_user = FactoryBot.create(:user, :govuk_editor, name: "James")
 
     guide = user.create_edition(:guide, panopticon_id: @artefact.id, overview: "My Overview", title: "My Title", slug: "my-title")
     edition = guide
@@ -41,8 +41,8 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   def template_user_and_published_transaction
-    user = FactoryBot.create(:user, name: "Ben")
-    other_user = FactoryBot.create(:user, name: "James")
+    user = FactoryBot.create(:user, :govuk_editor, name: "Ben")
+    other_user = FactoryBot.create(:user, :govuk_editor, name: "James")
 
     transaction = user.create_edition(:transaction, title: "My title", slug: "my-title", panopticon_id: @artefact.id, need_to_know: "Credit card required")
     transaction.save!
@@ -111,7 +111,7 @@ class WorkflowTest < ActiveSupport::TestCase
 
   test "a guide should be marked as having reviewables if requested for review" do
     guide = template_guide
-    user = FactoryBot.create(:user, name: "Ben")
+    user = FactoryBot.create(:user, :govuk_editor, name: "Ben")
     assert_not guide.in_review?
     assert_nil guide.review_requested_at
 
@@ -132,8 +132,8 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   test "guide workflow" do
-    user = FactoryBot.create(:user, name: "Ben")
-    other_user = FactoryBot.create(:user, name: "James")
+    user = FactoryBot.create(:user, :govuk_editor, name: "Ben")
+    other_user = FactoryBot.create(:user, :govuk_editor, name: "James")
 
     guide = user.create_edition(:guide, title: "My Title", slug: "my-title", panopticon_id: @artefact.id)
     edition = guide
@@ -151,8 +151,8 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   test "skip review workflow" do
-    user = FactoryBot.create(:user, name: "Ben", permissions: %w[skip_review])
-    other = FactoryBot.create(:user, name: "Ben", permissions: %w[signin])
+    user = FactoryBot.create(:user, name: "Ben", permissions: %w[govuk_editor skip_review])
+    other = FactoryBot.create(:user, :govuk_editor, name: "Ben")
 
     edition = user.create_edition(:guide, title: "My Title", slug: "my-title", panopticon_id: @artefact.id)
 
@@ -166,8 +166,8 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   test "when fact check has been initiated it can be skipped" do
-    user = FactoryBot.create(:user, name: "Ben")
-    other_user = FactoryBot.create(:user, name: "James")
+    user = FactoryBot.create(:user, :govuk_editor, name: "Ben")
+    other_user = FactoryBot.create(:user, :govuk_editor, name: "James")
 
     edition = user.create_edition(:guide, panopticon_id: @artefact.id, overview: "My Overview", title: "My Title", slug: "my-title")
 
@@ -183,8 +183,8 @@ class WorkflowTest < ActiveSupport::TestCase
 
   # until we improve the validation to produce few or no false positives
   test "when processing fact check, it is not validated" do
-    user = FactoryBot.create(:user, name: "Ben")
-    other_user = FactoryBot.create(:user, name: "James")
+    user = FactoryBot.create(:user, :govuk_editor, name: "Ben")
+    other_user = FactoryBot.create(:user, :govuk_editor, name: "James")
 
     guide = user.create_edition(:guide, panopticon_id: FactoryBot.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
     edition = guide
@@ -198,8 +198,8 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   test "fact_check editions can resend the email" do
-    user = FactoryBot.create(:user, name: "Ben")
-    other_user = FactoryBot.create(:user, name: "James")
+    user = FactoryBot.create(:user, :govuk_editor, name: "Ben")
+    other_user = FactoryBot.create(:user, :govuk_editor, name: "James")
 
     guide = user.create_edition(:guide, panopticon_id: FactoryBot.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
     edition = guide
@@ -212,8 +212,8 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   test "fact_check editions can't resend the email if their most recent status action somehow isn't a fact check one" do
-    user = FactoryBot.create(:user, name: "Ben")
-    other_user = FactoryBot.create(:user, name: "James")
+    user = FactoryBot.create(:user, :govuk_editor, name: "Ben")
+    other_user = FactoryBot.create(:user, :govuk_editor, name: "James")
 
     guide = user.create_edition(:guide, panopticon_id: FactoryBot.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
     edition = guide
@@ -228,8 +228,8 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   test "fact_check_received can go back to out for fact_check" do
-    user = FactoryBot.create(:user, name: "Ben")
-    other_user = FactoryBot.create(:user, name: "James")
+    user = FactoryBot.create(:user, :govuk_editor, name: "Ben")
+    other_user = FactoryBot.create(:user, :govuk_editor, name: "James")
 
     guide = user.create_edition(:guide, panopticon_id: FactoryBot.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
     edition = guide
@@ -244,8 +244,8 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   test "when processing fact check, an edition can request for amendments" do
-    user = FactoryBot.create(:user, name: "Ben")
-    other_user = FactoryBot.create(:user, name: "James")
+    user = FactoryBot.create(:user, :govuk_editor, name: "Ben")
+    other_user = FactoryBot.create(:user, :govuk_editor, name: "James")
 
     guide = user.create_edition(:guide, panopticon_id: FactoryBot.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
     edition = guide
@@ -260,9 +260,9 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   test "ready items may require further amendments" do
-    user = FactoryBot.create(:user, name: "Ben")
-    other_user = FactoryBot.create(:user, name: "James")
-    FactoryBot.create(:user, name: "Fiona")
+    user = FactoryBot.create(:user, :govuk_editor, name: "Ben")
+    other_user = FactoryBot.create(:user, :govuk_editor, name: "James")
+    FactoryBot.create(:user, :govuk_editor, name: "Fiona")
 
     guide = user.create_edition(:guide, panopticon_id: FactoryBot.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
     edition = guide
@@ -280,8 +280,8 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   test "check counting reviews" do
-    user = FactoryBot.create(:user, name: "Ben")
-    other_user = FactoryBot.create(:user, name: "James")
+    user = FactoryBot.create(:user, :govuk_editor, name: "Ben")
+    other_user = FactoryBot.create(:user, :govuk_editor, name: "James")
 
     guide = user.create_edition(:guide, title: "My Title", slug: "my-title", panopticon_id: @artefact.id)
     edition = guide
@@ -300,7 +300,7 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   test "user should not be able to review a guide they requested review for" do
-    user = FactoryBot.create(:user, name: "Ben")
+    user = FactoryBot.create(:user, :govuk_editor, name: "Ben")
 
     guide = user.create_edition(:guide, title: "My Title", slug: "my-title", panopticon_id: @artefact.id)
     edition = guide
@@ -311,7 +311,7 @@ class WorkflowTest < ActiveSupport::TestCase
   end
 
   test "user should not be able to okay a guide they requested review for" do
-    user = FactoryBot.create(:user, name: "Ben")
+    user = FactoryBot.create(:user, :govuk_editor, name: "Ben")
 
     guide = user.create_edition(:guide, title: "My Title", slug: "my-title", panopticon_id: @artefact.id)
     edition = guide
@@ -408,7 +408,7 @@ class WorkflowTest < ActiveSupport::TestCase
 
   context "creating a new version of an edition" do
     setup do
-      @user = User.new
+      @user = FactoryBot.create(:user, :govuk_editor)
       @edition = FactoryBot.create(:edition, state: :published)
     end
 
@@ -466,13 +466,13 @@ class WorkflowTest < ActiveSupport::TestCase
 
     should "transition an edition with link validation errors to fact_check_received state" do
       assert @edition.invalid?
-      receive_fact_check(User.new, @edition)
+      receive_fact_check(FactoryBot.create(:user, :govuk_editor), @edition)
       assert_equal "fact_check_received", @edition.reload.state
     end
 
     should "record the action" do
       assert_difference "@edition.actions.count", 1 do
-        receive_fact_check(User.new, @edition)
+        receive_fact_check(FactoryBot.create(:user, :govuk_editor), @edition)
       end
       assert_equal "receive_fact_check", @edition.actions.last.request_type
     end
@@ -480,7 +480,7 @@ class WorkflowTest < ActiveSupport::TestCase
 
   context "#schedule_for_publishing" do
     setup do
-      @user = FactoryBot.build(:user)
+      @user = FactoryBot.create(:user, :govuk_editor)
       @publish_at = 1.day.from_now.utc
       @activity_details = { publish_at: @publish_at, comment: "Go schedule !" }
     end

--- a/test/models/workflow_test.rb
+++ b/test/models/workflow_test.rb
@@ -379,11 +379,17 @@ class WorkflowTest < ActiveSupport::TestCase
     assert_equal "archived", edition.state
   end
 
-  test "an edition cannot be moved into archive state if not govuk_editor" do
+  test "an edition cannot be created if not govuk_editor" do
     user = FactoryBot.create(:user)
+    assert_nil user.create_edition(:programme, panopticon_id: @artefact.id, title: "My title", slug: "my-slug")
+  end
+
+  test "an edition cannot be moved into archive state if not govuk_editor" do
+    user = FactoryBot.create(:user, :govuk_editor)
     edition = user.create_edition(:programme, panopticon_id: @artefact.id, title: "My title", slug: "my-slug")
-    user.progress(edition, request_type: :archive)
-    assert_equal "draft", edition.state
+    other_user = FactoryBot.create(:user)
+    other_user.progress(edition, request_type: :archive)
+    assert_not_equal "archive", edition.state
   end
 
   test "User can request amendments for an edition they just approved" do

--- a/test/models/workflow_test.rb
+++ b/test/models/workflow_test.rb
@@ -379,6 +379,13 @@ class WorkflowTest < ActiveSupport::TestCase
     assert_equal "archived", edition.state
   end
 
+  test "an edition cannot be moved into archive state if not govuk_editor" do
+    user = FactoryBot.create(:user)
+    edition = user.create_edition(:programme, panopticon_id: @artefact.id, title: "My title", slug: "my-slug")
+    user.progress(edition, request_type: :archive)
+    assert_equal "draft", edition.state
+  end
+
   test "User can request amendments for an edition they just approved" do
     user1, user2 = template_users
     edition = user1.create_edition(:answer, panopticon_id: @artefact.id, title: "Answer foo", slug: "answer-foo")

--- a/test/models/workflow_test.rb
+++ b/test/models/workflow_test.rb
@@ -431,6 +431,11 @@ class WorkflowTest < ActiveSupport::TestCase
       assert_nil @user.new_version(@edition)
     end
 
+    should "return nil if user is not govuk_editor" do
+      other_user = FactoryBot.create(:user)
+      assert_nil other_user.new_version(@edition)
+    end
+
     should "record the action" do
       new_version = @user.new_version(@edition)
       assert_equal "new_version", new_version.actions.last.request_type

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -8,9 +8,14 @@ FactoryBot.define do
     sequence(:uid) { |n| "uid-#{n}" }
     sequence(:name) { |n| "Joe Bloggs #{n}" }
     sequence(:email) { |n| "joe#{n}@bloggs.com" }
+
     if defined?(GDS::SSO::Config)
       # Grant permission to signin to the app using the gem
       permissions { %w[signin] }
+    end
+
+    trait :govuk_editor do
+      permissions { %w[govuk_editor signin] }
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -78,7 +78,7 @@ class ActiveSupport::TestCase
   end
 
   def login_as_stub_user
-    @user = FactoryBot.create(:user, name: "Stub User")
+    @user = FactoryBot.create(:user, :govuk_editor, name: "Stub User")
     request.env["warden"] = stub(authenticate!: true, authenticated?: true, user: @user)
   end
 

--- a/test/unit/edition_clone_test.rb
+++ b/test/unit/edition_clone_test.rb
@@ -2,8 +2,8 @@ require "test_helper"
 
 class EditionCloneTest < ActiveSupport::TestCase
   def setup
-    @user = User.create! uid: "123", name: "Grandmaster Flash"
-    @other_user = User.create! uid: "321", name: "Furious Five"
+    @user = FactoryBot.create(:user, :govuk_editor, uid: "123", name: "Grandmaster Flash")
+    @other_user = FactoryBot.create(:user, :govuk_editor, uid: "321", name: "Furious Five")
 
     @artefact = FactoryBot.create(:artefact, name: "Childcare", slug: "childcare")
     stub_calendars_has_no_bank_holidays(in_division: "england-and-wales")

--- a/test/unit/edition_duplicator_test.rb
+++ b/test/unit/edition_duplicator_test.rb
@@ -6,8 +6,8 @@ require "edition_duplicator"
 # are the clear, minimal dependencies.
 class EditionDuplicatorTest < ActiveSupport::TestCase
   setup do
-    @laura = FactoryBot.create(:user)
-    @fred  = FactoryBot.create(:user)
+    @laura = FactoryBot.create(:user, :govuk_editor)
+    @fred  = FactoryBot.create(:user, :govuk_editor)
     @guide = FactoryBot.create(:guide_edition)
     stub_register_published_content
   end

--- a/test/unit/edition_progressor_test.rb
+++ b/test/unit/edition_progressor_test.rb
@@ -132,5 +132,17 @@ class EditionProgressorTest < ActiveSupport::TestCase
         assert_equal 0, Sidekiq::ScheduledSet.new.size
       end
     end
+
+    should "not dequeue a scheduled job if not govuk_editor" do
+      Sidekiq::Testing.disable! do
+        publish_at = 1.day.from_now
+        @guide.update!(state: :scheduled_for_publishing, publish_at: publish_at)
+        ScheduledPublisher.perform_at(publish_at, @guide.id.to_s)
+
+        activity = { request_type: "cancel_scheduled_publishing", comment: "stop!" }
+        command = EditionProgressor.new(@guide, FactoryBot.create(:user))
+        assert_not command.progress(activity)
+      end
+    end
   end
 end

--- a/test/unit/edition_progressor_test.rb
+++ b/test/unit/edition_progressor_test.rb
@@ -3,7 +3,7 @@ require "edition_progressor"
 
 class EditionProgressorTest < ActiveSupport::TestCase
   setup do
-    @laura = FactoryBot.create(:user)
+    @laura = FactoryBot.create(:user, :govuk_editor)
     @guide = FactoryBot.create(:guide_edition, panopticon_id: FactoryBot.create(:artefact).id)
     stub_register_published_content
   end

--- a/test/unit/guide_edition_test.rb
+++ b/test/unit/guide_edition_test.rb
@@ -13,8 +13,8 @@ class GuideEditionTest < ActiveSupport::TestCase
   end
 
   def publisher_and_guide
-    user = User.create!(uid: "123", name: "Ben")
-    other_user = User.create!(uid: "321", name: "James")
+    user = FactoryBot.create(:user, :govuk_editor, uid: "123", name: "Ben")
+    other_user = FactoryBot.create(:user, :govuk_editor, uid: "321", name: "James")
 
     guide = user.create_edition(:guide, panopticon_id: FactoryBot.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
     edition = guide

--- a/test/unit/primary_listing_presenter_test.rb
+++ b/test/unit/primary_listing_presenter_test.rb
@@ -2,8 +2,8 @@ require "test_helper"
 
 class PrimaryListingPresenterTest < ActiveSupport::TestCase
   def setup_users
-    alice = User.create!(uid: "123")
-    bob = User.create!(uid: "321")
+    alice = FactoryBot.create(:user, :govuk_editor)
+    bob = FactoryBot.create(:user, :govuk_editor)
     [alice, bob]
   end
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -2,15 +2,15 @@ require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
   test "it doesn't try to send a fact check email if no addresses were given" do
-    user = User.create!(name: "bob")
+    user = FactoryBot.create(:user, :govuk_editor, name: "bob")
     EventMailer.expects(:request_fact_check).never
     trans = user.create_edition(:transaction, title: "test answer", slug: "test", panopticon_id: FactoryBot.create(:artefact).id)
     assert_not send_fact_check(user, trans)
   end
 
   test "when an user publishes a guide, a status message is sent on the message bus" do
-    user = User.create!(uid: "123", name: "bob")
-    second_user = User.create!(uid: "321", name: "dave")
+    user = FactoryBot.create(:user, :govuk_editor, uid: "123", name: "bob")
+    second_user = FactoryBot.create(:user, :govuk_editor, uid: "321", name: "dave")
 
     trans = user.create_edition(:transaction, title: "test answer", slug: "test", panopticon_id: FactoryBot.create(:artefact).id)
     request_review(user, trans)


### PR DESCRIPTION
This makes changes to the action processors to ensure that the user has the `govuk_editor` permission before performing the action. See individual commits for more details.

This is the precursor to adding a new `welsh_editor` permission which permits access to certain actions without the `govuk_editor` permission but only for Welsh language documents.

[Trello Card](https://trello.com/c/Hq2qgwiI/2155-8-give-permission-in-publisher-for-welsh-teams-in-departments-to-update-only-welsh-content)