### PR TITLE
Update the user interface to store, validate and retrieve the devolved administration data

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -67,3 +67,13 @@
 .vertical-drag {
   cursor: ns-resize;
 }
+
+.inset-text-field {
+  border-left: 5px solid #bcbcbc;
+  padding: 6px 0 6px 10px;
+  margin-left: 25px;
+
+  .inset-text-field-label {
+    font-weight: normal;
+  }
+}

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -259,12 +259,15 @@ protected
         licence_overview
       ]
     when :local_transaction_edition
-      %i[
-        lgsl_code
-        lgil_code
-        introduction
-        more_information
-        need_to_know
+      [
+        :lgsl_code,
+        :lgil_code,
+        :introduction,
+        :more_information,
+        :need_to_know,
+        { scotland_availability_attributes: %i[type alternative_url] },
+        { wales_availability_attributes: %i[type alternative_url] },
+        { northern_ireland_availability_attributes: %i[type alternative_url] },
       ]
     when :place_edition
       %i[

--- a/app/models/local_transaction_edition.rb
+++ b/app/models/local_transaction_edition.rb
@@ -13,6 +13,10 @@ class LocalTransactionEdition < Edition
   embeds_one :wales_availability, class_name: DevolvedAdministrationAvailability, autobuild: true
   embeds_one :northern_ireland_availability, class_name: DevolvedAdministrationAvailability, autobuild: true
 
+  accepts_nested_attributes_for :scotland_availability
+  accepts_nested_attributes_for :wales_availability
+  accepts_nested_attributes_for :northern_ireland_availability
+
   GOVSPEAK_FIELDS = %i[introduction more_information need_to_know].freeze
 
   validate :valid_lgsl_code

--- a/app/views/local_transactions/_fields.html.erb
+++ b/app/views/local_transactions/_fields.html.erb
@@ -48,6 +48,49 @@
           <%= f.text_area :need_to_know, rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
         </span>
       </div>
+
+      <% administrations = {
+        "Scotland" => :scotland_availability,
+        "Wales" => :wales_availability,
+        "Northern Ireland" => :northern_ireland_availability
+      } %>
+      <% administrations.each do |title, field_name| %>
+        <%= f.fields_for field_name do |f| %>
+          <p class="h4"><%= title %></p>
+          <div class="form-group">
+            <div class="radio">
+              <%= f.label :type_local_authority_service, class: "control-label" do %>
+                <%= f.radio_button :type, 'local_authority_service', disabled: @resource.locked_for_edits? %>
+                Service available from local council
+              <% end %>
+            </div>
+          </div>
+          <div class="form-group">
+            <div class="radio">
+              <%= f.label :type_devolved_administration_service, class: "control-label" do %>
+                <%= f.radio_button :type, 'devolved_administration_service', disabled: @resource.locked_for_edits? %>
+                Service available from devolved administration (or a similar service is available)
+              <% end %>
+            </div>
+          </div>
+          <div class="form-group inset-text-field">
+            <div class="form-label">
+              <%= f.label :alternative_url, "Enter the URL of the devolved administration website page", class: "inset-text-field-label" %>
+            </div>
+            <div class="form-wrapper">
+              <%= f.text_field :alternative_url, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+            </div>
+          </div>
+          <div class="form-group">
+            <div class="radio">
+              <%= f.label :type_unavailable, class: "control-label" do %>
+                <%= f.radio_button :type, 'unavailable', disabled: @resource.locked_for_edits? %>
+                Service not available
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
     </fieldset>
   </div>
 </div>


### PR DESCRIPTION
## What

In a [previous PR](https://github.com/alphagov/publisher/pull/1456/) we have adapted the [`LocalTransactionEdition`](https://github.com/alphagov/publisher/blob/3e083c9998692847cbb7325c0e9234684dc1be35/app/models/local_transaction_edition.rb) and [`DevolvedAdministrationAvailability`](https://github.com/alphagov/publisher/blob/3e083c9998692847cbb7325c0e9234684dc1be35/app/models/devolved_administration_availability.rb) models so that each `LocalTransactionEdition` has a 1:1 relationship with a Scotland, Wales & Northern Ireland `DevolvedAdministrationAvailability` instance.

We now need to update the user interface so that these devolved administration availability entries can be created & maintained.

## Why

We want to provide publishers with the means to specify whether a Local Transaction is only available in particular devolved administrations and to allow them to control the devolved administration availability themselves.

There is an [MVP UI design available](https://trello-attachments.s3.amazonaws.com/5ea1b10bd5e5988b8e0a8690/607d981400f41b805ffe9f5e/7ba499a85ec9eb441cb82bce9a7d0c5d/MVP_implementation.png) that the UI changes should match - although [the actual content has changed from the original design](https://docs.google.com/document/d/1pT0hglrcisw0NH8M3aEOo-LQuBd9x6IjIb7Cx__TqDg/edit) so the final design should also reflect these changes.
 
[Trello](https://trello.com/c/Ip1IP9YU/403-update-publisher-interface-to-store-devolved-administration-data-for-a-local-transaction)

## Screenshots

### Before

![screencapture-publisher-dev-gov-uk-editions-60cb5ebe39b2d700017cd974-2021-06-29-10_00_32](https://user-images.githubusercontent.com/44037625/124260332-79498180-db27-11eb-8529-6a55838bf38a.png)

### After

![screencapture-publisher-dev-gov-uk-editions-60cb5ebe39b2d700017cd974-2021-07-02-10_52_54](https://user-images.githubusercontent.com/44037625/124260226-5b7c1c80-db27-11eb-8463-84e69ce1960b.png)

### After - Published Edition

![screencapture-publisher-dev-gov-uk-editions-60cb5ebe39b2d700017cd974-2021-07-02-11_17_23](https://user-images.githubusercontent.com/44037625/124260242-6171fd80-db27-11eb-93c6-25191b69be4d.png)

### After - Creation of New Edition

![screencapture-publisher-dev-gov-uk-editions-60dee7c139b2d700014b9141-2021-07-02-11_17_55](https://user-images.githubusercontent.com/44037625/124260268-6931a200-db27-11eb-841c-5f913a4f029c.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
