### PR TITLE
Redirect to parent for multi-part documents

### DIFF
--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -52,6 +52,7 @@ class UnpublishService
             path: "/#{artefact.slug}",
             type: "prefix",
             destination: redirect_url,
+            segments_mode: "ignore",
           },
         ],
         discard_drafts: true,

--- a/test/unit/services/unpublish_service_test.rb
+++ b/test/unit/services/unpublish_service_test.rb
@@ -67,6 +67,7 @@ class UnpublishServiceTest < ActiveSupport::TestCase
                     path: "/foo",
                     type: "prefix",
                     destination: "/bar",
+                    segments_mode: "ignore",
                   },
                 ],
                 discard_drafts: true)


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/4408343

Depends on: https://github.com/alphagov/publishing-e2e-tests/pull/405

Previously we defaulted to preserving sub-paths when redirecting a
part of an unpublishing, multi-part document. Example:

https://www.gov.uk/starting-to-import/moving-goods-from-eu-countries ->
https://www.gov.uk/import-goods-into-uk/moving-goods-from-eu-countries

because

www.gov.uk/starting-to-import ->
www.gov.uk/import-goods-into-uk

This switches to ignoring sub-paths and redirecting to the intended
destination, since the redirect destination is unlikely to have an
equivalent set of sub-paths, for the original multi-part document.

Note that this was actually the original behaviour [1], but seems to
have gotten lost in the transition to use Publishing API. Note also
that this change will only affect future unpublishings.

[1]: https://github.com/alphagov/publisher/commit/4e99717ca249a2ddc5eb12b7706559638b66596b#diff-4ff77634db0844a5899517fbff45fd12d3c07932e818bef741b8e39287145809L62


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️