### PR TITLE
Render govspeak help for editions with fields that can use it and ensure it works on dynamically added fields

### DIFF
--- a/app/assets/javascripts/modules/parts.js
+++ b/app/assets/javascripts/modules/parts.js
@@ -5,6 +5,7 @@
   Modules.Parts = function () {
     this.start = function (element) {
       element.on('change', 'input.title', generateSlug)
+      element.on('nested:fieldAdded:parts', addPasteHtmlToGovspeak)
       element.on('nested:fieldAdded:parts', updatePartOrders)
       element.on('nested:fieldAdded:parts', removeValidationMessages)
 
@@ -24,6 +25,12 @@
             $slugInput.removeClass('yellow-fade')
           }, 2000)
         }
+      }
+
+      function addPasteHtmlToGovspeak () {
+        var input = element.find('.body').slice(-1)
+        var pasteHtmlToGovspeak = new GOVUKAdmin.Modules.PasteHtmlToGovspeak()
+        pasteHtmlToGovspeak.start(input)
       }
 
       function makePartsSortable () {

--- a/app/assets/javascripts/smart-answers.js
+++ b/app/assets/javascripts/smart-answers.js
@@ -55,6 +55,9 @@
       node.find('.node-label').text(nodeLabel(kind, index))
       node.addClass(kind).attr('id', nodeId(kind, index))
 
+      var body = node.find('.node-body')
+      addPasteHtmlToGovspeak(body)
+
       var questions = $('.nodes .question:visible')
       var outcomes = $('.nodes .outcome:visible')
 
@@ -98,6 +101,11 @@
       function nodeLabel (kind, index) {
         var capitalizedKind = kind.charAt(0).toUpperCase() + kind.slice(1)
         return capitalizedKind + ' ' + index
+      }
+
+      function addPasteHtmlToGovspeak (field) {
+        var pasteHtmlToGovspeak = new GOVUKAdmin.Modules.PasteHtmlToGovspeak()
+        pasteHtmlToGovspeak.start(field)
       }
     },
     indexOfKind: function (kind) {

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -105,6 +105,18 @@ class Edition
     HelpPageEdition
   ].freeze
 
+  HAS_GOVSPEAK_FIELDS = %w[
+    AnswerEdition
+    GuideEdition
+    HelpPageEdition
+    LicenceEdition
+    LocalTransactionEdition
+    PlaceEdition
+    ProgrammeEdition
+    SimpleSmartAnswerEdition
+    TransactionEdition
+  ].freeze
+
   validates :title, presence: { message: "Enter a title" }
   validates :version_number, presence: true, uniqueness: { scope: :panopticon_id }
   validates :panopticon_id, presence: true

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -28,6 +28,14 @@
         <div role="tabpanel" class="tab-pane <% if active_tab.name == 'edit'%>active<% end %>" id="edit">
           <div class="link-check-report col-md-4">
             <%= render 'link_check_reports/link_check_report', edition: @edition, report: @edition.latest_link_check_report %>
+
+            <% if @edition.class.to_s.in?(Edition::HAS_GOVSPEAK_FIELDS) %>
+              <h3 class="remove-top-margin add-bottom-margin">Govspeak help</h3>
+
+              <div class="well">
+                <%= render "shared/govspeak_help" %>
+              </div>
+            <% end %>
           </div>
 
           <%= resource_form(@resource) do |f| %>

--- a/app/views/guides/_fields.html.erb
+++ b/app/views/guides/_fields.html.erb
@@ -46,15 +46,6 @@
     <% end %>
 
   </div>
-
-  <div class="col-md-4">
-    <h3 class="remove-top-margin add-bottom-margin">Govspeak help</h3>
-
-    <div class="well">
-      <%= render "shared/govspeak_help" %>
-    </div>
-  </div>
-
 </div>
 
 <%= render partial: 'shared/workflow_buttons', locals: { f: f } %>

--- a/app/views/programmes/_fields.html.erb
+++ b/app/views/programmes/_fields.html.erb
@@ -27,14 +27,6 @@
     </section>
 
   </div>
-
-  <div class="col-md-4">
-    <h3 class="remove-top-margin add-bottom-margin">Govspeak help</h3>
-
-    <div class="well">
-      <%= render "shared/govspeak_help" %>
-    </div>
-  </div>
 </div>
 
 <%= render partial: 'shared/workflow_buttons', locals: { f: f } %>

--- a/app/views/shared/_part.html.erb
+++ b/app/views/shared/_part.html.erb
@@ -1,5 +1,5 @@
 <%= form_group(f, :body) do %>
-  <%= f.text_area :body, rows: 25, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control", data: {
+  <%= f.text_area :body, rows: 25, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control body", data: {
     module: "paste-html-to-govspeak"
   } %>
 <% end %>

--- a/spec/javascripts/spec/parts_spec.js
+++ b/spec/javascripts/spec/parts_spec.js
@@ -4,24 +4,40 @@ describe('A parts module', function () {
   var parts,
     element
 
+  function createHtmlPasteEvent (html = null) {
+    var event = new window.Event('paste')
+    event.clipboardData = {
+      getData: (type) => {
+        if (type === 'text/html') {
+          return html
+        }
+      }
+    }
+
+    return event
+  }
+
   beforeEach(function () {
     element = $('<div>' +
       '<div id="part_1" class="part">' +
         '<div class="js-sort-handle">Part title 1</div>' +
         '<input class="title" name="part_1_title" type="text" value="Part title 1">' +
         '<input class="slug" name="part_1_slug" type="text" value="part-title-1">' +
+        '<textarea class="body" name="part_1_body">part-body-1</textarea>' +
         '<input class="order" name="part_1_order" type="hidden" value="1">' +
       '</div>' +
       '<div id="part_2" class="part">' +
         '<div class="js-sort-handle">Part title 2</div>' +
         '<input class="title" name="part_2_title" type="text" value="Part title 2">' +
         '<input class="slug" name="part_2_slug" type="text" value="part-title-2">' +
+        '<textarea class="body" name="part_2_body">part-body-2</textarea>' +
         '<input class="order" name="part_2_order" type="hidden" value="2">' +
       '</div>' +
       '<div id="part_3" class="part">' +
         '<div class="js-sort-handle">Part title 3</div>' +
         '<input class="title" name="part_3_title" type="text" value="Part title 3">' +
         '<input class="slug" name="part_3_slug" type="text" value="part-title-3">' +
+        '<textarea class="body" name="part_3_body">part-body-3</textarea>' +
         '<input class="order" name="part_3_order" type="hidden" value="3">' +
       '</div>' +
     '</div>')
@@ -63,6 +79,7 @@ describe('A parts module', function () {
         '<div class="js-sort-handle"></div>' +
         '<input class="error has-error title" name="part_4_title" type="text" value="">' +
         '<input class="slug" name="part_4_slug" type="text" value="">' +
+        '<textarea class="body" name="part_4_body"></textarea>' +
         '<input class="order" name="part_4_order" type="hidden" value="">' +
         '<div class="error has-error" id="error-block">Error</div>' +
       '</div>')
@@ -88,6 +105,13 @@ describe('A parts module', function () {
 
     it('removes validation errors on the newly added part', function () {
       expect($('#part_4').find('.error, .has-error').length).toBe(0)
+    })
+
+    it('applies the paste html to govspeak data module to the new parts body field', function () {
+      var $textarea = $('#part_4').find('.body')[0]
+      $textarea.dispatchEvent(createHtmlPasteEvent('<h2>This is a h2</h2>'))
+
+      expect($textarea.value).toEqual('## This is a h2')
     })
   })
 


### PR DESCRIPTION
## Description 

We've done some work to allow paste to govspeak. As part of this work we've updated the govspeak guidance. However, currently, it's only rendered on Guides and Programmes.

We should expose it on any edition type that has fields that can use govspeak.

<img width="1010" alt="image" src="https://user-images.githubusercontent.com/42515961/172838105-ef1428cd-929e-475f-a3d9-bd960fff9063.png">

Additionally, it is not working for fields that are dynamically created using JavaScript. A list of the affected fields are:

 - The body fields for Parts (GuidEdition)
- The body fields for nodes (questions and answers for  SimpleSmartAnswerEdition)

## Trello card

https://trello.com/c/20l0GFJl/440-add-paste-html-to-govspeak-to-mainstream-publisher

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
