### PR TITLE
Update downtime message inputs to include labels

### DIFF
--- a/app/assets/stylesheets/downtime.scss
+++ b/app/assets/stylesheets/downtime.scss
@@ -7,3 +7,18 @@
     margin-right: $default-horizontal-margin;
   }
 }
+
+.downtime-dates p {
+  font-weight: bold;
+  font-size: 16px;
+}
+
+.date {
+  width: auto;
+}
+
+.joining-on {
+  @media screen and (min-width: 600px) {
+    margin-top: 40px;
+  }
+}

--- a/app/views/downtimes/_form.html.erb
+++ b/app/views/downtimes/_form.html.erb
@@ -6,27 +6,79 @@
    </p>
 <% end %>
 
-<div class="form-group form-inline js-start-time">
-  <%= f.label :start_time, 'This service will be unavailable from' %><br />
-  <span>
-  <%= f.time_select :start_time, { default: 1.hour.from_now.beginning_of_hour, ignore_date: true }, { class: 'date form-control' } %>
-</span>
-  <b class="add-left-margin add-right-margin">on</b>
-  <%= f.date_select :start_time, { order: [:day, :month, :year], default: Date.tomorrow,
-    start_year: Date.today.year, end_year: Date.today.year.next }, { class: 'date form-control' } %>
+<div class="downtime-dates">
+  <div class="form-group">
+    <p>This service will be unavailable from</p>
+  </div>
+
+  <div class="row js-start-time">
+    <div class="form-group date col-sm-1">
+      <%= f.label :start_time, "Hour", for: "downtime_start_time_4i" %>
+      <%= select_hour @downtime.start_time&.hour || 1.hour.from_now.beginning_of_hour, { field_name: "start_time(4i)", prefix: "downtime" }, { class: "form-control date" } %>
+    </div>
+
+    <div class="form-group date col-sm-1">
+      <%= f.label :start_time, "Minute", for: "downtime_start_time_5i" %>
+      <%= select_minute @downtime.start_time&.minute, { field_name: "start_time(5i)", prefix: "downtime" }, { class: "form-control date" } %>
+    </div>
+
+    <div class="form-group date col-sm-1">
+      <p class="joining-on">on</p>
+    </div>
+
+    <div class="form-group date col-sm-1">
+      <%= f.label :start_time, "Day", for: "downtime_start_time_3i" %>
+      <%= select_day @downtime.start_time&.day || Date.tomorrow.day, { field_name: "start_time(3i)", prefix: "downtime" }, { class: "form-control date" } %>
+    </div>
+    <div class="form-group date col-sm-1">
+      <%= f.label :start_time, "Month", for: "downtime_start_time_2i" %>
+      <%= select_month@downtime.start_time&.month || Date.tomorrow.month, { field_name: "start_time(2i)", prefix: "downtime" }, { class: "form-control date" } %>
+    </div>
+
+    <div class="form-group date col-sm-1">
+      <%= f.label :start_time, "Year", for: "downtime_start_time_1i" %>
+      <%= select_year @downtime.start_time&.year || Date.tomorrow.year, { field_name: "start_time(1i)", prefix: "downtime" }, { class: "form-control date" } %>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <p>to</p>
+  </div>
+
+  <div class="row js-stop-time">
+
+    <div class="form-group date col-sm-1">
+      <%= f.label :end_time, "Hour", for: "downtime_end_time_4i" %>
+      <%= select_hour @downtime.end_time&.hour || 1.hour.from_now.beginning_of_hour, { field_name: "end_time(4i)", prefix: "downtime" }, { class: "form-control date" } %>
+    </div>
+
+    <div class="form-group date col-sm-1">
+      <%= f.label :end_time, "Minute", for: "downtime_end_time_5i" %>
+      <%= select_minute @downtime.end_time&.minute, { field_name: "end_time(5i)", prefix: "downtime" }, { class: "form-control date" } %>
+    </div>
+
+    <div class="form-group date col-sm-1">
+      <p class="joining-on">on</p>
+    </div>
+
+    <div class="form-group date col-sm-1">
+      <%= f.label :start_time, "Day", for: "downtime_end_time_3i" %>
+      <%= select_day @downtime.end_time&.day || Date.tomorrow.day, { field_name: "end_time(3i)", prefix: "downtime" }, { class: "form-control date" } %>
+    </div>
+
+    <div class="form-group date col-sm-1">
+      <%= f.label :end_time, "Month", for: "downtime_end_time_2i" %>
+      <%= select_month @downtime.end_time&.month || Date.tomorrow.month, { field_name: "end_time(2i)", prefix: "downtime" }, { class: "form-control date" } %>
+    </div>
+
+    <div class="form-group date col-sm-1">
+      <%= f.label :end_time, "Year", for: "downtime_end_time_1i" %>
+      <%= select_year @downtime.end_time&.year || Date.tomorrow.year, { field_name: "end_time(1i)", prefix: "downtime" }, { class: "form-control date" } %>
+    </div>
+  </div>
 </div>
 
-<div class="form-group form-inline js-stop-time">
-  <%= f.label :end_time, 'to' %><br />
-  <span>
-  <%= f.time_select :end_time, { default: 1.hour.from_now.beginning_of_hour, ignore_date: true }, { class: 'date form-control' } %>
-  </span>
-  <b class="add-left-margin add-right-margin">on</b>
-  <%= f.date_select :end_time, { order: [:day, :month, :year], default: Date.tomorrow,
-    start_year: Date.today.year, end_year: Date.today.year.next }, { class: 'date form-control' } %>
-</div>
-
-<hr />
+<hr>
 
 <%= form_group(f, :message) do %>
   <%= f.text_area :message, class: 'form-control input-md-6 js-downtime-message', rows: 5 %>
@@ -37,4 +89,4 @@
   <span class="js-schedule-message">Messages appear on the start page one day before the downtime is due.</span>
 </p>
 
-<hr />
+<hr>


### PR DESCRIPTION
### Description

This is part of the work to make our applications more accessible.

The `date_select` and `time_select` methods do not allow you to pass a label in as on option. This means that the fields are inaccessible for screen readers. I've used it to use more granular select fields (date, month, year etc.) and added labels.

### Screenshots

|Before|After|
|---------------|---------------|
|<img width="545" alt="image" src="https://user-images.githubusercontent.com/42515961/155137274-4ffd950c-e73b-4cb0-bc4d-b93132f32485.png">|<img width="607" alt="image" src="https://user-images.githubusercontent.com/42515961/155137063-28cd83d1-8f99-4452-b7c6-f359df9438cd.png">|

### Trello card 

https://trello.com/c/1lMcyxjF/245-upgrade-orphaned-labels-mainstream

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
