### PR TITLE
Add all-urls report

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -23,6 +23,10 @@ class ReportsController < ApplicationController
     send_report "content_workflow"
   end
 
+  def all_urls
+    send_report "all_urls"
+  end
+
 private
 
   def report_last_updated(report)

--- a/app/presenters/all_urls_presenter.rb
+++ b/app/presenters/all_urls_presenter.rb
@@ -1,0 +1,19 @@
+class AllUrlsPresenter < OrganisationContentPresenter
+  def build_csv(csv)
+    csv << column_headings.collect { |ch| ch.to_s.humanize }
+    scope.each do |item|
+      csv << build_row(item)
+
+      next unless item.latest_edition.respond_to? :parts
+
+      item.latest_edition.parts.each do |part|
+        csv << build_row_for_part(part, item)
+      end
+    end
+  end
+
+  def build_row_for_part(part, parent)
+    # Id,Name,Format,Slug,State,Browse pages,Topics,Organisations
+    [part.id.to_s, part.title, "", "#{parent.slug}/#{part.slug}", "", "", "", ""]
+  end
+end

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -19,5 +19,9 @@
   <strong><%= link_to 'Content summary and workflow history', content_workflow_report_path(format: :csv) %></strong><br />
   <%= report_last_updated("content_workflow")%>
 </p>
+<p>
+  <strong><%= link_to 'All URLs', all_urls_report_path(format: :csv) %></strong><br />
+  <%= report_last_updated("all_urls")%>
+</p>
 
 <% content_for :page_title, "Reports" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,7 @@ Rails.application.routes.draw do
   get "reports/organisation-content" => "reports#organisation_content", :as => :organisation_content_report
   get "reports/edition-churn" => "reports#edition_churn", as: "edition_churn_report"
   get "reports/content_workflow" => "reports#content_workflow", as: "content_workflow_report"
+  get "reports/all-urls" => "reports#all_urls", as: "all_urls_report"
 
   get "user_search" => "user_search#index"
 

--- a/lib/csv_report_generator.rb
+++ b/lib/csv_report_generator.rb
@@ -35,6 +35,10 @@ class CsvReportGenerator
       ),
 
       ContentWorkflowPresenter.new(Edition.published.order(created_at: :desc)),
+
+      AllUrlsPresenter.new(
+        Artefact.where(owning_app: "publisher").not_in(state: %w[archived]),
+      ),
     ]
   end
 

--- a/test/unit/all_urls_presenter_test.rb
+++ b/test/unit/all_urls_presenter_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+class AllUrlsPresenterTest < ActiveSupport::TestCase
+  setup do
+    @response = {
+      "content_id" => "",
+      "expanded_links" => {
+        "mainstream_browse_pages" => [
+          {
+            "base_path" => "/browse/business/support",
+          },
+          {
+            "base_path" => "/browse/tax/vat",
+          },
+        ],
+        "organisations" => [
+          {
+            "title" => "HMRC",
+          },
+        ],
+        "topics" => [
+          {
+            "base_path" => "/topic/business-tax/vat",
+          },
+        ],
+      },
+    }
+  end
+
+  should "provide a CSV export of content tagged to an organisation" do
+    document = FactoryBot.create(
+      :artefact,
+      name: "Important document",
+      kind: "answer",
+    )
+
+    @response["content_id"] = document.content_id
+    stub_publishing_api_has_expanded_links(@response)
+
+    FactoryBot.create(
+      :edition,
+      panopticon_id: document.id,
+    )
+
+    csv = AllUrlsPresenter.new(
+      Artefact.where(owning_app: "publisher").not_in(state: %w[archived]),
+    ).to_csv
+    data = CSV.parse(csv, headers: true)
+
+    assert_equal "Important document", data[0]["Name"]
+    assert_equal "answer", data[0]["Format"]
+    assert_equal "HMRC", data[0]["Organisations"]
+    assert_equal "business-tax/vat", data[0]["Topics"]
+    assert_equal "business/support,tax/vat", data[0]["Browse pages"]
+  end
+
+  should "handle artefacts without editions" do
+    FactoryBot.create(
+      :artefact,
+      name: "Important document",
+    )
+
+    csv = AllUrlsPresenter.new(
+      Artefact.where(owning_app: "publisher").not_in(state: %w[archived]),
+    ).to_csv
+    data = CSV.parse(csv, headers: true)
+
+    assert_equal "Important document", data[0]["Name"]
+  end
+end


### PR DESCRIPTION
Generate a CSV report containing all URLs, not only top-level ones. This is based on an existing report, but with an extra iteration step to account for multi-part publications.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

https://trello.com/c/fhtbsEgu/2528-create-a-mainstream-url-report-which-shows-all-urls