### PR TITLE
Remove need for REDIS_HOST and REDIS_PORT env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,22 +5,24 @@ RUN apt-get update && apt-get install -y nodejs && apt-get install npm -y
 RUN npm install -g phantomjs-prebuilt@2 --unsafe-perm
 RUN gem install foreman
 
+# This image is only intended to be able to run this app in a production RAILS_ENV
+ENV RAILS_ENV production
+
 ENV GOVUK_APP_NAME publisher
 ENV MONGODB_URI mongodb://mongo/govuk_content_development
-ENV TEST_MONGODB_URI mongodb://mongo/govuk_content_publisher_test
 ENV PORT 3000
-ENV RAILS_ENV development
-ENV REDIS_HOST redis
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME
 
 WORKDIR $APP_HOME
 ADD Gemfile* $APP_HOME/
-RUN bundle install
+RUN bundle config set deployment 'true'
+RUN bundle config set without 'development test'
+RUN bundle install --jobs 4
 ADD . $APP_HOME
 
-RUN GOVUK_APP_DOMAIN=www.gov.uk GOVUK_WEBSITE_ROOT=www.gov.uk RAILS_ENV=production bundle exec rails assets:precompile
+RUN GOVUK_APP_DOMAIN=www.gov.uk GOVUK_WEBSITE_ROOT=www.gov.uk bundle exec rails assets:precompile
 
 HEALTHCHECK CMD curl --silent --fail localhost:$PORT || exit 1
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "jquery-ui-rails"
 gem "kaminari"
 gem "kaminari-mongoid"
 gem "mail-notify"
-gem "mlanett-redis-lock" # Only used in some importers
+gem "mlanett-redis-lock"
 gem "momentjs-rails"
 gem "mongo"
 gem "mongoid"
@@ -27,9 +27,9 @@ gem "nested_form", git: "https://github.com/alphagov/nested_form.git", branch: "
 gem "null_logger"
 gem "plek"
 gem "rails_autolink"
-gem "rest-client", require: false # Only used in some importers
-gem "retriable", require: false # Only used in some importers
-gem "reverse_markdown", require: false # Only used in some importers
+gem "rest-client", require: false
+gem "retriable", require: false
+gem "reverse_markdown", require: false
 gem "sassc-rails"
 gem "select2-rails", "3.5.9.1" # Updating this will mean updating the styling as 4 & > have a new approach to class names.
 gem "state_machines"

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,57 +1,6 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "1dd7580ea4eb3c303e870dad82dc5223592fd36c4b44bec6ab6ea0a0c1affbc0",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "lib/csv_report_generator.rb",
-      "line": 14,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "redis.lock(\"publisher:#{Rails.env}:report_generation_lock\", :life => 15.minutes)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "CsvReportGenerator",
-        "method": "run!"
-      },
-      "user_input": "Rails.env",
-      "confidence": "Weak",
-      "note": "We don't pass any user data to this string."
-    },
-    {
-      "warning_type": "Dangerous Send",
-      "warning_code": 23,
-      "fingerprint": "3f2c31f15778e6b65e944692da7e7a60ce09767a71010060f5237c62d5e0ae41",
-      "check_name": "Send",
-      "message": "User controlled method execution",
-      "file": "app/views/root/index.html.erb",
-      "line": 53,
-      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
-      "code": "@presenter.send((\"drafts\" or params[:list]))",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "RootController",
-          "method": "index",
-          "line": 20,
-          "file": "app/controllers/root_controller.rb",
-          "rendered": {
-            "name": "root/index",
-            "file": "app/views/root/index.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "root/index"
-      },
-      "user_input": "params[:list]",
-      "confidence": "High",
-      "note": "The params[:list] argument is already checked before the template gets rendered by @presenter.acceptable_list?(@list)."
-    },
-    {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
       "fingerprint": "73de97a88f3e6fef8a35ced89420323264c5014cde36875b2795a1ac9cf85015",
@@ -128,8 +77,28 @@
       "user_input": "params[:list].presence",
       "confidence": "High",
       "note": "The params[:list] argument is already checked before the template gets rendered by @presenter.acceptable_list?(@list)."
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "d3d42c84d0b0acf57ccb1c9d1133ca43389fd725d0471016013e52bf59269b83",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "lib/csv_report_generator.rb",
+      "line": 11,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Redis.current.lock(\"publisher:#{Rails.env}:report_generation_lock\", :life => 15.minutes)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "CsvReportGenerator",
+        "method": "run!"
+      },
+      "user_input": "Rails.env",
+      "confidence": "Weak",
+      "note": "We don't pass any user data to this string."
     }
   ],
-  "updated": "2019-12-06 15:44:17 +0000",
-  "brakeman_version": "4.7.2"
+  "updated": "2021-01-15 21:34:56 +0000",
+  "brakeman_version": "4.10.1"
 }

--- a/lib/csv_report_generator.rb
+++ b/lib/csv_report_generator.rb
@@ -1,6 +1,5 @@
 require "redis"
 require "redis-lock"
-require_relative "redis_config"
 
 class CsvReportGenerator
   include RedisConfig
@@ -11,7 +10,7 @@ class CsvReportGenerator
   end
 
   def run!
-    redis.lock("publisher:#{Rails.env}:report_generation_lock", life: 15.minutes) do
+    Redis.current.lock("publisher:#{Rails.env}:report_generation_lock", life: 15.minutes) do
       reports.each do |report|
         Rails.logger.debug "Generating #{path}/#{report.report_name}.csv"
         report.write_csv(path)

--- a/lib/csv_report_generator.rb
+++ b/lib/csv_report_generator.rb
@@ -2,8 +2,6 @@ require "redis"
 require "redis-lock"
 
 class CsvReportGenerator
-  include RedisConfig
-
   def self.csv_path
     ENV["GOVUK_APP_ROOT"] ||= Rails.root
     File.join(ENV["GOVUK_APP_ROOT"], "reports")

--- a/lib/redis_config.rb
+++ b/lib/redis_config.rb
@@ -1,7 +1,0 @@
-module RedisConfig
-  REDIS_CONFIG = {
-    host: ENV["REDIS_HOST"] || "127.0.0.1",
-    port: ENV["REDIS_PORT"] || 6379,
-    namespace: "publisher",
-  }.freeze
-end

--- a/script/mail_fetcher
+++ b/script/mail_fetcher
@@ -14,7 +14,6 @@ require "fact_check_email_handler"
 
 require "redis"
 require "redis-lock"
-require_relative "../lib/redis_config"
 
 def redis
   Redis.new(RedisConfig::REDIS_CONFIG)
@@ -39,7 +38,7 @@ handler = FactCheckEmailHandler.new(Publisher::Application.fact_check_config)
 # that long.
 AUTOMATIC_LOCK_EXPIRY = (5 * 60) # seconds
 begin
-  redis.lock("publisher:#{Rails.env}:fact_check_processing_lock", life: AUTOMATIC_LOCK_EXPIRY) do |lock|
+  Redis.current.lock("publisher:#{Rails.env}:fact_check_processing_lock", life: AUTOMATIC_LOCK_EXPIRY) do |lock|
     handler.process do
       lock.extend_life(AUTOMATIC_LOCK_EXPIRY)
     end


### PR DESCRIPTION
Trello: https://trello.com/c/dXud4WIt/206-inconsistent-redisurl-config

This is one of the few GOV.UK projects that uses this old approach to
configuring Redis - whereas most of the other ones use the approach
supported natively by the Redis gem [1] of using REDIS_URL. Removing
this will allow us to remove the need for REDIS_HOST and REDIS_PORT env
vars in our architecture and also allows this code to be simplified.

It's worth noting that the namespace attribute in the Redis config had
no effect (it's a Sidekiq argument for Redis not a native Redis one) and
that the app already has hardcoded Redis namespacing when it is used.

[1]: https://github.com/redis/redis-rb

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
