### PR TITLE
HUB-815: Remove disconnecting Verify IDPs

### DIFF
--- a/lib/service_sign_in/check-income-tax.cy.yaml
+++ b/lib/service_sign_in/check-income-tax.cy.yaml
@@ -9,7 +9,7 @@ choose_sign_in:
       hint_text: Bydd gennych Ddynodydd Defnyddiwr (ID) os ydych wedi cofrestru i wneud pethau fel cyflwyno'ch Ffurflen Dreth Hunanasesiad ar-lein.
     - text: Defnyddio GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-tax-estimate?journey_hint=uk_idp_sign_in
-      hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Barclays, Digidentity, Experian, Swyddfa'r Post neu SecureIdentity.
+      hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Digidentity neu Swyddfa'r Post.
     - text: Creu cyfrif
       slug: creu-cyfrif
       hint_text: Os nad oes gennych un o'r cyfrifon hyn eisoes, gallwn eich helpu i ddewis p'un ai i ddefnyddio Porth y Llywodraeth neu GOV.UK Verify
@@ -49,4 +49,4 @@ create_new_account:
 
 
 update_type: minor
-change_note: Updated Verify links to use correct hints and redirects
+change_note: Updated choose sign in page to remove disconnecting identity providers.

--- a/lib/service_sign_in/check-income-tax.en.yaml
+++ b/lib/service_sign_in/check-income-tax.en.yaml
@@ -9,7 +9,7 @@ choose_sign_in:
       hint_text: You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.
     - text: Sign in with GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-tax-estimate?journey_hint=uk_idp_sign_in
-      hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
+      hint_text: You’ll have an account if you’ve already proved your identity with either Digidentity or Post Office.
     - text: Create an account
       slug: create-account
       hint_text: If you do not already have one of these accounts, we'll help you choose whether to use Government Gateway or GOV.UK Verify.
@@ -45,4 +45,4 @@ create_new_account:
     {button}[Choose GOV.UK Verify](https://www.signin.service.gov.uk/initiate-journey/hmrc-tax-estimate?journey_hint=registration){/button}
 
 update_type: minor
-change_note: Updated create account page content to be more accurate and help people choose.
+change_note: Updated choose sign in page to remove disconnecting identity providers.

--- a/lib/service_sign_in/check-state-pension.cy.yaml
+++ b/lib/service_sign_in/check-state-pension.cy.yaml
@@ -12,7 +12,7 @@ choose_sign_in:
       hint_text: Bydd gennych Ddynodydd Defnyddiwr (ID) os ydych wedi cofrestru i wneud pethau fel cyflwyno'ch Ffurflen Dreth Hunanasesiad ar-lein.
     - text: Defnyddio GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=uk_idp_sign_in
-      hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Barclays, Digidentity, Experian, Swyddfa'r Post neu SecureIdentity.
+      hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Digidentity neu Swyddfa'r Post.
     - text: Creu cyfrif
       slug: creu-cyfrif
       hint_text: Os nad oes gennych un o'r cyfrifon hyn eisoes, gallwn eich helpu i ddewis p'un ai i ddefnyddio Porth y Llywodraeth neu GOV.UK Verify
@@ -46,4 +46,4 @@ create_new_account:
     Bydd cwmni ardystiedig bob tro'n gwirio pwy ydych pan fyddwch yn cofrestru gyda GOV.UK Verify. Mae pob un ohonynt yn bodloni safonau diogelwch sydd wedi'u gosod gan y Llywodraeth.
 
 update_type: minor
-change_note: Updated Verify links to use correct hints and redirects
+change_note: Updated choose sign in page to remove disconnecting identity providers.

--- a/lib/service_sign_in/check-state-pension.en.yaml
+++ b/lib/service_sign_in/check-state-pension.en.yaml
@@ -12,7 +12,7 @@ choose_sign_in:
       hint_text: You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.
     - text: Sign in with GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=uk_idp_sign_in
-      hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
+      hint_text: You’ll have an account if you’ve already proved your identity with either Digidentity or Post Office.
     - text: Create an account
       slug: create-account
       hint_text: If you do not already have one of these accounts, we'll help you choose whether to use Government Gateway or GOV.UK Verify.
@@ -48,4 +48,5 @@ create_new_account:
     <a role="button" class="gem-c-button govuk-button" href="https://www.signin.service.gov.uk/initiate-journey/hmrc-your-state-pension?journey_hint=registration" data-module="cross-domain-tracking" data-tracking-code="UA-43414424-1" data-tracking-name="govspeakButtonTracker" data-tracking-track-event="true">Choose GOV.UK Verify</a>
 
 update_type: minor
-change_note: Updated create account page content to be more accurate and help people choose.
+change_note: 
+change_note: Updated choose sign in page to remove disconnecting identity providers.

--- a/lib/service_sign_in/check-update-company-car-tax.cy.yaml
+++ b/lib/service_sign_in/check-update-company-car-tax.cy.yaml
@@ -9,7 +9,7 @@ choose_sign_in:
       hint_text: Bydd gennych Ddynodydd Defnyddiwr (ID) os ydych wedi cofrestru i wneud pethau fel cyflwyno'ch Ffurflen Dreth Hunanasesiad ar-lein.
     - text: Defnyddio GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-company-car-tax?journey_hint=uk_idp_sign_in
-      hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Barclays, Digidentity, Experian, Swyddfa'r Post neu SecureIdentity.
+      hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Digidentity neu Swyddfa'r Posty.
     - text: Creu cyfrif
       slug: creu-cyfrif
       hint_text: Os nad oes gennych un o'r cyfrifon hyn eisoes, gallwn eich helpu i ddewis p'un ai i ddefnyddio Porth y Llywodraeth neu GOV.UK Verify
@@ -49,4 +49,4 @@ create_new_account:
 
 
 update_type: minor
-change_note: Updated Verify links to use correct hints and redirects
+change_note: Updated choose sign in page to remove disconnecting identity providers.

--- a/lib/service_sign_in/check-update-company-car-tax.en.yaml
+++ b/lib/service_sign_in/check-update-company-car-tax.en.yaml
@@ -9,7 +9,7 @@ choose_sign_in:
       hint_text: You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.
     - text: Sign in with GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-company-car-tax?journey_hint=uk_idp_sign_in
-      hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
+      hint_text: You’ll have an account if you’ve already proved your identity with either Digidentity or Post Office.
     - text: Create an account
       slug: create-account
       hint_text: If you do not already have one of these accounts, we'll help you choose whether to use Government Gateway or GOV.UK Verify.
@@ -45,4 +45,4 @@ create_new_account:
     {button}[Choose GOV.UK Verify](https://www.signin.service.gov.uk/initiate-journey/hmrc-company-car-tax?journey_hint=registration){/button}
 
 update_type: minor
-change_note: Updated create account page content to be more accurate and help people choose.
+change_note: Updated choose sign in page to remove disconnecting identity providers.

--- a/lib/service_sign_in/claim-rural-payments.en.yaml
+++ b/lib/service_sign_in/claim-rural-payments.en.yaml
@@ -10,9 +10,9 @@ choose_sign_in:
       hint_text: You'll have a CRN and password if you've already registered for the Rural Payments service.
     - text: Sign in with GOV.UK Verify
       url: https://www.ruralpayments.service.gov.uk/auth/ida/request
-      hint_text: You'll have an account if you've already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
+      hint_text: You'll have an account if you've already proved your identity with either Digidentity or Post Office.
     - text: Register for the Rural Payments service
       url: https://www.gov.uk/guidance/register-for-rural-payments
       hint_text: You must register before you can make a rural payment claim.
-update_type: major
-change_note: A new page for Rural Payments (no welsh, no create account)
+update_type: minor
+change_note: Updated choose sign in page to remove disconnecting identity providers.

--- a/lib/service_sign_in/file_self_assessment.cy.yaml
+++ b/lib/service_sign_in/file_self_assessment.cy.yaml
@@ -9,7 +9,7 @@ choose_sign_in:
       hint_text: Bydd gennych chi ID defnyddiwr os ydych chi wedi cofrestru ar gyfer Hunanasesiad neu wedi ffeilio ffurflen dreth ar-lein yn y gorffennol.
     - text: Mewngofnodi gan ddefnyddio GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-isa?journey_hint=uk_idp_sign_in
-      hint_text: Bydd gennych chi gyfrif os ydych chi wedi profi'n barod pwy ydych chi naill ai gyda Barclays, Digidentity, Experian, Swyddfa'r Post neu SecureIdentity.
+      hint_text: Bydd gennych chi gyfrif os ydych chi wedi profi'n barod pwy ydych chi naill ai gyda Digidentity neu Swyddfa'r Post.
     - text: Cofrestru ar gyfer Hunanasesiad
       slug: cofrestru-hunan-asesiad
       hint_text: Os ydych chi’n ffeilio ar-lein am y tro cyntaf, bydd angen i chi gofrestru ar gyfer Hunanasesiad yn gyntaf.
@@ -31,4 +31,4 @@ create_new_account:
 
     *[UTR]: Cyfeirnod Trethdalwr Unigryw
 update_type: minor
-change_note: Updated Verify links to use correct hints and redirects
+change_note: Updated choose sign in page to remove disconnecting identity providers.

--- a/lib/service_sign_in/file_self_assessment.en.yaml
+++ b/lib/service_sign_in/file_self_assessment.en.yaml
@@ -10,9 +10,9 @@ choose_sign_in:
       hint_text: You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before.
     - text: Sign in with GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-isa?journey_hint=uk_idp_sign_in
-      hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
+      hint_text: You’ll have an account if you’ve already proved your identity with either Digidentity or Post Office.
     - text: Register for Self Assessment
       url: https://www.gov.uk/register-for-self-assessment
       hint_text: You must register before you can file your first tax return.
 update_type: minor
-change_note: Redirect Register for Self Assessment page to /register-for-self-assessment.
+change_note: Updated choose sign in page to remove disconnecting identity providers.

--- a/lib/service_sign_in/personal-tax-account.cy.yaml
+++ b/lib/service_sign_in/personal-tax-account.cy.yaml
@@ -9,7 +9,7 @@ choose_sign_in:
       hint_text: Bydd gennych Ddynodydd Defnyddiwr (ID) os ydych wedi cofrestru i wneud pethau fel cyflwyno'ch Ffurflen Dreth Hunanasesiad ar-lein.
     - text: Defnyddio GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-personal-tax-account?journey_hint=uk_idp_sign_in
-      hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Barclays, Digidentity, Experian, Swyddfa'r Post neu SecureIdentity.
+      hint_text: Bydd gennych gyfrif os ydych eisoes wedi profi pwy ydych gyda naill ai Digidentity neu Swyddfa'r Post.
     - text: Creu cyfrif
       slug: creu-cyfrif
       hint_text: Os nad oes gennych un o'r cyfrifon hyn eisoes, gallwn eich helpu i ddewis p'un ai i ddefnyddio Porth y Llywodraeth neu GOV.UK Verify
@@ -46,4 +46,4 @@ create_new_account:
 
     Bydd mewngofnodi am y tro cyntaf, yn cychwyn eich cyfrif treth personol. Gallwch ddefnyddio hwn i wirio'ch cofnodion gyda CThEM a rheoli'ch manylion eraill.
 update_type: minor
-change_note: Updated Verify links to use correct hints and redirects
+change_note: Updated choose sign in page to remove disconnecting identity providers.

--- a/lib/service_sign_in/personal-tax-account.en.yaml
+++ b/lib/service_sign_in/personal-tax-account.en.yaml
@@ -9,7 +9,7 @@ choose_sign_in:
       hint_text: You’ll have a user ID if you’ve signed up to do things like file your Self Assessment tax return online.
     - text: Sign in with GOV.UK Verify
       url: https://www.signin.service.gov.uk/initiate-journey/hmrc-personal-tax-account?journey_hint=uk_idp_sign_in
-      hint_text: You’ll have an account if you’ve already proved your identity with either Barclays, Digidentity, Experian, Post Office or SecureIdentity.
+      hint_text: You’ll have an account if you’ve already proved your identity with either Digidentity or Post Office.
     - text: Create an account
       slug: create-account
       hint_text: If you do not already have one of these accounts, we'll help you choose whether to use Government Gateway or GOV.UK Verify.
@@ -45,4 +45,4 @@ create_new_account:
     {button}[Choose GOV.UK Verify](https://www.signin.service.gov.uk/initiate-journey/hmrc-personal-tax-account?journey_hint=registration){/button}
 
 update_type: minor
-change_note: Updated create account page content to be more accurate and help people choose.
+change_note: Updated choose sign in page to remove disconnecting identity providers.


### PR DESCRIPTION
Experian, SecureIdentity and Barclays are disconnecting from Verify on
March 23rd 2021. This content needs to be deployed in synch with their
disconnection.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
