### PR TITLE
Remove service 1287

### DIFF
--- a/data/local_services.csv
+++ b/data/local_services.csv
@@ -116,7 +116,6 @@ LGSL,Description,Providing Tier
 1135,Find out about transport for 16-19 year olds in education,county/unitary
 1140,Find out about emergency school closures,county/unitary
 1145,Find your local 14-19 prospectus,county/unitary
-1287,Find out about coronavirus,all
 1307,Get information on services disrupted by severe weather,all
 1579,Find out about family information services,county/unitary
 1580,Find out how to hold a street party,all


### PR DESCRIPTION
Trello: https://trello.com/c/gZBD3k3A

# What's changed?

Removes service 1287, "Get coronavirus help from your local council".

# Why?

The "Get coronavirus help from your local council" is being retired as:

1. Numerous local councils no longer offer the help listed in the start
page, making the start page of the look up misleading and out-of-date.
2. Less than 50% of users find it useful
3. User feedback states that local council pages are broken, incorrect
or unhelpful
4. Nobody is updating links or following up with local councils on this.
5. Its proposition is confusing and unclear

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
