### PR TITLE
Modify publisher L-sep validation

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -463,11 +463,13 @@ class Edition
   end
 
   def remove_line_separator_character
-    return unless respond_to?(:parts)
-
     character = "\u2028"
-    parts.each do |part|
-      part.body = part.body.to_s.gsub(character, "")
+    if respond_to?(:parts)
+      parts.each do |part|
+        part.body = part.body.to_s.gsub(character, "")
+      end
+    elsif respond_to?(:body)
+      self.body = body.to_s.gsub(character, "") unless body.nil?
     end
   end
 

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -1221,7 +1221,7 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   context "where the body contains a line separator character" do
-    should "remove character on save" do
+    should "remove character on save with 2 part edition" do
       edition = FactoryBot.create(:guide_edition_with_two_parts)
       edition.parts.first.body = "Some text \u2028with a line separator character"
       edition.save!


### PR DESCRIPTION
Quick addition to the validation for publisher documents that means
documents without 'parts' that just have a 'body' are also
caught by the validation.

Related: https://trello.com/c/TGUvoJsP/2432-3-remove-l-sep-characters-from-already-published-publisher-content
Original PR: https://github.com/alphagov/publisher/pull/1416

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
