### PR TITLE
Update Govspeak link text and add paste to markdown guidance

### DIFF
--- a/app/views/shared/_govspeak_help.html.erb
+++ b/app/views/shared/_govspeak_help.html.erb
@@ -1,6 +1,19 @@
 <section class="govspeak_help">
 
-<p>For full examples see: <a href="https://govspeak-preview.herokuapp.com/guide" target="_blank" rel="noopener noreferrer external">the Govspeak Guide</a>.</p>
+<p>For full examples, <a href="https://govspeak-preview.publishing.service.gov.uk/guide" target="_blank" rel="noopener noreferrer external">read the Govspeak Guide (opens in new tab)</a>.</p>
+ 
+<h4>Paste and convert to Markdown</h4>
+<p>You can paste formatted text and it’ll be converted into Govspeak Markdown in fields which use and support Markdown.</p>
+<p>This works best when copy and pasting from text editing software like Word or Google Docs. It is less likely to recognise formatting from PDFs.</p>
+<p>It will convert:</p>
+<ul>
+  <li>headings</li>
+  <li>bullets</li>
+  <li>numbered lists</li>
+  <li>links</li>
+  <li>email links</li>
+</ul>
+<p>Other formatting, such as tables, will be removed and only plain text pasted. You’ll need to write the Markdown for these separately.</p>
 
 <h4>Headers</h4>
 <p class="help-block">Note that the page already has a top heading from the article name.</p>


### PR DESCRIPTION
This pull request:

- updates the link to the Govspeak guidance
- improves the link text to the Govspeak guidance
- adds 'paste to markdown' guidance

https://trello.com/c/20l0GFJl

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
