### PR TITLE
Pass GOVUK_CI_GITHUB_TOKEN to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,3 +34,4 @@ jobs:
     secrets:
       WEBHOOK_TOKEN: ${{ secrets.ARGO_EVENTS_WEBHOOK_TOKEN }}
       WEBHOOK_URL: ${{ secrets.ARGO_EVENTS_WEBHOOK_URL }}
+      GOVUK_CI_GITHUB_API_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}


### PR DESCRIPTION
The deploy workflow now requires the GOVUK_CI_GITHUB_TOKEN to make the API call
to check if the actor has the correct permissions to trigger a deployment.
