### PR TITLE
Fix textarea heights after formtastic removal

### DIFF
--- a/app/views/answers/_fields.html.erb
+++ b/app/views/answers/_fields.html.erb
@@ -8,7 +8,7 @@
           <%= f.label :body %>
         </span>
         <span class="form-wrapper">
-          <%= f.text_area :body, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+          <%= f.text_area :body, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
         </span>
       </div>
     </fieldset>

--- a/app/views/campaigns/_fields.html.erb
+++ b/app/views/campaigns/_fields.html.erb
@@ -64,7 +64,7 @@
       <%= f.label :body %>
     </span>
     <span class="form-wrapper">
-      <%= f.text_area :body, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+      <%= f.text_area :body, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
     </span>
   </div>
 </fieldset>

--- a/app/views/completed_transactions/_fields.html.erb
+++ b/app/views/completed_transactions/_fields.html.erb
@@ -8,7 +8,7 @@
           <%= f.label :body %>
         </span>
         <span class="form-wrapper">
-          <%= f.text_area :body, disabled: "disabled", class: "input-md-10 form-control" %>
+          <%= f.text_area :body, rows: 20, disabled: "disabled", class: "input-md-10 form-control" %>
           <span class="help-block">The body text is overwritten by the service feedback survey</span>
         </span>
       </div>

--- a/app/views/help_pages/_fields.html.erb
+++ b/app/views/help_pages/_fields.html.erb
@@ -7,7 +7,7 @@
           <%= f.label :body %>
         </span>
         <span class="form-wrapper">
-          <%= f.text_area :body, disabled: @resource.locked_for_edits?, class: "form-control" %>
+          <%= f.text_area :body, rows: 20, disabled: @resource.locked_for_edits?, class: "form-control" %>
         </span>
       </div>
     </fieldset>

--- a/app/views/licences/_fields.html.erb
+++ b/app/views/licences/_fields.html.erb
@@ -47,7 +47,7 @@
           <%= f.label :licence_overview %>
         </span>
         <span class="form-wrapper">
-          <%= f.text_area :licence_overview, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+          <%= f.text_area :licence_overview, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
         </span>
       </div>
     </fieldset>

--- a/app/views/places/_fields.html.erb
+++ b/app/views/places/_fields.html.erb
@@ -27,7 +27,7 @@
           <%= f.label :more_information %>
         </span>
         <span class="form-wrapper">
-          <%= f.text_area :more_information, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+          <%= f.text_area :more_information, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
         </span>
       </div>
 

--- a/app/views/shared/_transaction_variant.html.erb
+++ b/app/views/shared/_transaction_variant.html.erb
@@ -63,7 +63,7 @@
             <%= f.label :more_information %>
           </span>
           <span class="form-wrapper">
-            <%= f.text_area :more_information, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+            <%= f.text_area :more_information, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
           </span>
         </div>
 
@@ -72,7 +72,7 @@
             <%= f.label :alternate_methods, "Other ways to apply" %>
           </span>
           <span class="form-wrapper">
-            <%= f.text_area :alternate_methods, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+            <%= f.text_area :alternate_methods, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
             <span class="help-block">Alternative ways of completing this transaction. Not displayed on front end if left blank.</span>
           </span>
         </div>

--- a/app/views/transactions/_fields.html.erb
+++ b/app/views/transactions/_fields.html.erb
@@ -47,7 +47,7 @@
           <%= f.label :more_information %>
         </span>
         <span class="form-wrapper">
-          <%= f.text_area :more_information, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+          <%= f.text_area :more_information, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
         </span>
       </div>
 
@@ -56,7 +56,7 @@
           <%= f.label :alternate_methods, "Other ways to apply" %>
         </span>
         <span class="form-wrapper">
-          <%= f.text_area :alternate_methods, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+          <%= f.text_area :alternate_methods, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
           <span class="help-block">Alternative ways of completing this transaction. Not displayed on front end if left blank.</span>
         </span>
       </div>

--- a/app/views/videos/_fields.html.erb
+++ b/app/views/videos/_fields.html.erb
@@ -51,7 +51,7 @@
               <%= f.label :body %>
             </span>
             <span class="form-wrapper">
-              <%= f.text_area :body, disabled: @resource.locked_for_edits?, class: "form-control" %>
+              <%= f.text_area :body, rows: 20, disabled: @resource.locked_for_edits?, class: "form-control" %>
             </span>
           </div>
         </div>


### PR DESCRIPTION
The formtastic gem adds a default rows value of 20 to textarea tags so add that back in after removal of the gem in 23fe204.
