### PR TITLE
Add error summary to js pages

### DIFF
--- a/app/assets/javascripts/modules/ajax_save.js
+++ b/app/assets/javascripts/modules/ajax_save.js
@@ -96,6 +96,8 @@
 
         if (typeof responseJSON === 'object') {
           showErrors(responseJSON)
+          destroyErrorSummaryComponent()
+          displayErrorSummaryComponent(responseJSON)
           trackErrors(JSON.stringify(responseJSON))
 
           if (typeof responseJSON.base === 'object') {
@@ -107,6 +109,7 @@
 
         message.addClass('workflow-message-error').removeClass('workflow-message-saving')
         message.html('We had some problems saving. ' + messageAddendum)
+
         hideTimeout = setTimeout(hide, 4000)
 
         // Save errored, form still has unsaved changes
@@ -126,6 +129,54 @@
             list.append('<li>' + errorMessages[j] + '</li>')
           }
         })
+      }
+
+      function displayErrorSummaryComponent (errors) {
+        createErrorSummaryComponent()
+
+        $.each(errors, function (errorKey, errorMessages) {
+          for (var i = 0, m = errorMessages.length; i < m; i++) {
+            if (errorKey !== 'parts' && errorMessages[i] !== 'is invalid') {
+              createAndAppendLinkToErrorSummaryComponent(errorKey, errorMessages[i])
+            }
+          }
+        })
+      }
+
+      function createErrorSummaryComponent () {
+        var heading = document.getElementsByClassName('page-title')[0]
+
+        var div = document.createElement('div')
+        div.id = 'error-summary'
+        div.classList.add('alert', 'alert-danger')
+        heading.after(div)
+
+        var h3 = document.createElement('h3')
+        h3.id = 'error-heading'
+        h3.innerText = 'There is a problem'
+        div.append(h3)
+
+        var ul = document.createElement('ul')
+        ul.classList.add('no-bullets')
+        div.append(ul)
+      }
+
+      function createAndAppendLinkToErrorSummaryComponent (errorKey, errorMessage) {
+        var ul = document.getElementsByClassName('no-bullets')[0]
+        var list = document.createElement('li')
+        var errorLink = document.createElement('a')
+        errorLink.href = '#edition_' + errorKey
+        errorLink.innerText = errorMessage
+        ul.append(list)
+        list.append(errorLink)
+      }
+
+      function destroyErrorSummaryComponent () {
+        var errorSummaryComponent = document.getElementById('error-summary')
+
+        if (errorSummaryComponent != null) {
+          errorSummaryComponent.remove()
+        }
       }
 
       function trackErrors (label) {
@@ -151,6 +202,7 @@
 
       function reset () {
         hideErrors()
+        destroyErrorSummaryComponent()
         clearTimeout(hideTimeout)
         message.removeClass(function (index, css) {
           return (css.match(/(^|\s)workflow-message-\S+/g) || []).join(' ')

--- a/app/assets/javascripts/modules/ajax_save_with_parts.js
+++ b/app/assets/javascripts/modules/ajax_save_with_parts.js
@@ -21,7 +21,6 @@
       function error (evt, response) {
         var responseJSON = response.responseJSON
         var partErrors = typeof responseJSON === 'object' && (responseJSON.parts || responseJSON.variants)
-
         if (partErrors) {
           $.each(partErrors[0], showPartErrors)
         }
@@ -46,8 +45,20 @@
           var list = $errorElement.find('.error-block')
           for (var j = 0, m = messages.length; j < m; j++) {
             list.append('<li>' + messages[j] + '</li>')
+            var elementId = '#' + $errorElement.find('input')[0].id
+            appendPartErrorsToErrorSummaryComponent(elementId, messages[j])
           }
         })
+      }
+
+      function appendPartErrorsToErrorSummaryComponent (elementId, message) {
+        var ul = document.getElementById('error-summary').childNodes[1]
+        var list = document.createElement('li')
+        var errorLink = document.createElement('a')
+        errorLink.href = elementId
+        errorLink.innerText = message
+        ul.append(list)
+        list.append(errorLink)
       }
 
       function updatePart (part) {

--- a/spec/javascripts/spec/ajax_save_with_parts.spec.js
+++ b/spec/javascripts/spec/ajax_save_with_parts.spec.js
@@ -2,7 +2,8 @@ describe('An ajax save with parts module', function () {
   'use strict'
 
   var ajaxSaveWithParts,
-    element
+    element,
+    form
 
   beforeAll(function () {
     // Stub a bootstrap collapse method on jQuery
@@ -18,7 +19,13 @@ describe('An ajax save with parts module', function () {
   })
 
   beforeEach(function () {
-    element = $('<form action="some/url">' +
+    element = $('<div>' +
+      '<div class="page-title"></div>' +
+      '<div id="error-summary">' +
+      '<h3>There is a problem</h3>' +
+      '<ul></ul>' +
+      '</div>' +
+      '<form action="some/url">' +
       '<div class="js-status-message"></div>' +
       '<div class="fields">' +
         '<a href="#" class="js-part-toggle">' +
@@ -83,11 +90,14 @@ describe('An ajax save with parts module', function () {
         '</div>' +
       '</div>' +
       '<input type="submit" class="js-save" value="Save">' +
-    '</form>')
+    '</form>' +
+    '</div>'
+    )
 
     $('body').append(element)
+    form = element.find('form')
     ajaxSaveWithParts = new GOVUKAdmin.Modules.AjaxSaveWithParts()
-    ajaxSaveWithParts.start(element)
+    ajaxSaveWithParts.start(form)
   })
 
   afterEach(function () {
@@ -111,7 +121,7 @@ describe('An ajax save with parts module', function () {
 
   describe('when the form is saved successfully', function () {
     beforeEach(function () {
-      element.trigger('success.ajaxsave.admin', {
+      form.trigger('success.ajaxsave.admin', {
         parts:
         [{ _id: { $oid: '5f00000001' }, order: 1, slug: 'updated-title-1', title: 'Updated title 1' },
           { _id: { $oid: '5f00000002' }, order: 2, slug: 'updated-title-2', title: 'Updated title 2' }]
@@ -119,26 +129,26 @@ describe('An ajax save with parts module', function () {
     })
 
     it('updates the part titles based on their IDs', function () {
-      expect(element.find('.js-part-title').eq(0).text()).toBe('Updated title 1')
-      expect(element.find('.js-part-title').eq(1).text()).toBe('Updated title 2')
+      expect(form.find('.js-part-title').eq(0).text()).toBe('Updated title 1')
+      expect(form.find('.js-part-title').eq(1).text()).toBe('Updated title 2')
     })
 
     it('updates the toggle href and target based on its slug', function () {
-      expect(element.find('.js-part-toggle-target').eq(0).attr('id')).toBe('updated-title-1')
-      expect(element.find('.js-part-toggle-target').eq(1).attr('id')).toBe('updated-title-2')
-      expect(element.find('.js-part-toggle').eq(0).attr('href')).toBe('#updated-title-1')
-      expect(element.find('.js-part-toggle').eq(1).attr('href')).toBe('#updated-title-2')
+      expect(form.find('.js-part-toggle-target').eq(0).attr('id')).toBe('updated-title-1')
+      expect(form.find('.js-part-toggle-target').eq(1).attr('id')).toBe('updated-title-2')
+      expect(form.find('.js-part-toggle').eq(0).attr('href')).toBe('#updated-title-1')
+      expect(form.find('.js-part-toggle').eq(1).attr('href')).toBe('#updated-title-2')
     })
 
     it('removes deleted parts from the DOM to prevent inclusion in subsequent posts', function () {
-      expect(element.find('#edition_parts_attributes_101_title_input').length).toBe(1)
-      expect(element.find('#edition_parts_attributes_deleted_title_input').length).toBe(0)
+      expect(form.find('#edition_parts_attributes_101_title_input').length).toBe(1)
+      expect(form.find('#edition_parts_attributes_deleted_title_input').length).toBe(0)
     })
   })
 
   describe('when a new part is added and the form is saved', function () {
     beforeEach(function () {
-      element.trigger('success.ajaxsave.admin', {
+      form.trigger('success.ajaxsave.admin', {
         parts:
         [{ _id: { $oid: '5f00000001' }, order: 1, slug: 'updated-title-1', title: 'Updated title 1' },
           { _id: { $oid: '5f00000002' }, order: 2, slug: 'updated-title-2', title: 'Updated title 2' },
@@ -147,7 +157,7 @@ describe('An ajax save with parts module', function () {
     })
 
     it('adds a hidden input containing the part’s new ID', function () {
-      var $input = element.find('input[value="5f00000003"]')
+      var $input = form.find('input[value="5f00000003"]')
 
       expect($input.length).toBe(1)
       expect($input.attr('id')).toBe('edition_part_4535667_id')
@@ -155,18 +165,18 @@ describe('An ajax save with parts module', function () {
     })
 
     it('updates the part’s title', function () {
-      expect(element.find('.js-part-title').eq(2).text()).toBe('Updated title 3')
+      expect(form.find('.js-part-title').eq(2).text()).toBe('Updated title 3')
     })
 
     it('updates the toggle href and target based on its slug', function () {
-      expect(element.find('.js-part-toggle-target').eq(2).attr('id')).toBe('updated-title-3')
-      expect(element.find('.js-part-toggle').eq(2).attr('href')).toBe('#updated-title-3')
+      expect(form.find('.js-part-toggle-target').eq(2).attr('id')).toBe('updated-title-3')
+      expect(form.find('.js-part-toggle').eq(2).attr('href')).toBe('#updated-title-3')
     })
   })
 
   describe('when the form save errors', function () {
     beforeEach(function () {
-      element.trigger('errors.ajaxsave.admin', {
+      form.trigger('errors.ajaxsave.admin', {
         responseJSON: {
           parts:
         [
@@ -181,18 +191,35 @@ describe('An ajax save with parts module', function () {
     })
 
     it('shows the error messages', function () {
-      expect(element.find('#edition_parts_attributes_100_slug_input').is('.has-error')).toBe(true)
-      expect(element.find('#edition_parts_attributes_100_slug_input ul li').length).toBe(2)
-      expect(element.find('#edition_parts_attributes_100_slug_input ul li:first').text()).toBe('can\'t be blank')
-      expect(element.find('#edition_parts_attributes_100_slug_input ul li:last').text()).toBe('is invalid')
+      expect(form.find('#edition_parts_attributes_100_slug_input').is('.has-error')).toBe(true)
+      expect(form.find('#edition_parts_attributes_100_slug_input ul li').length).toBe(2)
+      expect(form.find('#edition_parts_attributes_100_slug_input ul li:first').text()).toBe('can\'t be blank')
+      expect(form.find('#edition_parts_attributes_100_slug_input ul li:last').text()).toBe('is invalid')
 
-      expect(element.find('#edition_parts_attributes_101_title_input').is('.has-error')).toBe(true)
-      expect(element.find('#edition_parts_attributes_101_title_input ul li').length).toBe(1)
-      expect(element.find('#edition_parts_attributes_101_title_input ul li:first').text()).toBe('can\'t be blank')
+      expect(form.find('#edition_parts_attributes_101_title_input').is('.has-error')).toBe(true)
+      expect(form.find('#edition_parts_attributes_101_title_input ul li').length).toBe(1)
+      expect(form.find('#edition_parts_attributes_101_title_input ul li:first').text()).toBe('can\'t be blank')
 
-      expect(element.find('#edition_parts_attributes_4535667_title_input').is('.has-error')).toBe(true)
-      expect(element.find('#edition_parts_attributes_4535667_title_input ul li').length).toBe(1)
-      expect(element.find('#edition_parts_attributes_4535667_title_input ul li:first').text()).toBe('must not walk on the grass')
+      expect(form.find('#edition_parts_attributes_4535667_title_input').is('.has-error')).toBe(true)
+      expect(form.find('#edition_parts_attributes_4535667_title_input ul li').length).toBe(1)
+      expect(form.find('#edition_parts_attributes_4535667_title_input ul li:first').text()).toBe('must not walk on the grass')
+    })
+
+    it('renders an error summary banner with the correct links to errors', function () {
+      var links = element.find('#error-summary').find('a')
+      var error1 = links[0]
+      var error2 = links[1]
+      var error3 = links[2]
+      var error4 = links[3]
+
+      expect(error1.hash).toBe('#edition_part_100_slug')
+      expect(error1.text).toBe("can't be blank")
+      expect(error2.hash).toBe('#edition_part_100_slug')
+      expect(error2.text).toBe('is invalid')
+      expect(error3.hash).toBe('#edition_part_101_title')
+      expect(error3.text).toBe("can't be blank")
+      expect(error4.hash).toBe('#edition_part_4535667_title')
+      expect(error4.text).toBe('must not walk on the grass')
     })
   })
 })

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -305,7 +305,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
 
     visit_edition guide
     select2 "Bob", css: "#s2id_edition_reviewer"
-    save_edition_and_assert_error("can't be the assignee")
+    save_edition_and_assert_error("can't be the assignee", "#edition_reviewer")
   end
 
   test "can deselect the guide reviewer" do

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -197,17 +197,19 @@ class JavascriptIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  def save_edition_and_assert_error(error_message = nil, link_href_if_javascript_disabled = nil)
+  def save_edition_and_assert_error(error_message = nil, link_href = nil)
     save_edition
+
     if using_javascript?
       assert page.has_content? "We had some problems saving"
-    else
-      # once we use add in a error summary component this line should be tested with
-      # and without js
-      assert page.has_content? "There is a problem"
-      assert page.has_link? error_message, href: link_href_if_javascript_disabled
     end
-    assert page.has_content? error_message if error_message.present?
+
+    if error_message.present?
+      assert page.has_content? "There is a problem"
+      assert page.has_content? error_message
+    end
+
+    assert page.has_link? error_message, href: link_href if link_href.present?
   end
 
   def save_tags_and_assert_success


### PR DESCRIPTION
### Description 

At the moment, with the exception of Smart Answers, the Edit Publication uses JS for progressive enhancement. All error handling takes place  within the `ajaxSave` and `ajaxSaveWithParts` modules.

This PR adds the error summary component/banner dynamically with the same design used on the non-JS pages. This banner links the user to the relevant input. 

### Changes made

Add error summary component when JS is on for the edit publication page

|Before|After|
|------------|------------|
|<img width="755" alt="image" src="https://user-images.githubusercontent.com/42515961/158408714-a74ff499-522c-4ab0-96c6-f55d54d3b4b7.png">|<img width="779" alt="image" src="https://user-images.githubusercontent.com/42515961/158409286-bf58ad48-1224-430b-a142-23d0a1e3d540.png">|

### Guidance for review 

I'm pretty inexperienced with JS so if i'm not using conventions please do yell and i'll update!

### Trello card 

https://trello.com/c/1lMcyxjF/245-fix-accessibility-issues-mainstream


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
