### PR TITLE
Improve invalid slug validation messages

### DIFF
--- a/app/models/part.rb
+++ b/app/models/part.rb
@@ -19,7 +19,7 @@ class Part
   validates :title, presence: true
   validates :slug, presence: true
   validates :slug, exclusion: { in: %w[video], message: "Can not be video" }
-  validates :slug, format: { with: /\A[a-z0-9\-]+\Z/i }
+  validates :slug, format: { with: /\A[a-z0-9\-]+\Z/i, message: "can only consist of lower case characters, numbers and hyphens" }
   validates_with SafeHtml
   validates_with LinkValidator
 end

--- a/app/models/simple_smart_answer_edition/node/option.rb
+++ b/app/models/simple_smart_answer_edition/node/option.rb
@@ -15,7 +15,7 @@ class SimpleSmartAnswerEdition < Edition
       default_scope -> { order_by(order: :asc) }
 
       validates :label, :next_node, presence: true
-      validates :slug, format: { with: /\A[a-z0-9-]+\z/ }
+      validates :slug, format: { with: /\A[a-z0-9-]+\z/, message: "can only consist of lower case characters, numbers and hyphens" }
 
       before_validation :populate_slug
 

--- a/app/models/variant.rb
+++ b/app/models/variant.rb
@@ -23,7 +23,7 @@ class Variant
   validates :title, presence: true
   validates :slug, presence: true
   validates :slug, exclusion: { in: %w[video], message: "Can not be video" }
-  validates :slug, format: { with: /\A[a-z0-9\-]+\Z/i }
+  validates :slug, format: { with: /\A[a-z0-9\-]+\Z/i, message: "can only consist of lower case characters, numbers and hyphens" }
   validates_with SafeHtml
   validates_with LinkValidator
 end

--- a/test/integration/adding_parts_to_guides_test.rb
+++ b/test/integration/adding_parts_to_guides_test.rb
@@ -140,7 +140,7 @@ class AddingPartsToGuidesTest < JavascriptIntegrationTest
           assert page.has_css?('.has-error[id*="slug"]')
           assert page.has_css?(".js-error li", count: 2)
           assert page.has_css?(".js-error li", text: "can't be blank")
-          assert page.has_css?(".js-error li", text: "is invalid")
+          assert page.has_css?(".js-error li", text: "can only consist of lower case characters, numbers and hyphens")
         end
 
         within :css, "#parts div.fields:nth-of-type(3)" do

--- a/test/integration/adding_variants_to_transactions_test.rb
+++ b/test/integration/adding_variants_to_transactions_test.rb
@@ -143,7 +143,7 @@ class AddingVariantsToTransactionsTest < JavascriptIntegrationTest
           assert page.has_css?('.has-error[id*="slug"]')
           assert page.has_css?(".js-error li", count: 2)
           assert page.has_css?(".js-error li", text: "can't be blank")
-          assert page.has_css?(".js-error li", text: "is invalid")
+          assert page.has_css?(".js-error li", text: "can only consist of lower case characters, numbers and hyphens")
         end
 
         within :css, "#parts div.fields:nth-of-type(3)" do

--- a/test/models/parted_test.rb
+++ b/test/models/parted_test.rb
@@ -12,7 +12,7 @@ class PartedTest < ActiveSupport::TestCase
     assert_not edition.valid?
 
     assert_equal({ title: ["can't be blank"] }, edition.errors[:parts][0]["54c10d4d759b743528000010:1"])
-    assert_equal({ slug: ["can't be blank", "is invalid"] }, edition.errors[:parts][0]["54c10d4d759b743528000011:2"])
+    assert_equal({ slug: ["can't be blank", "can only consist of lower case characters, numbers and hyphens"] }, edition.errors[:parts][0]["54c10d4d759b743528000011:2"])
     assert_equal 2, edition.errors[:parts][0].length
   end
 

--- a/test/models/varianted_test.rb
+++ b/test/models/varianted_test.rb
@@ -12,7 +12,7 @@ class VariantedTest < ActiveSupport::TestCase
     assert_not edition.valid?
 
     assert_equal({ title: ["can't be blank"] }, edition.errors[:variants][0]["54c10d4d759b743528000010:1"])
-    assert_equal({ slug: ["can't be blank", "is invalid"] }, edition.errors[:variants][0]["54c10d4d759b743528000011:2"])
+    assert_equal({ slug: ["can't be blank", "can only consist of lower case characters, numbers and hyphens"] }, edition.errors[:variants][0]["54c10d4d759b743528000011:2"])
     assert_equal 2, edition.errors[:variants][0].length
   end
 end


### PR DESCRIPTION
## What 

Currently, the messaging around invalid slug's for GuideEdition, TransactionEdition, and SimpleSmartAnswerEdition simply states that the slug `is invalid`. This does not help the user understand why the slug is invalid, so diagnosing the issue takes longer than it would if a more meaningful message were output, and correcting the issue is a somewhat trial-and-error experience - especially for the novice user.

This pull request adds more helpful and specific messages when the user experiences an invalid slug.

## Why

The user should be able to diagnose and correct the issue quickly and easily.

[Trello](https://trello.com/c/SvOnnXeB/530-update-parts-and-variants-validation-errors-in-publisher)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
