### PR TITLE
Validation errors not being displayed in the user interface

### DIFF
--- a/app/assets/javascripts/modules/ajax_save.js
+++ b/app/assets/javascripts/modules/ajax_save.js
@@ -117,15 +117,14 @@
 
       function showErrors (errors) {
         $.each(errors, function (errorKey, errorMessages) {
-          var errorElement = element.find('#edition_' + errorKey + '_input')
-          var $list = $('<ul class="help-block js-error"></ul>')
+          var errorElement = element.find('#edition_' + errorKey)
+          var parents = errorElement.parents('.form-group')
+          parents.addClass('has-error')
 
-          errorElement.addClass('has-error')
+          var list = parents.find('.error-block')
           for (var j = 0, m = errorMessages.length; j < m; j++) {
-            $list.append('<li>' + errorMessages[j] + '</li>')
+            list.append('<li>' + errorMessages[j] + '</li>')
           }
-
-          errorElement.append($list)
         })
       }
 
@@ -136,6 +135,7 @@
       }
 
       function hideErrors () {
+        element.find('.error-block').empty()
         element.find('.js-error').remove()
         element.find('.has-error').removeClass('has-error')
       }

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -77,3 +77,7 @@
     font-weight: normal;
   }
 }
+
+.has-error {
+  color: #a94442;
+}

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,0 +1,32 @@
+module FormHelper
+  def form_errors(errors)
+    tag.ul(class: %w[help-block error-block]) do
+      safe_join(errors.map { |e| tag.li(e) })
+    end
+  end
+
+  def form_group(form, field_name, label: nil, help: nil, attributes: {}, &block)
+    raise "No input field given" unless block_given?
+
+    errors = form.object.errors[field_name]
+    attributes[:class] = Array(attributes[:class]) << "form-group"
+    attributes[:class] << "has-error" if errors.any?
+
+    tag.div(attributes) do
+      wrapped_label = tag.div(class: "form-label") { form_label_element(form, field_name, label) }
+      wrapped_field = tag.div(class: "form-wrapper", &block)
+      errors = form_errors(errors)
+      help = tag.div(class: "help-block") { help } if help
+
+      safe_join([wrapped_label, wrapped_field, errors, help])
+    end
+  end
+
+private
+
+  def form_label_element(form, field_name, label)
+    return label if label&.match?(/\A<label/) # already a label element
+
+    form.label(field_name, label)
+  end
+end

--- a/app/models/local_transaction_edition.rb
+++ b/app/models/local_transaction_edition.rb
@@ -17,6 +17,8 @@ class LocalTransactionEdition < Edition
   accepts_nested_attributes_for :wales_availability
   accepts_nested_attributes_for :northern_ireland_availability
 
+  after_validation :merge_embedded_errors
+
   GOVSPEAK_FIELDS = %i[introduction more_information need_to_know].freeze
 
   validate :valid_lgsl_code
@@ -52,5 +54,16 @@ class LocalTransactionEdition < Edition
       new_edition.northern_ireland_availability = northern_ireland_availability.clone
     end
     new_edition
+  end
+
+private
+
+  def merge_embedded_errors
+    %i[scotland_availability wales_availability northern_ireland_availability].each do |availability|
+      nested_errors = public_send(availability).errors
+      nested_errors.each do |key, value|
+        errors.add("#{availability}_attributes_#{key}", value)
+      end
+    end
   end
 end

--- a/app/views/editions/_reviewer_field.html.erb
+++ b/app/views/editions/_reviewer_field.html.erb
@@ -1,12 +1,3 @@
-<% error_class = @resource.errors.has_key?(:reviewer) ? ' error has-error' : '' -%>
-<div id="edition_reviewer_input" class="form-group<%= error_class %>">
-  <label for="edition_reviewer" class="control-label">Reviewer</label>
-  <%= f.select :reviewer, User.enabled.order_by([[:name, :asc]]).collect{ |p| [p.name, p.name] }, { :include_blank => true }, { :class => "form-control input-md-3 #{error_class}", :disabled => @resource.locked_for_edits?, "data-module" => 'assignee-select'} %>
-  <% if @resource.errors.has_key?(:reviewer) -%>
-    <ul class="help-block js-error">
-    <% @resource.errors[:reviewer].each do |error| -%>
-      <li><%= error %></li>
-    <% end -%>
-    </ul>
-  <% end -%>
-</div>
+<%= form_group(f, :reviewer) do %>
+  <%= f.select :reviewer, User.enabled.order_by([[:name, :asc]]).collect{ |p| [p.name, p.name] }, { :include_blank => true }, { :class => "form-control input-md-3", :disabled => @resource.locked_for_edits?, "data-module" => 'assignee-select'} %>
+<% end %>

--- a/app/views/licences/_fields.html.erb
+++ b/app/views/licences/_fields.html.erb
@@ -3,14 +3,9 @@
     <fieldset class="inputs">
       <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
 
-      <div class="form-group">
-        <span class="form-label">
-          <%= f.label :licence_identifier %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_field :licence_identifier, disabled: @resource.locked_for_edits?, class: "input-md-3 form-control" %>
-        </span>
-      </div>
+      <%= form_group(f, :licence_identifier, label: "Licence identifier") do %>
+        <%= f.text_field :licence_identifier, disabled: @resource.locked_for_edits?, class: "input-md-3 form-control" %>
+      <% end %>
 
       <div class="form-group">
         <span class="form-label">
@@ -22,15 +17,9 @@
         </span>
       </div>
 
-      <div class="form-group">
-        <span class="form-label">
-          <%= f.label :continuation_link, "Link to competent authority" %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_field :continuation_link, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
-          <span class="help-block">Link as deep as possible.</span>
-        </span>
-      </div>
+      <%= form_group(f, :continuation_link, label: "Link to competent authority", help: "Link as deep as possible.") do %>
+        <%= f.text_field :continuation_link, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+      <% end %>
 
       <div class="form-group">
         <span class="form-label">

--- a/app/views/local_transactions/_devolved_administrations.html.erb
+++ b/app/views/local_transactions/_devolved_administrations.html.erb
@@ -1,0 +1,41 @@
+<% administrations = {
+  "Scotland" => :scotland_availability,
+  "Wales" => :wales_availability,
+  "Northern Ireland" => :northern_ireland_availability
+} %>
+<% administrations.each do |title, field_name| %>
+  <%= f.fields_for field_name do |f| %>
+    <p class="h4 add-top-margin"><%= title %></p>
+
+    <div class="form-group">
+      <div class="radio">
+        <%= f.label :type_local_authority_service, class: "control-label" do %>
+          <%= f.radio_button :type, 'local_authority_service', disabled: @resource.locked_for_edits? %>
+          Service available from local council
+        <% end %>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <div class="radio">
+        <%= f.label :type_devolved_administration_service, class: "control-label" do %>
+          <%= f.radio_button :type, 'devolved_administration_service', disabled: @resource.locked_for_edits? %>
+          Service available from devolved administration (or a similar service is available)
+        <% end %>
+      </div>
+    </div>
+
+    <%= form_group(f, :alternative_url, label: "Enter the URL of the devolved administration website page", attributes: { class: %w[inset-text-field] }) do %>
+      <%= f.text_field :alternative_url, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+    <% end %>
+
+    <div class="form-group">
+      <div class="radio">
+        <%= f.label :type_unavailable, class: "control-label" do %>
+          <%= f.radio_button :type, 'unavailable', disabled: @resource.locked_for_edits? %>
+          Service not available
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/local_transactions/_fields.html.erb
+++ b/app/views/local_transactions/_fields.html.erb
@@ -10,14 +10,9 @@
         </span>
       </div>
 
-      <div class="form-group">
-        <span class="form-label">
-          <%= f.label :lgil_code, "LGIL code" %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_field :lgil_code, disabled: @resource.locked_for_edits?, class: "input-md-4 form-control" %>
-        </span>
-      </div>
+      <%= form_group(f, :lgil_code, label: "LGIL code") do %>
+        <%= f.text_field :lgil_code, disabled: @resource.locked_for_edits?, class: "input-md-4 form-control" %>
+      <% end %>
 
       <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
 
@@ -49,48 +44,7 @@
         </span>
       </div>
 
-      <% administrations = {
-        "Scotland" => :scotland_availability,
-        "Wales" => :wales_availability,
-        "Northern Ireland" => :northern_ireland_availability
-      } %>
-      <% administrations.each do |title, field_name| %>
-        <%= f.fields_for field_name do |f| %>
-          <p class="h4"><%= title %></p>
-          <div class="form-group">
-            <div class="radio">
-              <%= f.label :type_local_authority_service, class: "control-label" do %>
-                <%= f.radio_button :type, 'local_authority_service', disabled: @resource.locked_for_edits? %>
-                Service available from local council
-              <% end %>
-            </div>
-          </div>
-          <div class="form-group">
-            <div class="radio">
-              <%= f.label :type_devolved_administration_service, class: "control-label" do %>
-                <%= f.radio_button :type, 'devolved_administration_service', disabled: @resource.locked_for_edits? %>
-                Service available from devolved administration (or a similar service is available)
-              <% end %>
-            </div>
-          </div>
-          <div class="form-group inset-text-field">
-            <div class="form-label">
-              <%= f.label :alternative_url, "Enter the URL of the devolved administration website page", class: "inset-text-field-label" %>
-            </div>
-            <div class="form-wrapper">
-              <%= f.text_field :alternative_url, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
-            </div>
-          </div>
-          <div class="form-group">
-            <div class="radio">
-              <%= f.label :type_unavailable, class: "control-label" do %>
-                <%= f.radio_button :type, 'unavailable', disabled: @resource.locked_for_edits? %>
-                Service not available
-              <% end %>
-            </div>
-          </div>
-        <% end %>
-      <% end %>
+      <%= render partial: 'local_transactions/devolved_administrations', locals: { f: f, resource: @resource } %>
     </fieldset>
   </div>
 </div>

--- a/app/views/shared/_common_edition_attributes.html.erb
+++ b/app/views/shared/_common_edition_attributes.html.erb
@@ -8,14 +8,9 @@
 <%= render partial: 'reviewer_field', locals: { f: f } if @resource.in_review? %>
 <%= render partial: 'major_change_fields', locals: { f: f } if @resource.published_edition %>
 
-<div class="form-group">
-  <span class="form-label">
-    <%= f.label :title %>
-  </span>
-  <span class="form-wrapper">
-    <%= f.text_field :title, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
-  </span>
-</div>
+<%= form_group(f, :title, label: "Title") do %>
+  <%= f.text_field :title, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+<% end %>
 
 <div class="form-group checkbox">
   <div class="form-wrapper emphasised-field add-bottom-margin input-md-7">

--- a/app/views/simple_smart_answers/_node.html.erb
+++ b/app/views/simple_smart_answers/_node.html.erb
@@ -33,7 +33,7 @@
           <%= o.link_to_remove "<i class=\"glyphicon glyphicon-remove glyphicon-smaller-than-text add-right-margin\"></i> Remove option".html_safe,
             :class => "btn btn-default add-left-margin remove-option" %>
           <% if o.object.errors.has_key?(:next_node) -%>
-            <span class="help-inline"><%= o.object.errors[:next_node].join(', ') %></span>
+            <span class="has-error help-inline"><%= o.object.errors[:next_node].join(', ') %></span>
           <% end -%>
         </div>
       <% end %>

--- a/app/views/transactions/_fields.html.erb
+++ b/app/views/transactions/_fields.html.erb
@@ -70,15 +70,9 @@
         </span>
       </div>
 
-      <div class="form-group add-top-margin">
-        <span class="form-label">
-          <%= f.label :department_analytics_profile, "Service analytics profile" %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_area :department_analytics_profile, placeholder: 'UA-XXXXXX-X', rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-2 form-control" %>
-          <span class="help-block">Let service teams track user journeys between GOV.UK and their service using Google Analytics.</span>
-        </span>
-      </div>
+      <%= form_group(f, :department_analytics_profile, label: "Service analytics profile", help: "Let service teams track user journeys between GOV.UK and their service using Google Analytics.", attributes: { class: %w[add-top-margin] }) do %>
+        <%= f.text_area :department_analytics_profile, placeholder: 'UA-XXXXXX-X', rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-2 form-control" %>
+      <% end %>
     </fieldset>
   </div>
 </div>

--- a/spec/javascripts/spec/ajax_save.spec.js
+++ b/spec/javascripts/spec/ajax_save.spec.js
@@ -9,11 +9,23 @@ describe('An ajax save module', function () {
   beforeEach(function () {
     element = $('<form action="some/url">' +
       '<div class="js-status-message"></div>' +
-      '<div id="edition_test_input">' +
-        '<input type="text" name="test" value="prefilled value">' +
+      '<div class="form-group">' +
+      '  <div class="form-label">' +
+      '    <label for="edition_test">Test</label>' +
+      '  </div>' +
+      '  <div class="form-wrapper">' +
+      '    <input class="" type="text" value="prefilled value" name="edition_test" id="edition_test">' +
+      '  </div>' +
+      '  <ul class="help-block error-block"></ul>' +
       '</div>' +
-      '<div id="edition_another_input">' +
-        '<input type="text" name="another" value="another value">' +
+      '<div class="form-group">' +
+      '  <div class="form-wrapper">' +
+      '    <label for="edition_another">' +
+      '      <input type="checkbox" value="1" name="edition_another" id="edition_another">' +
+      '      Another' +
+      '    </label>' +
+      '  </div>' +
+      '  <ul class="help-block error-block"></ul>' +
       '</div>' +
       '<input class="js-no-ajax" type="text" name="fake-file-input">' +
       '<input class="js-no-ajax" type="checkbox" name="remove-file-checkbox" value="1">' +
@@ -101,7 +113,7 @@ describe('An ajax save module', function () {
       expect($.ajax).toHaveBeenCalled()
       expect(ajaxOptions.type).toBe('POST')
       expect(ajaxOptions.url).toBe('some/url.json')
-      expect(ajaxOptions.data).toBe('test=prefilled+value&another=another+value&fake-file-input=')
+      expect(ajaxOptions.data).toBe('edition_test=prefilled+value&fake-file-input=')
     })
   })
 
@@ -197,9 +209,12 @@ describe('An ajax save module', function () {
 
     it('shows the error alongside the erroring field', function () {
       ajaxError({ test: ['must be changed'] })
-      expect(element.find('#edition_test_input').is('.has-error')).toBe(true)
-      expect(element.find('#edition_test_input ul li').length).toBe(1)
-      expect(element.find('#edition_test_input ul li:first').text()).toBe('must be changed')
+
+      var parents = element.find('#edition_test').parents('.form-group')
+
+      expect(parents.is('.has-error')).toBe(true)
+      expect(parents.find('.error-block li').length).toBe(1)
+      expect(parents.find('.error-block li:first').text()).toBe('must be changed')
     })
 
     it('includes the base error in the save dialogue', function () {
@@ -217,14 +232,18 @@ describe('An ajax save module', function () {
     it('can show multiple errors', function () {
       ajaxError({ test: ['must be changed', 'must be blue'], another: ['must rhyme'] })
 
-      expect(element.find('#edition_test_input').is('.has-error')).toBe(true)
-      expect(element.find('#edition_test_input ul li').length).toBe(2)
-      expect(element.find('#edition_test_input ul li:first').text()).toBe('must be changed')
-      expect(element.find('#edition_test_input ul li:last').text()).toBe('must be blue')
+      var el = element.find('#edition_test')
+      var parents = el.parents('.form-group')
+      expect(parents.is('.has-error')).toBe(true)
+      expect(parents.find('.error-block li').length).toBe(2)
+      expect(parents.find('.error-block li:first').text()).toBe('must be changed')
+      expect(parents.find('.error-block li:last').text()).toBe('must be blue')
 
-      expect(element.find('#edition_another_input').is('.has-error')).toBe(true)
-      expect(element.find('#edition_another_input ul li').length).toBe(1)
-      expect(element.find('#edition_another_input ul li:first').text()).toBe('must rhyme')
+      el = element.find('#edition_another')
+      parents = el.parents('.form-group')
+      expect(parents.is('.has-error')).toBe(true)
+      expect(parents.find('.error-block li').length).toBe(1)
+      expect(parents.find('.error-block li:first').text()).toBe('must rhyme')
     })
 
     it('triggers an error.ajaxsave.admin dom event', function () {

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -331,7 +331,7 @@ class EditionsControllerTest < ActionController::TestCase
     should "show the edit page again if updating fails" do
       Edition.expects(:find).returns(@guide)
       @guide.stubs(:update).returns(false)
-      @guide.expects(:errors).at_least_once.returns(title: %w[values])
+      @guide.errors.add(:title, "values")
 
       post :update,
            params: {
@@ -344,7 +344,7 @@ class EditionsControllerTest < ActionController::TestCase
     should "show the resource base errors if present" do
       Edition.expects(:find).returns(@guide)
       @guide.stubs(:update).returns(false)
-      @guide.expects(:errors).at_least_once.returns(base: ["Editions scheduled for publishing can't be edited"])
+      @guide.errors.add(:base, "Editions scheduled for publishing can't be edited")
 
       post :update, params: { id: @guide.id, edition: {} }
 

--- a/test/integration/edition_major_change_test.rb
+++ b/test/integration/edition_major_change_test.rb
@@ -45,11 +45,7 @@ class EditionMajorChangeTest < JavascriptIntegrationTest
         should "validate that the change note is present for a major change" do
           visit_edition @second_edition
           check("edition_major_change")
-          save_edition_and_assert_error
-
-          within("#edition_change_note_input .help-block") do
-            assert page.has_content?("can't be blank")
-          end
+          save_edition_and_assert_error("can't be blank")
 
           fill_in "edition_change_note", with: "Something changed"
           save_edition_and_assert_success

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -305,9 +305,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
 
     visit_edition guide
     select("Bob", from: "Reviewer")
-    save_edition_and_assert_error
-
-    assert page.has_css?(".form-group.has-error li", text: "can't be the assignee")
+    save_edition_and_assert_error("can't be the assignee")
   end
 
   test "can deselect the guide reviewer" do

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -203,9 +203,10 @@ class JavascriptIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  def save_edition_and_assert_error
+  def save_edition_and_assert_error(error = nil)
     save_edition
     assert page.has_content? "We had some problems saving"
+    assert page.has_content? error if error.present?
   end
 
   def save_tags_and_assert_success

--- a/test/unit/helpers/form_helper_test.rb
+++ b/test/unit/helpers/form_helper_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+class FormHelperTest < ActionView::TestCase
+  context "form_errors" do
+    should "return an unordered list with errors when there are errors present" do
+      expected = '<ul class="help-block error-block"><li>One</li><li>Two</li><li>Three</li></ul>'
+
+      assert_equal expected, form_errors(%w[One Two Three])
+    end
+
+    should "return an empty unordered list when there are no errors present" do
+      expected = '<ul class="help-block error-block"></ul>'
+
+      assert_equal expected, form_errors([])
+    end
+  end
+
+  context "form_group" do
+    setup do
+      object = stub(field_name: "", errors: Hash.new([]))
+      @form = FormBuilder.new("edition", object, self, {})
+    end
+
+    should "return the input wrapped within a form group" do
+      output = form_group(@form, :field_name) { @form.text_field(:field_name) }
+      label = '<div class="form-label"><label for="edition_field_name">Field name</label></div>'
+      wrapped_field = '<div class="form-wrapper"><input type="text" value="" name="edition[field_name]" id="edition_field_name" /></div>'
+      error_block = '<ul class="help-block error-block"></ul>'
+
+      assert_equal %(<div class="form-group">#{label}#{wrapped_field}#{error_block}</div>), output
+    end
+
+    should "include help text if that is provided" do
+      output = form_group(@form, :field_name, help: "Help block text") { @form.text_field(:field_name) }
+      help_block = '<div class="help-block">Help block text</div>'
+
+      assert_match help_block, output
+    end
+
+    should "accept, and not wrap, a label element passed in" do
+      output = form_group(@form, :field_name, label: "Custom label text") { @form.text_field(:field_name) }
+      custom_label = '<div class="form-label"><label for="edition_field_name">Custom label text</label></div>'
+
+      assert_match custom_label, output
+    end
+
+    should "return a form-group html structure with a custom attributes" do
+      output = form_group(@form, :field_name, attributes: { id: :field_id, class: %i[one two] }) { @form.text_field(:field_name) }
+      custom_attributes = '<div id="field_id" class="one two form-group">'
+
+      assert_match custom_attributes, output
+    end
+
+    should "return a form-group html structure with a has-error class when any errors are present" do
+      object = stub(field_name: "field_name", errors: Hash.new(["cannot be blank", "must be unique"]))
+      form = FormBuilder.new("edition", object, self, {})
+      output = form_group(form, :field_name) { form.text_field(:field_name) }
+      form_group_with_errors = '<div class="form-group has-error">'
+
+      assert_match form_group_with_errors, output
+      assert_match "cannot be blank", output
+    end
+
+    should "raise an exception if there is no input field given as a block" do
+      assert_raises(RuntimeError, "No input field given") do
+        form_group(@form, :test_field)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Model validation error messages in user interface are currently not being displayed to users.

We should make sure that - whether the user has JavaScript enabled or not - all model validation error messages are shown to the user and the appropriate field and field label are highlighted. 

Tests should exist that catch any change in the desired behaviour.

## Why

The user should be able to diagnose and correct the issue quickly and easily.

The current user experience is sub-optimal. The user might experience a record that fails to save for example, but no error is shown and no indication is given as to which field generated the error. This gives a somewhat "trial and error" experience for the user and is generally disappointing for them.

Error messaging should be made consistent across the application with all models and formats behaving in the same way. 

This should include: 

- devolved administrations on local transactions, 
- parts on various formats, 
- steps on simple smart answers, and 
- any other quirky fields that may exist

[Trello](https://trello.com/c/I5aCsCPB/474-validation-errors-not-being-displayed-in-publisher)

Co-authored-by: Alex Newton <@GDSNewt>
Co-authored-by: Jonathan Hallam <@JonathanHallam>

## Screenshots - with JavaScript enabled

![answer](https://user-images.githubusercontent.com/44037625/127308104-ffc98b14-9af1-4dc8-a524-5cf1a1f0f6b7.png)
![licence](https://user-images.githubusercontent.com/44037625/127308146-468a7d7f-79d8-46f5-9c27-2eb5ccea692a.png)
![local-transaction](https://user-images.githubusercontent.com/44037625/127308162-2b77dee5-39be-4828-82ad-e8f9ed7bba45.png)

## Screenshots - without JavaScript enabled

![answer](https://user-images.githubusercontent.com/44037625/127308206-4a5a45c9-3116-4730-ae8a-21dd2c9c60bd.png)
![licence](https://user-images.githubusercontent.com/44037625/127308265-d174248f-f431-485c-994c-b646402aa611.png)
![local-transaction](https://user-images.githubusercontent.com/44037625/127308277-d931ab92-9ae8-4050-80a4-6145cd1e3a6d.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
