### PR TITLE
Add puma via govuk_app_config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ RUN apt-get update -qq && apt-get upgrade -y
 RUN curl -sL https://deb.nodesource.com/setup_9.x | bash -
 RUN apt-get update && apt-get install -y nodejs && apt-get install npm -y
 RUN npm install -g phantomjs-prebuilt@2 --unsafe-perm
-RUN gem install foreman
 
 # This image is only intended to be able to run this app in a production RAILS_ENV
 ENV RAILS_ENV production
@@ -28,4 +27,4 @@ RUN GOVUK_APP_DOMAIN=www.gov.uk GOVUK_WEBSITE_ROOT=www.gov.uk bundle exec rails 
 
 HEALTHCHECK CMD curl --silent --fail localhost:$PORT || exit 1
 
-CMD foreman run web
+CMD bundle exec puma

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,8 +172,9 @@ GEM
       jquery-rails (~> 4.3.1)
       plek (>= 2.1.0)
       rails (>= 3.2.0)
-    govuk_app_config (4.0.1)
+    govuk_app_config (4.1.0)
       logstasher (>= 1.2.2, < 2.2.0)
+      puma (~> 5.0)
       sentry-rails (~> 4.5.0)
       sentry-ruby (~> 4.5.0)
       statsd-ruby (~> 1.5.0)
@@ -338,7 +339,7 @@ GEM
     public_suffix (4.0.6)
     puma (5.3.2)
       nio4r (~> 2.0)
-    racc (1.5.2)
+    racc (1.6.0)
     rack (2.2.3)
     rack-protection (2.1.0)
       rack
@@ -529,7 +530,7 @@ GEM
       chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   ruby

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config/govuk_puma"
+GovukPuma.configure_rails(self)


### PR DESCRIPTION
This PR adds `Puma` via govuk_app_config. Puma was previously installed indirectly through the dependency on `govuk_test` as part of the `dev` and `test` groups; given that we want to run Puma in production, we are instead configuring it via govuk_app_config.

**This PR is reliant on [changes to govuk_app_config](https://github.com/alphagov/govuk_app_config/pull/214)**

[Trello card](https://trello.com/c/irrbEFMV/668)