### PR TITLE
Convert input fields to use FormHelper in Publisher

### DIFF
--- a/app/views/answers/_fields.html.erb
+++ b/app/views/answers/_fields.html.erb
@@ -3,14 +3,9 @@
     <fieldset class="inputs">
       <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
 
-      <div class="form-group">
-        <span class="form-label">
-          <%= f.label :body %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_area :body, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
-        </span>
-      </div>
+      <%= form_group(f, :body) do %>
+        <%= f.text_area :body, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+      <% end %>
     </fieldset>
   </div>
 </div>

--- a/app/views/artefacts/new.html.erb
+++ b/app/views/artefacts/new.html.erb
@@ -20,44 +20,23 @@
         <div class="well">
           <%= f.hidden_field :content_id, value: @artefact.content_id %>
 
-          <div class="form-group">
-            <span class="form-label">
-              <%= f.label :name, "Title" %>
-            </span>
-            <span class="form-wrapper">
-              <%= f.text_field :name, class: "input-md-6 form-control" %>
-            </span>
-          </div>
+          <%= form_group(f, :name, label: "Title") do %>
+            <%= f.text_field :name, class: "input-md-6 form-control" %>
+          <% end %>
 
-          <div class="form-group">
-            <span class="form-label">
-              <%= f.label :slug %>
-            </span>
-            <span class="form-wrapper">
-              <%= f.text_field :slug, class: "input-md-6 form-control" %>
-              <span class="help-block">For example: lower-case-hyphen-separated</span>
-            </span>
-          </div>
+          <%= form_group(f, :slug, help: "For example: lower-case-hyphen-separated") do %>
+            <%= f.text_field :slug, class: "input-md-6 form-control" %>
+          <% end %>
 
-          <div class="form-group">
-            <span class="form-label">
-              <%= f.label :kind, "Format" %>
-            </span>
-            <span class="form-wrapper">
-              <%= f.select :kind, formats.map { |s| [s.humanize, s]}, { include_blank: "Select a format" }, { class: "input-md-4 form-control" } %>
-            </span>
-          </div>
+          <%= form_group(f, :kind, label: "Format") do %>
+            <%= f.select :kind, formats.map { |s| [s.humanize, s]}, { include_blank: "Select a format" }, { class: "input-md-4 form-control" } %>
+          <% end %>
 
           <%= f.hidden_field :owning_app, value: 'publisher' %>
 
-          <div class="form-group">
-            <span class="form-label">
-              <%= f.label :language %>
-            </span>
-            <span class="form-wrapper">
-              <%= f.select :language, { "English" => "en", "Welsh" => "cy" }, {}, { class: "input-md-4 form-control" } %>
-            </span>
-          </div>
+          <%= form_group(f, :language) do %>
+            <%= f.select :language, { "English" => "en", "Welsh" => "cy" }, {}, { class: "input-md-4 form-control" } %>
+          <% end %>
         </div>
 
         <div class="form-actions">

--- a/app/views/completed_transactions/_fields.html.erb
+++ b/app/views/completed_transactions/_fields.html.erb
@@ -3,15 +3,9 @@
     <fieldset class="inputs">
       <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
 
-      <div class="form-group">
-        <span class="form-label">
-          <%= f.label :body %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_area :body, rows: 20, disabled: "disabled", class: "input-md-10 form-control" %>
-          <span class="help-block">The body text is overwritten by the service feedback survey</span>
-        </span>
-      </div>
+      <%= form_group(f, :body, help: "The body text is overwritten by the service feedback survey") do %>
+        <%= f.text_area :body, rows: 20, disabled: "disabled", class: "input-md-10 form-control" %>
+      <% end %>
     </fieldset>
   </div>
 </div>
@@ -45,32 +39,17 @@
         { checked: (f.object.promotion_choice == "electric_vehicle"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-electric-vehicle' } %>
       <%= f.label :promotion_choice, "Promote electric vehicles", value: 'electric_vehicle' %>
 
-      <div class="form-group promotion-choice-url" id="promotion-choice-url">
-        <span class="form-label">
-          <%= f.label :promotion_choice_url %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_field :promotion_choice_url, disabled: @resource.locked_for_edits?, class: "input-md-8 form-control" %>
-        </span>
-      </div>
+      <%= form_group(f, :promotion_choice_url, attributes: { id: "promotion-choice-url" }) do %>
+        <%= f.text_field :promotion_choice_url, disabled: @resource.locked_for_edits?, class: "input-md-8 form-control" %>
+      <% end %>
 
-      <div class="form-group promotion-choice-url promotion-choice-opt-in-out-url" id="promotion-choice-opt-in-url">
-        <span class="form-label">
-          <%= f.label :promotion_choice_opt_in_url %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_field :promotion_choice_opt_in_url, disabled: @resource.locked_for_edits?, class: "input-md-8 form-control" %>
-        </span>
-      </div>
+      <%= form_group(f, :promotion_choice_opt_in_url, attributes: { class: %w[promotion-choice-url promotion-choice-opt-in-out-url], id: "promotion-choice-opt-in-url" }) do %>
+        <%= f.text_field :promotion_choice_opt_in_url, disabled: @resource.locked_for_edits?, class: "input-md-8 form-control" %>
+      <% end %>
 
-      <div class="form-group promotion-choice-url promotion-choice-opt-in-out-url" id="promotion-choice-opt-out-url">
-        <span class="form-label">
-          <%= f.label :promotion_choice_opt_out_url %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_field :promotion_choice_opt_out_url, disabled: @resource.locked_for_edits?, class: "input-md-8 form-control" %>
-        </span>
-      </div>
+      <%= form_group(f, :promotion_choice_opt_out_url, attributes: { class: %w[promotion-choice-url promotion-choice-opt-in-out-url], id: "promotion-choice-opt-out-url" }) do %>
+        <%= f.text_field :promotion_choice_opt_out_url, disabled: @resource.locked_for_edits?, class: "input-md-8 form-control" %>
+      <% end %>
     </div>
 
   </div>

--- a/app/views/downtimes/_form.html.erb
+++ b/app/views/downtimes/_form.html.erb
@@ -28,10 +28,9 @@
 
 <hr />
 
-<div class="form-group">
-  <%= f.label :message %>
+<%= form_group(f, :message) do %>
   <%= f.text_area :message, class: 'form-control input-md-6 js-downtime-message', rows: 5 %>
-</div>
+<% end %>
 
 <p class="add-bottom-margin help-note">
   <span class="glyphicon glyphicon-exclamation-sign"></span>

--- a/app/views/editions/_major_change_fields.html.erb
+++ b/app/views/editions/_major_change_fields.html.erb
@@ -1,18 +1,6 @@
-<div class="form-group" id="edition_change_note_input">
-  <span class="form-label">
-    <%= f.label :change_note, "Summary of changes to this edition" %>
-  </span>
-  <span class="form-wrapper">
-    <%= f.text_area :change_note, rows: 3, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
-  </span>
-  <% if f.object.errors[:change_note].any? %>
-    <ul class="help-block has-error">
-      <% f.object.errors[:change_note].each do |error| %>
-        <li><%= error %></li>
-      <% end %>
-    </ul>
-  <% end %>
-</div>
+<%= form_group(f, :change_note, label: "Summary of changes to this edition", attributes: { id: "edition_change_note_input" }) do %>
+  <%= f.text_area :change_note, rows: 3, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+<% end %>
 
 <div class="form-group emphasised-field add-bottom-margin checkbox">
   <span class="form-wrapper">

--- a/app/views/help_pages/_fields.html.erb
+++ b/app/views/help_pages/_fields.html.erb
@@ -2,14 +2,10 @@
   <div class="col-md-8">
     <fieldset class="inputs">
       <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
-      <div class="form-group">
-        <span class="form-label">
-          <%= f.label :body %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_area :body, rows: 20, disabled: @resource.locked_for_edits?, class: "form-control" %>
-        </span>
-      </div>
+
+      <%= form_group(f, :body) do %>
+        <%= f.text_area :body, rows: 20, disabled: @resource.locked_for_edits?, class: "form-control" %>
+      <% end %>
     </fieldset>
   </div>
 </div>

--- a/app/views/licences/_fields.html.erb
+++ b/app/views/licences/_fields.html.erb
@@ -7,38 +7,21 @@
         <%= f.text_field :licence_identifier, disabled: @resource.locked_for_edits?, class: "input-md-3 form-control" %>
       <% end %>
 
-      <div class="form-group">
-        <span class="form-label">
-          <%= f.label :will_continue_on %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_field :will_continue_on, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
-          <span class="help-block">Text to follow the statement 'This will continue on. eg. "the HMRC website"'</span>
-        </span>
-      </div>
+      <%= form_group(f, :will_continue_on, help: "Text to follow the statement 'This will continue on. eg. \"the HMRC website\"'") do %>
+        <%= f.text_field :will_continue_on, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+      <% end %>
 
       <%= form_group(f, :continuation_link, label: "Link to competent authority", help: "Link as deep as possible.") do %>
         <%= f.text_field :continuation_link, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
       <% end %>
 
-      <div class="form-group">
-        <span class="form-label">
-          <%= f.label :licence_short_description %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_area :licence_short_description, rows: 2, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
-          <span class="help-block">One line curated description, will appear in Licence Finder results</span>
-        </span>
-      </div>
+      <%= form_group(f, :licence_short_description, help: "One line curated description, will appear in Licence Finder results") do %>
+        <%= f.text_area :licence_short_description, rows: 2, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+      <% end %>
 
-      <div class="form-group">
-        <span class="form-label">
-          <%= f.label :licence_overview %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_area :licence_overview, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
-        </span>
-      </div>
+      <%= form_group(f, :licence_overview) do %>
+        <%= f.text_area :licence_overview, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+      <% end %>
     </fieldset>
   </div>
 </div>

--- a/app/views/licences/new.html.erb
+++ b/app/views/licences/new.html.erb
@@ -13,14 +13,9 @@
 <% end %>
 
 <%= form_for(@publication, :url => editions_path, :as => :edition, :html => { :id => 'edition-form' } ) do |f| %>
-  <div class="form-group">
-    <span class="form-label">
-      <%= f.label :licence_identifier %>
-    </span>
-    <span class="form-wrapper">
-      <%= f.text_field :licence_identifier, class: "form-control" %>
-    </span>
-  </div>
+  <%= form_group(f, :licence_identifier) do %>
+    <%= f.text_field :licence_identifier, class: "form-control" %>
+  <% end %>
 
   <fieldset class="inputs">
     <input type="hidden" name="edition[kind]" value="licence">

--- a/app/views/local_transactions/_fields.html.erb
+++ b/app/views/local_transactions/_fields.html.erb
@@ -1,14 +1,9 @@
 <div class="row">
   <div class="col-md-8">
     <fieldset class="inputs">
-      <div class="form-group">
-        <span class="form-label">
-          <%= f.label :lgsl_code, "LGSL code" %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_field :lgsl_code, disabled: true, class: "input-md-4 form-control" %>
-        </span>
-      </div>
+      <%= form_group(f, :lgsl_code, label: "LGSL code") do %>
+        <%= f.text_field :lgsl_code, disabled: true, class: "input-md-4 form-control" %>
+      <% end %>
 
       <%= form_group(f, :lgil_code, label: "LGIL code") do %>
         <%= f.text_field :lgil_code, disabled: @resource.locked_for_edits?, class: "input-md-4 form-control" %>
@@ -16,33 +11,17 @@
 
       <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
 
-      <div class="form-group">
-        <span class="form-label">
-          <%= f.label :introduction, "Introductory paragraph" %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_area :introduction, rows: 8, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
-          <span class="help-block">Set the scene for the user. Explain that it's the responsibility of the local council and that we'll take you there.</span>
-        </span>
-      </div>
+      <%= form_group(f, :introduction, label: "Introductory paragraph", help: "Set the scene for the user. Explain that it's the responsibility of the local council and that we'll take you there.") do %>
+        <%= f.text_area :introduction, rows: 8, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+      <% end %>
 
-      <div class="form-group">
-        <span class="form-label">
-          <%= f.label :more_information %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_area :more_information, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
-        </span>
-      </div>
+      <%= form_group(f, :more_information) do %>
+        <%= f.text_area :more_information, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+      <% end %>
 
-      <div class="form-group">
-        <span class="form-label">
-          <%= f.label :need_to_know, "What you need to know" %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_area :need_to_know, rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
-        </span>
-      </div>
+      <%= form_group(f, :need_to_know, label: "What you need to know") do %>
+        <%= f.text_area :need_to_know, rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+      <% end %>
 
       <%= render partial: 'local_transactions/devolved_administrations', locals: { f: f, resource: @resource } %>
     </fieldset>

--- a/app/views/local_transactions/new.html.erb
+++ b/app/views/local_transactions/new.html.erb
@@ -13,28 +13,18 @@
 
 <%= form_for(@publication, as: :edition, url: editions_path, html: { id: 'edition-form', novalidate: 'novalidate' } ) do |f| %>
   <fieldset class="inputs">
-    <div class="form-group">
-      <span class="form-label">
-        <%= f.label :lgsl_code, "LGSL code" %>
-      </span>
-      <span class="form-wrapper">
-        <%= f.text_field :lgsl_code, class: "form-control" %>
-      </span>
-    </div>
+    <%= form_group(f, :lgsl_code, label: "LGSL code") do %>
+      <%= f.text_field :lgsl_code, class: "form-control" %>
+    <% end %>
 
     <input type="hidden" name="edition[kind]" value="local_transaction">
     <%= f.hidden_field :panopticon_id %>
     <%= f.hidden_field :title %>
     <%= f.hidden_field :slug %>
 
-    <div class="form-group">
-      <span class="form-label">
-        <%= f.label :lgil_code, "LGIL code" %>
-      </span>
-      <span class="form-wrapper">
-        <%= f.text_field :lgil_code, class: "form-control" %>
-      </span>
-    </div>
+    <%= form_group(f, :lgil_code, label: "LGIL code") do %>
+      <%= f.text_field :lgil_code, class: "form-control" %>
+    <% end %>
   </fieldset>
   <%= f.submit "Create Local transaction edition", class: 'btn btn-success' %>
 <% end %>

--- a/app/views/places/_fields.html.erb
+++ b/app/views/places/_fields.html.erb
@@ -3,42 +3,21 @@
     <fieldset class="inputs">
       <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
 
-      <div class="form-group">
-        <span class="form-label">
-          <%= f.label :place_type %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_field :place_type, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
-          <span class="help-block">This is the 'slug' assigned in the imminence app</span>
-        </span>
-      </div>
+      <%= form_group(f, :place_type, label: "This is the 'slug' assigned in the imminence app") do %>
+        <%= f.text_field :place_type, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+      <% end %>
 
-      <div class="form-group">
-        <span class="form-label">
-          <%= f.label :introduction %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_area :introduction, rows: 5, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
-        </span>
-      </div>
+      <%= form_group(f, :introduction) do %>
+        <%= f.text_area :introduction, rows: 5, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+      <% end %>
 
-      <div class="form-group">
-        <span class="form-label">
-          <%= f.label :more_information %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_area :more_information, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
-        </span>
-      </div>
+      <%= form_group(f, :more_information) do %>
+        <%= f.text_area :more_information, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+      <% end %>
 
-      <div class="form-group add-top-margin">
-        <span class="form-label">
-          <%= f.label :need_to_know, "What you need to know" %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_area :need_to_know, rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
-        </span>
-      </div>
+      <%= form_group(f, :need_to_know, label: "What you need to know", attributes: { class: %w[add-top-margin] }) do %>
+        <%= f.text_area :need_to_know, rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+      <% end %>
     </fieldset>
   </div>
 </div>

--- a/app/views/shared/_common_edition_attributes.html.erb
+++ b/app/views/shared/_common_edition_attributes.html.erb
@@ -21,12 +21,6 @@
   </div>
 </div>
 
-<div class="form-group">
-  <span class="form-label">
-    <%= f.label :overview, "Meta tag description" %>
-  </span>
-  <span class="form-wrapper">
-    <%= f.text_area :overview, rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
-    <span class="help-block">Some search engines will display this if they cannot find what they need in the main text</span>
-  </span>
-</div>
+<%= form_group(f, :overview, label: "Meta tag description", help: "Some search engines will display this if they cannot find what they need in the main text") do %>
+  <%= f.text_area :overview, rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+<% end %>

--- a/app/views/shared/_metadata.html.erb
+++ b/app/views/shared/_metadata.html.erb
@@ -4,23 +4,13 @@
       <div class="col-md-12">
         <%= f.hidden_field :id, value: @artefact.id %>
 
-        <div class="form-group">
-          <span class="form-label">
-            <%= f.label :slug %>
-          </span>
-          <span class="form-wrapper">
-            <%= f.text_field :slug, class: "form-control input-md-6" %>
-          </span>
-        </div>
+        <%= form_group(f, :slug) do %>
+          <%= f.text_field :slug, class: "form-control input-md-6" %>
+        <% end %>
 
-        <div class="form-group">
-          <span class="form-label">
-            <%= f.label :language %>
-          </span>
-          <span class="form-wrapper">
-            <%= f.text_field :language, class: "form-control input-md-6" %>
-          </span>
-        </div>
+        <%= form_group(f, :language) do %>
+          <%= f.text_field :language, class: "form-control input-md-6" %>
+        <% end %>
       </div>
     </div>
     <%= f.submit 'Update metadata', class: "btn btn-success btn-large" %>

--- a/app/views/shared/_transaction_variant.html.erb
+++ b/app/views/shared/_transaction_variant.html.erb
@@ -40,44 +40,21 @@
           <%= form_errors(f.object.errors[:slug]) %>
         </div>
 
-        <div class="form-group">
-          <span class="form-label">
-            <%= f.label :introduction, "Introductory paragraph" %>
-          </span>
-          <span class="form-wrapper">
-            <%= f.text_area :introduction, rows: 8, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
-            <span class="help-block">Set the scene for the user. What is about to happen? (eg. "you will need to fill in a form, print it out and take it to the post office")</span>
-          </span>
-        </div>
+        <%= form_group(f, :introduction, label: "Introductory paragraph", help: "Set the scene for the user. What is about to happen? (eg. \"you will need to fill in a form, print it out and take it to the post office\")") do %>
+          <%= f.text_area :introduction, rows: 8, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+        <% end %>
 
-        <div class="form-group">
-          <span class="form-label">
-            <%= f.label :link, "Link to start of transaction" %>
-          </span>
-          <span class="form-wrapper">
-            <%= f.text_field :link, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
-            <span class="help-block">Link as deep as possible.</span>
-          </span>
-        </div>
+        <%= form_group(f, :link, label: "Link to start of transaction", help: "Link as deep as possible.") do %>
+          <%= f.text_field :link, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+        <% end %>
 
-        <div class="form-group">
-          <span class="form-label">
-            <%= f.label :more_information %>
-          </span>
-          <span class="form-wrapper">
-            <%= f.text_area :more_information, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
-          </span>
-        </div>
+        <%= form_group(f, :more_information) do %>
+          <%= f.text_area :more_information, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+        <% end %>
 
-        <div class="form-group">
-          <span class="form-label">
-            <%= f.label :alternate_methods, "Other ways to apply" %>
-          </span>
-          <span class="form-wrapper">
-            <%= f.text_area :alternate_methods, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
-            <span class="help-block">Alternative ways of completing this transaction. Not displayed on front end if left blank.</span>
-          </span>
-        </div>
+        <%= form_group(f, :alternate_methods, label: "Other ways to apply", help: "Alternative ways of completing this transaction. Not displayed on front end if left blank.") do %>
+          <%= f.text_area :alternate_methods, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+        <% end %>
 
         <%= f.hidden_field :order, class: 'order', disabled: !editable %>
 

--- a/app/views/simple_smart_answers/_fields.html.erb
+++ b/app/views/simple_smart_answers/_fields.html.erb
@@ -4,14 +4,9 @@
       <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
       <div class="row">
         <div class="col-md-10">
-          <div class="form-group">
-            <span class="form-label">
-              <%= f.label :body %>
-            </span>
-            <span class="form-wrapper">
-              <%= f.text_area :body, rows: 5, disabled: @resource.locked_for_edits?, class: "form-control" %>
-            </span>
-          </div>
+          <%= form_group(f, :body) do %>
+            <%= f.text_area :body, rows: 5, disabled: @resource.locked_for_edits?, class: "form-control" %>
+          <% end %>
         </div>
       </div>
     </fieldset>

--- a/app/views/transactions/_fields.html.erb
+++ b/app/views/transactions/_fields.html.erb
@@ -3,15 +3,9 @@
     <fieldset class="inputs">
       <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
 
-      <div class="form-group">
-        <span class="form-label">
-          <%= f.label :introduction, "Introductory paragraph" %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_area :introduction, rows: 8, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
-          <span class="help-block">Set the scene for the user. What is about to happen? (eg. "you will need to fill in a form, print it out and take it to the post office")</span>
-        </span>
-      </div>
+      <%= form_group(f, :introduction, label: "Introductory paragraph", help: "Set the scene for the user. What is about to happen? (eg. \"you will need to fill in a form, print it out and take it to the post office\")") do %>
+        <%= f.text_area :introduction, rows: 8, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+      <% end %>
 
       <div class="form-group">
         <label for="edition_start_button_text">Start button text:</label><br/>
@@ -22,53 +16,25 @@
         <% end %>
       </div>
 
-      <div class="form-group">
-        <span class="form-label">
-          <%= f.label :will_continue_on %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_field :will_continue_on, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
-          <span class="help-block">Text to follow the statement "This will continue on". eg. "the HMRC website"</span>
-        </span>
-      </div>
+      <%= form_group(f, :will_continue_on, help: "Text to follow the statement 'This will continue on. eg. \"the HMRC website\"'") do %>
+        <%= f.text_field :will_continue_on, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+      <% end %>
 
-      <div class="form-group">
-        <span class="form-label">
-          <%= f.label :link, "Link to start of transaction" %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_field :link, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
-          <span class="help-block">Link as deep as possible.</span>
-        </span>
-      </div>
+      <%= form_group(f, :link, label: "Link to start of transaction", help: "Link as deep as possible.") do %>
+        <%= f.text_field :link, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+      <% end %>
 
-      <div class="form-group">
-        <span class="form-label">
-          <%= f.label :more_information %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_area :more_information, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
-        </span>
-      </div>
+      <%= form_group(f, :more_information) do %>
+        <%= f.text_area :more_information, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+      <% end %>
 
-      <div class="form-group">
-        <span class="form-label">
-          <%= f.label :alternate_methods, "Other ways to apply" %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_area :alternate_methods, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
-          <span class="help-block">Alternative ways of completing this transaction. Not displayed on front end if left blank.</span>
-        </span>
-      </div>
+      <%= form_group(f, :alternate_methods, label: "Other ways to apply", help: "Alternative ways of completing this transaction. Not displayed on front end if left blank.") do %>
+        <%= f.text_area :alternate_methods, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+      <% end %>
 
-      <div class="form-group add-top-margin">
-        <span class="form-label">
-          <%= f.label :need_to_know, "What you need to know" %>
-        </span>
-        <span class="form-wrapper">
-          <%= f.text_area :need_to_know, rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
-        </span>
-      </div>
+      <%= form_group(f, :need_to_know, label: "What you need to know", attributes: { class: %w[add-top-margin] } ) do %>
+        <%= f.text_area :need_to_know, rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+      <% end %>
 
       <%= form_group(f, :department_analytics_profile, label: "Service analytics profile", help: "Let service teams track user journeys between GOV.UK and their service using Google Analytics.", attributes: { class: %w[add-top-margin] }) do %>
         <%= f.text_area :department_analytics_profile, placeholder: 'UA-XXXXXX-X', rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-2 form-control" %>


### PR DESCRIPTION
## What

A `FormHelper` module was introduced into Publisher via [this PR](https://github.com/alphagov/publisher/pull/1478).

This helper creates a consistent HTML structure, classes, help and error blocks etc for input fields (see example below). But it has so far only been applied to fields that can generate model validation errors.

Ideally, we want a consistent approach and structure across as many fields as possible - wether or not they generate model validation errors.

This change converts all fields - where it is sensible and possible to do so - to use the `FormHelper` module. 

We ignore the following - retired - formats:

- CampaignEdition
- ProgrammeEdition
- VideoEdition

### Example

This `FormHelper` entry...

```ruby
form_group(f, :field_id, label: "Custom field label", help: "Some helpful text") do
  form.text_field :field_id, class: "form-control"
end
```

Generates this HTML structure...

```html
<div class="form-group">
  <div class="form-label">
    <label for="field_id">Custom field label</label>
  </div>
  <div class="form-wrapper">
    <input type="text" name="field_id" id="field_id" class="form-control">
  </div>
  <div class="help-block">Some helpful text</div>
  <ul class="help-block error-block"></ul>
</div>
```

## Why

A consistent approach to the way input fields are constructed will help those working with and updating the codebase, and simplify the user interface. It should also help if (the rather old version of) Bootstrap were to be updated or removed.

[Trello](https://trello.com/c/QnOEgTxW/531-convert-all-input-fields-to-use-formhelper-in-publisher)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
