### PR TITLE
Remove references to alphagov.co.uk

### DIFF
--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -3,7 +3,6 @@ class EventMailer < ApplicationMailer
 
   helper(PathsHelper)
   helper(WorkingDaysHelper)
-  default from: "Winston (GOV.UK Publisher) <winston@alphagov.co.uk>"
 
   def any_action(action, recipient_email)
     @action = action

--- a/app/validators/safe_html.rb
+++ b/app/validators/safe_html.rb
@@ -4,8 +4,8 @@ require "plek"
 class SafeHtml < ActiveModel::Validator
   ALLOWED_IMAGE_HOSTS = [
     # URLs for the local environment
-    URI.parse(Plek.new.website_root).host, # eg www.preview.alphagov.co.uk
-    URI.parse(Plek.new.asset_root).host,   # eg assets-origin.preview.alphagov.co.uk
+    URI.parse(Plek.new.website_root).host, # eg www.gov.uk
+    URI.parse(Plek.new.asset_root).host,   # eg assets.publishing.service.gov.uk
 
     # Hardcode production URLs so that content copied from production is valid
     "www.gov.uk",

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,7 +1,0 @@
-require File.expand_path("production.rb", File.dirname(__FILE__))
-
-Publisher::Application.configure do
-  config.action_mailer.smtp_settings = { enable_starttls_auto: false }
-
-  config.action_mailer.default_url_options = { host: "guides.staging.alphagov.co.uk:8080" }
-end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,6 +43,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.action_mailer.default_options = { from: "winston@dev.gov.uk" }
 
   config.action_mailer.default_url_options = { host: "example.com" }
 

--- a/config/fact_check.yml
+++ b/config/fact_check.yml
@@ -4,7 +4,7 @@
 # If we ever want to change this format, we'll need to support some notion of
 # legacy formats, so we still pick up emails to old addresses
 subject_prefix: <%=ENV.fetch("FACT_CHECK_SUBJECT_PREFIX", "") %>
-reply_to_address: <%=ENV.fetch("FACT_CHECK_REPLY_TO_ADDRESS", "factcheck+dev@alphagov.co.uk") %>
+reply_to_address: <%=ENV.fetch("FACT_CHECK_REPLY_TO_ADDRESS", "factcheck@dev.gov.uk") %>
 reply_to_id: <%=ENV.fetch("FACT_CHECK_REPLY_TO_ID", nil) %>
 
 fetcher:

--- a/script/mail_fetcher
+++ b/script/mail_fetcher
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
-# Check all emails in the gmail inbox. Find any sent to an address matching the pattern
-# factcheck+{rails_environment}-#{publication_id}@alphagov.co.uk
+# Check all emails in the gmail inbox.
 #
 # Any messages successfully processed will be moved out of the inbox. Others are left
 # there, so we can review that messages are getting processed properly by going into the

--- a/test/fixtures/fact_check_emails/base64.txt
+++ b/test/fixtures/fact_check_emails/base64.txt
@@ -1,5 +1,5 @@
-                                                                                                                                                                                                                                                               
-Delivered-To: factcheck+production-4ecbb1d3e76e624707000033@alphagov.co.uk
+
+Delivered-To: factcheck@dev.gov.uk
 Received: by 10.220.195.137 with SMTP id ec9cs93359vcb;
         Wed, 14 Dec 2011 01:33:02 -0800 (PST)
 Received: by 10.180.4.42 with SMTP id h10mr3090107wih.22.1323855178442;
@@ -21,8 +21,8 @@ Received: from gateway-201.energis.gsi.gov.uk (HELO mx.hosting-e.gsi.gov.uk) (19
 X-IronPort-AV: E=Sophos;i="4.71,351,1320624000"; 
    d="scan'208";a="47736601"
 From: "Stanley, Mark" <Mark.Stanley@justice.gsi.gov.uk>
-To: "factcheck+production-4ecbb1d3e76e624707000033@alphagov.co.uk"
-	<factcheck+production-4ecbb1d3e76e624707000033@alphagov.co.uk>
+To: "factcheck@dev.gov.uk"
+	<factcheck@dev.gov.uk>
 Date: Wed, 14 Dec 2011 09:32:55 +0000
 Subject: RE: [FACT CHECK REQUESTED] Courts - the different types
 Thread-Topic: [FACT CHECK REQUESTED] Courts - the different types

--- a/test/fixtures/fact_check_emails/hidden_nasty.txt
+++ b/test/fixtures/fact_check_emails/hidden_nasty.txt
@@ -1,4 +1,4 @@
-Delivered-To: factcheck+production-4e6e1b2fe2ba8022d100000a@alphagov.co.uk
+Delivered-To: factcheck@dev.gov.uk
 Received: by 10.220.193.201 with SMTP id dv9cs282215vcb;
         Mon, 28 Nov 2011 03:37:02 -0800 (PST)
 Received: by 10.205.135.6 with SMTP id ie6mr17070013bkc.69.1322480220653;
@@ -20,8 +20,8 @@ Received: from gateway-201.energis.gsi.gov.uk (HELO mx.hosting-e.gsi.gov.uk) (19
 X-IronPort-AV: E=Sophos;i="4.69,583,1315177200"; 
    d="scan'208";a="46381388"
 From: "Stanley, Mark" <Mark.Stanley@justice.gsi.gov.uk>
-To: "factcheck+production-4e6e1b2fe2ba8022d100000a@alphagov.co.uk"
-  <factcheck+production-4e6e1b2fe2ba8022d100000a@alphagov.co.uk>
+To: "factcheck@dev.gov.uk"
+  <factcheck@dev.gov.uk>
 Date: Mon, 28 Nov 2011 11:36:57 +0000
 Subject: RE: [FACT CHECK REQUESTED] Find out if someone has an attorney or
  deputy acting for them
@@ -45,7 +45,7 @@ This is some text
 <script>function(){alert("hello I am evil");}</script>
 
 -----Original Message-----
-From: Beta Editorial Team [mailto:winston@alphagov.co.uk]=20
+From: Beta Editorial Team [mailto:winston@dev.gov.uk]=20
 Sent: 31 October 2011 16:50
 To: Stanley, Mark
 Subject: [FACT CHECK REQUESTED] Find out if someone has an attorney or dep=
@@ -55,8 +55,7 @@ Hello - thank you for fact-checking the beta version of www.gov.uk
 
 Please read this content and check it's factually correct.
 
-PLEASE SEND COMMENTS TO THIS EMAIL ADDRESS: factcheck+production-4e6e1b2fe=
-2ba8022d100000a@alphagov.co.uk
+PLEASE SEND COMMENTS TO THIS EMAIL ADDRESS: factcheck@dev.gov.uk
 
 If you spot something that's incorrect, please let us know by:
 
@@ -70,8 +69,8 @@ Please don't rewrite the text - just point out any factual errors. We will=
 
 Title: Find out if someone has an attorney or deputy acting for them
 
-http://www.production.alphagov.co.uk/find-someones-attorney-or-deputy?edit=
-ion=3D1
+http://publisher.publishing.service.gov.uk/find-someones-attorney-or-deput=
+y?edition=3D1
 
 Thanks,
 Beta editorial team

--- a/test/fixtures/fact_check_emails/pound_symbol.txt
+++ b/test/fixtures/fact_check_emails/pound_symbol.txt
@@ -1,4 +1,4 @@
-Delivered-To: factcheck+production-4e6e1b2fe2ba8022d100000a@alphagov.co.uk
+Delivered-To: factcheck@dev.gov.uk
 Received: by 10.220.193.201 with SMTP id dv9cs282215vcb;
         Mon, 28 Nov 2011 03:37:02 -0800 (PST)
 Received: by 10.205.135.6 with SMTP id ie6mr17070013bkc.69.1322480220653;
@@ -20,8 +20,8 @@ Received: from gateway-201.energis.gsi.gov.uk (HELO mx.hosting-e.gsi.gov.uk) (19
 X-IronPort-AV: E=Sophos;i="4.69,583,1315177200"; 
    d="scan'208";a="46381388"
 From: "Stanley, Mark" <Mark.Stanley@justice.gsi.gov.uk>
-To: "factcheck+production-4e6e1b2fe2ba8022d100000a@alphagov.co.uk"
-	<factcheck+production-4e6e1b2fe2ba8022d100000a@alphagov.co.uk>
+To: "factcheck@dev.gov.uk"
+	<factcheck@dev.gov.uk>
 Date: Mon, 28 Nov 2011 11:36:57 +0000
 Subject: RE: [FACT CHECK REQUESTED] Find out if someone has an attorney or
  deputy acting for them
@@ -56,7 +56,7 @@ stice=20
 Ministry of Justice | Creating a safe, just and democratic society
 
 -----Original Message-----
-From: Beta Editorial Team [mailto:winston@alphagov.co.uk]=20
+From: Beta Editorial Team [mailto:winston@dev.gov.uk]=20
 Sent: 31 October 2011 16:50
 To: Stanley, Mark
 Subject: [FACT CHECK REQUESTED] Find out if someone has an attorney or dep=
@@ -66,8 +66,7 @@ Hello - thank you for fact-checking the beta version of www.gov.uk
 
 Please read this content and check it's factually correct.
 
-PLEASE SEND COMMENTS TO THIS EMAIL ADDRESS: factcheck+production-4e6e1b2fe=
-2ba8022d100000a@alphagov.co.uk
+PLEASE SEND COMMENTS TO THIS EMAIL ADDRESS: factcheck@dev.gov.uk
 
 If you spot something that's incorrect, please let us know by:
 
@@ -81,8 +80,8 @@ Please don't rewrite the text - just point out any factual errors. We will=
 
 Title: Find out if someone has an attorney or deputy acting for them
 
-http://www.production.alphagov.co.uk/find-someones-attorney-or-deputy?edit=
-ion=3D1
+http://publisher.publishing.service.gov.uk/find-someones-attorney-or-deput=
+y?edition=3D1
 
 Thanks,
 Beta editorial team

--- a/test/unit/fact_check_message_processor_test.rb
+++ b/test/unit/fact_check_message_processor_test.rb
@@ -20,7 +20,7 @@ class FactCheckMessageProcessorTest < ActiveSupport::TestCase
   end
 
   def sample_processor(_body_text = "I approve")
-    basic_message = Mail.new(to: "factcheck+test-4e1dac78e2ba80076000000e@alphagov.co.uk", subject: "Fact Checked", body: "I approve")
+    basic_message = Mail.new(to: "factcheck@dev.gov.uk", subject: "Fact Checked", body: "I approve")
     FactCheckMessageProcessor.new(basic_message)
   end
 
@@ -36,7 +36,7 @@ class FactCheckMessageProcessorTest < ActiveSupport::TestCase
   test "it extracts the body as utf8 acceptable to mongo" do
     windows_string = "Hallo Umläute".encode("Windows-1252")
     message = Mail.new(
-      to: "factcheck+test-4e1dac78e2ba80076000000e@alphagov.co.uk",
+      to: "factchecke@dev.gov.uk",
       subject: "Fact Checked",
       body: windows_string,
       content_type: "text/plain; charset=Windows-1252",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This removes the references to alphagov.co.uk principally as a way to indicate that it isn't used as part of the email fact-checking process. This was done to resolve confusion as to whether there is still a need for the Google account that powered this fact-checking process.

alphagov.co.uk was the original hostname that GOV.UK launched on before moving to alpha.gov.uk and finally www.gov.uk.