### PR TITLE
Ensure errors have links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ group :test do
   gem "database_cleaner"
   gem "factory_bot_rails"
   gem "govuk-content-schema-test-helpers"
+  gem "launchy"
   gem "minitest-reporters"
   gem "mocha"
   gem "rails-controller-testing"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,6 +251,8 @@ GEM
     kgio (2.11.4)
     kramdown (2.3.1)
       rexml
+    launchy (2.5.0)
+      addressable (~> 2.7)
     link_header (0.0.8)
     logstasher (2.1.5)
       activesupport (>= 5.2)
@@ -550,6 +552,7 @@ DEPENDENCIES
   jquery-ui-rails
   kaminari
   kaminari-mongoid
+  launchy
   mail-notify
   minitest-reporters
   mlanett-redis-lock

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@
 @import 'notes';
 @import 'workflow';
 @import 'broken_links_report';
+@import 'error_summary';
 
 // Pages
 @import 'downtime';

--- a/app/assets/stylesheets/error_summary.scss
+++ b/app/assets/stylesheets/error_summary.scss
@@ -1,0 +1,11 @@
+.error-summary {
+  ul {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  li a {
+    text-decoration: underline;
+  }
+}

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -30,9 +30,9 @@ class EditionsController < InheritedResources::Base
 
     @tagging_update = tagging_update_form
     @artefact = @resource.artefact
-
     render action: "show"
   end
+
   alias_method :metadata, :show
   alias_method :history, :show
   alias_method :admin, :show
@@ -55,7 +55,7 @@ class EditionsController < InheritedResources::Base
       redirect_to edition_path(@publication)
     else
       setup_view_paths_for(@publication)
-      render action: "new"
+      render template: "new"
     end
   end
 
@@ -112,7 +112,6 @@ class EditionsController < InheritedResources::Base
         @tagging_update = tagging_update_form
         @linkables = Tagging::Linkables.new
         @artefact = @resource.artefact
-        flash.now[:danger] = format_failure_message(resource)
         render action: "show"
       end
       success.json do
@@ -311,7 +310,8 @@ protected
         promotion_choice_opt_in_url
         promotion_choice_opt_out_url
       ]
-    else # answer_edition, help_page_edition
+    else
+      # answer_edition, help_page_edition
       [
         :body,
       ]
@@ -405,13 +405,6 @@ private
       meets_user_needs: [],
       ordered_related_items: [],
     ).to_h
-  end
-
-  def format_failure_message(resource)
-    resource_base_errors = resource.errors[:base]
-    return resource.errors[:base].join("<br />") if resource_base_errors.present?
-
-    "We had some problems saving. Please check the form below."
   end
 
   def progress_edition(resource, activity_params)

--- a/app/helpers/error_summary_helper.rb
+++ b/app/helpers/error_summary_helper.rb
@@ -1,0 +1,75 @@
+module ErrorSummaryHelper
+  def errors_to_display(edition)
+    case edition
+    when SimpleSmartAnswerEdition
+      smart_answer_errors(edition)
+    when GuideEdition
+      guide_errors(edition)
+    else
+      edition_errors(edition)
+    end
+  end
+
+private
+
+  def edition_errors(edition)
+    top_level_errors(edition).map { |error, href| [error.message, href] }
+  end
+
+  def top_level_errors(edition)
+    edition.errors.map { |error| [error, "#edition_#{error.attribute}"] }
+  end
+
+  def smart_answer_errors(smart_answer)
+    edition_errors = top_level_errors(smart_answer)
+
+    nested_errors = []
+
+    smart_answer.nodes.each do |node|
+      node.errors.each do |error|
+        nested_errors << [error, href_for_node(node, error.attribute)]
+      end
+
+      node.options.each do |option|
+        option.errors.each do |error|
+          nested_errors << [error, href_for_option(option, node, error.attribute)]
+        end
+      end
+    end
+
+    # Errors with attributes of options or nodes will be an error for a option / node as a whole (rather than the individual field) and not helpful
+    # Errors with an attribute of 'slug' will be slugs which are derived, rather than being input explicitly, so are not useful error messages
+    (edition_errors + nested_errors)
+      .reject { |error, _| %i[nodes options slug].include?(error.attribute) }
+      .map { |error, href| [error.message, href] }
+  end
+
+  def guide_errors(guide)
+    edition_errors = top_level_errors(guide)
+
+    parts_errors = []
+
+    guide.parts.each do |part|
+      part.errors.each do |error|
+        parts_errors << [error, href_for_part(part, error.attribute)]
+      end
+    end
+
+    (edition_errors + parts_errors)
+      .reject { |error, _| error.attribute == :parts } # Errors with attributes of parts will be an error for a part as a whole (rather than the individual field) and not helpful
+      .map { |error, href| [error.message, href] }
+  end
+
+  def href_for_node(node, attribute)
+    "#edition_nodes_attributes_#{node.order - 1}_#{attribute}"
+  end
+
+  def href_for_option(option, node, attribute)
+    attr = attribute == :next_node ? "node" : attribute
+    "#edition_nodes_attributes_#{node.order - 1}_options_attributes_#{node.options.find_index(option)}_#{attr}"
+  end
+
+  def href_for_part(part, attribute)
+    "#edition_parts_attributes_#{part.guide_edition.parts.find_index(part)}_#{attribute}"
+  end
+end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -18,7 +18,7 @@ module FormHelper
       errors = form_errors(errors)
       help = tag.div(class: "help-block") { help } if help
 
-      safe_join([wrapped_label, wrapped_field, errors, help])
+      safe_join([wrapped_label, help, errors, wrapped_field])
     end
   end
 

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,7 +1,9 @@
 module FormHelper
-  def form_errors(errors)
-    tag.ul(class: %w[help-block error-block]) do
-      safe_join(errors.map { |e| tag.li(e) })
+  def form_errors(errors, field_name)
+    tag.div(id: "error-#{field_name.to_s.dasherize}") do
+      tag.ul(class: %w[help-block error-block]) do
+        safe_join(errors.map { |e| tag.li(e) })
+      end
     end
   end
 
@@ -15,7 +17,7 @@ module FormHelper
     tag.div(**attributes) do
       wrapped_label = tag.div(class: "form-label") { form_label_element(form, field_name, label) }
       wrapped_field = tag.div(class: "form-wrapper", &block)
-      errors = form_errors(errors)
+      errors = form_errors(errors, field_name)
       help = tag.div(class: "help-block") { help } if help
 
       safe_join([wrapped_label, help, errors, wrapped_field])

--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -94,9 +94,9 @@ class Artefact
   before_update :record_update_action
   after_update :update_editions
 
-  validates :name, presence: true
-  validates :slug, presence: true, uniqueness: true, slug: true
-  validates :kind, inclusion: { in: ->(_x) { FORMATS } }
+  validates :name, presence: { message: "Enter a title" }
+  validates :slug, presence: { message: "Enter a slug" }, uniqueness: true, slug: true
+  validates :kind, inclusion: { in: ->(_x) { FORMATS }, message: "Select a format" }
   validates :state, inclusion: { in: %w[draft live archived] }
   validates :owning_app, presence: true
   validates :language, inclusion: { in: %w[en cy] }

--- a/app/models/downtime.rb
+++ b/app/models/downtime.rb
@@ -8,9 +8,9 @@ class Downtime
 
   belongs_to :artefact, optional: true
 
-  validates :message, :start_time, :end_time, :artefact, presence: true
-  validate :end_time_is_in_future, on: :create
   validate :start_time_precedes_end_time
+  validate :end_time_is_in_future, on: :create
+  validates :message, :start_time, :end_time, :artefact, presence: true
 
   def self.for(artefact)
     where(artefact_id: artefact.id).first
@@ -27,10 +27,10 @@ class Downtime
 private
 
   def end_time_is_in_future
-    errors.add(:end_time, "must be in the future") if end_time && !end_time.future?
+    errors.add(:end_time, "End time must be in the future") if end_time && !end_time.future?
   end
 
   def start_time_precedes_end_time
-    errors.add(:start_time, "must be earlier than end time") if start_time && end_time && start_time >= end_time
+    errors.add(:start_time, "Start time must be earlier than end time") if start_time && end_time && start_time >= end_time
   end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -105,7 +105,7 @@ class Edition
     HelpPageEdition
   ].freeze
 
-  validates :title, presence: true
+  validates :title, presence: { message: "Enter a title" }
   validates :version_number, presence: true, uniqueness: { scope: :panopticon_id }
   validates :panopticon_id, presence: true
   validates_with SafeHtml

--- a/app/models/guide_edition.rb
+++ b/app/models/guide_edition.rb
@@ -6,7 +6,7 @@ class GuideEdition < Edition
 
   strip_attributes only: :video_url
 
-  field :video_url,     type: String
+  field :video_url, type: String
   field :video_summary, type: String
   field :hide_chapter_navigation, type: Boolean
 

--- a/app/models/licence_edition.rb
+++ b/app/models/licence_edition.rb
@@ -9,9 +9,9 @@ class LicenceEdition < Edition
 
   GOVSPEAK_FIELDS = [:licence_overview].freeze
 
-  validates :licence_identifier, presence: true
+  validates :licence_identifier, presence: { message: "Enter a licence identifier" }
   validate :licence_identifier_unique
-  validates :continuation_link, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]), allow_blank: true }
+  validates :continuation_link, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]), allow_blank: true, message: "Continuation link is invalid" }
 
   def whole_body
     [licence_short_description, licence_overview].join("\n\n")
@@ -29,7 +29,7 @@ private
       :licence_identifier => licence_identifier,
       :panopticon_id.ne => panopticon_id,
     ).any?
-      errors.add(:licence_identifier, :taken)
+      errors.add(:licence_identifier, "Licence identifier is already taken")
     end
   end
 end

--- a/app/models/local_transaction_edition.rb
+++ b/app/models/local_transaction_edition.rb
@@ -21,12 +21,14 @@ class LocalTransactionEdition < Edition
 
   GOVSPEAK_FIELDS = %i[introduction more_information need_to_know].freeze
 
-  validate :valid_lgsl_code
-  validates :lgil_code, numericality: { only_integer: true, message: "can only be whole number between 0 and 999." }
+  validate :valid_lgsl_code, if: -> { lgsl_code.present? }
+  validates :lgil_code, presence: { message: "Enter a LGIL code" }
+  validates :lgsl_code, presence: { message: "Enter a LGSL code" }
+  validates :lgil_code, numericality: { only_integer: true, message: "LGIL code can only be a whole number between 0 and 999" }, if: -> { lgil_code.present? }
 
   def valid_lgsl_code
     unless service
-      errors.add(:lgsl_code, "#{lgsl_code} not recognised")
+      errors.add(:lgsl_code, "LGSL code is not recognised")
     end
   end
 

--- a/app/models/part.rb
+++ b/app/models/part.rb
@@ -16,10 +16,19 @@ class Part
 
   GOVSPEAK_FIELDS = [:body].freeze
 
-  validates :title, presence: true
-  validates :slug, presence: true
+  validate :validate_title_is_present, :validate_slug_is_present
   validates :slug, exclusion: { in: %w[video], message: "Can not be video" }
-  validates :slug, format: { with: /\A[a-z0-9\-]+\Z/i, message: "can only consist of lower case characters, numbers and hyphens" }
+  validates :slug, format: { with: /\A[a-z0-9\-]+\Z/i, message: "Slug can only consist of lower case characters, numbers and hyphens" }
   validates_with SafeHtml
   validates_with LinkValidator
+
+private
+
+  def validate_title_is_present
+    errors.add(:title, "Enter a title for Part #{guide_edition.parts.find_index(self) + 1}") if title.blank?
+  end
+
+  def validate_slug_is_present
+    errors.add(:slug, "Enter a slug for Part #{guide_edition.parts.find_index(self) + 1}") if slug.blank?
+  end
 end

--- a/app/models/simple_smart_answer_edition/node.rb
+++ b/app/models/simple_smart_answer_edition/node.rb
@@ -23,7 +23,8 @@ class SimpleSmartAnswerEdition < Edition
       outcome
     ].freeze
 
-    validates :title, :kind, presence: true
+    validate :title_is_present
+    validates :kind, presence: true
     validates :kind, inclusion: { in: KINDS }
     validates :slug, presence: true, format: { with: /\A[a-z0-9-]+\z/ }
 
@@ -34,6 +35,10 @@ class SimpleSmartAnswerEdition < Edition
 
     def outcomes_have_no_options
       errors.add(:options, "cannot be added for an outcome") if options.present? && options.any? && kind == "outcome"
+    end
+
+    def title_is_present
+      errors.add(:title, "Enter a title for #{slug.humanize.gsub('-', ' ')}") if title.blank?
     end
   end
 end

--- a/app/models/simple_smart_answer_edition/node/option.rb
+++ b/app/models/simple_smart_answer_edition/node/option.rb
@@ -14,8 +14,9 @@ class SimpleSmartAnswerEdition < Edition
 
       default_scope -> { order_by(order: :asc) }
 
-      validates :label, :next_node, presence: true
-      validates :slug, format: { with: /\A[a-z0-9-]+\z/, message: "can only consist of lower case characters, numbers and hyphens" }
+      validate :validate_label_is_present
+      validate :validate_node_is_selected
+      validates :slug, format: { with: /\A[a-z0-9-]+\z/, message: "Slug can only consist of lower case characters, numbers and hyphens" }
 
       before_validation :populate_slug
 
@@ -25,6 +26,22 @@ class SimpleSmartAnswerEdition < Edition
         if label.present? && !slug_changed?
           self.slug = ActiveSupport::Inflector.parameterize(label)
         end
+      end
+
+      def question_number_string
+        node.slug.humanize.gsub("-", " ")
+      end
+
+      def option_number_string
+        "Option #{node.options.find_index(self) + 1}"
+      end
+
+      def validate_label_is_present
+        errors.add(:label, "Enter a label for #{question_number_string}, #{option_number_string}") if label.blank?
+      end
+
+      def validate_node_is_selected
+        errors.add(:next_node, "Select a node for #{question_number_string}, #{option_number_string}") if next_node.blank?
       end
     end
   end

--- a/app/models/transaction_edition.rb
+++ b/app/models/transaction_edition.rb
@@ -17,7 +17,7 @@ class TransactionEdition < Edition
 
   GOVSPEAK_FIELDS = %i[introduction more_information alternate_methods need_to_know].freeze
 
-  validates :department_analytics_profile, format: { with: /UA-\d+-\d+/i, allow_blank: true }
+  validates :department_analytics_profile, format: { with: /UA-\d+-\d+/i, allow_blank: true, message: "Invalid format for service analytics profile: must be in format UA-xxxxx-x where xs are digits" }
   validates :start_button_text, presence: true
   validates_with SafeHtml
 

--- a/app/models/variant.rb
+++ b/app/models/variant.rb
@@ -23,7 +23,7 @@ class Variant
   validates :title, presence: true
   validates :slug, presence: true
   validates :slug, exclusion: { in: %w[video], message: "Can not be video" }
-  validates :slug, format: { with: /\A[a-z0-9\-]+\Z/i, message: "can only consist of lower case characters, numbers and hyphens" }
+  validates :slug, format: { with: /\A[a-z0-9\-]+\Z/i, message: "Slug can only consist of lower case characters, numbers and hyphens" }
   validates_with SafeHtml
   validates_with LinkValidator
 end

--- a/app/views/artefacts/new.html.erb
+++ b/app/views/artefacts/new.html.erb
@@ -5,15 +5,7 @@
       <h1><%= yield :page_title %></h1>
     </legend>
 
-    <% if @artefact.errors.count > 0 %>
-      <div class="alert alert-danger">
-        <ul>
-          <% @artefact.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
+<%= render :partial => 'shared/error_summary', locals: { object: @artefact} %>
 
     <div class="row">
       <div class="col-md-12">

--- a/app/views/downtimes/_form.html.erb
+++ b/app/views/downtimes/_form.html.erb
@@ -1,10 +1,6 @@
 <%= f.hidden_field :artefact_id %>
 
-<% if @downtime.errors.any? %>
-   <p class="alert alert-danger">
-     Errors: <%= @downtime.errors.full_messages.to_sentence %>
-   </p>
-<% end %>
+<%= render :partial => 'shared/error_summary', locals: { object: @downtime} %>
 
 <div class="downtime-dates">
   <div class="form-group">

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -1,5 +1,20 @@
 <% @edition = @resource %>
   <%= render 'shared/edition_header' %>
+
+  <% errors_hash = errors_to_display(@edition) %>
+  <% if !errors_hash.empty? %>
+    <div id="error-summary" class="alert alert-danger error-summary">
+      <h2 class="add-bottom-margin">There is a problem</h2>
+      <ul>
+        <% errors_hash.each do |error_message, html_ref| %>
+          <li>
+            <a href="<%= html_ref %>"><%= error_message %></a>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
   <div class="tabbable" data-module="tab-switcher" role="tabpanel">
     <ul class="nav nav-tabs" role="tablist">
       <% tabs_for(current_user, @edition).each do |tab| %>

--- a/app/views/licences/new.html.erb
+++ b/app/views/licences/new.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, "New Licence" %>
+
 <div class="page-header">
   <h1>New Licence</h1>
 </div>

--- a/app/views/licences/new.html.erb
+++ b/app/views/licences/new.html.erb
@@ -8,11 +8,7 @@
   We need a bit more information to create your licence.
 </p>
 
-<% if @publication.errors.any? %>
-   <p class="alert alert-danger">
-     Errors: <%= @publication.errors.full_messages.uniq.to_sentence %>
-   </p>
-<% end %>
+<%= render :partial => 'shared/error_summary', locals: { object: @publication } %>
 
 <%= form_for(@publication, :url => editions_path, :as => :edition, :html => { :id => 'edition-form' } ) do |f| %>
   <%= form_group(f, :licence_identifier) do %>

--- a/app/views/local_transactions/new.html.erb
+++ b/app/views/local_transactions/new.html.erb
@@ -1,3 +1,5 @@
+<%= content_for :page_title, "New Local Transaction" %>
+
 <div class="page-header">
   <h1>New Local Transaction</h1>
 </div>

--- a/app/views/local_transactions/new.html.erb
+++ b/app/views/local_transactions/new.html.erb
@@ -7,11 +7,7 @@
   We need a bit more information to create your local transaction.
 </p>
 
-<% if @publication.errors.any? %>
-  <p class="alert alert-danger">
-    Errors: <%= @publication.errors.full_messages.uniq.to_sentence %>
-  </p>
-<% end %>
+<%= render :partial => 'shared/error_summary', locals: { object: @publication} %>
 
 <%= form_for(@publication, as: :edition, url: editions_path, html: { id: 'edition-form', novalidate: 'novalidate' } ) do |f| %>
   <fieldset class="inputs">

--- a/app/views/shared/_error_summary.html.erb
+++ b/app/views/shared/_error_summary.html.erb
@@ -1,0 +1,13 @@
+<% if object.errors.any? %>
+  <div id="error-summary" class="alert alert-danger error-summary">
+    <h2 class="add-bottom-margin">There is a problem</h2>
+    <ul>
+      <% object.errors.each do |error| %>
+      <li>
+        <% model = object.class.superclass.to_s == "Object" ? object.class : object.class.superclass %>
+        <a href="#<%= model.to_s.underscore + "_" + error.attribute.to_s %>"><%= error.message %></a>
+      </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/simple_smart_answers/_node.html.erb
+++ b/app/views/simple_smart_answers/_node.html.erb
@@ -8,9 +8,9 @@
   <div class="form-group">
     <div class="form-wrapper">
       <%= f.label :title, "Title" %>
+      <%= form_errors(f.object.errors[:title], "title") %>
       <%= f.text_field :title, class: "node-title form-control" %>
     </div>
-    <%= form_errors(f.object.errors[:title]) %>
   </div>
 
   <div class="form-group">
@@ -29,19 +29,19 @@
           <div class="row">
             <div class="form-group col-md-3">
               <%= f.label :label, "Answer #{o.index.to_i + 1}",for: "edition_nodes_attributes_#{o.options[:parent_builder].index}_options_attributes_#{o.index}_label" %>
+              <%= form_errors(o.object.errors[:label], "label") %>
               <%= o.text_field :label, class: "option-label form-control" %>
-              <%= form_errors(o.object.errors[:label]) %>
             </div>
 
             <div class="form-group col-md-6">
               <%= f.label :next_node, "Next question for user", for: "edition_nodes_attributes_#{o.options[:parent_builder].index}_options_attributes_#{o.index}_node" %>
               <%= o.hidden_field :next_node, class: "next-node-id" %>
+              <%= form_errors(o.object.errors[:next_node], "node") %>
               <select id="edition_nodes_attributes_<%= o.options[:parent_builder].index %>_options_attributes_<%= o.index %>_node" class="form-control required next-node-list" name="next-node-list">
                 <option value="" class="default">Select a node..</option>
                 <optgroup label="Questions" class="question-list"></optgroup>
                 <optgroup label="Outcomes" class="outcome-list"></optgroup>
               </select>
-              <%= form_errors(o.object.errors[:next_node]) %>
             </div>
 
             <div class="form-group col-md-3">

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -341,16 +341,6 @@ class EditionsControllerTest < ActionController::TestCase
       assert_response 200
     end
 
-    should "show the resource base errors if present" do
-      Edition.expects(:find).returns(@guide)
-      @guide.stubs(:update).returns(false)
-      @guide.errors.add(:base, "Editions scheduled for publishing can't be edited")
-
-      post :update, params: { id: @guide.id, edition: {} }
-
-      assert_equal "Editions scheduled for publishing can't be edited", flash[:danger]
-    end
-
     should "save the edition changes while performing an activity" do
       post :update,
            params: {

--- a/test/integration/add_artefact_test.rb
+++ b/test/integration/add_artefact_test.rb
@@ -17,7 +17,14 @@ class AddArtefactTest < ActionDispatch::IntegrationTest
 
     click_button "Save and go to item"
 
-    assert page.has_content?("Help page slugs must have a help/ prefix")
+    within "#error-summary" do
+      assert page.has_content?("There is a problem")
+      assert page.has_link?("Help page slugs must have a help/ prefix", href: "#artefact_slug")
+    end
+
+    within "#error-slug" do
+      assert page.has_content?("Help page slugs must have a help/ prefix")
+    end
 
     fill_in "Slug", with: "help/thingy"
 

--- a/test/integration/adding_parts_to_guides_test.rb
+++ b/test/integration/adding_parts_to_guides_test.rb
@@ -139,14 +139,14 @@ class AddingPartsToGuidesTest < JavascriptIntegrationTest
         within :css, "#parts div.fields:nth-of-type(2)" do
           assert page.has_css?('.has-error[id*="slug"]')
           assert page.has_css?(".has-error li", count: 2)
-          assert page.has_css?(".has-error li", text: "can't be blank")
-          assert page.has_css?(".has-error li", text: "can only consist of lower case characters, numbers and hyphens")
+          assert page.has_css?(".has-error li", text: "Enter a slug for Part 2")
+          assert page.has_css?(".has-error li", text: "Slug can only consist of lower case characters, numbers and hyphens")
         end
 
         within :css, "#parts div.fields:nth-of-type(3)" do
           assert page.has_css?('.has-error[id*="title"]')
           assert page.has_css?(".has-error li", count: 1)
-          assert page.has_css?(".has-error li", text: "can't be blank")
+          assert page.has_css?(".has-error li", text: "Enter a title for Part 3")
         end
       end
     end

--- a/test/integration/adding_variants_to_transactions_test.rb
+++ b/test/integration/adding_variants_to_transactions_test.rb
@@ -143,7 +143,7 @@ class AddingVariantsToTransactionsTest < JavascriptIntegrationTest
           assert page.has_css?('.has-error[id*="slug"]')
           assert page.has_css?(".has-error li", count: 2)
           assert page.has_css?(".has-error li", text: "can't be blank")
-          assert page.has_css?(".has-error li", text: "can only consist of lower case characters, numbers and hyphens")
+          assert page.has_css?(".has-error li", text: "Slug can only consist of lower case characters, numbers and hyphens")
         end
 
         within :css, "#parts div.fields:nth-of-type(3)" do

--- a/test/integration/downtime_integration_test.rb
+++ b/test/integration/downtime_integration_test.rb
@@ -83,6 +83,10 @@ class DowntimeIntegrationTest < JavascriptIntegrationTest
     Time.zone.now.next_year.year
   end
 
+  def date_in_the_past
+    Time.zone.local(Time.zone.now.last_year.year, 1, 1, 12, 0)
+  end
+
   def first_of_july_next_year_at_midday_bst
     Time.zone.local(next_year, 7, 1, 12, 0)
   end

--- a/test/integration/downtime_with_invalid_dates_test.rb
+++ b/test/integration/downtime_with_invalid_dates_test.rb
@@ -1,0 +1,54 @@
+require "integration_test_helper"
+
+class DowntimeWithInvalidDates < ActionDispatch::IntegrationTest
+  setup do
+    setup_users
+
+    @edition = FactoryBot.create(
+      :transaction_edition,
+      :published,
+      title: "Apply to become a driving instructor",
+      slug: "apply-to-become-a-driving-instructor",
+    )
+
+    WebMock.reset!
+    stub_any_publishing_api_put_content
+    stub_any_publishing_api_publish
+  end
+
+  test "Scheduling new downtime with invalid dates" do
+    DowntimeScheduler.stubs(:schedule_publish_and_expiry)
+
+    visit root_path
+    click_link "Downtime"
+    click_link "Apply to become a driving instructor"
+
+    enter_start_time 1.day.ago
+    enter_end_time 1.day.ago - 1.day
+
+    click_button "Schedule downtime message"
+
+    assert page.has_link?("End time must be in the future", href: "#downtime_end_time")
+    assert page.has_link?("Start time must be earlier than end time", href: "#downtime_start_time")
+  end
+
+  def enter_start_time(start_time)
+    complete_date_inputs("downtime_start_time", start_time)
+  end
+
+  def enter_end_time(end_time)
+    complete_date_inputs("downtime_end_time", end_time)
+  end
+
+  def complete_date_inputs(input_id, time)
+    select time.year.to_s, from: "#{input_id}_1i"
+    select time.strftime("%B"), from: "#{input_id}_2i"
+    select time.day.to_s, from: "#{input_id}_3i"
+    select pad_digit_to_two_digits(time.hour.to_s), from: "#{input_id}_4i"
+    select time.strftime("%M"), from: "#{input_id}_5i"
+  end
+
+  def pad_digit_to_two_digits(hour_string)
+    hour_string.length == 1 ? "0#{hour_string}" : hour_string
+  end
+end

--- a/test/integration/edit_artefact_test.rb
+++ b/test/integration/edit_artefact_test.rb
@@ -14,7 +14,7 @@ class EditArtefactTest < ActionDispatch::IntegrationTest
     fill_in "Slug", with: ""
     click_button "Update metadata"
 
-    assert page.has_content?("Slug can't be blank")
+    assert page.has_content?("Enter a slug")
 
     fill_in "Slug", with: "thingy-mc-thingface"
 

--- a/test/integration/edition_major_change_test.rb
+++ b/test/integration/edition_major_change_test.rb
@@ -45,7 +45,7 @@ class EditionMajorChangeTest < JavascriptIntegrationTest
         should "validate that the change note is present for a major change" do
           visit_edition @second_edition
           check("edition_major_change")
-          save_edition_and_assert_error("can't be blank")
+          save_edition_and_assert_error("can't be blank", "#edition_change_note")
 
           fill_in "edition_change_note", with: "Something changed"
           save_edition_and_assert_success

--- a/test/integration/edition_tab_test.rb
+++ b/test/integration/edition_tab_test.rb
@@ -38,7 +38,7 @@ class EditionTabTest < JavascriptIntegrationTest
       assert_tab_active("edit", "Edit")
 
       fill_in "Title", with: ""
-      save_edition_and_assert_error
+      save_edition_and_assert_error("Enter a title", "#edition_title")
       assert_tab_active("edit", "Edit")
     end
 

--- a/test/integration/local_transaction_create_edit_test.rb
+++ b/test/integration/local_transaction_create_edit_test.rb
@@ -41,7 +41,17 @@ class LocalTransactionCreateEditTest < JavascriptIntegrationTest
     fill_in "LGSL code", with: "2"
     click_on "Create Local transaction edition"
 
-    assert page.has_content? "Lgsl code 2 not recognised"
+    assert page.has_link?("LGSL code is not recognised", href: "#edition_lgsl_code")
+  end
+
+  test "creating a local transaction with a bad LGIL code displays an appropriate error" do
+    visit "/publications/#{@artefact.id}"
+    assert page.has_content? "We need a bit more information to create your local transaction."
+
+    fill_in "LGIL code", with: "word"
+    click_on "Create Local transaction edition"
+
+    assert page.has_link?("LGIL code can only be a whole number between 0 and 999", href: "#edition_lgil_code")
   end
 
   test "creating a local transaction requests an LGSL and a LGIL code" do
@@ -98,7 +108,7 @@ class LocalTransactionCreateEditTest < JavascriptIntegrationTest
       visit_edition edition
       fill_in "Title", with: ""
 
-      save_edition_and_assert_error
+      save_edition_and_assert_error("Enter a title", "#edition_title")
     end
   end
 

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -250,6 +250,34 @@ class SimpleSmartAnswersTest < JavascriptIntegrationTest
       end
     end
 
+    should "raise appropriate validation errors" do
+      find("#edition_title").set("")
+
+      click_link("Add outcome")
+
+      save_edition
+
+      within "#error-summary" do
+        assert page.has_content?("Enter a title")
+        assert page.has_content?("Enter a label for Question 1, Option 1")
+        assert page.has_content?("Enter a title for Outcome 1")
+        assert page.has_content?("Enter a title for Question 1")
+        assert page.has_content?("Select a node for Question 1, Option 1")
+        assert_not page.has_content?("is invalid")
+        assert_not page.has_content?("Slug can only consist of lower case characters, numbers and hyphens")
+      end
+
+      within ".nodes .question:first-child" do
+        assert page.has_content?("Enter a title for Question 1")
+        assert page.has_content?("Enter a label for Question 1, Option 1")
+        assert page.has_content?("Select a node for Question 1, Option 1")
+      end
+
+      within ".nodes .outcome:nth-child(2)" do
+        assert page.has_content?("Enter a title for Outcome 1")
+      end
+    end
+
     should "persist a valid smart answer" do
       within ".nodes .question:first-child" do
         find(:css, "input.node-title").set("Which driving licence do you hold?")

--- a/test/integration/transaction_create_edit_test.rb
+++ b/test/integration/transaction_create_edit_test.rb
@@ -75,7 +75,10 @@ class TransactionCreateEditTest < JavascriptIntegrationTest
       visit_edition transaction
 
       fill_in "Service analytics profile", with: "UA-INVALID-SPACE-FLIGHT"
-      save_edition_and_assert_error
+      save_edition_and_assert_error(
+        "Invalid format for service analytics profile: must be in format UA-xxxxx-x where xs are digits",
+        "#edition_department_analytics_profile",
+      )
 
       fill_in "Service analytics profile", with: "UA-00100000-1"
       save_edition_and_assert_success

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -10,7 +10,7 @@ class ActionDispatch::IntegrationTest
   include Warden::Test::Helpers
 
   teardown do
-    Capybara.reset_sessions!    # Forget the (simulated) browser state
+    Capybara.reset_sessions! # Forget the (simulated) browser state
     Capybara.use_default_driver # Revert Capybara.current_driver to Capybara.default_driver
     GDS::SSO.test_user = nil
   end
@@ -19,7 +19,7 @@ class ActionDispatch::IntegrationTest
     # This may not be the right way to do things. We rely on the gds-sso
     # having a strategy that uses the first user. We probably want some
     # tests that cover the oauth interaction properly
-    @author   = FactoryBot.create(:user, :govuk_editor, name: "Author",   email: "test@example.com")
+    @author = FactoryBot.create(:user, :govuk_editor, name: "Author", email: "test@example.com")
     @reviewer = FactoryBot.create(:user, :govuk_editor, name: "Reviewer", email: "test@example.com")
   end
 
@@ -197,10 +197,17 @@ class JavascriptIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  def save_edition_and_assert_error(error = nil)
+  def save_edition_and_assert_error(error_message = nil, link_href_if_javascript_disabled = nil)
     save_edition
-    assert page.has_content? "We had some problems saving"
-    assert page.has_content? error if error.present?
+    if using_javascript?
+      assert page.has_content? "We had some problems saving"
+    else
+      # once we use add in a error summary component this line should be tested with
+      # and without js
+      assert page.has_content? "There is a problem"
+      assert page.has_link? error_message, href: link_href_if_javascript_disabled
+    end
+    assert page.has_content? error_message if error_message.present?
   end
 
   def save_tags_and_assert_success

--- a/test/models/downtime_test.rb
+++ b/test/models/downtime_test.rb
@@ -34,7 +34,7 @@ class DowntimeTest < ActiveSupport::TestCase
       downtime = FactoryBot.build(:downtime, end_time: Time.zone.yesterday)
 
       assert_not downtime.valid?
-      assert_includes downtime.errors[:end_time], "must be in the future"
+      assert_includes downtime.errors[:end_time], "End time must be in the future"
     end
 
     should "validate end time is in future only on create" do
@@ -48,7 +48,7 @@ class DowntimeTest < ActiveSupport::TestCase
       downtime = FactoryBot.build(:downtime, start_time: Time.zone.today + 2, end_time: Time.zone.today + 1)
 
       assert_not downtime.valid?
-      assert_includes downtime.errors[:start_time], "must be earlier than end time"
+      assert_includes downtime.errors[:start_time], "Start time must be earlier than end time"
     end
   end
 

--- a/test/models/parted_test.rb
+++ b/test/models/parted_test.rb
@@ -11,8 +11,8 @@ class PartedTest < ActiveSupport::TestCase
 
     assert_not edition.valid?
 
-    assert_equal({ title: ["can't be blank"] }, edition.errors[:parts][0]["54c10d4d759b743528000010:1"])
-    assert_equal({ slug: ["can't be blank", "can only consist of lower case characters, numbers and hyphens"] }, edition.errors[:parts][0]["54c10d4d759b743528000011:2"])
+    assert_equal({ title: ["Enter a title for Part 1"] }, edition.errors[:parts][0]["54c10d4d759b743528000010:1"])
+    assert_equal({ slug: ["Enter a slug for Part 2", "Slug can only consist of lower case characters, numbers and hyphens"] }, edition.errors[:parts][0]["54c10d4d759b743528000011:2"])
     assert_equal 2, edition.errors[:parts][0].length
   end
 

--- a/test/models/simple_smart_answer_option_test.rb
+++ b/test/models/simple_smart_answer_option_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class SimpleSmartAnswerOptionTest < ActiveSupport::TestCase
   context "given a smart answer exists with a node" do
     setup do
-      @node = SimpleSmartAnswerEdition::Node.new(slug: "question1", title: "Question One?", kind: "question")
+      @node = SimpleSmartAnswerEdition::Node.new(slug: "question1", title: "Question One?", kind: "question", order: 1)
       @edition = FactoryBot.create(
         :simple_smart_answer_edition,
         nodes: [

--- a/test/models/varianted_test.rb
+++ b/test/models/varianted_test.rb
@@ -12,7 +12,7 @@ class VariantedTest < ActiveSupport::TestCase
     assert_not edition.valid?
 
     assert_equal({ title: ["can't be blank"] }, edition.errors[:variants][0]["54c10d4d759b743528000010:1"])
-    assert_equal({ slug: ["can't be blank", "can only consist of lower case characters, numbers and hyphens"] }, edition.errors[:variants][0]["54c10d4d759b743528000011:2"])
+    assert_equal({ slug: ["can't be blank", "Slug can only consist of lower case characters, numbers and hyphens"] }, edition.errors[:variants][0]["54c10d4d759b743528000011:2"])
     assert_equal 2, edition.errors[:variants][0].length
   end
 end

--- a/test/unit/helpers/error_summary_helper_test.rb
+++ b/test/unit/helpers/error_summary_helper_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+
+class ErrorSummaryHelperTest < ActionView::TestCase
+  include ErrorSummaryHelper
+
+  def guide_with_title_and_parts(title, parts)
+    GuideEdition.new(title: title, parts: parts, panopticon_id: "Some_id")
+  end
+
+  context "A Guide Edition" do
+    should "For a Guide, errors_to_display returns useful error messages and correct hrefs for invalid fields" do
+      valid_part = Part.new(title: "some part", slug: "another-slug")
+      invalid_part_1 = Part.new(title: "", slug: "invalid slug with spaces")
+      invalid_part_2 = Part.new(title: "valid title", slug: "another invalid slug")
+
+      guide_with_invalid_data = guide_with_title_and_parts("", [valid_part, invalid_part_1, invalid_part_2])
+
+      guide_with_invalid_data.valid?
+
+      expected_errors = [
+        ["Enter a title", "#edition_title"],
+        ["Enter a title for Part 2", "#edition_parts_attributes_1_title"],
+        ["Slug can only consist of lower case characters, numbers and hyphens", "#edition_parts_attributes_1_slug"],
+        ["Slug can only consist of lower case characters, numbers and hyphens", "#edition_parts_attributes_2_slug"],
+      ]
+
+      assert_equal expected_errors, errors_to_display(guide_with_invalid_data)
+    end
+  end
+
+  context "A Simple Smart Answer" do
+    should "errors_to_display returns useful error messages and correct hrefs for invalid fields" do
+      valid_outcome_node = SimpleSmartAnswerEdition::Node.new(kind: "outcome", title: "Node 1", slug: "node-1", order: 1)
+
+      valid_option = SimpleSmartAnswerEdition::Node::Option.new(next_node: "Node 1", label: "Some label")
+      invalid_option_1 = SimpleSmartAnswerEdition::Node::Option.new(next_node: "Node 1", label: "")
+      invalid_option_2 = SimpleSmartAnswerEdition::Node::Option.new(next_node: "", label: "Another label")
+      question_node_with_valid_and_invalid_options = SimpleSmartAnswerEdition::Node.new(kind: "question", title: "", slug: "node-2", order: 2, options: [valid_option, invalid_option_1, invalid_option_2])
+
+      outcome_node_without_title = SimpleSmartAnswerEdition::Node.new(kind: "outcome", title: "", slug: "node-3", order: 3)
+
+      simple_smart_answer = SimpleSmartAnswerEdition.new(title: "", panopticon_id: "Some_id", nodes: [valid_outcome_node, question_node_with_valid_and_invalid_options, outcome_node_without_title])
+
+      simple_smart_answer.valid?
+
+      expected_errors = [
+        ["Enter a title", "#edition_title"],
+        ["Enter a title for Node 2", "#edition_nodes_attributes_1_title"],
+        ["Enter a label for Node 2, Option 2", "#edition_nodes_attributes_1_options_attributes_1_label"],
+        ["Select a node for Node 2, Option 3", "#edition_nodes_attributes_1_options_attributes_2_node"],
+        ["Enter a title for Node 3", "#edition_nodes_attributes_2_title"],
+      ]
+
+      assert_equal expected_errors, errors_to_display(simple_smart_answer)
+    end
+  end
+
+  context "An Edition without nested fields" do
+    should "For an Edition without nested fields, errors_to_display returns useful error messages and correct hrefs for invalid fields" do
+      invalid_edition = LocalTransactionEdition.new(title: "", panopticon_id: "Some_id", lgil_code: 1.11)
+
+      invalid_edition.valid?
+
+      expected_errors = [
+        ["Enter a title", "#edition_title"],
+        ["Enter a LGSL code", "#edition_lgsl_code"],
+        ["LGIL code can only be a whole number between 0 and 999", "#edition_lgil_code"],
+      ]
+
+      assert_equal expected_errors, errors_to_display(invalid_edition)
+    end
+  end
+end

--- a/test/unit/helpers/form_helper_test.rb
+++ b/test/unit/helpers/form_helper_test.rb
@@ -27,7 +27,7 @@ class FormHelperTest < ActionView::TestCase
       wrapped_field = '<div class="form-wrapper"><input type="text" value="" name="edition[field_name]" id="edition_field_name" /></div>'
       error_block = '<ul class="help-block error-block"></ul>'
 
-      assert_equal %(<div class="form-group">#{label}#{wrapped_field}#{error_block}</div>), output
+      assert_equal %(<div class="form-group">#{label}#{error_block}#{wrapped_field}</div>), output
     end
 
     should "include help text if that is provided" do

--- a/test/unit/helpers/form_helper_test.rb
+++ b/test/unit/helpers/form_helper_test.rb
@@ -3,15 +3,15 @@ require "test_helper"
 class FormHelperTest < ActionView::TestCase
   context "form_errors" do
     should "return an unordered list with errors when there are errors present" do
-      expected = '<ul class="help-block error-block"><li>One</li><li>Two</li><li>Three</li></ul>'
+      expected = '<div id="error-field-name"><ul class="help-block error-block"><li>One</li><li>Two</li><li>Three</li></ul></div>'
 
-      assert_equal expected, form_errors(%w[One Two Three])
+      assert_equal expected, form_errors(%w[One Two Three], "field_name")
     end
 
     should "return an empty unordered list when there are no errors present" do
-      expected = '<ul class="help-block error-block"></ul>'
+      expected = '<div id="error-field-name"><ul class="help-block error-block"></ul></div>'
 
-      assert_equal expected, form_errors([])
+      assert_equal expected, form_errors([], "field_name")
     end
   end
 
@@ -25,7 +25,7 @@ class FormHelperTest < ActionView::TestCase
       output = form_group(@form, :field_name) { @form.text_field(:field_name) }
       label = '<div class="form-label"><label for="edition_field_name">Field name</label></div>'
       wrapped_field = '<div class="form-wrapper"><input type="text" value="" name="edition[field_name]" id="edition_field_name" /></div>'
-      error_block = '<ul class="help-block error-block"></ul>'
+      error_block = '<div id="error-field-name"><ul class="help-block error-block"></ul></div>'
 
       assert_equal %(<div class="form-group">#{label}#{error_block}#{wrapped_field}</div>), output
     end


### PR DESCRIPTION
This PR aims to improve the accessibility of publisher by improving how validation errors are displayed on and work within a page. [Accessibility best practice says](https://www.w3.org/WAI/tutorials/forms/notifications/#listing-errors) that when a validation error occurs on a form, the error messages should be listed at the top of the page and link to the field where the failed validation occurred. The scope of this PR is to fix this for all document types within the app, although the metadata tab for each document type is left for a subsequent PR as this potentially requires a restructuring of the application.

All errors should now:

* Appear under a clear banner at the top of the page, without bullet points
* Be linked to the input where the validation failed
* Have a clear error message that references the label of the input where validation failed
* Also appear above the input where the validation failed



Sample before / after:

|Before|After| 
|------------|------------|
|<img width="500" alt="accessibility-before" src="https://user-images.githubusercontent.com/25515510/158826494-16ba9081-2a30-4b79-b8e3-df3a209cb873.png">|<img width="500" alt="accessibility-after" src="https://user-images.githubusercontent.com/25515510/158826516-a8b2d63c-ebb0-427a-b8b4-4c6debee8635.png">|


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
