### PR TITLE
Add Temporary Rake task to remove old Artefact

### DIFF
--- a/lib/tasks/temp_remove_landlord_immigration_check.rake
+++ b/lib/tasks/temp_remove_landlord_immigration_check.rake
@@ -1,0 +1,5 @@
+desc "Remove Landlord Immigration Check page"
+
+task remove_landlord_immigration_check: :environment do
+  Artefact.find_by(slug: "landlord-immigration-check").delete
+end


### PR DESCRIPTION
StartPages are now published in SmartAnswers, and this example is
leftover from before they were moved from Publisher.

There is now a need for Publisher to re-use the `landlord-immigration-check`
slug, and this new Artefact cannot be created while the slug is associated
with the old StartPage.

[trello](https://trello.com/c/4mogKZrw/2584-temporarily-take-down-check-if-someone-can-rent-your-residential-property-remove-the-start-page-button-replace-the-start-page-te)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
