### PR TITLE
Add restrictions for user with `welsh_editor` permissions

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -5,7 +5,9 @@ class EditionsController < InheritedResources::Base
   actions :create, :update, :destroy
   defaults resource_class: Edition, collection_name: "editions", instance_name: "resource"
   before_action :setup_view_paths, except: %i[index new create]
-  before_action :require_editor_permissions, only: %i[update duplicate progress review destroy]
+  before_action only: %i[update duplicate progress review destroy admin] do
+    require_editor_permissions
+  end
   before_action only: %i[unpublish process_unpublish] do
     require_govuk_editor(redirect_path: edition_path(resource))
   end

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -335,6 +335,11 @@ protected
   def update_assignment(edition, assignee)
     return if edition.assigned_to == assignee
 
+    unless assignee.has_editor_permissions?(resource)
+      flash[:danger] = "Chosen assignee does not have correct editor permissions."
+      return
+    end
+
     if assignee
       current_user.assign(edition, assignee)
     else

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -5,7 +5,7 @@ class EditionsController < InheritedResources::Base
   actions :create, :update, :destroy
   defaults resource_class: Edition, collection_name: "editions", instance_name: "resource"
   before_action :setup_view_paths, except: %i[index new create]
-  before_action :require_editor_permissions, only: %i[update duplicate progress review]
+  before_action :require_editor_permissions, only: %i[update duplicate progress review destroy]
   before_action only: %i[unpublish process_unpublish] do
     require_govuk_editor(redirect_path: edition_path(resource))
   end

--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -22,7 +22,11 @@ module TabsHelper
     Edition::Tab.all
   end
 
-  def tabs_for(user)
-    tabs.reject { |tab| tab.name == "unpublish" unless user.govuk_editor? }
+  def tabs_for(user, resource)
+    tabs_to_remove = []
+    tabs_to_remove << "admin" unless user.has_editor_permissions?(resource)
+    tabs_to_remove << "unpublish" unless user.govuk_editor?
+
+    tabs.reject { |tab| tabs_to_remove.include?(tab.name) }
   end
 end

--- a/app/lib/govuk_content_models/action_processors/approve_fact_check_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/approve_fact_check_processor.rb
@@ -1,9 +1,6 @@
 module GovukContentModels
   module ActionProcessors
     class ApproveFactCheckProcessor < BaseProcessor
-      def process?
-        actor.govuk_editor?
-      end
     end
   end
 end

--- a/app/lib/govuk_content_models/action_processors/assign_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/assign_processor.rb
@@ -1,10 +1,6 @@
 module GovukContentModels
   module ActionProcessors
     class AssignProcessor < BaseProcessor
-      def process?
-        actor.govuk_editor?
-      end
-
       def process
         edition.set(assigned_to_id: action_attributes[:recipient_id])
         edition.reload

--- a/app/lib/govuk_content_models/action_processors/resend_fact_check_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/resend_fact_check_processor.rb
@@ -1,10 +1,6 @@
 module GovukContentModels
   module ActionProcessors
     class ResendFactCheckProcessor < BaseProcessor
-      def process?
-        actor.govuk_editor?
-      end
-
       def process
         return false unless edition.latest_status_action.is_fact_check_request?
 

--- a/app/lib/govuk_content_models/action_processors/send_fact_check_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/send_fact_check_processor.rb
@@ -1,10 +1,6 @@
 module GovukContentModels
   module ActionProcessors
     class SendFactCheckProcessor < BaseProcessor
-      def process?
-        actor.govuk_editor?
-      end
-
       def process
         return false if action_attributes[:email_addresses].blank?
 

--- a/app/lib/govuk_content_models/action_processors/skip_fact_check_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/skip_fact_check_processor.rb
@@ -1,9 +1,6 @@
 module GovukContentModels
   module ActionProcessors
     class SkipFactCheckProcessor < BaseProcessor
-      def process?
-        actor.govuk_editor?
-      end
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,6 +67,8 @@ class User
   end
 
   def assign(edition, recipient)
+    return unless has_editor_permissions?(edition) && recipient.has_editor_permissions?(edition)
+
     GovukContentModels::ActionProcessors::AssignProcessor.new(self, edition, recipient_id: recipient.id).processed_edition
   end
 

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -2,7 +2,7 @@
   <%= render 'shared/edition_header' %>
   <div class="tabbable" data-module="tab-switcher" role="tabpanel">
     <ul class="nav nav-tabs" role="tablist">
-      <% tabs_for(current_user).each do |tab| %>
+      <% tabs_for(current_user, @edition).each do |tab| %>
         <li <% if tab == active_tab %>class="active"<% end %>>
           <%= tab_link(tab, edition_path(@edition)) %>
         </li>

--- a/app/views/shared/_common_edition_attributes.html.erb
+++ b/app/views/shared/_common_edition_attributes.html.erb
@@ -1,8 +1,10 @@
 <%= hidden_field_tag "return_to", params[:return_to] if params[:return_to] %>
-<div class="form-group">
-  <label for="edition_assigned_to_id">Assigned to</label>
-  <%= f.select :assigned_to_id, enabled_users_select_options, {}, {:class => 'form-control input-md-3', :disabled => @resource.locked_for_edits?, "data-module" => 'assignee-select'} %>
-</div>
+  <% if current_user.has_editor_permissions?(@resource) %>
+    <div class="form-group">
+      <label for="edition_assigned_to_id">Assigned to</label>
+      <%= f.select :assigned_to_id, enabled_users_select_options, {}, {:class => 'form-control input-md-3', :disabled => @resource.locked_for_edits?, "data-module" => 'assignee-select'} %>
+    </div>
+  <% end %>
 <%= render partial: 'reviewer_field', locals: { f: f } if @resource.in_review? %>
 <%= render partial: 'major_change_fields', locals: { f: f } if @resource.published_edition %>
 

--- a/app/views/shared/_fact_check.html.erb
+++ b/app/views/shared/_fact_check.html.erb
@@ -1,9 +1,13 @@
 <div class="alert alert-info">
   <% if @resource.latest_status_action %>
     <p><%= @resource.latest_status_action.requester.name %> requested this edition be fact checked. We&rsquo;re awaiting a response.</p>
-    <%= resend_fact_check_buttons(@resource) %>
+    <% if current_user.has_editor_permissions?(@resource) %>
+      <%= resend_fact_check_buttons(@resource) %>
+    <% end %>
   <% else %>
     <p>Someone requested this edition be fact checked. We&rsquo;re awaiting a response.</p>
   <% end %>
-  <%= render 'shared/request_amendments' %>
+  <% if current_user.has_editor_permissions?(@resource) %>
+    <%= render 'shared/request_amendments' %>
+  <% end %>
 </div>

--- a/app/views/shared/_fact_check_received.html.erb
+++ b/app/views/shared/_fact_check_received.html.erb
@@ -1,10 +1,14 @@
 <div class="alert alert-info">
-  <p>We have received a fact check response for this edition. Please check the response in History &amp; Notes, and select an action below.</p>
+  <p>We have received a fact check response for this edition.</p>
 
-  <div class="workflow-buttons">
-    <%= fact_check_buttons(@resource)%>
-  </div>
-  <% if activity_forms_required? %>
-    <%= fact_check_forms(@resource)%>
-  <% end %>
+   <% if current_user.has_editor_permissions?(@resource)%>
+    <p>Please check the response in History &amp; Notes, and select an action below.</p>
+
+    <div class="workflow-buttons">
+      <%= fact_check_buttons(@resource)%>
+    </div>
+    <% if activity_forms_required? %>
+      <%= fact_check_forms(@resource)%>
+    <% end %>
+  <% end%>
 </div>

--- a/app/views/shared/_ready.html.erb
+++ b/app/views/shared/_ready.html.erb
@@ -1,4 +1,6 @@
-<div class="alert alert-info">
-  <p>Request this edition to be amended further.</p>
-  <%= render 'shared/request_amendments' %>
-</div>
+ <% if current_user.has_editor_permissions?(@resource)%>
+  <div class="alert alert-info">
+    <p>Request this edition to be amended further.</p>
+    <%= render 'shared/request_amendments' %>
+  </div>
+<% end %>

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -787,6 +787,31 @@ class EditionsControllerTest < ActionController::TestCase
         delete :destroy, params: { id: @guide.id }
       end
     end
+
+    context "Welsh editors" do
+      setup do
+        login_as_welsh_editor
+        @welsh_guide = FactoryBot.create(:guide_edition, :welsh)
+      end
+
+      should "not be able to destroy non-Welsh editions" do
+        assert_difference("GuideEdition.count", 0) do
+          delete :destroy, params: { id: @guide.id }
+        end
+
+        assert_redirected_to edition_path(@guide)
+        assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
+      end
+
+      should "be able to destroy Welsh editions" do
+        assert_difference("GuideEdition.count", -1) do
+          delete :destroy, params: { id: @welsh_guide.id }
+        end
+
+        assert_redirected_to(:controller => "root", "action" => "index")
+        assert_equal "Guide destroyed", flash[:success]
+      end
+    end
   end
 
   context "#index" do

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -846,6 +846,38 @@ class EditionsControllerTest < ActionController::TestCase
     end
   end
 
+  context "#admin" do
+    setup do
+      @guide = FactoryBot.create(:guide_edition)
+    end
+
+    should "show the admin page for the edition" do
+      get :admin, params: { id: @guide.id }
+
+      assert_response :success
+    end
+
+    context "Welsh editors" do
+      setup do
+        login_as_welsh_editor
+        @welsh_guide = FactoryBot.create(:guide_edition, :welsh)
+      end
+
+      should "be able to see the admin page for Welsh editions" do
+        get :admin, params: { id: @welsh_guide.id }
+
+        assert_response :success
+      end
+
+      should "not be able to see the admin page for non-Welsh editions" do
+        get :admin, params: { id: @guide.id }
+
+        assert_redirected_to edition_path(@guide)
+        assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
+      end
+    end
+  end
+
   context "#diff" do
     should "we can diff the last edition" do
       first_edition = FactoryBot.create(:guide_edition, state: "published")

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -570,6 +570,28 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     save_edition_and_assert_success
   end
 
+  test "Welsh editors can assign users to Welsh editions" do
+    guide.artefact.update!(language: "cy")
+
+    login_as("WelshEditor")
+    visit edition_path(guide)
+
+    select "Bob", from: "Assigned to"
+    save_edition_and_assert_success
+    guide.reload
+
+    assert_equal guide.assigned_to, bob
+
+    save_edition_and_assert_success
+  end
+
+  test "Welsh editors cannot assign users to non-Welsh editions" do
+    login_as("WelshEditor")
+    visit edition_path(guide)
+
+    assert page.has_no_content? "Assigned to"
+  end
+
   test "Welsh editors cannot see publishing buttons for non-Welsh 'ready' editions" do
     edition = FactoryBot.create(:edition, :ready, panopticon_id: FactoryBot.create(:artefact).id)
     login_as("WelshEditor")

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -417,16 +417,6 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     assert page.has_content? guide.title
   end
 
-  test "can't progress from fact-check if not govuk_editor" do
-    guide.update!(state: "fact_check_received")
-
-    login_as FactoryBot.create(:user)
-
-    visit_edition guide
-    send_action guide, "Minor or no changes required", "Approve fact check", "Hurrah!"
-    assert page.has_content? "You do not have correct editor permissions for this action."
-  end
-
   test "can go back to fact-check from fact-check received" do
     guide.update!(state: "fact_check_received")
 
@@ -590,6 +580,68 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     visit edition_path(guide)
 
     assert page.has_no_content? "Assigned to"
+  end
+
+  test "Welsh editors may not see buttons to respond to fact checks" do
+    edition = FactoryBot.create(:edition, :fact_check_received)
+    login_as("WelshEditor")
+
+    visit_edition edition
+
+    assert page.has_content?("We have received a fact check response for this edition")
+    assert_not page.has_css?(".btn.btn-info", text: "Needs major changes")
+    assert_not page.has_css?(".btn.btn-info", text: "Minor or no changes required")
+  end
+
+  test "Welsh editors may see buttons to respond to fact checks for Welsh editions" do
+    edition = FactoryBot.create(:edition, :fact_check_received, :welsh)
+    login_as("WelshEditor")
+
+    visit_edition edition
+
+    assert page.has_content?("We have received a fact check response for this edition")
+    assert page.has_css?(".btn.btn-info", text: "Needs major changes")
+    assert page.has_css?(".btn.btn-info", text: "Minor or no changes required")
+  end
+
+  test "Welsh editors may not request more work for fact checked edition" do
+    edition = FactoryBot.create(:edition, :fact_check)
+    login_as("WelshEditor")
+
+    visit_edition edition
+
+    assert page.has_content?("We’re awaiting a response")
+    assert_not page.has_css?(".btn.btn-info", text: "Needs more work")
+  end
+
+  test "Welsh editors may request more work for fact checked Welsh edition" do
+    edition = FactoryBot.create(:edition, :fact_check, :welsh)
+    login_as("WelshEditor")
+
+    visit_edition edition
+
+    assert page.has_content?("We’re awaiting a response")
+    assert page.has_css?(".btn.btn-info", text: "Needs more work")
+  end
+
+  test "Welsh editors may not request more work for 'ready' non-Welsh editions" do
+    edition = FactoryBot.create(:edition, :ready)
+    login_as("WelshEditor")
+
+    visit_edition edition
+
+    assert_not page.has_content?("Request this edition to be amended further.")
+    assert_not page.has_css?(".btn.btn-info", text: "Needs more work")
+  end
+
+  test "Welsh editors may request more work for 'ready' Welsh editions" do
+    edition = FactoryBot.create(:edition, :ready, :welsh)
+    login_as("WelshEditor")
+
+    visit_edition edition
+
+    assert page.has_content?("Request this edition to be amended further.")
+    assert page.has_css?(".btn.btn-info", text: "Needs more work")
   end
 
   test "Welsh editors cannot see publishing buttons for non-Welsh 'ready' editions" do

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -640,9 +640,17 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal bob, edition.assigned_to
   end
 
-  test "cannot assign if user is not govuk_editor" do
+  test "cannot assign if user does not have correct editor permissions" do
     alice = FactoryBot.create(:user, name: "alice")
     bob = FactoryBot.create(:user, :govuk_editor, name: "bob")
+    edition = FactoryBot.create(:guide_edition, panopticon_id: @artefact.id, state: "ready")
+    alice.assign(edition, bob)
+    assert_nil edition.assigned_to
+  end
+
+  test "cannot assign if recipient does not have correct editor permissions" do
+    alice = FactoryBot.create(:user, :govuk_editor, name: "alice")
+    bob = FactoryBot.create(:user, name: "bob")
     edition = FactoryBot.create(:guide_edition, panopticon_id: @artefact.id, state: "ready")
     alice.assign(edition, bob)
     assert_nil edition.assigned_to

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -113,6 +113,14 @@ FactoryBot.define do
       state { "ready" }
     end
 
+    trait :fact_check do
+      state { "fact_check" }
+    end
+
+    trait :fact_check_received do
+      state { "fact_check_received" }
+    end
+
     trait :in_review do
       state { "in_review" }
       review_requested_at { Time.zone.now }

--- a/test/unit/tabs_helper_test.rb
+++ b/test/unit/tabs_helper_test.rb
@@ -40,15 +40,23 @@ class TabsHelperTest < ActionView::TestCase
     end
   end
 
-  context "#tabs_for(user)" do
+  context "#tabs_for" do
     should "return all tabs if user is govuk_editor" do
+      guide = FactoryBot.create(:guide_edition)
       user = FactoryBot.create(:user, :govuk_editor)
-      assert_equal tabs_for(user), tabs
+      assert_equal tabs_for(user, guide), tabs
     end
 
     should "return all tabs except `unpublish` if user is not govuk_editor" do
-      user = FactoryBot.create(:user)
-      assert_equal %w[unpublish], (tabs - tabs_for(user)).map(&:name)
+      guide = FactoryBot.create(:guide_edition, :welsh)
+      user = FactoryBot.create(:user, :welsh_editor)
+      assert_equal %w[unpublish], (tabs - tabs_for(user, guide)).map(&:name)
+    end
+
+    should "exclude `admin` tab if a user has insufficient editor permissions" do
+      guide = FactoryBot.create(:guide_edition)
+      user = FactoryBot.create(:user, :welsh_editor)
+      assert_equal %w[admin unpublish], (tabs - tabs_for(user, guide)).map(&:name)
     end
   end
 end


### PR DESCRIPTION
This PR adds further functionality for users with `welsh_editor` permissions, following https://github.com/alphagov/publisher/pull/1360

Users must have correct permissions to:
*  assign other users to an edition. The assigned user must also have correct permissions. This option is hidden without correct permissions.
* destroy an edition.
* view an edition's admin page.
* see fact-check workflow buttons (the requests these buttons submit have already been addressed in the above PR)

[Trello](https://trello.com/c/Hq2qgwiI/2155-8-give-permission-in-publisher-for-welsh-teams-in-departments-to-update-only-welsh-content)
