### PR TITLE
Add temporary rake task to fix redirect on a document

### DIFF
--- a/lib/tasks/temporary_data_hygiene.rake
+++ b/lib/tasks/temporary_data_hygiene.rake
@@ -1,0 +1,11 @@
+namespace :temporary_data_hygiene do
+  desc "Fix redirect URL for unpublished document /disposal-of-dredged-material-at-sea"
+  task redirect_dredged_material: :environment do
+    current_user = User.find("5bfc0db3e5274a7e7111a5d7") # Bruce Bolt
+
+    edition = Edition.find_by(slug: "disposal-of-dredged-material-at-sea", state: "archived")
+    edition.artefact.update!(redirect_url: "/guidance/do-i-need-a-marine-licence")
+
+    UnpublishService.call(edition.artefact, current_user, edition.artefact.redirect_url)
+  end
+end


### PR DESCRIPTION
The document `/disposal-of-dredged-material-at-sea` was unpublished in 2018 and redirected to `/guidance/do-i-need-a-marine-licence#disposing-of-dredged-material-at-sea`.  However, as the redirect is implemented with segment mode (i.e. everything after the original slug is forwarded with the redirect), router rejected the redirect as the URL contains a fragment, which is incompatible with segment mode.

This meant the document was never unpublished and has remained in place since then. An [error is logged by Content Store](https://sentry.io/organizations/govuk/issues/2661224471/), as the downstream request to router fails.

Everytime a page that is linked gets updated, the link expansion process attempts to re-unpublish this page, which fails and another error is logged.

By updating the URL to not include a fragment, this document can finally be unpublished, which will also stop the errors from being logged into Sentry.

This is executed by running the following rake task:
```
rake temporary_data_hygiene:redirect_dredged_material
```

The rake task can be removed after it has been run in production.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello card](https://trello.com/c/YxCmomv2/160-fix-redirect-on-unpublished-publisher-document-disposal-of-dredged-waste-at-sea)