### PR TITLE
Remove service 1113

### DIFF
--- a/data/local_services.csv
+++ b/data/local_services.csv
@@ -112,7 +112,6 @@ LGSL,Description,Providing Tier
 860,Find out about liquor licences,district/unitary
 867,Find out about local consultations,all
 870,Find out about community safety,all
-1113,Find out about volunteering,all
 1116,Find out about Youth Opportunity Funding,county/unitary
 1135,Find out about transport for 16-19 year olds in education,county/unitary
 1140,Find out about emergency school closures,county/unitary


### PR DESCRIPTION
Trello: https://trello.com/c/3YVLHZM2

# What's changed and why?

Removes service 1113 as most of the links for the service are broken and users are now being redirected to static content.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
