### PR TITLE
Add restricted access to users with `welsh_editor` permissions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,4 +34,11 @@ class ApplicationController < ActionController::Base
   def notify_bad_request(_exception)
     render plain: "Error: One or more recipients not in GOV.UK Notify team (code: 400)", status: :bad_request
   end
+
+  def require_govuk_editor(redirect_path: root_path)
+    return if current_user.govuk_editor?
+
+    flash[:danger] = "You do not have permission to see this page."
+    redirect_to redirect_path
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,4 +41,11 @@ class ApplicationController < ActionController::Base
     flash[:danger] = "You do not have permission to see this page."
     redirect_to redirect_path
   end
+
+  def require_editor_permissions
+    return if current_user.has_editor_permissions?(resource)
+
+    flash[:danger] = "You do not have correct editor permissions for this action."
+    redirect_to edition_path(resource)
+  end
 end

--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -1,4 +1,6 @@
 class ArtefactsController < ApplicationController
+  before_action :require_govuk_editor
+
   def new
     @artefact = Artefact.new(content_id: SecureRandom.uuid)
   end

--- a/app/controllers/downtimes_controller.rb
+++ b/app/controllers/downtimes_controller.rb
@@ -1,4 +1,5 @@
 class DowntimesController < ApplicationController
+  before_action :require_govuk_editor
   before_action :load_edition, except: [:index]
   before_action :process_params, only: %i[create update]
 

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -5,7 +5,7 @@ class EditionsController < InheritedResources::Base
   actions :create, :update, :destroy
   defaults resource_class: Edition, collection_name: "editions", instance_name: "resource"
   before_action :setup_view_paths, except: %i[index new create]
-  before_action :require_editor_permissions, only: %i[update duplicate progress]
+  before_action :require_editor_permissions, only: %i[update duplicate progress review]
   before_action only: %i[unpublish process_unpublish] do
     require_govuk_editor(redirect_path: edition_path(resource))
   end

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -5,7 +5,7 @@ class EditionsController < InheritedResources::Base
   actions :create, :update, :destroy
   defaults resource_class: Edition, collection_name: "editions", instance_name: "resource"
   before_action :setup_view_paths, except: %i[index new create]
-  before_action :require_editor_permissions, only: %i[duplicate]
+  before_action :require_editor_permissions, only: %i[update duplicate]
   after_action :report_state_counts, only: %i[create duplicate progress destroy]
 
   def index

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -6,6 +6,9 @@ class EditionsController < InheritedResources::Base
   defaults resource_class: Edition, collection_name: "editions", instance_name: "resource"
   before_action :setup_view_paths, except: %i[index new create]
   before_action :require_editor_permissions, only: %i[update duplicate progress]
+  before_action only: %i[unpublish process_unpublish] do
+    require_govuk_editor(redirect_path: edition_path(resource))
+  end
   after_action :report_state_counts, only: %i[create duplicate progress destroy]
 
   def index

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -5,6 +5,7 @@ class EditionsController < InheritedResources::Base
   actions :create, :update, :destroy
   defaults resource_class: Edition, collection_name: "editions", instance_name: "resource"
   before_action :setup_view_paths, except: %i[index new create]
+  before_action :require_editor_permissions, only: %i[duplicate]
   after_action :report_state_counts, only: %i[create duplicate progress destroy]
 
   def index
@@ -55,7 +56,7 @@ class EditionsController < InheritedResources::Base
 
   def duplicate
     command = EditionDuplicator.new(resource, current_user)
-    target_edition_class_name = (params[:to] + "_edition").classify if params[:to]
+    target_edition_class_name = "#{params[:to]}_edition".classify if params[:to]
 
     if !resource.can_create_new_edition?
       flash[:warning] = "Another person has created a newer edition"

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -5,7 +5,7 @@ class EditionsController < InheritedResources::Base
   actions :create, :update, :destroy
   defaults resource_class: Edition, collection_name: "editions", instance_name: "resource"
   before_action :setup_view_paths, except: %i[index new create]
-  before_action :require_editor_permissions, only: %i[update duplicate]
+  before_action :require_editor_permissions, only: %i[update duplicate progress]
   after_action :report_state_counts, only: %i[create duplicate progress destroy]
 
   def index

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,5 +1,6 @@
 class NotesController < InheritedResources::Base
   belongs_to :edition
+  before_action :require_editor_permissions
 
   include PathsHelper
 

--- a/app/helpers/edition_activity_buttons_helper.rb
+++ b/app/helpers/edition_activity_buttons_helper.rb
@@ -30,12 +30,19 @@ module EditionActivityButtonsHelper
   end
 
   def progress_buttons(edition, options = {})
-    [
+    buttons = [
       ["Fact check", "send_fact_check"],
       ["2nd pair of eyes", "request_review"],
-      *scheduled_publishing_buttons(edition),
-      publish_button(edition),
-    ].map { |title, activity, button_color = "primary"|
+    ]
+
+    if current_user.has_editor_permissions?(edition)
+      buttons.push(
+        *scheduled_publishing_buttons(edition),
+        publish_button(edition),
+      )
+    end
+
+    buttons = buttons.map do |title, activity, button_color = "primary"|
       disabled = !edition.send("can_#{activity}?")
       next if disabled && options.fetch(:skip_disabled_buttons, false)
 
@@ -43,7 +50,9 @@ module EditionActivityButtonsHelper
               "##{activity}_form",
               data: { toggle: "modal" },
               class: "btn btn-large btn-#{button_color} #{'disabled' if disabled}"
-    }.join("\n").html_safe
+    end
+
+    buttons.join("\n").html_safe
   end
 
   def scheduled_publishing_buttons(edition)

--- a/app/helpers/edition_activity_buttons_helper.rb
+++ b/app/helpers/edition_activity_buttons_helper.rb
@@ -32,11 +32,11 @@ module EditionActivityButtonsHelper
   def progress_buttons(edition, options = {})
     buttons = [
       ["Fact check", "send_fact_check"],
-      ["2nd pair of eyes", "request_review"],
     ]
 
     if current_user.has_editor_permissions?(edition)
       buttons.push(
+        ["2nd pair of eyes", "request_review"],
         *scheduled_publishing_buttons(edition),
         publish_button(edition),
       )

--- a/app/helpers/edition_activity_buttons_helper.rb
+++ b/app/helpers/edition_activity_buttons_helper.rb
@@ -11,8 +11,10 @@ module EditionActivityButtonsHelper
 
   def review_buttons(edition)
     buttons = []
-    buttons << build_review_button(edition, "request_amendments", "Needs more work")
-    buttons << build_review_button(edition, "approve_review", "OK for publication")
+    if current_user.has_editor_permissions?(edition)
+      buttons << build_review_button(edition, "request_amendments", "Needs more work")
+      buttons << build_review_button(edition, "approve_review", "OK for publication")
+    end
     buttons.join("\n").html_safe
   end
 

--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -21,4 +21,8 @@ module TabsHelper
   def tabs
     Edition::Tab.all
   end
+
+  def tabs_for(user)
+    tabs.reject { |tab| tab.name == "unpublish" unless user.govuk_editor? }
+  end
 end

--- a/app/lib/govuk_content_models/action_processors/approve_review_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/approve_review_processor.rb
@@ -2,7 +2,7 @@ module GovukContentModels
   module ActionProcessors
     class ApproveReviewProcessor < BaseProcessor
       def process?
-        actor.govuk_editor? && requester_different?
+        requester_different?
       end
     end
   end

--- a/app/lib/govuk_content_models/action_processors/cancel_scheduled_publishing_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/cancel_scheduled_publishing_processor.rb
@@ -1,9 +1,6 @@
 module GovukContentModels
   module ActionProcessors
     class CancelScheduledPublishingProcessor < BaseProcessor
-      def process?
-        actor.govuk_editor?
-      end
     end
   end
 end

--- a/app/lib/govuk_content_models/action_processors/new_version_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/new_version_processor.rb
@@ -2,7 +2,7 @@ module GovukContentModels
   module ActionProcessors
     class NewVersionProcessor < BaseProcessor
       def process?
-        actor.govuk_editor? && edition.published?
+        edition.published?
       end
 
       def process

--- a/app/lib/govuk_content_models/action_processors/publish_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/publish_processor.rb
@@ -1,9 +1,6 @@
 module GovukContentModels
   module ActionProcessors
     class PublishProcessor < BaseProcessor
-      def process?
-        actor.govuk_editor?
-      end
     end
   end
 end

--- a/app/lib/govuk_content_models/action_processors/request_amendments_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/request_amendments_processor.rb
@@ -2,8 +2,6 @@ module GovukContentModels
   module ActionProcessors
     class RequestAmendmentsProcessor < BaseProcessor
       def process?
-        return false unless actor.govuk_editor?
-
         if edition.in_review?
           requester_different?
         else

--- a/app/lib/govuk_content_models/action_processors/request_review_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/request_review_processor.rb
@@ -1,9 +1,6 @@
 module GovukContentModels
   module ActionProcessors
     class RequestReviewProcessor < BaseProcessor
-      def process?
-        actor.govuk_editor?
-      end
     end
   end
 end

--- a/app/lib/govuk_content_models/action_processors/schedule_for_publishing_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/schedule_for_publishing_processor.rb
@@ -1,10 +1,6 @@
 module GovukContentModels
   module ActionProcessors
     class ScheduleForPublishingProcessor < BaseProcessor
-      def process?
-        actor.govuk_editor?
-      end
-
       def process
         publish_at = action_attributes.delete(:publish_at).to_time.utc
         action_attributes[:request_details] = { scheduled_time: publish_at }

--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -115,6 +115,10 @@ class Artefact
     attributes["language"] || "en"
   end
 
+  def welsh?
+    language == "cy"
+  end
+
   def normalise
     return if kind.blank?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -77,4 +77,8 @@ class User
   def govuk_editor?
     permissions.include?("govuk_editor")
   end
+
+  def welsh_editor?
+    permissions.include?("welsh_editor")
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,4 +81,8 @@ class User
   def welsh_editor?
     permissions.include?("welsh_editor")
   end
+
+  def has_editor_permissions?(resource)
+    govuk_editor? || (welsh_editor? && resource.artefact.welsh?)
+  end
 end

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -2,7 +2,7 @@
   <%= render 'shared/edition_header' %>
   <div class="tabbable" data-module="tab-switcher" role="tabpanel">
     <ul class="nav nav-tabs" role="tablist">
-      <% tabs.each do |tab| %>
+      <% tabs_for(current_user).each do |tab| %>
         <li <% if tab == active_tab %>class="active"<% end %>>
           <%= tab_link(tab, edition_path(@edition)) %>
         </li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,8 +12,12 @@
 
 <% content_for :navbar_items do %>
   <%= nav_link 'Publications', root_path %>
-  <%= nav_link 'Add artefact', new_artefact_path %>
-  <%= nav_link 'Downtime', downtimes_path %>
+
+  <% if current_user.govuk_editor? %>
+    <%= nav_link 'Add artefact', new_artefact_path %>
+    <%= nav_link 'Downtime', downtimes_path %>
+  <% end %>
+
   <%= nav_link 'Reports', reports_path %>
   <%= nav_link 'Search by user', user_search_path %>
 <% end %>

--- a/app/views/root/_publication.html.erb
+++ b/app/views/root/_publication.html.erb
@@ -66,10 +66,12 @@
   <% end %>
   <% if tab && (tab == :archived || tab == :published) %>
     <td>
-      <% if publication.can_create_new_edition? %>
-        <%= link_to 'Create new edition', duplicate_edition_path(publication), class: 'btn btn-default', method: :post %>
-      <% elsif publication.in_progress_sibling %>
-        <%= link_to 'Edit newer edition', edition_path(publication.in_progress_sibling), html_options = { "class" => "btn btn-info"} %>
+      <% if current_user.has_editor_permissions?(publication) %>
+        <% if publication.can_create_new_edition? %>
+          <%= link_to 'Create new edition', duplicate_edition_path(publication), class: 'btn btn-default', method: :post %>
+        <% elsif publication.in_progress_sibling %>
+          <%= link_to 'Edit newer edition', edition_path(publication.in_progress_sibling), html_options = { "class" => "btn btn-info"} %>
+        <% end %>
       <% end %>
     </td>
   <% end %>

--- a/app/views/root/_reviewer.html.erb
+++ b/app/views/root/_reviewer.html.erb
@@ -1,6 +1,6 @@
 <% if publication.reviewer and publication.reviewer.present? -%>
   <%= publication.reviewer %>
-<% elsif current_user != publication.assigned_to -%>
+<% elsif current_user != publication.assigned_to && current_user.has_editor_permissions?(publication) -%>
   <%= form_for :edition, url: review_edition_path(publication._id), method: :put do |f| %>
     <%= f.hidden_field :reviewer, value: current_user.name %>
     <%= f.submit "Claim 2i", class: "btn btn-primary" %>

--- a/app/views/shared/_history.html.erb
+++ b/app/views/shared/_history.html.erb
@@ -68,16 +68,18 @@
     <a href="#" class="js-toggle-all">Expand all notes</a>
   </p>
 
-  <div class="add-bottom-margin">
-    <a href="#save-edition-note" class="btn btn-primary" data-toggle="modal"><i class="glyphicon glyphicon-comment add-right-margin"></i>Add edition note</a>
-    <a href="#update-important-note" class="btn btn-default" data-toggle="modal"><i class="glyphicon glyphicon-exclamation-sign add-right-margin"></i>Update important note</a>
-    <% if @resource.important_note %>
-      <%= form_for(@resource.important_note, :url=> resolve_note_path, :html => { :class => "add-left-margin inline" }, :method => "put") do |f| %>
-        <%= hidden_field_tag :edition_id, resource.id %>
-        <%= f.submit :class=>"btn btn-default", :value => 'Delete important note' %>
+  <% if current_user.has_editor_permissions?(@resource) %>
+    <div class="add-bottom-margin">
+      <a href="#save-edition-note" class="btn btn-primary" data-toggle="modal"><i class="glyphicon glyphicon-comment add-right-margin"></i>Add edition note</a>
+      <a href="#update-important-note" class="btn btn-default" data-toggle="modal"><i class="glyphicon glyphicon-exclamation-sign add-right-margin"></i>Update important note</a>
+      <% if @resource.important_note %>
+        <%= form_for(@resource.important_note, :url=> resolve_note_path, :html => { :class => "add-left-margin inline" }, :method => "put") do |f| %>
+          <%= hidden_field_tag :edition_id, resource.id %>
+          <%= f.submit :class=>"btn btn-default", :value => 'Delete important note' %>
+        <% end %>
       <% end %>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 
   <p class="add-bottom-margin">
     <% if resource.published? %>

--- a/app/views/shared/_workflow_buttons.html.erb
+++ b/app/views/shared/_workflow_buttons.html.erb
@@ -5,15 +5,19 @@
         <% if @resource.locked_for_edits? %>
           <%= @resource.error_description %> can't be changed.
           <%= preview_button(@resource) %>
-          <% if @resource.can_create_new_edition? %>
-            <%= link_to 'Create new edition', duplicate_edition_path(@resource), class: 'btn btn-primary btn-large', method: :post %>
-          <% end %>
-          <% if @resource.in_progress_sibling.present? %>
-            <%= link_to 'Edit existing newer edition', edition_path(@resource.in_progress_sibling), html_options: { "class" => "btn btn-primary btn-large"} %>
+           <% if current_user.has_editor_permissions?(@resource) %>
+            <% if @resource.can_create_new_edition? %>
+              <%= link_to 'Create new edition', duplicate_edition_path(@resource), class: 'btn btn-primary btn-large', method: :post %>
+            <% end %>
+            <% if @resource.in_progress_sibling.present? %>
+              <%= link_to 'Edit existing newer edition', edition_path(@resource.in_progress_sibling), html_options: { "class" => "btn btn-primary btn-large"} %>
+            <% end %>
           <% end %>
           <%= progress_buttons(@resource, skip_disabled_buttons: true) %>
         <% else %>
-          <%= f.submit 'Save', id: 'save-edition', class: 'btn btn-success btn-large js-save' %>
+          <% if current_user.has_editor_permissions?(@resource) %>
+            <%= f.submit 'Save', id: 'save-edition', class: 'btn btn-success btn-large js-save' %>
+          <% end %>
           <%= preview_button(@resource) %>
           <%= progress_buttons(@resource) %>
         <% end %>

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class ArtefactsControllerTest < ActionController::TestCase
+  context "#new" do
+    should "allow creation if govuk_editor" do
+      login_as_govuk_editor
+
+      get :new
+
+      assert_response :ok
+    end
+
+    should "not allow creation if welsh_editor" do
+      login_as_welsh_editor
+
+      get :new
+
+      assert_response :redirect
+      assert_redirected_to controller: "root", action: "index"
+      assert_includes flash[:danger], "do not have permission"
+    end
+  end
+end

--- a/test/functional/downtimes_controller_test.rb
+++ b/test/functional/downtimes_controller_test.rb
@@ -18,6 +18,16 @@ class DowntimesControllerTest < ActionController::TestCase
         assert_select "h4.publication-table-title", text: edition.title
       end
     end
+
+    should "redirect to root page if welsh_editor" do
+      login_as_welsh_editor
+
+      get :index
+
+      assert_response :redirect
+      assert_redirected_to controller: "root", action: "index"
+      assert_includes flash[:danger], "do not have permission"
+    end
   end
 
   context "#new" do

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -287,6 +287,45 @@ class EditionsControllerTest < ActionController::TestCase
              },
            }
     end
+
+    context "Welsh editors" do
+      setup { login_as_welsh_editor }
+
+      should "be able to update Welsh editions" do
+        artefact = FactoryBot.create(:artefact, :welsh)
+        edition = FactoryBot.create(:guide_edition, :ready, panopticon_id: artefact.id)
+
+        post :update,
+             params: {
+               id: edition.id,
+               edition: {
+                 title: "Updated title",
+               },
+             }
+
+        assert_redirected_to edition_path(edition)
+        edition.reload
+        assert_equal edition.title, "Updated title"
+      end
+
+      should "not be able to update non-Welsh editions" do
+        artefact = FactoryBot.create(:artefact)
+        edition = FactoryBot.create(:guide_edition, :ready, panopticon_id: artefact.id)
+
+        post :update,
+             params: {
+               id: edition.id,
+               edition: {
+                 title: "Updated title",
+               },
+             }
+
+        assert_redirected_to edition_path(edition)
+        edition.reload
+        assert_not_equal edition.title, "Updated title"
+        assert_equal "You do not have permission to create a new edition.", flash[:danger]
+      end
+    end
   end
 
   context "#review" do

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -501,6 +501,40 @@ class EditionsControllerTest < ActionController::TestCase
       @guide.reload
       assert_equal bob.name, @guide.reviewer
     end
+
+    context "Welsh editors" do
+      setup do
+        @welsh_guide = FactoryBot.create(:guide_edition, :welsh, :in_review)
+        login_as_welsh_editor
+        @welsh_user = @user
+      end
+
+      should "be able to claim a review for Welsh editions" do
+        put :review,
+            params: {
+              id: @welsh_guide.id,
+              edition: { reviewer: @welsh_user.name },
+            }
+
+        assert_redirected_to edition_path(@welsh_guide)
+        assert_equal "You are the reviewer of this guide.", flash[:success]
+        @welsh_guide.reload
+        assert_equal @welsh_user.name, @welsh_guide.reviewer
+      end
+
+      should "not be able to claim a review for non-Welsh editions" do
+        put :review,
+            params: {
+              id: @guide.id,
+              edition: { reviewer: @welsh_user.name },
+            }
+
+        assert_redirected_to edition_path(@guide)
+        assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
+        @guide.reload
+        assert_nil @guide.reviewer
+      end
+    end
   end
 
   context "#destroy" do

--- a/test/functional/notes_controller_test.rb
+++ b/test/functional/notes_controller_test.rb
@@ -1,0 +1,141 @@
+require "test_helper"
+
+class NotesControllerTest < ActionController::TestCase
+  setup do
+    login_as_stub_user
+    stub_linkables
+    stub_holidays_used_by_fact_check
+  end
+
+  context "#create" do
+    setup do
+      @edition = FactoryBot.create(:edition)
+      @note_text = "A New Note!"
+    end
+
+    context "when a comment is not provided" do
+      should "resolve any ImportantNotes if the edition has an existing ImportantNote" do
+        post :create,
+             params: {
+               edition_id: @edition.id,
+               note: {
+                 type: "important_note",
+                 comment: "Important note text",
+               },
+             }
+
+        @edition.reload
+        assert_equal "Important note text", @edition.actions.first.comment
+        assert_equal "important_note", @edition.actions.first.request_type
+
+        post :create,
+             params: {
+               edition_id: @edition.id,
+               note: {
+                 type: "important_note",
+               },
+             }
+
+        assert_redirected_to history_edition_path(@edition)
+        assert_includes flash[:success], "Note resolved"
+
+        @edition.reload
+        assert_nil @edition.actions.last.comment
+        assert_equal "important_note_resolved", @edition.actions.last.request_type
+      end
+
+      should "flash a warning that the note did not save if the edition does not have an existing ImportantNote" do
+        post :create,
+             params: {
+               edition_id: @edition.id,
+               note: {
+                 type: "note",
+               },
+             }
+
+        @edition.reload
+
+        assert_redirected_to history_edition_path(@edition)
+        assert_includes flash[:warning], "Didn’t save empty note"
+        assert_equal [], @edition.actions
+      end
+    end
+
+    context "when a comment is provided" do
+      should "confirm the note was successfully recorded" do
+        post :create,
+             params: {
+               edition_id: @edition.id,
+               note: {
+                 type: "note",
+                 comment: @note_text,
+               },
+             }
+
+        @edition.reload
+
+        assert_redirected_to history_edition_path(@edition)
+        assert_includes flash[:success], "Note recorded"
+        assert_equal @note_text, @edition.actions.first.comment
+      end
+
+      should "flash a danger message if the note did not save" do
+        @user.stubs(:record_note).with(@edition, @note_text, "note").returns(false)
+
+        post :create,
+             params: {
+               edition_id: @edition.id,
+               note: {
+                 type: "note",
+                 comment: @note_text,
+               },
+             }
+
+        @edition.reload
+
+        assert_redirected_to history_edition_path(@edition)
+        assert_includes flash[:danger], "Note failed to save"
+        assert_equal [], @edition.actions
+      end
+    end
+
+    context "Welsh editors" do
+      setup do
+        login_as_welsh_editor
+      end
+
+      should "not be able to create notes for non-Welsh editions" do
+        post :create,
+             params: {
+               edition_id: @edition.id,
+               note: {
+                 type: "note",
+                 comment: @note_text,
+               },
+             }
+
+        assert_redirected_to edition_path(@edition)
+        assert_includes flash[:danger], "You do not have correct editor permissions for this action."
+      end
+
+      should "be able to create notes for Welsh editions" do
+        welsh_edition = FactoryBot.create(:edition, :welsh)
+
+        post :create,
+             params: {
+               edition_id: welsh_edition.id,
+               note: {
+                 type: "note",
+                 comment: "Welsh note text",
+               },
+             }
+
+        welsh_edition.reload
+
+        assert_redirected_to history_edition_path(welsh_edition)
+        assert_includes flash[:success], "Note recorded"
+        assert_equal "Welsh note text", welsh_edition.actions.first.comment
+      end
+    end
+  end
+end

--- a/test/integration/edition_history_test.rb
+++ b/test/integration/edition_history_test.rb
@@ -175,6 +175,52 @@ class EditionHistoryTest < JavascriptIntegrationTest
         assert page.has_css?(".callout-important-note tr:first-child td", text: "An updated note")
       end
     end
+
+    context "Welsh editors" do
+      setup do
+        user = FactoryBot.create(:user, :welsh_editor, name: "Author", email: "test@example.com")
+        @welsh_edition = FactoryBot.create(:guide_edition, :welsh, state: "ready")
+        login_as(user)
+      end
+
+      should "not see options to add notes to non-Welsh editions" do
+        visit_edition @answer
+        click_on "History and notes"
+        assert page.has_no_css?("#edition-history .btn.btn-primary", text: "Add edition note")
+        assert page.has_no_css?("#edition-history .btn.btn-default", text: "Update important note")
+      end
+
+      should "be able to add notes to Welsh editions" do
+        visit_edition @welsh_edition
+        click_on "History and notes"
+
+        click_on "Add edition note"
+
+        within "#save-edition-note" do
+          fill_in "Note", with: "A simple Welsh note"
+          click_on "Save edition note"
+        end
+
+        assert page.has_content?("Note recorded")
+        assert page.has_css?(".action-note", text: "A simple Welsh note")
+      end
+
+      should "be able to add important notes to Welsh editions" do
+        visit_edition @welsh_edition
+        click_on "History and notes"
+
+        click_on "Update important note"
+
+        within "#update-important-note" do
+          fill_in "Important note", with: "An important Welsh note"
+          click_on "Save important note"
+        end
+
+        assert page.has_content?("Note recorded")
+
+        assert page.has_css?(".callout-important-note ", text: "An important Welsh note")
+      end
+    end
   end
 
   def add_important_note(note)

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -392,7 +392,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
 
     visit_edition guide
     send_action guide, "OK for publication", "OK for publication", "Yup, looks good"
-    assert page.has_content? "Couldn't approve review"
+    assert page.has_content? "You do not have correct editor permissions for this action."
   end
 
   test "can skip fact-check" do

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -610,6 +610,26 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     assert page.has_css?(".btn.btn-large.btn-primary", text: "Publish now")
   end
 
+  test "Welsh editors cannot see review buttons for non-Welsh editions" do
+    edition = FactoryBot.create(:edition, :in_review, panopticon_id: FactoryBot.create(:artefact).id)
+    login_as("WelshEditor")
+
+    visit_edition edition
+
+    assert_not page.has_link?("Needs more work", href: "#request_amendments_form")
+    assert_not page.has_link?("OK for publication", href: "#approve_review_form")
+  end
+
+  test "Welsh editors can see review buttons for Welsh editions" do
+    edition = FactoryBot.create(:edition, :in_review, :welsh)
+    login_as("WelshEditor")
+
+    visit_edition edition
+
+    assert page.has_link?("Needs more work", href: "#request_amendments_form")
+    assert page.has_link?("OK for publication", href: "#approve_review_form")
+  end
+
   test "Welsh editors cannot see buttons to request a review for non-Welsh editions" do
     edition = FactoryBot.create(:edition, :draft, panopticon_id: FactoryBot.create(:artefact).id)
     login_as("WelshEditor")

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -610,6 +610,25 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     assert page.has_css?(".btn.btn-large.btn-primary", text: "Publish now")
   end
 
+  test "Welsh editors cannot see buttons to request a review for non-Welsh editions" do
+    edition = FactoryBot.create(:edition, :draft, panopticon_id: FactoryBot.create(:artefact).id)
+    login_as("WelshEditor")
+
+    visit_edition edition
+
+    assert_not page.has_link?("2nd pair of eyes", href: "#request_review_form")
+  end
+
+  test "Welsh editors can see buttons to request a review for Welsh editions" do
+    edition = FactoryBot.create(:edition, :draft, :welsh)
+    login_as("WelshEditor")
+
+    visit_edition edition
+    find_link("2nd pair of eyes", href: "#request_review_form").click
+
+    assert page.has_button?("Send to 2nd pair of eyes", type: "submit")
+  end
+
   test "can preview a draft article on draft-origin" do
     guide.update!(state: "draft")
 

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -434,7 +434,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
 
     visit_edition guide
     send_action guide, "Minor or no changes required", "Approve fact check", "Hurrah!"
-    assert page.has_content? "Couldn't approve fact check"
+    assert page.has_content? "You do not have correct editor permissions for this action."
   end
 
   test "can go back to fact-check from fact-check received" do

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -384,17 +384,6 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     assert page.has_content? guide.title
   end
 
-  test "can't approve review if not govuk_editor" do
-    guide.state = "in_review"
-    guide.save!(validate: false)
-
-    login_as FactoryBot.create(:user)
-
-    visit_edition guide
-    send_action guide, "OK for publication", "OK for publication", "Yup, looks good"
-    assert page.has_content? "You do not have correct editor permissions for this action."
-  end
-
   test "can skip fact-check" do
     guide.update!(state: "fact_check")
 

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -581,6 +581,46 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     save_edition_and_assert_success
   end
 
+  test "Welsh editors cannot see publishing buttons for non-Welsh 'ready' editions" do
+    edition = FactoryBot.create(:edition, :ready, panopticon_id: FactoryBot.create(:artefact).id)
+    login_as("WelshEditor")
+
+    visit_edition edition
+
+    assert_not page.has_css?(".btn.btn-large.btn-warning", text: "Schedule")
+    assert_not page.has_css?(".btn.btn-large.btn-primary", text: "Publish")
+  end
+
+  test "Welsh editors can see publishing buttons for Welsh 'ready' editions" do
+    edition = FactoryBot.create(:edition, :ready, :welsh)
+    login_as("WelshEditor")
+
+    visit_edition edition
+
+    assert page.has_css?(".btn.btn-large.btn-warning", text: "Schedule")
+    assert page.has_css?(".btn.btn-large.btn-primary", text: "Publish")
+  end
+
+  test "Welsh editors cannot see publishing buttons for non-Welsh 'scheduled' editions" do
+    edition = FactoryBot.create(:edition, :scheduled_for_publishing, panopticon_id: FactoryBot.create(:artefact).id)
+    login_as("WelshEditor")
+
+    visit_edition edition
+
+    assert_not page.has_css?(".btn.btn-large.btn-warning", text: "Cancel scheduled publishing")
+    assert_not page.has_css?(".btn.btn-large.btn-primary", text: "Publish now")
+  end
+
+  test "Welsh editors can see publishing buttons for Welsh 'scheduled' editions" do
+    edition = FactoryBot.create(:edition, :scheduled_for_publishing, :welsh)
+    login_as("WelshEditor")
+
+    visit_edition edition
+
+    assert page.has_css?(".btn.btn-large.btn-danger", text: "Cancel scheduled publishing")
+    assert page.has_css?(".btn.btn-large.btn-primary", text: "Publish now")
+  end
+
   test "can preview a draft article on draft-origin" do
     guide.update!(state: "draft")
 

--- a/test/integration/root_overview_test.rb
+++ b/test/integration/root_overview_test.rb
@@ -263,6 +263,32 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
     assert page.has_css?("#publication-list-container tbody tr:first-child td:nth-child(6)", text: "")
   end
 
+  test "Welsh editors can see claim 2i button in Welsh editions" do
+    stub_linkables
+    FactoryBot.create(:guide_edition, :in_review, :welsh)
+    welsh_editor = FactoryBot.create(:user, :welsh_editor)
+
+    login_as(welsh_editor)
+    visit "/"
+    filter_by_user("All")
+    click_on "In review"
+
+    assert page.has_button?("Claim 2i")
+  end
+
+  test "Welsh editors cannot see claim 2i button in non-Welsh editions" do
+    stub_linkables
+    FactoryBot.create(:guide_edition, :in_review, panopticon_id: FactoryBot.create(:artefact).id)
+    welsh_editor = FactoryBot.create(:user, :welsh_editor)
+
+    login_as(welsh_editor)
+    visit "/"
+    filter_by_user("All")
+    click_on "In review"
+
+    assert_not page.has_button?("Claim 2i")
+  end
+
   test "filtering by published should show a table with an edition with a slug as a link" do
     FactoryBot.create(:user, :govuk_editor)
     FactoryBot.create(:guide_edition, state: "published", title: "Test", slug: "test-slug")

--- a/test/integration/skip_review_test.rb
+++ b/test/integration/skip_review_test.rb
@@ -6,7 +6,7 @@ class SkipReviewTest < JavascriptIntegrationTest
       :user,
       name: "Vincent Panache",
       email: "test@example.com",
-      permissions: %w[skip_review],
+      permissions: %w[skip_review govuk_editor],
     )
 
     stub_linkables
@@ -65,7 +65,7 @@ class SkipReviewTest < JavascriptIntegrationTest
       :user,
       name: "Editor",
       email: "thingy@example.com",
-      permissions: %w[editor],
+      permissions: %w[govuk_editor],
     )
 
     login_as editor

--- a/test/integration/unpublish_test.rb
+++ b/test/integration/unpublish_test.rb
@@ -64,4 +64,24 @@ class UnpublishTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  context "Welsh editors" do
+    setup do
+      @welsh_edition = FactoryBot.create(:guide_edition, :ready, :welsh)
+      @welsh_editor = FactoryBot.create(:user, :welsh_editor)
+      login_as(@welsh_editor)
+    end
+
+    should "not be able to see the unpublish tab for Welsh Editions" do
+      visit_edition @welsh_edition
+
+      assert_not page.has_css?(".nav.nav-tabs li", text: "Unpublish")
+    end
+
+    should "not be able to see the unpublish tab for non-Welsh Editions" do
+      visit_edition @edition
+
+      assert_not page.has_css?(".nav.nav-tabs li", text: "Unpublish")
+    end
+  end
 end

--- a/test/models/artefact_test.rb
+++ b/test/models/artefact_test.rb
@@ -351,6 +351,11 @@ class ArtefactTest < ActiveSupport::TestCase
       assert_equal "cy", a.language
     end
 
+    should "be welsh? if language is cy" do
+      artefact = FactoryBot.build(:artefact, language: "cy")
+      assert artefact.welsh?
+    end
+
     should "reject a language which is not english or welsh" do
       a = FactoryBot.build(:artefact)
       a.language = "pirate"

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -730,13 +730,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_nil edition.reload.publish_at
   end
 
-  test "cannot request review if not govuk_editor" do
-    edition = FactoryBot.create(:guide_edition, panopticon_id: @artefact.id, state: "draft")
-    user = User.create!(name: "George")
-    request_review(user, edition)
-    assert_equal edition.actions.size, 0
-  end
-
   test "edition can return latest status action of a specified request type" do
     edition = FactoryBot.create(:guide_edition, panopticon_id: @artefact.id, state: "draft")
     user = FactoryBot.create(:user, :govuk_editor, name: "George")

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -12,6 +12,11 @@ class UserTest < ActiveSupport::TestCase
     @artefact = FactoryBot.create(:artefact)
   end
 
+  test "is welsh_editor? if permissions include welsh_editor" do
+    user = FactoryBot.create(:user, :welsh_editor)
+    assert user.welsh_editor?
+  end
+
   test "should convert to string using name by preference" do
     user = User.new(name: "Bob", email: "user@example.com")
     assert_equal "Bob", user.to_s

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -12,6 +12,34 @@ class UserTest < ActiveSupport::TestCase
     @artefact = FactoryBot.create(:artefact)
   end
 
+  test "#has_editor_permissions? is true with govuk_editor and non-Welsh editions" do
+    govuk_editor = FactoryBot.create(:user, :govuk_editor)
+    edition = FactoryBot.create(:edition)
+
+    assert govuk_editor.has_editor_permissions?(edition)
+  end
+
+  test "#has_editor_permissions? is true with govuk_editor and Welsh editions" do
+    govuk_editor = FactoryBot.create(:user, :govuk_editor)
+    welsh_edition = FactoryBot.create(:edition, :welsh)
+
+    assert govuk_editor.has_editor_permissions?(welsh_edition)
+  end
+
+  test "#has_editor_permissions? is false with welsh_editor and non-Welsh editions" do
+    welsh_editor = FactoryBot.create(:user, :welsh_editor)
+    edition = FactoryBot.create(:edition)
+
+    assert_not welsh_editor.has_editor_permissions?(edition)
+  end
+
+  test "#has_editor_permissions? is true with welsh_editor and Welsh editions" do
+    welsh_editor = FactoryBot.create(:user, :welsh_editor)
+    welsh_edition = FactoryBot.create(:edition, :welsh)
+
+    assert welsh_editor.has_editor_permissions?(welsh_edition)
+  end
+
   test "is welsh_editor? if permissions include welsh_editor" do
     user = FactoryBot.create(:user, :welsh_editor)
     assert user.welsh_editor?

--- a/test/models/workflow_test.rb
+++ b/test/models/workflow_test.rb
@@ -505,12 +505,6 @@ class WorkflowTest < ActiveSupport::TestCase
 
     should "schedule an edition for publishing if it is ready" do
       edition = FactoryBot.create(:edition, state: "ready")
-      schedule_for_publishing(FactoryBot.create(:user), edition, @activity_details)
-      assert_not edition.reload.scheduled_for_publishing?
-    end
-
-    should "not schedule an edition for publishing if user is not govuk_editor" do
-      edition = FactoryBot.create(:edition, state: "ready")
 
       schedule_for_publishing(@user, edition, @activity_details)
 

--- a/test/models/workflow_test.rb
+++ b/test/models/workflow_test.rb
@@ -431,11 +431,6 @@ class WorkflowTest < ActiveSupport::TestCase
       assert_nil @user.new_version(@edition)
     end
 
-    should "return nil if user is not govuk_editor" do
-      other_user = FactoryBot.create(:user)
-      assert_nil other_user.new_version(@edition)
-    end
-
     should "record the action" do
       new_version = @user.new_version(@edition)
       assert_equal "new_version", new_version.actions.last.request_type

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -17,6 +17,10 @@ FactoryBot.define do
     trait :govuk_editor do
       permissions { %w[govuk_editor signin] }
     end
+
+    trait :welsh_editor do
+      permissions { %w[welsh_editor signin] }
+    end
   end
 
   factory :disabled_user, parent: :user do

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -109,6 +109,10 @@ FactoryBot.define do
       state { "published" }
     end
 
+    trait :ready do
+      state { "ready" }
+    end
+
     trait :with_body do
       body { "Some body text" }
     end

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -113,6 +113,11 @@ FactoryBot.define do
       state { "ready" }
     end
 
+    trait :in_review do
+      state { "in_review" }
+      review_requested_at { Time.zone.now }
+    end
+
     trait :with_body do
       body { "Some body text" }
     end

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -118,6 +118,10 @@ FactoryBot.define do
       review_requested_at { Time.zone.now }
     end
 
+    trait :draft do
+      state { "draft" }
+    end
+
     trait :with_body do
       body { "Some body text" }
     end

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -96,6 +96,10 @@ FactoryBot.define do
       end
     end
 
+    trait :welsh do
+      panopticon_id { create(:artefact, language: "cy", kind: kind_for_artefact).id }
+    end
+
     trait :scheduled_for_publishing do
       state { "scheduled_for_publishing" }
       publish_at { 1.day.from_now }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -77,10 +77,21 @@ class ActiveSupport::TestCase
     Sidekiq::Worker.clear_all
   end
 
-  def login_as_stub_user
-    @user = FactoryBot.create(:user, :govuk_editor, name: "Stub User")
-    request.env["warden"] = stub(authenticate!: true, authenticated?: true, user: @user)
+  def login_as(user)
+    request.env["warden"] = stub(authenticate!: true, authenticated?: true, user: user)
   end
+
+  def login_as_govuk_editor
+    @user = FactoryBot.create(:user, :govuk_editor, name: "Stub User")
+    login_as(@user)
+  end
+
+  def login_as_welsh_editor
+    @user = FactoryBot.create(:user, :welsh_editor, name: "Stub User")
+    login_as(@user)
+  end
+
+  alias_method :login_as_stub_user, :login_as_govuk_editor
 
   include GdsApi::TestHelpers::PublishingApi
   include TagTestHelpers

--- a/test/unit/edition_progressor_test.rb
+++ b/test/unit/edition_progressor_test.rb
@@ -132,17 +132,5 @@ class EditionProgressorTest < ActiveSupport::TestCase
         assert_equal 0, Sidekiq::ScheduledSet.new.size
       end
     end
-
-    should "not dequeue a scheduled job if not govuk_editor" do
-      Sidekiq::Testing.disable! do
-        publish_at = 1.day.from_now
-        @guide.update!(state: :scheduled_for_publishing, publish_at: publish_at)
-        ScheduledPublisher.perform_at(publish_at, @guide.id.to_s)
-
-        activity = { request_type: "cancel_scheduled_publishing", comment: "stop!" }
-        command = EditionProgressor.new(@guide, FactoryBot.create(:user))
-        assert_not command.progress(activity)
-      end
-    end
   end
 end

--- a/test/unit/tabs_helper_test.rb
+++ b/test/unit/tabs_helper_test.rb
@@ -39,4 +39,16 @@ class TabsHelperTest < ActionView::TestCase
       assert_match "Edit", link
     end
   end
+
+  context "#tabs_for(user)" do
+    should "return all tabs if user is govuk_editor" do
+      user = FactoryBot.create(:user, :govuk_editor)
+      assert_equal tabs_for(user), tabs
+    end
+
+    should "return all tabs except `unpublish` if user is not govuk_editor" do
+      user = FactoryBot.create(:user)
+      assert_equal %w[unpublish], (tabs - tabs_for(user)).map(&:name)
+    end
+  end
 end


### PR DESCRIPTION
Following work in https://github.com/alphagov/publisher/pull/1348 to make it necessary for a user to have `govuk_editor` permissions to perform most actions, this PR adds further restrictions to users with a `welsh_editor` permission.

See individual commit messages for more context.

[Trello card](https://trello.com/c/Hq2qgwiI/2155-8-give-permission-in-publisher-for-welsh-teams-in-departments-to-update-only-welsh-content)


 