### PR TITLE
Update LocalService LGSL code

### DIFF
--- a/data/local_services.csv
+++ b/data/local_services.csv
@@ -126,4 +126,5 @@ LGSL,Description,Providing Tier
 1743,Find out about the Care Act 2014,county/unitary
 1788,"Find out about support for children who have difficulties with speech, language or communication",county/unitary
 1826,"Find out about the test and trace support payment scheme",district/unitary
+1827,"Find a COVID-19 rapid lateral flow test site",all
 100001,"Find a COVID-19 rapid lateral flow test site",all


### PR DESCRIPTION
## What

Add a LocalService with an LGSL code 1827.

## Why

The service was created using a dummy LGSL code (100001).  We now have
a real LGSL code for this service (1827) and would like to use it
instead of the dummy code.

For safety and to ensure there is no interruption to the service we need
to add the 1827 service - leaving the 100001 service in-place - until
the switch is complete. At that point we can remove the 100001 service.

[Trello](https://trello.com/c/MRGj9keG/210-local-lookup-lateral-mass-test-apply-the-proper-assigned-service-code-1827-agreed-with-local-government-authority)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
