### PR TITLE
Remove js-error CSS class

### DIFF
--- a/app/assets/javascripts/modules/ajax_save.js
+++ b/app/assets/javascripts/modules/ajax_save.js
@@ -136,7 +136,6 @@
 
       function hideErrors () {
         element.find('.error-block').empty()
-        element.find('.js-error').remove()
         element.find('.has-error').removeClass('has-error')
       }
 

--- a/app/assets/javascripts/modules/ajax_save_with_parts.js
+++ b/app/assets/javascripts/modules/ajax_save_with_parts.js
@@ -41,13 +41,12 @@
         $partContainer.find('.collapse').collapse('show')
         $.each(partErrors, function (fieldKey, messages) {
           var $errorElement = $partContainer.find('[id*=' + fieldKey + '_input]')
-          var $list = $('<ul class="help-block js-error"></ul>')
 
           $errorElement.addClass('has-error')
+          var list = $errorElement.find('.error-block')
           for (var j = 0, m = messages.length; j < m; j++) {
-            $list.append('<li>' + messages[j] + '</li>')
+            list.append('<li>' + messages[j] + '</li>')
           }
-          $errorElement.append($list)
         })
       }
 

--- a/app/assets/javascripts/modules/parts.js
+++ b/app/assets/javascripts/modules/parts.js
@@ -49,8 +49,8 @@
       function removeValidationMessages (evt) {
         var $part = $(evt.target)
 
-        $part.find('.error, .has-error').removeClass('error has-error')
-        $part.find('.js-error').remove()
+        $part.find('.error, .has-error').removeClass('error').removeClass('has-error')
+        $part.find('.error-block').empty()
       }
     }
   }

--- a/app/views/shared/_transaction_variant.html.erb
+++ b/app/views/shared/_transaction_variant.html.erb
@@ -16,8 +16,8 @@
           </span>
           <span class="form-wrapper">
             <%= f.text_field :title, disabled: @resource.locked_for_edits?, class: "title form-control" %>
+            <%= form_errors(f.object.errors[:title]) %>
           </span>
-          <%= form_errors(f.object.errors[:title]) %>
         </div>
 
         <%
@@ -36,8 +36,8 @@
             <span class="help-block">
               for example, title-of-part (no spaces, apostrophes or acronyms)
             </span>
+            <%= form_errors(f.object.errors[:slug]) %>
           </span>
-          <%= form_errors(f.object.errors[:slug]) %>
         </div>
 
         <div class="form-group">

--- a/spec/javascripts/spec/ajax_save.spec.js
+++ b/spec/javascripts/spec/ajax_save.spec.js
@@ -226,7 +226,6 @@ describe('An ajax save module', function () {
     it('ignores validation messages for fields it does not recognise', function () {
       ajaxError({ not_a_field: ['nonsense'] })
       expect(element.find('.has-error').length).toBe(0)
-      expect(element.find('.js-error').length).toBe(0)
     })
 
     it('can show multiple errors', function () {
@@ -277,7 +276,6 @@ describe('An ajax save module', function () {
         element.find('.js-save').trigger('click')
 
         expect(element.find('.has-error').length).toBe(0)
-        expect(element.find('.js-error').length).toBe(0)
       })
     })
   })

--- a/spec/javascripts/spec/ajax_save_with_parts.spec.js
+++ b/spec/javascripts/spec/ajax_save_with_parts.spec.js
@@ -31,6 +31,7 @@ describe('An ajax save with parts module', function () {
           '<input class="order" type="hidden" id="edition_part_100_order" name="edition[part][100][order]" value="1">' +
           '<div id="edition_parts_attributes_100_slug_input">' +
             '<input class="slug" type="text" id="edition_part_100_slug" name="edition[part][100][slug]" value="slug">' +
+            '<ul class="error-block"></ul>' +
           '</div>' +
           '<input type="hidden" id="edition_part_100_id" name="edition[part][100][id]" value="5f00000001">' +
         '</div>' +
@@ -42,6 +43,7 @@ describe('An ajax save with parts module', function () {
         '<div class="js-part-toggle-target" id="slug-2">' +
           '<div id="edition_parts_attributes_101_title_input">' +
             '<input class="title" type="text" id="edition_part_101_title" name="edition[part][101][title]" value="Title 2">' +
+            '<ul class="error-block"></ul>' +
           '</div>' +
           '<input class="order" type="hidden" id="edition_part_101_order" name="edition[part][101][order]" value="2">' +
           '<div id="edition_parts_attributes_101_slug_input">' +
@@ -58,6 +60,7 @@ describe('An ajax save with parts module', function () {
         '<div class="js-part-toggle-target" id="untitled-part">' +
           '<div id="edition_parts_attributes_4535667_title_input">' +
             '<input class="title" type="text" id="edition_part_4535667_title" name="edition[part][4535667][title]" value="Updated title 3">' +
+            '<ul class="error-block"></ul>' +
           '</div>' +
           '<input class="order" type="hidden" id="edition_part_4535667_order" name="edition[part][4535667][order]" value="3">' +
           '<div id="edition_parts_attributes_4535667_slug_input">' +

--- a/spec/javascripts/spec/ajax_save_with_parts.spec.js
+++ b/spec/javascripts/spec/ajax_save_with_parts.spec.js
@@ -178,9 +178,6 @@ describe('An ajax save with parts module', function () {
     })
 
     it('shows the error messages', function () {
-      expect(element.find('.has-error').length).toBe(3)
-      expect(element.find('ul.js-error').length).toBe(3)
-
       expect(element.find('#edition_parts_attributes_100_slug_input').is('.has-error')).toBe(true)
       expect(element.find('#edition_parts_attributes_100_slug_input ul li').length).toBe(2)
       expect(element.find('#edition_parts_attributes_100_slug_input ul li:first').text()).toBe('can\'t be blank')

--- a/spec/javascripts/spec/parts_spec.js
+++ b/spec/javascripts/spec/parts_spec.js
@@ -64,7 +64,7 @@ describe('A parts module', function () {
         '<input class="error has-error title" name="part_4_title" type="text" value="">' +
         '<input class="slug" name="part_4_slug" type="text" value="">' +
         '<input class="order" name="part_4_order" type="hidden" value="">' +
-        '<div class="js-error some-error">Error</div>' +
+        '<div class="error has-error" id="error-block">Error</div>' +
       '</div>')
       element.trigger('nested:fieldAdded:parts')
     })
@@ -87,7 +87,7 @@ describe('A parts module', function () {
     })
 
     it('removes validation errors on the newly added part', function () {
-      expect(element.find('.error, .has-error, .js-error, .some-error').length).toBe(0)
+      expect($('#part_4').find('.error, .has-error').length).toBe(0)
     })
   })
 

--- a/spec/javascripts/spec/parts_spec.js
+++ b/spec/javascripts/spec/parts_spec.js
@@ -74,7 +74,7 @@ describe('A parts module', function () {
     })
 
     it('allows the part to be sortable', function (done) {
-      $('#part_4').simulateDragSortable({ move: -2, handle: '.js-sort-handle' })
+      $('#part_4').simulateDragSortable({ move: -2, handle: '.js-sort-handle', tolerance: 0 })
 
       // Wait briefly until jquery ui has done its thing
       setTimeout(function () {

--- a/test/integration/adding_parts_to_guides_test.rb
+++ b/test/integration/adding_parts_to_guides_test.rb
@@ -138,15 +138,15 @@ class AddingPartsToGuidesTest < JavascriptIntegrationTest
 
         within :css, "#parts div.fields:nth-of-type(2)" do
           assert page.has_css?('.has-error[id*="slug"]')
-          assert page.has_css?(".js-error li", count: 2)
-          assert page.has_css?(".js-error li", text: "can't be blank")
-          assert page.has_css?(".js-error li", text: "can only consist of lower case characters, numbers and hyphens")
+          assert page.has_css?(".has-error li", count: 2)
+          assert page.has_css?(".has-error li", text: "can't be blank")
+          assert page.has_css?(".has-error li", text: "can only consist of lower case characters, numbers and hyphens")
         end
 
         within :css, "#parts div.fields:nth-of-type(3)" do
           assert page.has_css?('.has-error[id*="title"]')
-          assert page.has_css?(".js-error li", count: 1)
-          assert page.has_css?(".js-error li", text: "can't be blank")
+          assert page.has_css?(".has-error li", count: 1)
+          assert page.has_css?(".has-error li", text: "can't be blank")
         end
       end
     end

--- a/test/integration/adding_variants_to_transactions_test.rb
+++ b/test/integration/adding_variants_to_transactions_test.rb
@@ -141,15 +141,15 @@ class AddingVariantsToTransactionsTest < JavascriptIntegrationTest
 
         within :css, "#parts div.fields:nth-of-type(2)" do
           assert page.has_css?('.has-error[id*="slug"]')
-          assert page.has_css?(".js-error li", count: 2)
-          assert page.has_css?(".js-error li", text: "can't be blank")
-          assert page.has_css?(".js-error li", text: "can only consist of lower case characters, numbers and hyphens")
+          assert page.has_css?(".has-error li", count: 2)
+          assert page.has_css?(".has-error li", text: "can't be blank")
+          assert page.has_css?(".has-error li", text: "can only consist of lower case characters, numbers and hyphens")
         end
 
         within :css, "#parts div.fields:nth-of-type(3)" do
           assert page.has_css?('.has-error[id*="title"]')
-          assert page.has_css?(".js-error li", count: 1)
-          assert page.has_css?(".js-error li", text: "can't be blank")
+          assert page.has_css?(".has-error li", count: 1)
+          assert page.has_css?(".has-error li", text: "can't be blank")
         end
       end
     end


### PR DESCRIPTION
The js-error CSS class is appended to elements when model validation error messages are returned from an Ajax POST/Update request on an Edition.

The has-error CSS class is appended to elements when model validation errors messages are returned from a standard Rails HTTP form POST request on an Edition.

It is somewhat unnecessary to have two different classes which do the same thing so we are just going to utilise the 'has-error’ class included with bootstrap to meet our requirements.

There was some debate as to whether we should define our own CSS for error messaging; the rationale being that it would not be affected by future updates to bootstrap. We decided against doing that for now.

In addition to replacing 'js-error' we have removed some redundant code in the tests and made one test more specific to better suit the requirements of the test.

Finally we tweaked the html structure for variants and parts as the tests  were having some difficulty selecting the correct element

Co-authored-by: [Graham Lewis](https://github.com/gclssvglx)

[Trello](https://trello.com/c/Z3MdA3PD/532-resolve-having-both-js-error-and-has-error-css-classes-in-publisher)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
