### PR TITLE
Remove \u2028 (line separator) characters on save

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -113,7 +113,10 @@ class Edition
   validates_with ReviewerValidator
   validates :change_note, presence: { if: :major_change }
 
-  before_save :check_for_archived_artefact
+  before_save do
+    check_for_archived_artefact
+    remove_line_separator_character
+  end
 
   before_destroy do
     destroy_publishing_api_draft
@@ -457,6 +460,15 @@ class Edition
 
   def latest_link_check_report
     link_check_reports.last
+  end
+
+  def remove_line_separator_character
+    return unless respond_to?(:parts)
+
+    character = "\u2028"
+    parts.each do |part|
+      part.body = part.body.to_s.gsub(character, "")
+    end
   end
 
 private

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -1219,4 +1219,14 @@ class EditionTest < ActiveSupport::TestCase
       assert latest_report, edition.latest_link_check_report
     end
   end
+
+  context "where the body contains a line separator character" do
+    should "remove character on save" do
+      edition = FactoryBot.create(:guide_edition_with_two_parts)
+      edition.parts.first.body = "Some text \u2028with a line separator character"
+      edition.save!
+
+      assert_no_match(/\u2028/, edition.parts.first.body)
+    end
+  end
 end


### PR DESCRIPTION
We have found some editions contain a `\u2028` (line separator) character when the content has been copy-and-pasted from certain applications. This gets rendered in different ways in different browsers (e.g. an extra space, or sometimes a square box containing "L SEP").

This removes those characters when an edition is saved, so they never get published.

Trello card: https://trello.com/c/YQFCDuP8

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
