### PR TITLE
Modify config to allow custom assets host and location

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,7 +31,11 @@ module Publisher
     # Enable the asset pipeline
     config.assets.enabled = true
     config.assets.version = "1.0"
-    config.assets.prefix = "/assets"
+    config.assets.prefix = ENV.fetch("ASSETS_PREFIX", "/assets")
+
+    # allow overriding the asset host with an environment variable, useful for
+    # when router is proxying to this app but asset proxying isn't set up.
+    config.asset_host = ENV.fetch("ASSET_HOST", nil)
 
     config.action_mailer.notify_settings = {
       api_key: Rails.application.secrets.notify_api_key || "fake-test-api-key",


### PR DESCRIPTION
Currently, assets are served by [nginx](https://github.com/alphagov/govuk-puppet/blob/9da822c3bb38e6565e7835e66ecadc43cb35f025/modules/govuk/manifests/apps/publisher.pp#L154)
in EC2 while in ECS we'll serve assets using the same [`CloudFront and S3`](alphagov/govuk-infrastructure#192)
infrastructure across all the Rails apps.

Being able to set `config.asset_host` will allow the Publisher app to
point requests to its assets to the `CloudFront and S3` infrastructure.
While setting `config.assets.prefix`, will allow differentiation of assets
from different apps based on path in the same S3 bucket.

This change should be a no-op in the current platform because the
defaults for both of these config values is nil, and we won't set
these env vars with Puppet.


Ref:
1. [trello card](https://trello.com/c/XwlrmXRJ/458-enable-other-rails-app-to-serve-assets-the-new-way-ie-cloudfront-s3)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
