### PR TITLE
Fix issue flagged by Wave Accessibility Tool 

### DIFF
--- a/app/assets/javascripts/modules/related_content_items_select.js
+++ b/app/assets/javascripts/modules/related_content_items_select.js
@@ -29,7 +29,7 @@
 
     var buildAddRelatedItemEl = function () {
       var $inputGroupEl = $('<div class="input-group">')
-      var $inputEl = $('<input type="text" class="form-control js-path-field" placeholder="URL or path">')
+      var $inputEl = $('<input id="add-related-item" type="text" class="form-control js-path-field" placeholder="URL or path">')
       var $buttonGroupEl = $('<span class="input-group-btn"></span>')
       var $buttonEl = $('<button class="btn btn-default" type="button">Add related item</button>')
 

--- a/app/assets/stylesheets/bootstrap_and_overrides.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.scss
@@ -96,3 +96,8 @@ legend {
   color: #000000;
   border: 0;
 }
+
+legend p {
+  font-size: 16px;
+  font-weight: bold;
+}

--- a/app/assets/stylesheets/bootstrap_and_overrides.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.scss
@@ -93,3 +93,7 @@ select.date {
 .modal.in {
   visibility: visible;
 }
+
+legend {
+  color: #000000;
+}

--- a/app/assets/stylesheets/bootstrap_and_overrides.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.scss
@@ -94,4 +94,5 @@ select.date {
 
 legend {
   color: #000000;
+  border: 0;
 }

--- a/app/assets/stylesheets/bootstrap_and_overrides.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.scss
@@ -54,9 +54,7 @@ label.nav-header {
 }
 
 .help-inline {
-  padding-left: 0;
-  color: #888888;
-  max-width: 400px;
+  color: #666666;
 }
 
 // datetime selectors

--- a/app/views/answers/_fields.html.erb
+++ b/app/views/answers/_fields.html.erb
@@ -1,6 +1,10 @@
 <div class="row">
   <div class="col-md-8">
     <fieldset class="inputs">
+      <legend class="remove-bottom-margin">
+        <h2 class="remove-top-margin add-bottom-margin h3">Edit Answer</h2>
+      </legend>
+
       <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
 
       <%= form_group(f, :body) do %>

--- a/app/views/artefacts/new.html.erb
+++ b/app/views/artefacts/new.html.erb
@@ -1,20 +1,20 @@
 <%= content_for :page_title, "New artefact" %>
-<div class="page-header">
-  <h1><%= yield :page_title %></h1>
-</div>
-
-<% if @artefact.errors.count > 0 %>
-  <div class="alert alert-danger">
-    <ul>
-      <% @artefact.errors.full_messages.each do |message| %>
-      <li><%= message %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
-
 <%= form_for(@artefact, html: { class: 'artefact', id: 'edit_artefact' }) do |f| %>
   <fieldset class="inputs">
+    <legend class="page-header">
+      <h1><%= yield :page_title %></h1>
+    </legend>
+
+    <% if @artefact.errors.count > 0 %>
+      <div class="alert alert-danger">
+        <ul>
+          <% @artefact.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
     <div class="row">
       <div class="col-md-12">
         <div class="well">

--- a/app/views/completed_transactions/_fields.html.erb
+++ b/app/views/completed_transactions/_fields.html.erb
@@ -17,45 +17,49 @@
 <hr />
 <div class="row">
   <div class="col-md-8">
-    <h3 class="remove-top-margin">Promotions</h3>
-    <p class="help-block add-bottom-margin">
-      Display a promotion above the satisfaction survey
-    </p>
+    <fieldset>
+      <legend class="remove-bottom-margin">
+        <h3 class="remove-top-margin">Promotions</h3>
+      </legend>
 
-    <div class="form-group">
-      <%= f.radio_button :promotion_choice, 'none',
-        { checked: (f.object.promotion_choice == "none"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-none' } %>
-      <%= f.label :promotion_choice, "Don't promote anything on this page", value: 'none' %>
-      <br />
-      <%= f.radio_button :promotion_choice, 'organ_donor',
-        { checked: (f.object.promotion_choice == "organ_donor"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-organ-donor' } %>
-      <%= f.label :promotion_choice, "Promote organ donation", value: 'organ_donor' %>
-      <br />
-      <%= f.radio_button :promotion_choice, 'register_to_vote',
-        { checked: (f.object.promotion_choice == "register_to_vote"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-register-to-vote' } %>
-      <%= f.label :promotion_choice, "Promote register to vote", value: 'register_to_vote' %>
-      <br />
-      <%= f.radio_button :promotion_choice, 'mot_reminder',
-        { checked: (f.object.promotion_choice == "mot_reminder"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-mot-reminder' } %>
-      <%= f.label :promotion_choice, "Promote MOT reminders", value: 'mot_reminder' %>
-      <br />
-      <%= f.radio_button :promotion_choice, 'electric_vehicle',
-        { checked: (f.object.promotion_choice == "electric_vehicle"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-electric-vehicle' } %>
-      <%= f.label :promotion_choice, "Promote electric vehicles", value: 'electric_vehicle' %>
+      <p class="help-block add-bottom-margin">
+        Display a promotion above the satisfaction survey
+      </p>
 
-      <%= form_group(f, :promotion_choice_url, attributes: { id: "promotion-choice-url" }) do %>
-        <%= f.text_field :promotion_choice_url, disabled: @resource.locked_for_edits?, class: "input-md-8 form-control" %>
-      <% end %>
+      <div class="form-group">
+        <%= f.radio_button :promotion_choice, 'none',
+          { checked: (f.object.promotion_choice == "none"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-none' } %>
+        <%= f.label :promotion_choice, "Don't promote anything on this page", value: 'none' %>
+        <br />
+        <%= f.radio_button :promotion_choice, 'organ_donor',
+          { checked: (f.object.promotion_choice == "organ_donor"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-organ-donor' } %>
+        <%= f.label :promotion_choice, "Promote organ donation", value: 'organ_donor' %>
+        <br />
+        <%= f.radio_button :promotion_choice, 'register_to_vote',
+          { checked: (f.object.promotion_choice == "register_to_vote"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-register-to-vote' } %>
+        <%= f.label :promotion_choice, "Promote register to vote", value: 'register_to_vote' %>
+        <br />
+        <%= f.radio_button :promotion_choice, 'mot_reminder',
+          { checked: (f.object.promotion_choice == "mot_reminder"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-mot-reminder' } %>
+        <%= f.label :promotion_choice, "Promote MOT reminders", value: 'mot_reminder' %>
+        <br />
+        <%= f.radio_button :promotion_choice, 'electric_vehicle',
+          { checked: (f.object.promotion_choice == "electric_vehicle"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-electric-vehicle' } %>
+        <%= f.label :promotion_choice, "Promote electric vehicles", value: 'electric_vehicle' %>
 
-      <%= form_group(f, :promotion_choice_opt_in_url, attributes: { class: %w[promotion-choice-url promotion-choice-opt-in-out-url], id: "promotion-choice-opt-in-url" }) do %>
-        <%= f.text_field :promotion_choice_opt_in_url, disabled: @resource.locked_for_edits?, class: "input-md-8 form-control" %>
-      <% end %>
+        <%= form_group(f, :promotion_choice_url, attributes: { id: "promotion-choice-url" }) do %>
+          <%= f.text_field :promotion_choice_url, disabled: @resource.locked_for_edits?, class: "input-md-8 form-control" %>
+        <% end %>
 
-      <%= form_group(f, :promotion_choice_opt_out_url, attributes: { class: %w[promotion-choice-url promotion-choice-opt-in-out-url], id: "promotion-choice-opt-out-url" }) do %>
-        <%= f.text_field :promotion_choice_opt_out_url, disabled: @resource.locked_for_edits?, class: "input-md-8 form-control" %>
-      <% end %>
-    </div>
+        <%= form_group(f, :promotion_choice_opt_in_url, attributes: { class: %w[promotion-choice-url promotion-choice-opt-in-out-url], id: "promotion-choice-opt-in-url" }) do %>
+          <%= f.text_field :promotion_choice_opt_in_url, disabled: @resource.locked_for_edits?, class: "input-md-8 form-control" %>
+        <% end %>
 
+        <%= form_group(f, :promotion_choice_opt_out_url, attributes: { class: %w[promotion-choice-url promotion-choice-opt-in-out-url], id: "promotion-choice-opt-out-url" }) do %>
+          <%= f.text_field :promotion_choice_opt_out_url, disabled: @resource.locked_for_edits?, class: "input-md-8 form-control" %>
+        <% end %>
+      </div>
+    </fieldset>
   </div>
 </div>
 

--- a/app/views/completed_transactions/_fields.html.erb
+++ b/app/views/completed_transactions/_fields.html.erb
@@ -1,6 +1,10 @@
 <div class="row">
   <div class="col-md-8">
     <fieldset class="inputs">
+      <legend class="remove-bottom-margin">
+        <h2 class="remove-top-margin add-bottom-margin h3">Edit Completed transaction</h2>
+      </legend>
+
       <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
 
       <%= form_group(f, :body, help: "The body text is overwritten by the service feedback survey") do %>

--- a/app/views/downtimes/index.html.erb
+++ b/app/views/downtimes/index.html.erb
@@ -5,8 +5,10 @@
   <p class="lead">Show a message on a published transaction start page for a specific time.</p>
 </div>
 
-<h2 class="add-bottom-margin">Services</h2>
 <table class="table table-bordered table-striped" data-module="filterable-table">
+  <caption class="h2 remove-top-margin">
+    <h2 class="remove-top-margin remove-bottom-margin">Services</h2>
+  </caption>
   <thead>
     <tr class="table-header">
       <th>Service start page</th>
@@ -16,8 +18,9 @@
     <tr class="if-no-js-hide table-header-secondary">
       <td colspan="3">
         <form>
-          <label for="table-filter" class="rm">Filter services</label>
-          <input id="table-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter services (eg ‘driving’ or ‘scheduled downtime’)">
+          <label class="remove-bottom-margin" for="table-filter">Filter services</label>
+          <p class="help-inline">For example ‘driving’ or ‘scheduled downtime’</p>
+          <input id="table-filter" type="text" class="form-control normal js-filter-table-input">
         </form>
       </td>
     </tr>
@@ -26,11 +29,11 @@
     <% @transactions.each do |transaction| %>
     <tr>
       <td>
-        <h4 class="publication-table-title">
+        <h3 class="publication-table-title">
           <%= link_to transaction.title, Downtime.for(transaction.artefact).present? ?
                                           edit_edition_downtime_path(transaction) :
                                           new_edition_downtime_path(transaction) %>
-        </h4>
+        </h3>
         <%= link_to "/#{transaction.slug}", "#{Plek.new.website_root}/#{transaction.slug}", class: 'link-muted' %>
       </td>
         <% if downtime = Downtime.for(transaction.artefact) %>

--- a/app/views/guides/_fields.html.erb
+++ b/app/views/guides/_fields.html.erb
@@ -2,6 +2,10 @@
 <div class="row">
   <div class="col-md-8">
     <fieldset class="inputs">
+      <legend class="remove-bottom-margin">
+        <h2 class="remove-top-margin add-bottom-margin h3">Edit Guide</h2>
+      </legend>
+
       <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
     </fieldset>
   </div>

--- a/app/views/help_pages/_fields.html.erb
+++ b/app/views/help_pages/_fields.html.erb
@@ -1,6 +1,10 @@
 <div class="row">
   <div class="col-md-8">
     <fieldset class="inputs">
+      <legend class="remove-bottom-margin">
+        <h2 class="remove-top-margin add-bottom-margin h3">Edit Help page</h2>
+      </legend>
+
       <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
 
       <%= form_group(f, :body) do %>

--- a/app/views/licences/_fields.html.erb
+++ b/app/views/licences/_fields.html.erb
@@ -1,6 +1,10 @@
 <div class="row">
   <div class="col-md-8">
     <fieldset class="inputs">
+      <legend class="remove-bottom-margin">
+        <h2 class="remove-top-margin add-bottom-margin h3">Edit License</h2>
+      </legend>
+
       <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
 
       <%= form_group(f, :licence_identifier, label: "Licence identifier") do %>

--- a/app/views/local_transactions/_fields.html.erb
+++ b/app/views/local_transactions/_fields.html.erb
@@ -1,6 +1,10 @@
 <div class="row">
   <div class="col-md-8">
     <fieldset class="inputs">
+      <legend class="remove-bottom-margin">
+        <h2 class="remove-top-margin add-bottom-margin h3">Edit Local transaction</h2>
+      </legend>
+
       <%= form_group(f, :lgsl_code, label: "LGSL code") do %>
         <%= f.text_field :lgsl_code, disabled: true, class: "input-md-4 form-control" %>
       <% end %>

--- a/app/views/places/_fields.html.erb
+++ b/app/views/places/_fields.html.erb
@@ -1,6 +1,10 @@
 <div class="row">
   <div class="col-md-8">
     <fieldset class="inputs">
+      <legend class="remove-bottom-margin">
+        <h2 class="remove-top-margin add-bottom-margin h3">Edit Place</h2>
+      </legend>
+
       <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
 
       <%= form_group(f, :place_type, label: "This is the 'slug' assigned in the imminence app") do %>

--- a/app/views/root/_publication.html.erb
+++ b/app/views/root/_publication.html.erb
@@ -3,12 +3,12 @@
     <%= publication.format.underscore.humanize %>
   </td>
   <td class="title">
-    <h4 class="publication-table-title">
+    <h2 class="publication-table-title h4">
       <%= link_to publication.admin_list_title, edition_path(publication) %>
       <% if publication.in_beta? %>
         <span class="badge badge-beta">beta</span>
       <% end %>
-    </h4>
+    </h2>
 
     <% if publication.published? %>
       <%= link_to "/#{publication.slug}", "#{Plek.new.website_root}/#{publication.slug}", class: 'link-muted' %>

--- a/app/views/shared/_admin.html.erb
+++ b/app/views/shared/_admin.html.erb
@@ -1,17 +1,19 @@
+<h2 class="remove-top-margin add-bottom-margin h3">Admin</h2>
+
 <% if @resource.can_destroy? %>
-  <h3 class="remove-top-margin add-bottom-margin">Delete edition</h3>
+  <h3 class="remove-top-margin add-bottom-margin h4">Delete edition</h3>
   <%= button_to "Delete this edition – ##{@resource.version_number}", path_for_edition(@resource), :method => :delete, :class => "btn btn-danger" %>
 <% end %>
 
 <% if @resource.can_destroy? && @resource.fact_check? %><hr/><% end %>
 
 <% if @resource.fact_check? %>
-  <h3 class="add-bottom-margin">Skip fact check</h3>
+  <h3 class="add-bottom-margin h4">Skip fact check</h3>
   <%= button_to "Skip fact check", skip_fact_check_for_edition(@resource), :method => :post, :class => "btn btn-default" %>
 <% end %>
 
 <% if @edition.published? && @edition.can_create_new_edition? %>
-  <h3 class="remove-top-margin">Change format of edition</h3>
+  <h3 class="remove-top-margin h4">Change format of edition</h3>
 
 <%= render partial: "shared/clone_buttons",
     locals: {

--- a/app/views/shared/_clone_buttons.html.erb
+++ b/app/views/shared/_clone_buttons.html.erb
@@ -7,7 +7,7 @@
   </div>
 
   <%= form_for @resource, url: duplicate_edition_path(@resource, from: edition_class.to_s), method: "post" do |f| %>
-    <%= f.label :to, "Create as new" %>
+    <%= f.label :to, "Create as new", for: :to %>
     <%= select_tag :to, options_for_select(format_conversion_select_options(@resource)), class: "form-control input-md-3 add-bottom-margin"%>
     <%= f.submit "Change format", class: "btn btn-default" %>
   <% end %>

--- a/app/views/shared/_edition_history.html.erb
+++ b/app/views/shared/_edition_history.html.erb
@@ -14,7 +14,7 @@
       <ul class="panel-body list-unstyled remove-bottom-margin">
         <% edition_actions(edition).each do |action| %>
           <li class="action-<%= action_class(action) %> add-bottom-margin add-left-margin">
-            <h4>
+            <h3 class="h4">
               <div class="add-label-margin normal">
                 <time datetime="<%= action.created_at %>" class="text-muted add-label-margin">
                   <%= action.created_at.to_s(:govuk_date) %>
@@ -26,7 +26,7 @@
               <% else %>
                 GOV.UK Bot
               <% end %>
-            </h4>
+            </h3>
             <% if action_note?(action) %>
               <% if action.comment_sanitized %>
                 <div class="alert alert-error alert-block">

--- a/app/views/shared/_history.html.erb
+++ b/app/views/shared/_history.html.erb
@@ -62,7 +62,7 @@
 </div>
 
 <div id="edition-history" data-module="collapsible-group" data-expand-text="Expand all notes" data-collapse-text="Collapse all notes">
-  <h3 class="remove-top-margin add-bottom-margin">History and notes</h3>
+  <h2 class="remove-top-margin add-bottom-margin h3">History and notes</h2>
 
   <p class="add-bottom-margin if-no-js-hide">
     <a href="#" class="js-toggle-all">Expand all notes</a>

--- a/app/views/shared/_metadata.html.erb
+++ b/app/views/shared/_metadata.html.erb
@@ -1,3 +1,5 @@
+<h2 class="remove-top-margin add-bottom-margin h3">Metadata</h2>
+
 <% if Edition::PUBLISHING_API_DRAFT_STATES.include? publication.state %>
   <%= form_for(@artefact, :html => { :class => 'artefact', :id => 'edit_artefact'}) do |f| %>
     <div class="row">

--- a/app/views/shared/_related_external_links.html.erb
+++ b/app/views/shared/_related_external_links.html.erb
@@ -1,11 +1,12 @@
 <%= nested_form_for @artefact, url: update_related_external_links_edition_path(@resource) do |f| %>
+  <h2 class="remove-top-margin add-bottom-margin h3">Related external links</h2>
+
   <div class='alert alert-info'>
     Once saved, related external links will be visible on the site the next time
     this publication is published.
   </div>
 
   <div class="related-external-links fieldset-section">
-    <label class="section-label">Related external links</label><br />
     <%= f.fields_for :external_links do |link| %>
       <div class="nested-item">
         <div class="row relative">

--- a/app/views/shared/_tagging.html.erb
+++ b/app/views/shared/_tagging.html.erb
@@ -2,9 +2,10 @@
     <%= f.hidden_field :content_id %>
     <%= f.hidden_field :previous_version %>
 
+    <h2 class="remove-top-margin add-bottom-margin h3">Tagging</h2>
+
     <div class="row">
       <div class="col-md-7 edition-tags">
-
         <div class="form-group" id="edition_browse_pages_input">
           <%= f.label :mainstream_browse_pages, "Mainstream browse pages", class: 'control-label' %>
           <%= f.select :mainstream_browse_pages,

--- a/app/views/shared/_tagging.html.erb
+++ b/app/views/shared/_tagging.html.erb
@@ -95,11 +95,12 @@
         </div>
 
         <div class="form-group">
-          <label>
-            Related content items
-          </label>
-
           <fieldset data-module="related-content-items-select">
+            <legend class="remove-bottom-margin">
+              <label for="add-related-item">
+                Related content items
+              </label>
+            </legend>
             <ul class="list-unstyled js-list-sortable js-base-path-list">
             <% Array(@tagging_update.ordered_related_items).each do |related_item| %>
               <li>

--- a/app/views/shared/_unpublish.html.erb
+++ b/app/views/shared/_unpublish.html.erb
@@ -9,7 +9,7 @@
 
 <div class="well">
   <%= form_tag("/editions/#{@resource.id}/process_unpublish", method: "post") do %>
-    <h3 class="remove-top-margin add-bottom-margin">Unpublish</h3>
+    <h2 class="remove-top-margin add-bottom-margin">Unpublish</h2>
     <div class="form-group">
       <label>Redirect to</label>
       <span class="normal">

--- a/app/views/shared/_unpublish.html.erb
+++ b/app/views/shared/_unpublish.html.erb
@@ -3,7 +3,7 @@
     Warning
   </div>
   <div class="callout-body">
-    Unpublish a page from GOV.UK. This can’t be undone.
+    Unpublishing a page from GOV.UK can not be undone.
   </div>
 </div>
 
@@ -11,7 +11,7 @@
   <%= form_tag("/editions/#{@resource.id}/process_unpublish", method: "post") do %>
     <h2 class="remove-top-margin add-bottom-margin">Unpublish</h2>
     <div class="form-group">
-      <label>Redirect to</label>
+      <label for="redirect_url">Redirect to</label>
       <span class="normal">
         For example: <code>https://www.gov.uk/redirect-to-replacement-page</code>
       </span>

--- a/app/views/shared/_unpublish.html.erb
+++ b/app/views/shared/_unpublish.html.erb
@@ -3,7 +3,7 @@
     Warning
   </div>
   <div class="callout-body">
-    Unpublishing a page from GOV.UK can not be undone.
+    If you unpublish a page from GOV.UK it cannot be undone.
   </div>
 </div>
 

--- a/app/views/simple_smart_answers/_fields.html.erb
+++ b/app/views/simple_smart_answers/_fields.html.erb
@@ -1,6 +1,10 @@
 <div class="row">
   <div class="col-md-8">
     <fieldset class="inputs">
+      <legend class="remove-bottom-margin">
+        <h2 class="remove-top-margin add-bottom-margin h3">Edit Simple smart answer</h2>
+      </legend>
+
       <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
       <div class="row">
         <div class="col-md-10">

--- a/app/views/simple_smart_answers/_fields.html.erb
+++ b/app/views/simple_smart_answers/_fields.html.erb
@@ -20,11 +20,17 @@
 <div class="builder-container">
   <div class="row">
     <div class="col-md-8">
-    <label for="edition_start_button_text" class="control-label">Start button text:</label><br>
-      <% ["Start now", "Continue", "Find contact details", "Next"].each do |option| %>
-        <%= f.radio_button :start_button_text, option, disabled: @resource.locked_for_edits? %>
-        <%= f.label "start_button_text_#{option.gsub(" ","_").underscore}", option, class: "control-label input-md-3" %><br>
-      <% end %>
+      <div class="form-group">
+        <fieldset>
+          <legend class="remove-bottom-margin">
+            <p>Start button text:</p>
+          </legend>
+          <% ["Start now", "Continue", "Find contact details", "Next"].each do |option| %>
+            <%= f.radio_button :start_button_text, option, disabled: @resource.locked_for_edits? %>
+            <%= f.label "start_button_text_#{option.gsub(" ","_").underscore}", option, class: "control-label input-md-3" %><br>
+          <% end %>
+        </fieldset>
+      </div>
       <br>
     </div>
   </div>

--- a/app/views/simple_smart_answers/_node.html.erb
+++ b/app/views/simple_smart_answers/_node.html.erb
@@ -28,13 +28,13 @@
         <div class="form-inline form-group<%= o.object.errors.empty? ? '' : ' error' %>">
           <div class="row">
             <div class="form-group col-md-3">
-              <%= f.label :label, for: "edition_nodes_attributes_#{o.options[:parent_builder].index}_options_attributes_#{o.index}_label" %>
+              <%= f.label :label, "Answer #{o.index.to_i + 1}",for: "edition_nodes_attributes_#{o.options[:parent_builder].index}_options_attributes_#{o.index}_label" %>
               <%= o.text_field :label, class: "option-label form-control" %>
               <%= form_errors(o.object.errors[:label]) %>
             </div>
 
             <div class="form-group col-md-6">
-              <%= f.label :next_node, "Node", for: "edition_nodes_attributes_#{o.options[:parent_builder].index}_options_attributes_#{o.index}_node" %>
+              <%= f.label :next_node, "Next question for user", for: "edition_nodes_attributes_#{o.options[:parent_builder].index}_options_attributes_#{o.index}_node" %>
               <%= o.hidden_field :next_node, class: "next-node-id" %>
               <select id="edition_nodes_attributes_<%= o.options[:parent_builder].index %>_options_attributes_<%= o.index %>_node" class="form-control required next-node-list" name="next-node-list">
                 <option value="" class="default">Select a node..</option>

--- a/app/views/simple_smart_answers/_node.html.erb
+++ b/app/views/simple_smart_answers/_node.html.erb
@@ -7,14 +7,16 @@
 
   <div class="form-group">
     <div class="form-wrapper">
-      <%= f.text_field :title, placeholder: "The title of the outcome", class: "node-title form-control" %>
+      <%= f.label :title, "Title" %>
+      <%= f.text_field :title, class: "node-title form-control" %>
     </div>
     <%= form_errors(f.object.errors[:title]) %>
   </div>
 
   <div class="form-group">
     <span class="form-wrapper">
-      <%= f.text_area :body, rows: 10, placeholder: "Optional extra information", class: "node-body form-control" %>
+      <%= f.label :body, "Optional extra information" %>
+      <%= f.text_area :body, rows: 10, class: "node-body form-control" %>
     </span>
   </div>
 
@@ -26,13 +28,15 @@
         <div class="form-inline form-group<%= o.object.errors.empty? ? '' : ' error' %>">
           <div class="row">
             <div class="form-group col-md-3">
-              <%= o.text_field :label, placeholder: "Label", class: "option-label form-control" %>
+              <%= f.label :label, for: "edition_nodes_attributes_#{o.options[:parent_builder].index}_options_attributes_#{o.index}_label" %>
+              <%= o.text_field :label, class: "option-label form-control" %>
               <%= form_errors(o.object.errors[:label]) %>
             </div>
 
             <div class="form-group col-md-6">
+              <%= f.label :next_node, "Node", for: "edition_nodes_attributes_#{o.options[:parent_builder].index}_options_attributes_#{o.index}_node" %>
               <%= o.hidden_field :next_node, class: "next-node-id" %>
-              <select class="form-control required next-node-list" name="next-node-list">
+              <select id="edition_nodes_attributes_<%= o.options[:parent_builder].index %>_options_attributes_<%= o.index %>_node" class="form-control required next-node-list" name="next-node-list">
                 <option value="" class="default">Select a node..</option>
                 <optgroup label="Questions" class="question-list"></optgroup>
                 <optgroup label="Outcomes" class="outcome-list"></optgroup>

--- a/app/views/transactions/_fields.html.erb
+++ b/app/views/transactions/_fields.html.erb
@@ -1,20 +1,25 @@
 <div class="row">
   <div class="col-md-8">
     <fieldset class="inputs">
+      <legend class="remove-bottom-margin">
+        <h2 class="remove-top-margin add-bottom-margin h3">Edit Transaction</h2>
+      </legend>
+
       <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
 
       <%= form_group(f, :introduction, label: "Introductory paragraph", help: "Set the scene for the user. What is about to happen? (eg. \"you will need to fill in a form, print it out and take it to the post office\")") do %>
         <%= f.text_area :introduction, rows: 8, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
       <% end %>
 
-      <div class="form-group">
-        <label for="edition_start_button_text">Start button text:</label><br/>
+      <fieldset>
+        <legend>
+          <p class="start-button-text remove-bottom-margin">Start button text:</p>
+        </legend>
         <% ["Start now", "Sign in"].each do |option| %>
-        <%# radio_button(object_name, method, tag_value, options = {}) %>
           <%= f.radio_button :start_button_text, option, {class: "input-md-7", disabled: @resource.locked_for_edits?} %>
           <%= f.label "start_button_text_#{option.gsub(" ","_").underscore}", option %><br>
         <% end %>
-      </div>
+      </fieldset>
 
       <%= form_group(f, :will_continue_on, help: "Text to follow the statement 'This will continue on. eg. \"the HMRC website\"'") do %>
         <%= f.text_field :will_continue_on, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>

--- a/test/functional/downtimes_controller_test.rb
+++ b/test/functional/downtimes_controller_test.rb
@@ -13,9 +13,9 @@ class DowntimesControllerTest < ActionController::TestCase
       get :index
 
       assert_response :ok
-      assert_select "h4.publication-table-title", count: 0, text: unpublished_transaction_edition.title
+      assert_select "h3.publication-table-title", count: 0, text: unpublished_transaction_edition.title
       transaction_editions.each do |edition|
-        assert_select "h4.publication-table-title", text: edition.title
+        assert_select "h3.publication-table-title", text: edition.title
       end
     end
 

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -70,7 +70,7 @@ class SimpleSmartAnswersTest < JavascriptIntegrationTest
 
       within ".nodes .outcome" do
         assert page.has_content?("Outcome 1")
-        assert page.has_selector?("input.node-title[placeholder='The title of the outcome']")
+        assert page.has_content?("Title")
         assert page.has_selector?("textarea.node-body")
       end
     end


### PR DESCRIPTION
## Description

I've worked through each page of the application and have fixed issues flagged by Wave. This is largely fairly straightforward fixes for things like:

- adding legends/headings to fieldsets
- putting radio buttons in fieldsets
- adding missing labels
- linking labels to inputs
- ensuring headings are sequential
- replacing placeholders with hint text

## Screenshots

A lot of these changes are not visible, but effect how screen readers interact with the page. However, there are quite a few visible changes.

### Downtime index page

While this makes the page accessible it doesn't look great. Maybe it should be a filter off to the side like in specialist? Maybe it's fine as is. Open to suggestions.

|Before|After|
|------------|------------|
|<img width="709" alt="image" src="https://user-images.githubusercontent.com/42515961/157008853-611ccaef-5639-4e54-bb84-f3afe2957aa3.png">|<img width="933" alt="image" src="https://user-images.githubusercontent.com/42515961/157008726-691b998c-15ae-49a4-8f3a-37bacba895c8.png">|

### Edit publication page

#### H2s on nav tabs

I've added H2s for each tab and different type of publication. Some pages had them and some were missing so it's consistent now. I'll just add a couple of examples, but if you look locally you'll see them on each tab and for each type of publication.

|Before|After|
|------------|------------|
|<img width="582" alt="image" src="https://user-images.githubusercontent.com/42515961/157012757-5a3ad28d-fa4e-418a-bbdc-722eb930c7ad.png">|<img width="612" alt="image" src="https://user-images.githubusercontent.com/42515961/157012535-d98036bf-93bf-4369-9d9d-aa78a67bdf62.png">|

|Before|After|
|------------|------------|
|<img width="562" alt="image" src="https://user-images.githubusercontent.com/42515961/157012703-ef7ae751-ef1c-4639-bf94-e560b5767d0d.png">|<img width="553" alt="image" src="https://user-images.githubusercontent.com/42515961/157012590-30ea5789-4115-41a1-83fd-c72bab0cbcf6.png">|

#### Simple smart answers

There are no labels for any of the inputs in the questions and outcome sections

Question

I wonder if the text should be 'label 1, label 2'  etc. and the same with nodes? wdyt?

|Before|After| 
|------------|------------|
|<img width="829" alt="image" src="https://user-images.githubusercontent.com/42515961/157013583-d91cad5e-a33c-46f3-aa61-98fabe3813ae.png">|<img width="805" alt="image" src="https://user-images.githubusercontent.com/42515961/158435908-0091878e-c702-4c3b-8eb4-8af6e09c4aac.png">|

Outcome
|Before|After| 
|------------|------------|
|<img width="661" alt="image" src="https://user-images.githubusercontent.com/42515961/157013638-a9e59e17-59cd-47e3-bd1a-803b06a7dfd1.png">|<img width="649" alt="image" src="https://user-images.githubusercontent.com/42515961/157013710-79adc2b2-bf2e-4fca-9a6e-12a7473a756d.png">|


### Trello card

https://trello.com/c/1lMcyxjF/245-fix-accessibility-issues-mainstream

### Guidance for review

I've tried to keep the changes on each page in separate commits so it's easier to review. I'll squash them down before merge.

Error messaging is out of scope for this PR

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
