### PR TITLE
Revert "Use internal Frontend API"

### DIFF
--- a/lib/working_days_calculator.rb
+++ b/lib/working_days_calculator.rb
@@ -25,16 +25,7 @@ class WorkingDaysCalculator
 private
 
   def fetch_public_holidays
-    public_holidays_json = calendars_api.bank_holidays(@calendar_division)
+    public_holidays_json = GdsApi.calendars.bank_holidays(@calendar_division)
     public_holidays_json["events"].map { |event| Date.parse(event["date"]) }
-  end
-
-  def calendars_api
-    endpoint = if !Rails.env.production? || ENV["HEROKU_APP_NAME"].present?
-                 Plek.new.website_root
-               else
-                 Plek.find("frontend")
-               end
-    GdsApi::Calendars.new(endpoint)
   end
 end


### PR DESCRIPTION
After discussing with @kevindew we have decided to continue consuming these APIs via the public endpoint rather than using an internal endpoint.

The reasoning is that we prefer all requests to frontend applications to go through Fastly and router. This is particularly useful because Fastly caches requests to the APIs, and we have seen an incident in the past where these APIs could not handle high volumes of requests (and so require caching). We believe these APIs should probably not be served by frontend apps, and instead should be served by a different backend service, but this is out of scope of the replatforming project.

Reverts alphagov/publisher#1552