### PR TITLE
Remove "\u2028" temporary rake rask

### DIFF
--- a/lib/tasks/remove_lsep_char_temp.rake
+++ b/lib/tasks/remove_lsep_char_temp.rake
@@ -1,0 +1,11 @@
+desc "remove line seperator charactor"
+task remove_lsep_character: :environment do
+  editions = Edition
+    .nin(state: "archived")
+    .any_of(
+      { body: { "$regex" => "\u2028|\u2029" } },
+      { parts: { "$elemMatch" => { body: { "$regex" => "\u2028|\u2029" } } } },
+    )
+
+  editions.each(&:save!)
+end


### PR DESCRIPTION
 Temporary rake task to replace all "\u2028" characters for published editions

Trello: https://trello.com/c/TGUvoJsP/2432-3-remove-l-sep-characters-from-already-published-publisher-content

Co-authored-by: Callum Knights <callum.knights@digital.cabinet-office.gov.uk>

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
