### PR TITLE
Streamline Publisher Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.gitignore
+CONTRIBUTING.md
+Jenkinsfile
+README.md
+docs
+log
+spec
+test
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,33 @@
-ARG base_image=ruby:2.7.2
-FROM ${base_image}
-RUN apt-get update -qq && apt-get upgrade -y
+# TODO: make this default to govuk-ruby once it's being pushed somewhere public
+# (unless we decide to use Bitnami instead)
+ARG base_image=ruby:2.7.2-slim-buster
+
+FROM $base_image AS builder
+# TODO: have a separate build image which already contains the build-only deps.
+RUN apt-get update -qy && apt-get upgrade -y
+# TODO: Look to remove Node v9 (below) (E2E tests currently fail without it).
 RUN curl -sL https://deb.nodesource.com/setup_9.x | bash -
-RUN apt-get update && apt-get install -y nodejs && apt-get install npm -y
-RUN npm install -g phantomjs-prebuilt@2 --unsafe-perm
-
-# This image is only intended to be able to run this app in a production RAILS_ENV
-ENV RAILS_ENV production
-
-ENV GOVUK_APP_NAME publisher
-ENV MONGODB_URI mongodb://mongo/govuk_content_development
-ENV PORT 3000
-ENV ASSETS_PREFIX /assets/publisher
-
-ENV APP_HOME /app
-RUN mkdir $APP_HOME
-
-WORKDIR $APP_HOME
-ADD Gemfile* $APP_HOME/
+RUN apt-get update && apt-get install -y build-essential nodejs git npm && \
+    npm install -g phantomjs-prebuilt@2 --unsafe-perm
+# TODO: Can ASSETS_PREFIX default to `/assets/publisher` within Publisher?
+ENV RAILS_ENV=production GOVUK_APP_NAME=publisher ASSETS_PREFIX=/assets/publisher
+RUN mkdir /app
+WORKDIR /app
+COPY Gemfile Gemfile.lock .ruby-version /app/
 RUN bundle config set deployment 'true'
 RUN bundle config set without 'development test'
-RUN bundle install --jobs 4
-ADD . $APP_HOME
-
+RUN bundle install -j8 --retry=2
+COPY . /app
+# TODO: We probably don't want assets in the image; remove this once we have a proper deployment process which uploads to (e.g.) S3.
 RUN GOVUK_APP_DOMAIN=www.gov.uk GOVUK_WEBSITE_ROOT=www.gov.uk bundle exec rails assets:precompile
 
-HEALTHCHECK CMD curl --silent --fail localhost:$PORT || exit 1
-
+FROM $base_image
+RUN apt-get update -qy && apt-get upgrade -y && \
+    apt-get install -y nodejs
+# TODO: MONGODB_URI shouldn't be set here but seems to be required by E2E tests, figure out why.
+# TODO: Can ASSETS_PREFIX default to `/assets/publisher` within Publisher?
+ENV RAILS_ENV=production GOVUK_APP_NAME=publisher ASSETS_PREFIX=/assets/publisher MONGODB_URI=mongodb://mongo/govuk_content_development
+COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
+COPY --from=builder /app /app/
+WORKDIR /app
 CMD bundle exec puma


### PR DESCRIPTION
This PR streamlines the Publisher image by installing dependencies
etc in a new intermediate `builder` stage, before copying back the build
outputs to the output image.

We add a .dockerignore to omit files and directories which aren't needed
at runtime.

We set RAILS_ENV to production and remove HEALTHCHECK and PORT (since
these are not used in Kubernetes and would only serve to add ambiguity).

For now, the compiled Rails assets are still included in the output
image, even though they're unlikely to be of much use. We'll need assets
to be uploaded to a static serving service as a deployment step,
otherwise rolling updates won't be possible (because each pod would only
have the assets from its own version, not the next/previous version).

Alternatives considered: We tried using the Bitnami ruby images (which
have an attractive support/update policy) but ran into difficulties with
bundler and versions/locations of gems.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
