### PR TITLE
Add filtering for browse page derived topics

### DIFF
--- a/app/lib/tagging/linkables.rb
+++ b/app/lib/tagging/linkables.rb
@@ -8,6 +8,8 @@
 # to use `content_id`, we may move this functionality into a gem.
 module Tagging
   class Linkables
+    CACHE_OPTIONS = { expires_in: 15.minutes, race_condition_ttl: 30.seconds }.freeze
+
     def topics
       @topics ||= for_nested_document_type("topic")
     end
@@ -46,7 +48,25 @@ module Tagging
       items = get_tags_of_type(document_type)
         .select { |item| item.fetch("internal_name").include?(" / ") }
 
+      items = filter_browse_topics(items)
+
       organise_items(present_items(items))
+    end
+
+    # While we're migrating the Browse pages to topics we will briefly have a combination of the
+    # two in our model. We need to filter out the pages we brought across from the results.
+    def filter_browse_topics(items)
+      return items if items.empty? || items.first.fetch("base_path").exclude?("/topic/")
+
+      # Get topics that are not mainstream browse copies
+      valid_topics ||= Rails.cache.fetch("valid_topics", CACHE_OPTIONS) do
+        Services.publishing_api.get_content_items(document_type: "topic", per_page: 10_000, fields: %w[content_id details])["results"].select do |item|
+          item.dig("details", "mainstream_browse_origin").nil?
+        end
+      end
+
+      # Filter the invalid topics out of the items collection
+      items.select { |item| valid_topics.any? { |topic| topic.fetch("content_id") == item.fetch("content_id") } }
     end
 
     def present_items(items)

--- a/test/support/tag_test_helpers.rb
+++ b/test/support/tag_test_helpers.rb
@@ -20,8 +20,23 @@ module TagTestHelpers
         { base_path: "/topic/oil-and-gas/wells", internal_name: "Oil and Gas / Wells", publication_state: "published", content_id: "CONTENT-ID-WELLS" },
         { base_path: "/topic/oil-and-gas/fields", internal_name: "Oil and Gas / Fields", publication_state: "published", content_id: "CONTENT-ID-FIELDS" },
         { base_path: "/topic/oil-and-gas/distillation", internal_name: "Oil and Gas / Distillation", publication_state: "draft", content_id: "CONTENT-ID-DISTILL" },
+        { base_path: "/topic/employing-people-mainstream-copy/contracts-mainstream-copy", internal_name: "Employing People / Contracts", publication_state: "published", content_id: "CONTENT-ID-EMPLOYING-COPY" },
+        { base_path: "/topic/disabilities-mainstream-copy/benefits-mainstream-copy", internal_name: "Disabilities / Benefits", publication_state: "draft", content_id: "CONTENT-ID-BENEFIT-COPY" },
       ],
       document_type: "topic",
+    )
+
+    stub_publishing_api_has_content(
+      [
+        { base_path: "/topic/oil-and-gas/wells", internal_name: "Oil and Gas / Wells", publication_state: "published", content_id: "CONTENT-ID-WELLS" },
+        { base_path: "/topic/oil-and-gas/fields", internal_name: "Oil and Gas / Fields", publication_state: "published", content_id: "CONTENT-ID-FIELDS" },
+        { base_path: "/topic/oil-and-gas/distillation", internal_name: "Oil and Gas / Distillation", publication_state: "draft", content_id: "CONTENT-ID-DISTILL" },
+        { base_path: "/topic/employing-people-mainstream-copy/contracts-mainstream-copy", internal_name: "Employing People / Contracts", publication_state: "published", content_id: "CONTENT-ID-EMPLOYING-COPY", details: { mainstream_browse_origin: "notnil" } },
+        { base_path: "/topic/disabilities-mainstream-copy/benefits-mainstream-copy", internal_name: "Disabilities / Benefits", publication_state: "draft", content_id: "CONTENT-ID-BENEFIT-COPY", details: { mainstream_browse_origin: "" } },
+      ],
+      document_type: "topic",
+      per_page: 10_000,
+      fields: %w[content_id details],
     )
 
     stub_publishing_api_has_linkables(


### PR DESCRIPTION
While migrating Mainstream Browse pages to topics we need to prevent
the migrated clones from being visible to the user. Here we're adding
filtering to prevent items being show if the relevant field doesn't
exist or is true.

https://trello.com/c/m13ffUVc/292-update-publishing-apps-that-know-of-specialist-topics-to-hide-new-synced-ones

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
