### PR TITLE
Expand Notify Bad Request error message

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,7 +32,12 @@ class ApplicationController < ActionController::Base
   end
 
   def notify_bad_request(_exception)
-    render plain: "Error: One or more recipients not in GOV.UK Notify team (code: 400)", status: :bad_request
+    error = <<~ERROR
+      Error: One or more recipients not in GOV.UK Notify team (code: 400).
+      This error will not occur in Production.
+    ERROR
+
+    render plain: error, status: :bad_request
   end
 
   def require_govuk_editor(redirect_path: root_path)

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -270,7 +270,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
         click_on "Send"
       end
 
-      assert page.has_content? "Error: One or more recipients not in GOV.UK Notify team (code: 400)"
+      assert page.has_content? "Error: One or more recipients not in GOV.UK Notify team (code: 400).\nThis error will not occur in Production."
     end
   end
 


### PR DESCRIPTION
The NotifyBadRequest error will only appear in non-Production environments where there are AllowLists for our Notify accounts to prevent sending e-mails to unverified addresses.

This PR aims to help content design colleagues better understand the error, and add confidence it will not effect users on the live site.

[Trello](https://trello.com/c/qWcOV9Y7/2261-improve-factcheck-email-error-message)
