### PR TITLE
Remove option to sign into Verify with a European ID

### DIFF
--- a/lib/service_sign_in/check-income-tax.cy.yaml
+++ b/lib/service_sign_in/check-income-tax.cy.yaml
@@ -10,9 +10,6 @@ choose_sign_in:
     - text: Defnyddio GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-tax-estimate?journey_hint=uk_idp_sign_in
       hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Barclays, Digidentity, Experian, Swyddfa'r Post neu SecureIdentity.
-    - text: Defnyddiwch hunaniaeth digidol o wlad Ewropeaidd arall
-      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-tax-estimate?journey_hint=eidas_sign_in
-      hint_text: Os ydych yn rhan o gynllun ID mewn gwlad sy'n cymryd rhan, efallai y gallwch ei ddefnyddio yma.
     - text: Creu cyfrif
       slug: creu-cyfrif
       hint_text: Os nad oes gennych un o'r cyfrifon hyn eisoes, gallwn eich helpu i ddewis p'un ai i ddefnyddio Porth y Llywodraeth neu GOV.UK Verify

--- a/lib/service_sign_in/check-income-tax.en.yaml
+++ b/lib/service_sign_in/check-income-tax.en.yaml
@@ -10,9 +10,6 @@ choose_sign_in:
     - text: Sign in with GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-tax-estimate?journey_hint=uk_idp_sign_in
       hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
-    - text: Sign in with a digital identity from another European country
-      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-tax-estimate?journey_hint=eidas_sign_in
-      hint_text: If you’re part of an ID scheme in a participating country, you may be able to use it here.
     - text: Create an account
       slug: create-account
       hint_text: If you do not already have one of these accounts, we'll help you choose whether to use Government Gateway or GOV.UK Verify.

--- a/lib/service_sign_in/check-state-pension.cy.yaml
+++ b/lib/service_sign_in/check-state-pension.cy.yaml
@@ -13,9 +13,6 @@ choose_sign_in:
     - text: Defnyddio GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=uk_idp_sign_in
       hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Barclays, Digidentity, Experian, Swyddfa'r Post neu SecureIdentity.
-    - text: Defnyddiwch hunaniaeth digidol o wlad Ewropeaidd arall
-      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=eidas_sign_in
-      hint_text: Os ydych yn rhan o gynllun ID mewn gwlad sy'n cymryd rhan, efallai y gallwch ei ddefnyddio yma.
     - text: Creu cyfrif
       slug: creu-cyfrif
       hint_text: Os nad oes gennych un o'r cyfrifon hyn eisoes, gallwn eich helpu i ddewis p'un ai i ddefnyddio Porth y Llywodraeth neu GOV.UK Verify

--- a/lib/service_sign_in/check-state-pension.en.yaml
+++ b/lib/service_sign_in/check-state-pension.en.yaml
@@ -13,9 +13,6 @@ choose_sign_in:
     - text: Sign in with GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=uk_idp_sign_in
       hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
-    - text: Sign in with a digital identity from another European country
-      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=eidas_sign_in
-      hint_text: If you’re part of an ID scheme in a participating country, you may be able to use it here.
     - text: Create an account
       slug: create-account
       hint_text: If you do not already have one of these accounts, we'll help you choose whether to use Government Gateway or GOV.UK Verify.

--- a/lib/service_sign_in/check-update-company-car-tax.cy.yaml
+++ b/lib/service_sign_in/check-update-company-car-tax.cy.yaml
@@ -10,9 +10,6 @@ choose_sign_in:
     - text: Defnyddio GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-company-car-tax?journey_hint=uk_idp_sign_in
       hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Barclays, Digidentity, Experian, Swyddfa'r Post neu SecureIdentity.
-    - text: Defnyddiwch hunaniaeth digidol o wlad Ewropeaidd arall
-      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-company-car-tax?journey_hint=eidas_sign_in
-      hint_text: Os ydych yn rhan o gynllun ID mewn gwlad sy'n cymryd rhan, efallai y gallwch ei ddefnyddio yma.
     - text: Creu cyfrif
       slug: creu-cyfrif
       hint_text: Os nad oes gennych un o'r cyfrifon hyn eisoes, gallwn eich helpu i ddewis p'un ai i ddefnyddio Porth y Llywodraeth neu GOV.UK Verify

--- a/lib/service_sign_in/check-update-company-car-tax.en.yaml
+++ b/lib/service_sign_in/check-update-company-car-tax.en.yaml
@@ -10,9 +10,6 @@ choose_sign_in:
     - text: Sign in with GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-company-car-tax?journey_hint=uk_idp_sign_in
       hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
-    - text: Sign in with a digital identity from another European country
-      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-company-car-tax?journey_hint=eidas_sign_in
-      hint_text: If you’re part of an ID scheme in a participating country, you may be able to use it here.
     - text: Create an account
       slug: create-account
       hint_text: If you do not already have one of these accounts, we'll help you choose whether to use Government Gateway or GOV.UK Verify.

--- a/lib/service_sign_in/file_self_assessment.cy.yaml
+++ b/lib/service_sign_in/file_self_assessment.cy.yaml
@@ -10,9 +10,6 @@ choose_sign_in:
     - text: Mewngofnodi gan ddefnyddio GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-isa?journey_hint=uk_idp_sign_in
       hint_text: Bydd gennych chi gyfrif os ydych chi wedi profi'n barod pwy ydych chi naill ai gyda Barclays, Digidentity, Experian, Swyddfa'r Post neu SecureIdentity.
-    - text: Defnyddiwch hunaniaeth digidol o wlad Ewropeaidd arall
-      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-isa?journey_hint=eidas_sign_in
-      hint_text: Os ydych yn rhan o gynllun ID mewn gwlad sy'n cymryd rhan, efallai y gallwch ei ddefnyddio yma.
     - text: Cofrestru ar gyfer Hunanasesiad
       slug: cofrestru-hunan-asesiad
       hint_text: Os ydych chi’n ffeilio ar-lein am y tro cyntaf, bydd angen i chi gofrestru ar gyfer Hunanasesiad yn gyntaf.

--- a/lib/service_sign_in/file_self_assessment.en.yaml
+++ b/lib/service_sign_in/file_self_assessment.en.yaml
@@ -11,9 +11,6 @@ choose_sign_in:
     - text: Sign in with GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-isa?journey_hint=uk_idp_sign_in
       hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
-    - text: Sign in with a digital identity from another European country
-      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-isa?journey_hint=eidas_sign_in
-      hint_text: If you’re part of an ID scheme in a participating country, you may be able to use it here.
     - text: Register for Self Assessment
       url: https://www.gov.uk/register-for-self-assessment
       hint_text: You must register before you can file your first tax return.

--- a/lib/service_sign_in/personal-tax-account.cy.yaml
+++ b/lib/service_sign_in/personal-tax-account.cy.yaml
@@ -10,9 +10,6 @@ choose_sign_in:
     - text: Defnyddio GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-personal-tax-account?journey_hint=uk_idp_sign_in
       hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Barclays, Digidentity, Experian, Swyddfa'r Post neu SecureIdentity.
-    - text: Defnyddiwch hunaniaeth digidol o wlad Ewropeaidd arall
-      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-personal-tax-account?journey_hint=eidas_sign_in
-      hint_text: Os ydych yn rhan o gynllun ID mewn gwlad sy'n cymryd rhan, efallai y gallwch ei ddefnyddio yma.
     - text: Creu cyfrif
       slug: creu-cyfrif
       hint_text: Os nad oes gennych un o'r cyfrifon hyn eisoes, gallwn eich helpu i ddewis p'un ai i ddefnyddio Porth y Llywodraeth neu GOV.UK Verify

--- a/lib/service_sign_in/personal-tax-account.en.yaml
+++ b/lib/service_sign_in/personal-tax-account.en.yaml
@@ -10,9 +10,6 @@ choose_sign_in:
     - text: Sign in with GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-personal-tax-account?journey_hint=uk_idp_sign_in
       hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
-    - text: Sign in with a digital identity from another European country
-      url: https://www.signin.service.gov.uk/initiate-journey/hmrc-personal-tax-account?journey_hint=eidas_sign_in
-      hint_text: If you’re part of an ID scheme in a participating country, you may be able to use it here.
     - text: Create an account
       slug: create-account
       hint_text: If you do not already have one of these accounts, we'll help you choose whether to use Government Gateway or GOV.UK Verify.


### PR DESCRIPTION
## What
Remove the option to sign into Verify with an eID from a connected European country

## Why
Due to EU Exit transition

## How to review
Searched for the `?journey_hint=eidas_sign_in` url parameter, which routes a user to the Verify country picker page.
Deleted these entries.

I was unable to get the test suite to run locally, which is why this is in draft.
