### PR TITLE
Add a rake task to change a LocalService LGSL code

### DIFF
--- a/lib/tasks/local_service.rake
+++ b/lib/tasks/local_service.rake
@@ -1,0 +1,8 @@
+namespace :local_service do
+  desc "Update the temporary LGSL code of 100001"
+  task change_lgsl_code_100001: :environment do
+    draft = LocalTransactionEdition.find_by!(lgsl_code: 100_001, state: :draft)
+    LocalService.find_by!(lgsl_code: 100_001).update!(lgsl_code: 1827)
+    draft.update!(lgsl_code: 1827)
+  end
+end

--- a/test/lib/tasks/local_service_test.rb
+++ b/test/lib/tasks/local_service_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class LocalServiceTaskTest < ActiveSupport::TestCase
+  test "running the local_service:change_lgsl_code_10001 rake task changes the LGSL code" do
+    service = FactoryBot.create(:local_service, lgsl_code: 100_001)
+    edition = FactoryBot.create(:local_transaction_edition, lgsl_code: 100_001, lgil_code: 1)
+
+    Rake::Task["local_service:change_lgsl_code_100001"].execute
+    assert_equal 1827, service.reload.lgsl_code
+    assert_equal 1827, edition.reload.lgsl_code
+  end
+end


### PR DESCRIPTION
What

Add a rake task to change the LGSL code on a LocalService and all of its Editions.

Why

We want to be able to change an existing LocalService's LGSL code.

[Trello](https://trello.com/c/MRGj9keG/210-local-lookup-lateral-mass-test-apply-the-proper-assigned-service-code-1827-agreed-with-local-government-authority)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
