### PR TITLE
Use MongoDB 3.6 in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,10 @@
 
 library("govuk")
 
-node('mongodb-2.4') {
+node {
+  // Run against the MongoDB 3.6 Docker instance on GOV.UK CI
+  govuk.setEnvar("TEST_MONGODB_URI", "mongodb://127.0.0.1:27036/publisher")
+
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-publisher")
   govuk.buildProject(
     publishingE2ETests: true,


### PR DESCRIPTION
This application uses MongoDB 3.6 in production (via AWS DocumentDB) so it makes sense to test it against the same version. This change is necessary to use the MongoDB Ruby Driver from versions 2.16 and up.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
