### PR TITLE
Add Prometheus exporter for EKS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update -qy && apt-get upgrade -y && \
     apt-get install -y nodejs
 # TODO: MONGODB_URI shouldn't be set here but seems to be required by E2E tests, figure out why.
 # TODO: Can ASSETS_PREFIX default to `/assets/publisher` within Publisher?
-ENV RAILS_ENV=production GOVUK_APP_NAME=publisher ASSETS_PREFIX=/assets/publisher MONGODB_URI=mongodb://mongo/govuk_content_development
+ENV GOVUK_PROMETHEUS_EXPORTER=true RAILS_ENV=production GOVUK_APP_NAME=publisher ASSETS_PREFIX=/assets/publisher MONGODB_URI=mongodb://mongo/govuk_content_development
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/
 WORKDIR /app

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config/govuk_prometheus_exporter"
+GovukPrometheusExporter.configure


### PR DESCRIPTION
Enable Prometheus exporter for EKS by:
1. adding `GOVUK_PROMETHEUS_EXPORTER=true` to Dockerfile
2. adding Prometheus initializer

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
