### PR TITLE
Remove service 100001 from data/local_services.csv

### DIFF
--- a/data/local_services.csv
+++ b/data/local_services.csv
@@ -127,4 +127,3 @@ LGSL,Description,Providing Tier
 1788,"Find out about support for children who have difficulties with speech, language or communication",county/unitary
 1826,"Find out about the test and trace support payment scheme",district/unitary
 1827,"Find a COVID-19 rapid lateral flow test site",all
-100001,"Find a COVID-19 rapid lateral flow test site",all


### PR DESCRIPTION
What

Remove the service 100001 from data/local_service.csv.

Why

That service no longer exists.  It is now 1827.

[Trello](https://trello.com/c/MRGj9keG/210-local-lookup-lateral-mass-test-apply-the-proper-assigned-service-code-agreed-with-local-government-authority)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
