### PR TITLE
[DO NOT MERGE- WIP] DA modelling

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -259,12 +259,15 @@ protected
         licence_overview
       ]
     when :local_transaction_edition
-      %i[
-        lgsl_code
-        lgil_code
-        introduction
-        more_information
-        need_to_know
+      [
+        :lgsl_code,
+        :lgil_code,
+        :introduction,
+        :more_information,
+        :need_to_know,
+        scotland_availability: %i[type devolved_administration_service],
+        wales_availability: %i[type devolved_administration_service],
+        northern_ireland_availability: %i[type devolved_administration_service],
       ]
     when :place_edition
       %i[

--- a/app/models/devolved_administration_availability.rb
+++ b/app/models/devolved_administration_availability.rb
@@ -1,0 +1,7 @@
+class DevolvedAdministrationAvailability
+  include Mongoid::Document
+
+  embedded_in :local_transaction_edition
+  field :type, type: String, default: "local_authority_service"
+  field :alternative_url, type: String
+end

--- a/app/models/devolved_administration_availability.rb
+++ b/app/models/devolved_administration_availability.rb
@@ -4,4 +4,27 @@ class DevolvedAdministrationAvailability
   embedded_in :local_transaction_edition
   field :type, type: String, default: "local_authority_service"
   field :alternative_url, type: String
+
+  validates :type, inclusion: { in: %w[local_authority_service devolved_administration_service unavailable], allow_blank: true }
+  validate :alternative_url_presence
+  validate :alternative_url_format
+
+  def alternative_url_presence
+    if devolved_administration_service_selected? && alternative_url.blank?
+      errors.add(:alternative_url, "must be provided")
+    end
+  end
+
+  def alternative_url_format
+    if devolved_administration_service_selected? && alternative_url.present?
+      uri = URI.parse(alternative_url)
+      unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+        errors.add(:alternative_url, "invalid format")
+      end
+    end
+  end
+
+  def devolved_administration_service_selected?
+    type == "devolved_administration_service"
+  end
 end

--- a/app/models/local_transaction_edition.rb
+++ b/app/models/local_transaction_edition.rb
@@ -9,6 +9,10 @@ class LocalTransactionEdition < Edition
   field :more_information, type: String
   field :need_to_know, type: String
 
+  embeds_one :scotland_availability, class_name: DevolvedAdministrationAvailability, autobuild: true
+  embeds_one :wales_availability, class_name: DevolvedAdministrationAvailability, autobuild: true
+  embeds_one :northern_ireland_availability, class_name: DevolvedAdministrationAvailability, autobuild: true
+
   GOVSPEAK_FIELDS = %i[introduction more_information need_to_know].freeze
 
   validate :valid_lgsl_code

--- a/app/presenters/formats/local_transaction_presenter.rb
+++ b/app/presenters/formats/local_transaction_presenter.rb
@@ -28,6 +28,7 @@ module Formats
       {}.merge(introduction)
         .merge(more_information)
         .merge(need_to_know)
+        .merge(all_devolved_administration_availabilities)
     end
 
     def introduction
@@ -67,6 +68,22 @@ module Formats
           },
         ],
       }
+    end
+
+    def all_devolved_administration_availabilities
+      {
+        scotland_availability: devolved_administration_availability(edition.scotland_availability),
+        wales_availability: devolved_administration_availability(edition.wales_availability),
+        northern_ireland_availability: devolved_administration_availability(edition.northern_ireland_availability),
+      }.compact
+    end
+
+    def devolved_administration_availability(availability)
+      if availability.type == "devolved_administration_service"
+        { type: "devolved_administration_service", alternative_url: availability.alternative_url }
+      elsif availability.type == "unavailable"
+        { type: "unavailable" }
+      end
     end
 
     def service_tiers

--- a/app/views/local_transactions/_fields.html.erb
+++ b/app/views/local_transactions/_fields.html.erb
@@ -48,6 +48,45 @@
           <%= f.text_area :need_to_know, rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
         </span>
       </div>
+
+      <% administrations = {
+        "Scotland" => :scotland_availability,
+        "Wales" => :wales_availability,
+        "Northern Ireland" => :northern_ireland_availability
+      } %>
+
+      <% administrations.each do |title, field_name| %>
+        <%= f.fields_for field_name do |f| %>
+          <div class="form-group">
+            <span class="form-label">
+              <%= f.label :type, "Devolved Administrations - #{title}" %>
+            </span>
+            </br>
+            <span class="form-wrapper">
+              <%= f.radio_button :type, 'local_authority_service', disabled: @resource.locked_for_edits? %>
+              <%= f.label :type, "Service is handled by local authority", value: 'local_authority_service' %>
+            </span>
+            </br>
+            <span class="form-wrapper">
+              <%= f.radio_button :type, 'devolved_administration_service', disabled: @resource.locked_for_edits? %>
+              <%= f.label :type, "Service is handled by devolved administration", value: 'devolved_administration_service' %>
+            </span>
+            </br>
+            <span class="form-wrapper">
+              <%= f.radio_button :type, 'unavailable', disabled: @resource.locked_for_edits? %>
+              <%= f.label :type, "Service not available", value: 'unavailable' %>
+            </span>
+            </br>
+            <span class="form-label">
+              <%= f.label :alternative_url, "Enter devolved administration's website URL" %>
+            </span>
+            </br>
+            <span class="form-wrapper">
+              <%= f.text_field :alternative_url, class: "input-md-8 form-control", disabled: @resource.locked_for_edits? %>
+            </span>
+          </div>
+        <% end %>
+      <% end %>
     </fieldset>
   </div>
 </div>

--- a/test/models/devolved_administration_availability_test.rb
+++ b/test/models/devolved_administration_availability_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class DevolvedAdministrationAvailabilityTest < ActiveSupport::TestCase
+  test "should not be valid with an unallowed type value" do
+    devolved_administration_availability = FactoryBot.build(
+      :devolved_administration_availability,
+      type: "invalid_type",
+    )
+    assert_not devolved_administration_availability.valid?
+  end
+
+  test "should be valid with an allowed type value" do
+    devolved_administration_availability = FactoryBot.build(
+      :devolved_administration_availability,
+    )
+    assert devolved_administration_availability.valid?
+  end
+
+  test "should not be valid if alternative_url is not present when devolved_administration_service is selected" do
+    devolved_administration_availability = FactoryBot.build(
+      :devolved_administration_availability,
+      type: "devolved_administration_service",
+      alternative_url: "",
+    )
+    assert_not devolved_administration_availability.valid?
+  end
+
+  test "should be valid if alternative_url is present when devolved_administration_service is selected" do
+    devolved_administration_availability = FactoryBot.build(
+      :devolved_administration_availability,
+      type: "devolved_administration_service",
+      alternative_url: "https://www.scot.gov/service",
+    )
+    assert devolved_administration_availability.valid?
+  end
+
+  test "should not be valid if alternative_url is not a valid URI" do
+    devolved_administration_availability = FactoryBot.build(
+      :devolved_administration_availability,
+      type: "devolved_administration_service",
+      alternative_url: "abc",
+    )
+    assert_not devolved_administration_availability.valid?
+  end
+
+  test "should be valid if alternative_url is a valid URI" do
+    devolved_administration_availability = FactoryBot.build(
+      :devolved_administration_availability,
+      type: "devolved_administration_service",
+      alternative_url: "https://www.scot.gov/service",
+    )
+    assert devolved_administration_availability.valid?
+  end
+end

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -234,6 +234,9 @@ FactoryBot.define do
     introduction { "Test introduction" }
     more_information { "This is more information" }
     need_to_know { "This service is only available in England and Wales" }
+    scotland_availability { { type: 'local_authority', alternative_url: "" } }
+    wales_availability { { type: 'local_authority', alternative_url: ""} }
+    northern_ireland_availability { {type: 'local_authority', alternative_url: "" } }
   end
 
   factory :transaction_edition, parent: :edition, class: "TransactionEdition" do

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -2,6 +2,7 @@ require "factory_bot"
 require "answer_edition"
 require "artefact"
 require "user"
+require "devolved_administration_availability"
 
 FactoryBot.define do
   factory :user do
@@ -229,14 +230,34 @@ FactoryBot.define do
     end
   end
 
+  factory :devolved_administration_availability, class: "DevolvedAdministrationAvailability" do
+    type { "local_authority_service" }
+    alternative_url { "" }
+  end
+
   factory :local_transaction_edition, parent: :edition, class: "LocalTransactionEdition" do
     sequence(:lgsl_code) { |nlgsl| nlgsl }
     introduction { "Test introduction" }
     more_information { "This is more information" }
     need_to_know { "This service is only available in England and Wales" }
-    scotland_availability { { type: 'local_authority', alternative_url: "" } }
-    wales_availability { { type: 'local_authority', alternative_url: ""} }
-    northern_ireland_availability { {type: 'local_authority', alternative_url: "" } }
+
+    scotland_availability do
+      FactoryBot.build(
+        :devolved_administration_availability,
+      )
+    end
+
+    wales_availability do
+      FactoryBot.build(
+        :devolved_administration_availability,
+      )
+    end
+
+    northern_ireland_availability do
+      FactoryBot.build(
+        :devolved_administration_availability,
+      )
+    end
   end
 
   factory :transaction_edition, parent: :edition, class: "TransactionEdition" do

--- a/test/unit/presenters/formats/local_transaction_presenter_test.rb
+++ b/test/unit/presenters/formats/local_transaction_presenter_test.rb
@@ -23,6 +23,15 @@ class LocalTransactionPresenterTest < ActiveSupport::TestCase
       introduction: "hello",
       more_information: "more info",
       need_to_know: "for your eyes only",
+      scotland_availability: FactoryBot.build(
+        :devolved_administration_availability,
+      ),
+      wales_availability: FactoryBot.build(
+        :devolved_administration_availability,
+      ),
+      northern_ireland_availability: FactoryBot.build(
+        :devolved_administration_availability,
+      ),
     )
   end
 
@@ -137,6 +146,39 @@ class LocalTransactionPresenterTest < ActiveSupport::TestCase
         { path: "/foo", type: "prefix" },
       ]
       assert_equal expected, result[:routes]
+    end
+
+    context "[:scotland_availability]" do
+      should "not present the data if local_authority_service was selected" do
+        edition.scotland_availability = { type: "local_authority_service", alternative_url: "" }
+        edition.save!(validate: false)
+
+        expected = nil
+        assert_equal expected, result[:details][:scotland_availability]
+      end
+
+      should "present the type data if unavailable was selected" do
+        edition.scotland_availability = FactoryBot.build(
+          :devolved_administration_availability,
+          type: "unavailable",
+        )
+        edition.save!(validate: false)
+
+        expected = { type: "unavailable" }
+        assert_equal expected, result[:details][:scotland_availability]
+      end
+
+      should "present the type and url data if devolved_administration_service was selected" do
+        edition.scotland_availability = FactoryBot.build(
+          :devolved_administration_availability,
+          type: "devolved_administration_service",
+          alternative_url: "https://www.scot.gov/service",
+        )
+        edition.save!(validate: false)
+
+        expected = { type: "devolved_administration_service", alternative_url: "https://www.scot.gov/service" }
+        assert_equal expected, result[:details][:scotland_availability]
+      end
     end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello](https://trello.com/c/Kgr3I4Tz/401-store-devolved-administration-local-transaction-data-in-model-and-govuk-content-schema).

# What?
This an Initial experiment for modelling devolved administration availability data. 

Spike write up [here](https://docs.google.com/document/d/1vOwGK_X4zUVuaMr4_KU4o8Jpfdn7dskqDq2cFjbQrBI/edit?usp=sharing).

# Modelling

Makes use of Mongoid’s `embeds_one` which allows the data for each field to be stored as a hash.

```
l = LocalTransactionEdition.new
l.scotland_availability

=> #<DevolvedAdministrationAvailability _id: 60a77488a16d490001c09865, type: "devolved_administration", alternative_url: "https://www.scotland.gov/service">
```

# Presenting to the Publishing API

[Related content-schema example](https://github.com/alphagov/govuk-content-schemas/compare/national-applicability-local-transactions?expand=1).

# Naming 

Availability > applicability
DevolvedAdminstration > DevolvedNation
Alternative_url > devolved_nation (for presenting, I kept devolved_nation in the model/UI)
Unavailable > not_available


# Proposed tasks ahead

- The content-schema will need to be merged first.

- The modelling and presenting will be in one PR (probably split out from this PR if everyone is happy with it). 

- The data should then be added via Publisher for the two services currently handled by the bespoke Frontend code (https://www.gov.uk/find-covid-19-lateral-flow-test-site/ and https://www.gov.uk/test-and-trace-support-payment/).

- Updating the Frontend application based on the data sent to the content store will be a separate task.

- The UI in Publisher should then be added as a separate task. A basic view has been added in this PR for example purposes. This will be the final task.
