### PR TITLE
Precompile assets with prefix /assets/publisher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ENV RAILS_ENV production
 ENV GOVUK_APP_NAME publisher
 ENV MONGODB_URI mongodb://mongo/govuk_content_development
 ENV PORT 3000
+ENV ASSETS_PREFIX /assets/publisher
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME


### PR DESCRIPTION
Following on from #1435 where we introduced the ability to configure
the ASSETS_PREFIX by environment variable, there is a need to build
the docker images with the ASSETS_PREFIX=/assets/publisher so that
publisher directs client to this prefix path for its assets which
are stored in a S3 bucket.

Ref:
1. [trello card](https://trello.com/c/XwlrmXRJ/458-enable-other-rails-app-to-serve-assets-the-new-way-ie-cloudfront-s3)
2. [govuk-infrastructure pr](alphagov/govuk-infrastructure#221)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
