### PR TITLE
Devolved administration availability modelling

### DIFF
--- a/app/models/devolved_administration_availability.rb
+++ b/app/models/devolved_administration_availability.rb
@@ -1,0 +1,7 @@
+class DevolvedAdministrationAvailability
+  include Mongoid::Document
+
+  embedded_in :local_transaction_edition
+  field :type, type: String, default: "local_authority_service"
+  field :alternative_url, type: String
+end

--- a/app/models/devolved_administration_availability.rb
+++ b/app/models/devolved_administration_availability.rb
@@ -4,4 +4,26 @@ class DevolvedAdministrationAvailability
   embedded_in :local_transaction_edition
   field :type, type: String, default: "local_authority_service"
   field :alternative_url, type: String
+
+  validates :type, inclusion: { in: %w[local_authority_service devolved_administration_service unavailable] }
+  validates :alternative_url, presence: true, if: -> { devolved_administration_service? }
+  validate :alternative_url_format
+
+  def alternative_url_format
+    return if alternative_url.blank?
+
+    uri = begin
+      URI.parse(alternative_url)
+    rescue URI::Error
+      nil
+    end
+
+    unless uri.is_a?(URI::HTTPS)
+      errors.add(:alternative_url, "must be a full URL, starting with https://")
+    end
+  end
+
+  def devolved_administration_service?
+    type == "devolved_administration_service"
+  end
 end

--- a/app/models/local_transaction_edition.rb
+++ b/app/models/local_transaction_edition.rb
@@ -9,6 +9,10 @@ class LocalTransactionEdition < Edition
   field :more_information, type: String
   field :need_to_know, type: String
 
+  embeds_one :scotland_availability, class_name: DevolvedAdministrationAvailability, autobuild: true
+  embeds_one :wales_availability, class_name: DevolvedAdministrationAvailability, autobuild: true
+  embeds_one :northern_ireland_availability, class_name: DevolvedAdministrationAvailability, autobuild: true
+
   GOVSPEAK_FIELDS = %i[introduction more_information need_to_know].freeze
 
   validate :valid_lgsl_code

--- a/app/presenters/formats/local_transaction_presenter.rb
+++ b/app/presenters/formats/local_transaction_presenter.rb
@@ -28,6 +28,7 @@ module Formats
       {}.merge(introduction)
         .merge(more_information)
         .merge(need_to_know)
+        .merge(all_devolved_administration_availabilities)
     end
 
     def introduction
@@ -67,6 +68,23 @@ module Formats
           },
         ],
       }
+    end
+
+    def all_devolved_administration_availabilities
+      {
+        scotland_availability: devolved_administration_availability(edition.scotland_availability),
+        wales_availability: devolved_administration_availability(edition.wales_availability),
+        northern_ireland_availability: devolved_administration_availability(edition.northern_ireland_availability),
+      }.compact
+    end
+
+    def devolved_administration_availability(availability)
+      case availability.type
+      when "devolved_administration_service"
+        { type: "devolved_administration_service", alternative_url: availability.alternative_url }
+      when "unavailable"
+        { type: "unavailable" }
+      end
     end
 
     def service_tiers

--- a/test/models/devolved_administration_availability_test.rb
+++ b/test/models/devolved_administration_availability_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+
+class DevolvedAdministrationAvailabilityTest < ActiveSupport::TestCase
+  test "should not be valid with an unallowed type value" do
+    devolved_administration_availability = FactoryBot.build(
+      :devolved_administration_availability,
+      type: "invalid_type",
+    )
+    assert_not devolved_administration_availability.valid?
+  end
+
+  test "should be valid with an allowed type value" do
+    devolved_administration_availability = FactoryBot.build(
+      :devolved_administration_availability,
+      type: "unavailable",
+    )
+    assert devolved_administration_availability.valid?
+  end
+
+  test "should not be valid if alternative_url is not present when devolved_administration_service is selected" do
+    devolved_administration_availability = FactoryBot.build(
+      :devolved_administration_availability,
+      type: "devolved_administration_service",
+      alternative_url: "",
+    )
+    assert_not devolved_administration_availability.valid?
+  end
+
+  test "should be valid if alternative_url is present when devolved_administration_service is selected" do
+    devolved_administration_availability = FactoryBot.build(
+      :devolved_administration_availability,
+      type: "devolved_administration_service",
+      alternative_url: "https://www.scot.gov/service",
+    )
+    assert devolved_administration_availability.valid?
+  end
+
+  test "should not be valid if alternative_url does not begin with https" do
+    devolved_administration_availability = FactoryBot.build(
+      :devolved_administration_availability,
+      type: "devolved_administration_service",
+      alternative_url: "abc",
+    )
+    assert_not devolved_administration_availability.valid?
+  end
+
+  should "should not be valid if alternative_url is not a valid URI" do
+    devolved_administration_availability = FactoryBot.build(
+      :devolved_administration_availability,
+      type: "devolved_administration_service",
+      alternative_url: " ",
+    )
+
+    assert_not devolved_administration_availability.valid?
+  end
+
+  test "should be valid if alternative_url is a valid URI starting with https" do
+    devolved_administration_availability = FactoryBot.build(
+      :devolved_administration_availability,
+      type: "devolved_administration_service",
+      alternative_url: "https://www.scot.gov/service",
+    )
+    assert devolved_administration_availability.valid?
+  end
+end

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -229,6 +229,8 @@ FactoryBot.define do
     end
   end
 
+  factory :devolved_administration_availability
+
   factory :local_transaction_edition, parent: :edition, class: "LocalTransactionEdition" do
     sequence(:lgsl_code) { |nlgsl| nlgsl }
     introduction { "Test introduction" }

--- a/test/unit/presenters/formats/local_transaction_presenter_test.rb
+++ b/test/unit/presenters/formats/local_transaction_presenter_test.rb
@@ -138,5 +138,39 @@ class LocalTransactionPresenterTest < ActiveSupport::TestCase
       ]
       assert_equal expected, result[:routes]
     end
+
+    context "devolved administration availability" do
+      should "not present any devolved administration availability values by default" do
+        edition.save!(validate: false)
+        assert_not result[:details].key?(:wales_availability)
+        assert_not result[:details].key?(:scotland_availability)
+        assert_not result[:details].key?(:northern_ireland_availability)
+      end
+
+      should "not present the data if local_authority_service was selected" do
+        edition.scotland_availability = { type: "local_authority_service", alternative_url: "" }
+        edition.save!(validate: false)
+
+        assert_not result[:details].key?(:scotland_availability)
+      end
+
+      should "present the type data if unavailable was selected" do
+        edition.wales_availability.type = "unavailable"
+
+        edition.save!(validate: false)
+
+        expected = { type: "unavailable" }
+        assert_equal expected, result[:details][:wales_availability]
+      end
+
+      should "present the type and url data if devolved_administration_service was selected" do
+        edition.northern_ireland_availability = { type: "devolved_administration_service", alternative_url: "https://www.ni.gov/service" }
+
+        edition.save!(validate: false)
+
+        expected = { type: "devolved_administration_service", alternative_url: "https://www.ni.gov/service" }
+        assert_equal expected, result[:details][:northern_ireland_availability]
+      end
+    end
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/Kgr3I4Tz/401-store-devolved-administration-local-transaction-data-in-model-and-govuk-content-schema)

# What?

This work is part of a task to enable publishers to specify devolved administration (DA) service availability for local transactions. This PR models the data and was created as a result of a [spike implementation in Publisher](https://github.com/alphagov/publisher/pull/1451). 

[A related content schema has also been added](https://github.com/alphagov/govuk-content-schemas/pull/1060). This PR should NOT be merged until after the content-schema PR has been merged.


# Modelling

Makes use of Mongoid’s `embeds_one`. This allows data to be stored within a hash. It can then be queried from the parent object.

```
l = LocalTransactionEdition.new
l.scotland_availability

=> #<DevolvedAdministrationAvailability _id: 60a77488a16d490001c09865, type: "devolved_administration", alternative_url: "https://www.scotland.gov/service">
```

# Presenting to the Publishing API

[Related content-schema example](https://github.com/alphagov/govuk-content-schemas/compare/national-applicability-local-transactions?expand=1).

# Naming 

Availability > applicability
DevolvedAdminstration > DevolvedNation
Unavailable > not_available
Devolved_administration_service > available_url (as a type option)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Paired with @kevindew.