### PR TITLE
Make "More information" section a textarea

### DIFF
--- a/app/views/local_transactions/_fields.html.erb
+++ b/app/views/local_transactions/_fields.html.erb
@@ -36,7 +36,7 @@
           <%= f.label :more_information %>
         </span>
         <span class="form-wrapper">
-          <%= f.text_field :more_information, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+          <%= f.text_area :more_information, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
         </span>
       </div>
 


### PR DESCRIPTION
This field used to be a textarea and was mistakenly changed to a
text input on 25th September:
https://github.com/alphagov/publisher/commit/23fe2046ce136622e61083f4d67f9cf6e1ec4c86#diff-97ba2ccb37be2e3c9677e06479c533b447f523435d7a4ba056d743ebc94555e4R34-R49

It was clearly not intentional as the commit states:
> There should be no cosmetic change to the forms, as the relevant bootstrap classnames has been added to the HTML

However, the change has caused an issue whereby it is impossible
to write markdown across multiple lines. For example, beginning
with a heading `## If you live in Northern Ireland`, followed by
a section of content.

This is interfering with publishers' ability to publish updated
content. It is also not a one-off; see the 'More information'
field in https://publisher.staging.publishing.service.gov.uk/editions/600eed96e90e075313aa26b9
and how it is rendered on
https://draft-origin.staging.publishing.service.gov.uk/report-stray-dog.

Zendesk: https://govuk.zendesk.com/agent/tickets/4483903

## Before

<img width="738" alt="Screenshot 2021-03-08 at 11 38 01" src="https://user-images.githubusercontent.com/5111927/110316530-c5b20400-8002-11eb-8e40-c6991860ec53.png">

## After

<img width="675" alt="Screenshot 2021-03-08 at 11 37 52" src="https://user-images.githubusercontent.com/5111927/110316518-c21e7d00-8002-11eb-83bc-d821e9de1842.png">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
