### PR TITLE
Set RAILS_LOG_TO_STDOUT in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update -qy && apt-get upgrade -y && \
     apt-get install -y nodejs
 # TODO: MONGODB_URI shouldn't be set here but seems to be required by E2E tests, figure out why.
 # TODO: Can ASSETS_PREFIX default to `/assets/publisher` within Publisher?
-ENV RAILS_ENV=production GOVUK_APP_NAME=publisher ASSETS_PREFIX=/assets/publisher MONGODB_URI=mongodb://mongo/govuk_content_development
+ENV RAILS_ENV=production RAILS_LOG_TO_STDOUT=1 GOVUK_APP_NAME=publisher ASSETS_PREFIX=/assets/publisher MONGODB_URI=mongodb://mongo/govuk_content_development
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/
 WORKDIR /app


### PR DESCRIPTION
This always needs to be set when a Rails app is running in a container, so it makes sense to set it in the Dockerfile rather than making the user remember to set it.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️