### PR TITLE
Add additional healthcheck for MongoDB

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@
 Rails.application.routes.draw do
   get "/healthcheck",
       to: GovukHealthcheck.rack_response(
+        GovukHealthcheck::Mongoid,
         GovukHealthcheck::SidekiqRedis,
         Healthcheck::ScheduledPublishing,
       )


### PR DESCRIPTION
https://trello.com/c/epNWudCR/176-write-an-rfc-for-continuous-deployment-and-seek-review

This ensures we correctly report this app as unhealthy if it cannot
connect to its database, which can happen on single instances [1].
While this may be incidentally covered by Smoke tests, it's clearer
if we call it out explicitly.

[1]: https://docs.google.com/document/d/1q0dmaRaK1pnoKK_EGikdstUOtBEiaCaswMYS9ITFbL0/edit


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/publisher), after merging.