### PR TITLE
Add a sitemap.xml

### DIFF
--- a/app/controllers/sitemap_controller.rb
+++ b/app/controllers/sitemap_controller.rb
@@ -1,0 +1,9 @@
+class SitemapController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  skip_before_action :authenticate_user!
+
+  def index
+    @paths = Edition.published.flat_map(&:paths)
+    respond_to { |format| format.xml }
+  end
+end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -473,6 +473,16 @@ class Edition
     end
   end
 
+  def paths
+    paths = ["/#{slug}"]  # base path
+
+    if respond_to?(:parts)
+      paths += parts.map { |part| "/#{slug}/#{part.slug}" }
+    end
+
+    paths
+  end
+
 private
 
   def base_field_keys

--- a/app/views/sitemap/index.xml.erb
+++ b/app/views/sitemap/index.xml.erb
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <% @paths.each do |path| -%>
+    <url>
+      <loc><%= Plek.new.website_root %><%= path %></loc>
+    </url>
+  <% end -%>
+</urlset>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,5 +65,7 @@ Rails.application.routes.draw do
   # path parameter gets escaped
   get "/admin(/*path)", to: redirect { |params, _req| "/#{params[:path]}" }
 
+  get "/govuk-sitemap.xml" => "sitemap#index"
+
   mount GovukAdminTemplate::Engine, at: "/style-guide"
 end

--- a/test/functional/sitemap_controller_test.rb
+++ b/test/functional/sitemap_controller_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class SitemapControllerTest < ActionController::TestCase
+  context "with no editions" do
+    should "return an empty XML file" do
+      get :index
+
+      assert_response :success
+
+      assert_select "url > loc", false
+    end
+  end
+
+  context "with an edition" do
+    setup do
+      FactoryBot.create(:guide_edition, :published, slug: "test-path")
+    end
+
+    should "return an XML file containing the URL" do
+      get :index
+
+      assert_response :success
+
+      assert_select "url > loc", "http://www.dev.gov.uk/test-path", count: 1
+    end
+  end
+
+  context "with an edition and a part" do
+    setup do
+      edition = FactoryBot.create(:guide_edition, :published, slug: "test-path")
+      edition.parts.create!(title: "Test title", body: "Test body", slug: "test-part")
+    end
+
+    should "return an XML file containing the URLs" do
+      get :index
+
+      assert_response :success
+
+      urls = []
+      assert_select "url > loc", count: 2 do |elements|
+        urls = elements.map { |e| e.children.first.content }
+      end
+
+      assert_same_elements urls, %w[http://www.dev.gov.uk/test-path http://www.dev.gov.uk/test-path/test-part]
+    end
+  end
+end

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -1229,4 +1229,17 @@ class EditionTest < ActiveSupport::TestCase
       assert_no_match(/\u2028/, edition.parts.first.body)
     end
   end
+
+  context "#paths" do
+    should "include the base path" do
+      edition = FactoryBot.create(:guide_edition, slug: "test-path")
+      assert_equal edition.paths, ["/test-path"]
+    end
+
+    should "include any parts" do
+      edition = FactoryBot.create(:guide_edition, slug: "test-path")
+      edition.parts.create!(title: "Test title", body: "Test body", slug: "test-part")
+      assert_equal edition.paths, ["/test-path", "/test-path/test-part"]
+    end
+  end
 end


### PR DESCRIPTION
This adds a controller which renders a [sitemap.xml](https://en.wikipedia.org/wiki/Sitemaps) file containing just the URLs for pages published by this app. It's going to be given to a product called Siteimprove which the content team are using to run analysis on their pages.

I've intentionally not used the standard `/sitemap.xml` route, as it's not a sitemap of the Publisher app, it's a sitemap of the pages published by the app.

It's open to the public so that Siteimprove can access it, but we may need to re-think this in the future if it's starts getting indexed by other search engines. The work with Siteimprove is only going to be running for a year, so we might be able to remove it after that.

[Trello Card](https://trello.com/c/KmIPDJUQ/2540-5-publish-an-xml-feed-of-mainstream-urls)