### PR TITLE
Remove service 1827

### DIFF
--- a/data/local_services.csv
+++ b/data/local_services.csv
@@ -126,4 +126,3 @@ LGSL,Description,Providing Tier
 1743,Find out about the Care Act 2014,county/unitary
 1788,"Find out about support for children who have difficulties with speech, language or communication",county/unitary
 1826,"Find out about the test and trace support payment scheme",district/unitary
-1827,"Find a COVID-19 rapid lateral flow test site",all


### PR DESCRIPTION
Trello: https://trello.com/c/WwdltWkO

# What's changed and why?
Removes service 1827: "Find a COVID-19 rapid lateral flow test site" as this service has been replaced by one on the NHS.UK: https://maps.test-and-trace.nhs.uk/

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
