### PR TITLE
Remove the `test-and-trace-support-payment service`

### DIFF
--- a/data/local_services.csv
+++ b/data/local_services.csv
@@ -123,4 +123,3 @@ LGSL,Description,Providing Tier
 1742,Find the location of weighbridges,county/unitary
 1743,Find out about the Care Act 2014,county/unitary
 1788,"Find out about support for children who have difficulties with speech, language or communication",county/unitary
-1826,"Find out about the test and trace support payment scheme",district/unitary


### PR DESCRIPTION
What

Remove the [`test-and-trace-support-payment`](www.gov.uk/test-and-trace-support-payment) - LGSL code `1826`.

Why

The service is being retired.

[Trello](https://trello.com/c/x43TzxRn/774-placeholder-retire-test-and-trace-lookup-tech-work-on-7th-april)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
