### PR TITLE
Separate out scheduled publishing check & add RFC 141 healthcheck endpoints

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,0 +1,7 @@
+class HealthcheckController < ApplicationController
+  skip_before_action :authenticate_user!
+
+  def scheduled_publishing
+    render json: Healthcheck::ScheduledPublishing.new.to_hash
+  end
+end

--- a/app/models/healthcheck/scheduled_publishing.rb
+++ b/app/models/healthcheck/scheduled_publishing.rb
@@ -19,6 +19,13 @@ module Healthcheck
       "#{edition_count} scheduled edition(s); #{queue_size} item(s) queued"
     end
 
+    def to_hash
+      {
+        status: status,
+        message: message,
+      }
+    end
+
   private
 
     def queue_size_matches_edition_count?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,12 @@ Rails.application.routes.draw do
         Healthcheck::ScheduledPublishing,
       )
 
+  get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
+  get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
+    GovukHealthcheck::Mongoid,
+    GovukHealthcheck::SidekiqRedis,
+  )
+
   resources :notes do
     put "resolve", on: :member
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
     GovukHealthcheck::SidekiqRedis,
   )
 
+  get "/healthcheck/scheduled-publishing", to: "healthcheck#scheduled_publishing"
+
   resources :notes do
     put "resolve", on: :member
   end

--- a/test/integration/healthcheck_test.rb
+++ b/test/integration/healthcheck_test.rb
@@ -5,29 +5,6 @@ class HealthcheckTest < ActionDispatch::IntegrationTest
     JSON.parse(response.body)
   end
 
-  context "response structure" do
-    setup do
-      Edition.stubs(:scheduled_for_publishing).returns(stub(count: 0))
-      ScheduledPublisher.stubs(:queue_size).returns(0)
-    end
-
-    should "return a 200 response" do
-      get "/healthcheck"
-      assert_response :success
-    end
-
-    should "return an overall status field" do
-      get "/healthcheck"
-      assert_includes json, "status"
-    end
-
-    should "have a field for the checks" do
-      get "/healthcheck"
-      assert_includes json, "checks"
-      assert json["checks"].is_a? Hash
-    end
-  end
-
   context "scheduled count matches queue length" do
     setup do
       Edition.stubs(:scheduled_for_publishing).returns(stub(count: 0))
@@ -35,22 +12,15 @@ class HealthcheckTest < ActionDispatch::IntegrationTest
     end
 
     should "report the check is ok" do
-      get "/healthcheck"
-      assert_includes json["checks"], "schedule_queue"
-      assert_equal "ok", json["checks"]["schedule_queue"]["status"]
-    end
-
-    should "report the overall status as ok" do
-      get "/healthcheck"
+      get "/healthcheck/scheduled-publishing"
       assert_equal "ok", json["status"]
     end
 
     should "include a status message" do
-      get "/healthcheck"
-      assert_includes json["checks"], "schedule_queue"
+      get "/healthcheck/scheduled-publishing"
       assert_equal(
         "0 scheduled edition(s); 0 item(s) queued",
-        json["checks"]["schedule_queue"]["message"],
+        json["message"],
       )
     end
   end
@@ -62,23 +32,16 @@ class HealthcheckTest < ActionDispatch::IntegrationTest
     end
 
     should "report the check as a warning" do
-      get "/healthcheck"
-      assert_includes json["checks"], "schedule_queue"
-      assert_equal "warning", json["checks"]["schedule_queue"]["status"]
+      get "/healthcheck/scheduled-publishing"
+      assert_equal "warning", json["status"]
     end
 
     should "include a status message" do
-      get "/healthcheck"
-      assert_includes json["checks"], "schedule_queue"
+      get "/healthcheck/scheduled-publishing"
       assert_equal(
         "5 scheduled edition(s); 3 item(s) queued",
-        json["checks"]["schedule_queue"]["message"],
+        json["message"],
       )
-    end
-
-    should "report the overall status as a warning" do
-      get "/healthcheck"
-      assert_equal "warning", json["status"]
     end
   end
 end


### PR DESCRIPTION
Once govuk-puppet has been updated, the old endpoint can be removed.

See the RFC for more details.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)