### PR TITLE
Update Part model validation errors

### DIFF
--- a/app/views/shared/_part.html.erb
+++ b/app/views/shared/_part.html.erb
@@ -17,6 +17,7 @@
           <span class="form-wrapper">
             <%= f.text_field :title, disabled: @resource.locked_for_edits?, class: "title form-control" %>
           </span>
+          <%= form_errors(f.object.errors[:title]) %>
         </div>
 
         <%
@@ -36,6 +37,7 @@
               for example, title-of-part (no spaces, apostrophes or acronyms)
             </span>
           </span>
+          <%= form_errors(f.object.errors[:slug]) %>
         </div>
 
         <div class="form-group">


### PR DESCRIPTION
## What

Model validation error messages in Publisher are currently not being displayed to users.

We should make sure that - whether the user has JavaScript enabled or not - all model validation error messages are shown to the user and the appropriate field and field label are highlighted. 

This PR re-enables the model validation messages for the GuildeEdition format - Part child records.

## Why

The user should be able to diagnose and correct the issue quickly and easily.

[Trello](https://trello.com/c/SvOnnXeB/530-update-parts-and-variants-validation-errors-in-publisher)

Co-authored-by: Alex Newton <@GDSNewt>

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
