### PR TITLE
Use internal Frontend API

### DIFF
--- a/lib/working_days_calculator.rb
+++ b/lib/working_days_calculator.rb
@@ -25,7 +25,16 @@ class WorkingDaysCalculator
 private
 
   def fetch_public_holidays
-    public_holidays_json = GdsApi.calendars.bank_holidays(@calendar_division)
+    public_holidays_json = calendars_api.bank_holidays(@calendar_division)
     public_holidays_json["events"].map { |event| Date.parse(event["date"]) }
+  end
+
+  def calendars_api
+    endpoint = if !Rails.env.production? || ENV["HEROKU_APP_NAME"].present?
+                 Plek.new.website_root
+               else
+                 Plek.find("frontend")
+               end
+    GdsApi::Calendars.new(endpoint)
   end
 end


### PR DESCRIPTION
Publisher uses the public bank holidays API rather than the internal endpoint.

Using internal APIs is preferred - we won't need to give publisher credentials for this API in environments where this is necessary, and requests that stay in the VPC may be faster too.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
