### PR TITLE
Correct local service importer method name

### DIFF
--- a/lib/tasks/local_transactions.rake
+++ b/lib/tasks/local_transactions.rake
@@ -7,7 +7,7 @@ namespace :local_transactions do
 
   desc "Import services from the service list CSV"
   task update_services: :environment do
-    LocalServiceImporter.update
+    LocalServiceImporter.run
   end
 
   desc "Removes services that do not appear in the service list CSV"

--- a/test/unit/tasks/local_transactions_rake_test.rb
+++ b/test/unit/tasks/local_transactions_rake_test.rb
@@ -3,8 +3,8 @@ require "rake"
 
 class LocalTransactionsRakeTest < ActiveSupport::TestCase
   context "local_transactions:update_services" do
-    should "call LocalServiceImporter.update" do
-      LocalServiceImporter.expects(:update)
+    should "call LocalServiceImporter.run" do
+      LocalServiceImporter.expects(:run)
       Rake::Task["local_transactions:update_services"].invoke
     end
   end


### PR DESCRIPTION
Change of LocalServiceImporter method from update to run missed in
local_transactions:update_services rake task.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/publisher), after merging.
