### PR TITLE
Add paste html to govspeak

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,13 @@ ARG base_image=ruby:2.7.6-slim-buster
 FROM $base_image AS builder
 
 # TODO: have a separate build image which already contains the build-only deps.
-RUN apt-get update -qy && apt-get upgrade -y
+RUN apt-get update -qy && apt-get upgrade -y && apt-get install -y build-essential curl git
 
-# TODO: Look to remove Node v9 (below) (E2E tests currently fail without it).
-RUN curl -sL https://deb.nodesource.com/setup_9.x | bash -
-RUN apt-get update && apt-get install -y build-essential nodejs git npm && \
-    npm install -g yarn && \
-    npm install -g phantomjs-prebuilt@2 --unsafe-perm
+RUN curl -sL https://deb.nodesource.com/setup_lts.x | bash -
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+RUN apt-get update && apt-get install -y nodejs yarn && apt-get clean
 
 # TODO: Can ASSETS_PREFIX default to `/assets/publisher` within Publisher?
 ENV RAILS_ENV=production GOVUK_APP_NAME=publisher ASSETS_PREFIX=/assets/publisher
@@ -29,12 +29,12 @@ COPY . /app
 RUN GOVUK_APP_DOMAIN=www.gov.uk GOVUK_WEBSITE_ROOT=www.gov.uk bundle exec rails assets:precompile
 
 FROM $base_image
-RUN apt-get update -qy && apt-get upgrade -y && \
-    apt-get install -y nodejs
 
 # TODO: MONGODB_URI shouldn't be set here but seems to be required by E2E tests, figure out why.
 # TODO: Can ASSETS_PREFIX default to `/assets/publisher` within Publisher?
 ENV GOVUK_PROMETHEUS_EXPORTER=true RAILS_ENV=production GOVUK_APP_NAME=publisher ASSETS_PREFIX=/assets/publisher MONGODB_URI=mongodb://mongo/govuk_content_development
+
+COPY --from=builder /usr/bin/node* /usr/bin/
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,31 +2,41 @@
 ARG base_image=ruby:2.7.6-slim-buster
 
 FROM $base_image AS builder
+
 # TODO: have a separate build image which already contains the build-only deps.
 RUN apt-get update -qy && apt-get upgrade -y
+
 # TODO: Look to remove Node v9 (below) (E2E tests currently fail without it).
 RUN curl -sL https://deb.nodesource.com/setup_9.x | bash -
 RUN apt-get update && apt-get install -y build-essential nodejs git npm && \
+    npm install -g yarn && \
     npm install -g phantomjs-prebuilt@2 --unsafe-perm
+
 # TODO: Can ASSETS_PREFIX default to `/assets/publisher` within Publisher?
 ENV RAILS_ENV=production GOVUK_APP_NAME=publisher ASSETS_PREFIX=/assets/publisher
 RUN mkdir /app
+
 WORKDIR /app
-COPY Gemfile Gemfile.lock .ruby-version /app/
+COPY Gemfile Gemfile.lock .ruby-version package.json yarn.lock /app/
+
 RUN bundle config set deployment 'true'
 RUN bundle config set without 'development test'
 RUN bundle install -j8 --retry=2
+RUN yarn install --production --frozen-lockfile
 COPY . /app
+
 # TODO: We probably don't want assets in the image; remove this once we have a proper deployment process which uploads to (e.g.) S3.
 RUN GOVUK_APP_DOMAIN=www.gov.uk GOVUK_WEBSITE_ROOT=www.gov.uk bundle exec rails assets:precompile
 
 FROM $base_image
 RUN apt-get update -qy && apt-get upgrade -y && \
     apt-get install -y nodejs
+
 # TODO: MONGODB_URI shouldn't be set here but seems to be required by E2E tests, figure out why.
 # TODO: Can ASSETS_PREFIX default to `/assets/publisher` within Publisher?
 ENV GOVUK_PROMETHEUS_EXPORTER=true RAILS_ENV=production GOVUK_APP_NAME=publisher ASSETS_PREFIX=/assets/publisher MONGODB_URI=mongodb://mongo/govuk_content_development
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/
+
 WORKDIR /app
 CMD bundle exec puma

--- a/app/assets/javascripts/modules/paste_html_to_govspeak.js
+++ b/app/assets/javascripts/modules/paste_html_to_govspeak.js
@@ -1,0 +1,11 @@
+//= require paste-html-to-govspeak/dist/paste-html-to-markdown.js
+
+(function (Modules) {
+  'use strict'
+
+  Modules.PasteHtmlToGovspeak = function () {
+    this.start = function (element) {
+      element[0].addEventListener('paste', window.pasteHtmlToGovspeak.pasteListener)
+    }
+  }
+})(window.GOVUKAdmin.Modules)

--- a/app/views/answers/_fields.html.erb
+++ b/app/views/answers/_fields.html.erb
@@ -8,7 +8,9 @@
       <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
 
       <%= form_group(f, :body) do %>
-        <%= f.text_area :body, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+        <%= f.text_area :body, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control", data: {
+          module: "paste-html-to-govspeak"
+        } %>
       <% end %>
     </fieldset>
   </div>

--- a/app/views/help_pages/_fields.html.erb
+++ b/app/views/help_pages/_fields.html.erb
@@ -8,7 +8,9 @@
       <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
 
       <%= form_group(f, :body) do %>
-        <%= f.text_area :body, rows: 20, disabled: @resource.locked_for_edits?, class: "form-control" %>
+        <%= f.text_area :body, rows: 20, disabled: @resource.locked_for_edits?, class: "form-control", data: {
+          module: "paste-html-to-govspeak"
+        } %>
       <% end %>
     </fieldset>
   </div>

--- a/app/views/licences/_fields.html.erb
+++ b/app/views/licences/_fields.html.erb
@@ -24,7 +24,9 @@
       <% end %>
 
       <%= form_group(f, :licence_overview) do %>
-        <%= f.text_area :licence_overview, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+        <%= f.text_area :licence_overview, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control", data: {
+          module: "paste-html-to-govspeak"
+        } %>
       <% end %>
     </fieldset>
   </div>

--- a/app/views/local_transactions/_fields.html.erb
+++ b/app/views/local_transactions/_fields.html.erb
@@ -16,15 +16,21 @@
       <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
 
       <%= form_group(f, :introduction, label: "Introductory paragraph", help: "Set the scene for the user. Explain that it's the responsibility of the local council and that we'll take you there.") do %>
-        <%= f.text_area :introduction, rows: 8, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+        <%= f.text_area :introduction, rows: 8, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control", data: {
+          module: "paste-html-to-govspeak"
+        } %>
       <% end %>
 
       <%= form_group(f, :more_information) do %>
-        <%= f.text_area :more_information, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+        <%= f.text_area :more_information, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control", data: {
+          module: "paste-html-to-govspeak"
+        } %>
       <% end %>
 
       <%= form_group(f, :need_to_know, label: "What you need to know") do %>
-        <%= f.text_area :need_to_know, rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+        <%= f.text_area :need_to_know, rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control", data: {
+          module: "paste-html-to-govspeak"
+        } %>
       <% end %>
 
       <%= render partial: 'local_transactions/devolved_administrations', locals: { f: f, resource: @resource } %>

--- a/app/views/places/_fields.html.erb
+++ b/app/views/places/_fields.html.erb
@@ -12,15 +12,21 @@
       <% end %>
 
       <%= form_group(f, :introduction) do %>
-        <%= f.text_area :introduction, rows: 5, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+        <%= f.text_area :introduction, rows: 5, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control", data: {
+          module: "paste-html-to-govspeak"
+        } %>
       <% end %>
 
       <%= form_group(f, :more_information) do %>
-        <%= f.text_area :more_information, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+        <%= f.text_area :more_information, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control", data: {
+          module: "paste-html-to-govspeak"
+        } %>
       <% end %>
 
       <%= form_group(f, :need_to_know, label: "What you need to know", attributes: { class: %w[add-top-margin] }) do %>
-        <%= f.text_area :need_to_know, rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+        <%= f.text_area :need_to_know, rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control", data: {
+          module: "paste-html-to-govspeak"
+        } %>
       <% end %>
     </fieldset>
   </div>

--- a/app/views/shared/_part.html.erb
+++ b/app/views/shared/_part.html.erb
@@ -1,3 +1,5 @@
 <%= form_group(f, :body) do %>
-  <%= f.text_area :body, rows: 25, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+  <%= f.text_area :body, rows: 25, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control", data: {
+    module: "paste-html-to-govspeak"
+  } %>
 <% end %>

--- a/app/views/simple_smart_answers/_fields.html.erb
+++ b/app/views/simple_smart_answers/_fields.html.erb
@@ -9,7 +9,9 @@
       <div class="row">
         <div class="col-md-10">
           <%= form_group(f, :body) do %>
-            <%= f.text_area :body, rows: 5, disabled: @resource.locked_for_edits?, class: "form-control" %>
+            <%= f.text_area :body, rows: 5, disabled: @resource.locked_for_edits?, class: "form-control", data: {
+              module: "paste-html-to-govspeak"
+            } %>
           <% end %>
         </div>
       </div>

--- a/app/views/simple_smart_answers/_node.html.erb
+++ b/app/views/simple_smart_answers/_node.html.erb
@@ -16,7 +16,9 @@
   <div class="form-group">
     <span class="form-wrapper">
       <%= f.label :body, "Optional extra information" %>
-      <%= f.text_area :body, rows: 10, class: "node-body form-control" %>
+      <%= f.text_area :body, rows: 10, class: "node-body form-control", data: {
+        module: "paste-html-to-govspeak"
+      } %>
     </span>
   </div>
 

--- a/app/views/transactions/_fields.html.erb
+++ b/app/views/transactions/_fields.html.erb
@@ -8,7 +8,9 @@
       <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
 
       <%= form_group(f, :introduction, label: "Introductory paragraph", help: "Set the scene for the user. What is about to happen? (eg. \"you will need to fill in a form, print it out and take it to the post office\")") do %>
-        <%= f.text_area :introduction, rows: 8, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+        <%= f.text_area :introduction, rows: 8, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control", data: {
+          module: "paste-html-to-govspeak"
+        } %>
       <% end %>
 
       <fieldset>
@@ -30,15 +32,21 @@
       <% end %>
 
       <%= form_group(f, :more_information) do %>
-        <%= f.text_area :more_information, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+        <%= f.text_area :more_information, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control", data: {
+          module: "paste-html-to-govspeak"
+        } %>
       <% end %>
 
       <%= form_group(f, :alternate_methods, label: "Other ways to apply", help: "Alternative ways of completing this transaction. Not displayed on front end if left blank.") do %>
-        <%= f.text_area :alternate_methods, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control" %>
+        <%= f.text_area :alternate_methods, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control", data: {
+          module: "paste-html-to-govspeak"
+        } %>
       <% end %>
 
       <%= form_group(f, :need_to_know, label: "What you need to know", attributes: { class: %w[add-top-margin] } ) do %>
-        <%= f.text_area :need_to_know, rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
+        <%= f.text_area :need_to_know, rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control", data: {
+          module: "paste-html-to-govspeak"
+        } %>
       <% end %>
 
       <%= form_group(f, :department_analytics_profile, label: "Service analytics profile", help: "Let service teams track user journeys between GOV.UK and their service using Google Analytics.", attributes: { class: %w[add-top-margin] }) do %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -4,7 +4,7 @@
 Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path.
-# Rails.application.config.assets.paths << Emoji.images_path
+Rails.application.config.assets.paths << Rails.root.join("node_modules")
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,0 +1,2 @@
+# Maintain Rails < 7 behaviour of running yarn:install before assets:precompile
+Rake::Task["assets:precompile"].enhance(["yarn:install"])

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
     "standardx": "^7.0.0",
     "stylelint": "^14.8.5",
     "stylelint-config-gds": "^0.2.0"
+  },
+  "dependencies": {
+    "paste-html-to-govspeak": "^0.2.6"
   }
 }

--- a/spec/javascripts/spec/admin/modules/paste_html_to_govspeak.spec.js
+++ b/spec/javascripts/spec/admin/modules/paste_html_to_govspeak.spec.js
@@ -1,0 +1,29 @@
+describe('GOVUKAdmin.Modules.PasteHtmlToGovspeak', function () {
+  var textarea
+
+  function createHtmlPasteEvent (html = null) {
+    var event = new window.Event('paste')
+    event.clipboardData = {
+      getData: (type) => {
+        if (type === 'text/html') {
+          return html
+        }
+      }
+    }
+
+    return event
+  }
+
+  beforeEach(function () {
+    textarea = document.createElement('textarea')
+
+    var pasteHtmlToGovspeak = new GOVUKAdmin.Modules.PasteHtmlToGovspeak()
+    pasteHtmlToGovspeak.start($(textarea))
+  })
+
+  it('responds to a paste event by converting the HTML to Govspeak', function () {
+    textarea.dispatchEvent(createHtmlPasteEvent('<h2>This is a h2</h2>'))
+
+    expect(textarea.value).toEqual('## This is a h2')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1840,6 +1840,11 @@ parseurl@~1.3.3:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
+paste-html-to-govspeak@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/paste-html-to-govspeak/-/paste-html-to-govspeak-0.2.6.tgz#a7bbb5e2b7ce4b38a0fec68febf67001d4764163"
+  integrity sha512-vRF4DbxgVqaI5bCFWrNAxRHSPY1NYNAwKR9M1v0YB928kvrh0TOvPGY9R67nzRm44L8Fn/+TdILA/NldeN2RjQ==
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"


### PR DESCRIPTION
## What
Converts pasted formatted content to GovSpeak

## Why
This work will reduce the effort and time for publishers to create new content, including HTML attachments and as a result, increase interest in creating HTML attachments by default

https://trello.com/c/20l0GFJl/440-add-paste-html-to-govspeak-to-mainstream-publisher

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
