### PR TITLE
Duplicate DA values for new editions

### DIFF
--- a/app/models/local_transaction_edition.rb
+++ b/app/models/local_transaction_edition.rb
@@ -39,4 +39,14 @@ class LocalTransactionEdition < Edition
   def whole_body
     introduction
   end
+
+  def build_clone(target_class = nil)
+    new_edition = super
+    if new_edition.is_a?(LocalTransactionEdition)
+      new_edition.scotland_availability = scotland_availability.clone
+      new_edition.wales_availability = wales_availability.clone
+      new_edition.northern_ireland_availability = northern_ireland_availability.clone
+    end
+    new_edition
+  end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/TsRhfzNb/448-duplicate-devolved-administration-availability-values-when-new-editions-are-created)

Draft PR at the moment... i'll create a proper PR after testing the branch out on integration tomorrow (16/06) but feel free to start reviewing.

Devolved administration availability modelling was added in a [previous PR](https://github.com/alphagov/publisher/pull/1456).

A bug was discovered, in that the embedded fields in `DevolvedAdministrationAvailability` were not being copied when a new edition was created.

The reason for this is the `scotland_availability`, `wales_availability` and `northern_ireland` availability fields were not included in the array returned by the [type_specific_field_keys](https://github.com/alphagov/publisher/blob/main/app/models/edition.rb#L499) method. The test for duplicating editions used a different edition type, which is partly why the bug was missed.

This PR overrides the `build_clone` method to ensure that the devolved administration availability values are copied over when a new edition is created.




⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
