### PR TITLE
Honour `RAILS_LOG_TO_STDOUT` for Sidekiq and GdsApi client logs.

### DIFF
--- a/config/initializers/gds_api.rb
+++ b/config/initializers/gds_api.rb
@@ -1,8 +1,5 @@
-require "gds_api/base"
 require "gds_api/asset_manager"
 require "plek"
-
-GdsApi::Base.logger = Logger.new(Rails.root.join("log/#{Rails.env}.api_client.log"))
 
 # Need to provide a bearer token to authenticate to the asset manager.
 # This can be loaded from an environment variable, or this file can

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,9 +1,10 @@
-# Sample configuration file for Sidekiq.
+# Configuration file for Sidekiq.
 # Options here can still be overridden by cmd line args.
-#   sidekiq -C config.yml
 ---
 :verbose: true
-:concurrency:  2
-:logfile: ./log/sidekiq.log
+:concurrency: 2
+<% if ENV.key?('SIDEKIQ_LOGFILE') %>
+:logfile: <%= ENV['SIDEKIQ_LOGFILE'] %>
+<% end %>
 :queues:
   - default


### PR DESCRIPTION
All of our logs need to go to stdout/stderr when running on Kubernetes.

- Honour the `RAILS_LOG_TO_STDOUT` environment variable for GdsApi client logs.
- Have Sidekiq log to stdout by default and make the config forward-compatible with Sidekiq 6.

See commit messages for details.

https://trello.com/c/Jef1t4xU

Pair: @nsabri1