### PR TITLE
Move skip link component to :body_start in the layout

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,9 @@
   <%= yield :extra_headers %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/skip_link" %>
+<% content_for :body_start do %>
+  <%= render "govuk_publishing_components/components/skip_link" %>
+<% end %>
 
 <% content_for :navbar_items do %>
   <%= nav_link 'Publications', root_path %>


### PR DESCRIPTION
 Move skip link component to :body_start in the layout

This fixes a bug in a test that is currently failing on main. Moving the skip link component within the body starts ensures that the component is loaded within the document.

This was the hmtl output before 

<img width="575" alt="image" src="https://user-images.githubusercontent.com/42515961/160403972-1ba12082-ebf8-479f-a336-ea697effecae.png">

And after being moved inside the :body_start block

<img width="584" alt="image" src="https://user-images.githubusercontent.com/42515961/160404051-e8add7bb-1e21-459b-b934-3499313957aa.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
