### PR TITLE
Add skip link component from GOV.UK Design System

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,3 +18,6 @@
 // Pages
 @import 'downtime';
 @import 'smart_answer_builder';
+
+// GOVUK Design System
+@import "govuk_publishing_components/all_components";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,8 @@
   <%= yield :extra_headers %>
 <% end %>
 
+<%= render "govuk_publishing_components/components/skip_link" %>
+
 <% content_for :navbar_items do %>
   <%= nav_link 'Publications', root_path %>
 
@@ -23,25 +25,27 @@
 <% end %>
 
 <% content_for :content do %>
-  <% [:success, :info, :warning, :danger, :notice, :alert].select { |k| flash[k].present? }.each do |k| %>
-    <%
-      case k
-      when :notice
-        alert_class = "success"
-      when :alert
-        alert_class = "danger"
-      else
-        alert_class = k
-      end
-    %>
-    <div class="alert alert-<%= alert_class %>"
-      data-module="auto-track-event"
-      data-track-action="alert-<%= alert_class %>"
-      data-track-label="<%= strip_tags(flash[k]) %>">
-        <%= flash[k] %>
-    </div>
-  <% end %>
-  <%= yield %>
+  <div id="main-content">
+    <% [:success, :info, :warning, :danger, :notice, :alert].select { |k| flash[k].present? }.each do |k| %>
+      <%
+        case k
+        when :notice
+          alert_class = "success"
+        when :alert
+          alert_class = "danger"
+        else
+          alert_class = k
+        end
+      %>
+      <div class="alert alert-<%= alert_class %>"
+        data-module="auto-track-event"
+        data-track-action="alert-<%= alert_class %>"
+        data-track-label="<%= strip_tags(flash[k]) %>">
+          <%= flash[k] %>
+      </div>
+    <% end %>
+    <%= yield %>
+  </div>
 <% end %>
 
 <% content_for :footer_version, CURRENT_RELEASE_SHA %>


### PR DESCRIPTION
### Description 

This does the bare minimum work to use the skip link component from the GOV.UK Design system.

It simply adds the design system and renders the component in the application view.

If we want to use further components, we will likely have to add in more configuration.

<img width="903" alt="image" src="https://user-images.githubusercontent.com/42515961/157003222-6a221f5a-96a6-46f4-adea-50513011fb89.png">

### Trello card 

https://trello.com/c/1lMcyxjF/245-fix-accessibility-issues-mainstream

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
