### PR TITLE
Fix SimpleSmartAnswer UI issues in Publisher

### DIFF
--- a/app/assets/stylesheets/smart_answer_builder.css
+++ b/app/assets/stylesheets/smart_answer_builder.css
@@ -11,8 +11,9 @@
   margin: 30px 0 20px;
 }
 
+.builder-container .option input[type='text'],
 .builder-container .option select {
-  width: 450px;
+  width: 100%;
 }
 
 .builder-container .options ul {
@@ -29,5 +30,5 @@
 }
 
 .builder-container .option input[type='radio'] {
-  vertical-align: middle;
+  vertical-align: top;
 }

--- a/app/views/simple_smart_answers/_node.html.erb
+++ b/app/views/simple_smart_answers/_node.html.erb
@@ -4,10 +4,12 @@
     <%= f.link_to_remove "<i class=\"glyphicon glyphicon-remove glyphicon-smaller-than-text add-right-margin\"></i> Remove node".html_safe, :class => "btn btn-default pull-right remove-node" %>
   </legend>
   <%= f.hidden_field :order, class: 'node-order' %>
+
   <div class="form-group">
-    <span class="form-wrapper">
+    <div class="form-wrapper">
       <%= f.text_field :title, placeholder: "The title of the outcome", class: "node-title form-control" %>
-    </span>
+    </div>
+    <%= form_errors(f.object.errors[:title]) %>
   </div>
 
   <div class="form-group">
@@ -22,19 +24,26 @@
     <div class="options">
       <%= f.fields_for :options, :wrapper_class => "outcome-wrap option" do |o| %>
         <div class="form-inline form-group<%= o.object.errors.empty? ? '' : ' error' %>">
-          <%= o.text_field :label, placeholder: "Label", class: "option-label form-control" %>
-          <i class="glyphicon glyphicon-arrow-right add-left-margin add-right-margin"></i>
-          <%= o.hidden_field :next_node, class: "next-node-id" %>
-          <select class="form-control required next-node-list" name="next-node-list">
-            <option value="" class="default">Select a node..</option>
-            <optgroup label="Questions" class="question-list"></optgroup>
-            <optgroup label="Outcomes" class="outcome-list"></optgroup>
-          </select>
-          <%= o.link_to_remove "<i class=\"glyphicon glyphicon-remove glyphicon-smaller-than-text add-right-margin\"></i> Remove option".html_safe,
-            :class => "btn btn-default add-left-margin remove-option" %>
-          <% if o.object.errors.has_key?(:next_node) -%>
-            <span class="has-error help-inline"><%= o.object.errors[:next_node].join(', ') %></span>
-          <% end -%>
+          <div class="row">
+            <div class="form-group col-md-3">
+              <%= o.text_field :label, placeholder: "Label", class: "option-label form-control" %>
+              <%= form_errors(o.object.errors[:label]) %>
+            </div>
+
+            <div class="form-group col-md-6">
+              <%= o.hidden_field :next_node, class: "next-node-id" %>
+              <select class="form-control required next-node-list" name="next-node-list">
+                <option value="" class="default">Select a node..</option>
+                <optgroup label="Questions" class="question-list"></optgroup>
+                <optgroup label="Outcomes" class="outcome-list"></optgroup>
+              </select>
+              <%= form_errors(o.object.errors[:next_node]) %>
+            </div>
+
+            <div class="form-group col-md-3">
+              <%= o.link_to_remove "<i class=\"glyphicon glyphicon-remove glyphicon-smaller-than-text add-right-margin\"></i> Remove option".html_safe, :class => "btn btn-default pull-right remove-option" %>
+            </div>
+          </div>
         </div>
       <% end %>
       <%= f.link_to_add "<i class=\"glyphicon glyphicon-plus\"></i> Add an option".html_safe, :options, :class => "btn btn-primary" %>


### PR DESCRIPTION
## What

Model validation error messages in Publisher are currently not being displayed to users.

We should make sure that - whether the user has JavaScript enabled or not - all model validation error messages are shown to the user and the appropriate field and field label are highlighted. 

This PR improves the `SimpleSmartAnswer` format's `Node` UI by showing model validation error messaging, and fixing style/formatting issues with `Options`. 

## Why

The user should be able to diagnose and correct the issue quickly and easily.

[Trello](https://trello.com/c/HTrLSx0G/549-fix-simplesmartanswer-ui-issues-in-publisher)

## Screenshots

### Before
![before](https://user-images.githubusercontent.com/44037625/128729377-3cb80a68-5583-419a-b16f-6d2851201be2.png)

### After

![Screenshot 2021-08-11 at 12 07 46](https://user-images.githubusercontent.com/44037625/129018953-49350fc6-20a4-4d8d-a842-aecc5cc9cd7b.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
