### PR TITLE
Add duplicate service with correct LGSL code

### DIFF
--- a/data/local_services.csv
+++ b/data/local_services.csv
@@ -126,4 +126,5 @@ LGSL,Description,Providing Tier
 1743,Find out about the Care Act 2014,county/unitary
 1788,"Find out about support for children who have difficulties with speech, language or communication",county/unitary
 1826,"Find out about the test and trace support payment scheme",district/unitary
+1827,"Find a COVID-19 rapid lateral flow test site",all
 100001,"Find a COVID-19 rapid lateral flow test site",all


### PR DESCRIPTION
## What

We want to add a duplicate record for the lateral flow mass testing finder service with a code of `1827`. Once the `local_transactions:fetch_and_clean` rake task has been run, the LGSL code changed from `100001` to `1827` in `local-links-manager`, and `local-links-manager` and `publisher` are in-sync - the version of the service with the LGSL code of `100001` will be removed and the rake task re-run. 

It is hoped that introducing the new code this way will keep the service running smoothly without interruption.

## Why

When the lateral flow mass testing finder service was created, it was created with a dummy code of `100001`.  We now have a real code - `1827` - so would like to use this code instead of the dummy one.

[Trello](https://trello.com/c/MRGj9keG/210-llup-lateral-mass-test-apply-the-proper-assigned-service-code-1827-agreed-with-local-government-authority)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
