### PR TITLE
Use Redis.new rather than Redis.current

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -29,6 +29,9 @@
       },
       "user_input": "params[:list].presence",
       "confidence": "High",
+      "cwe_id": [
+        22
+      ],
       "note": ""
     },
     {
@@ -45,6 +48,10 @@
       "location": null,
       "user_input": null,
       "confidence": "Medium",
+      "cwe_id": [
+        565,
+        502
+      ],
       "note": "The params[:list] argument is already checked before the template gets rendered by @presenter.acceptable_list?(@list)."
     },
     {
@@ -76,18 +83,21 @@
       },
       "user_input": "params[:list].presence",
       "confidence": "High",
+      "cwe_id": [
+        77
+      ],
       "note": "The params[:list] argument is already checked before the template gets rendered by @presenter.acceptable_list?(@list)."
     },
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "d3d42c84d0b0acf57ccb1c9d1133ca43389fd725d0471016013e52bf59269b83",
+      "fingerprint": "814bc0a997725602aa2913dd902c8d77c28de9044d4562f60a898ad250d04b5a",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "lib/csv_report_generator.rb",
       "line": 11,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Redis.current.lock(\"publisher:#{Rails.env}:report_generation_lock\", :life => 15.minutes)",
+      "code": "Redis.new.lock(\"publisher:#{Rails.env}:report_generation_lock\", :life => 15.minutes)",
       "render_path": null,
       "location": {
         "type": "method",
@@ -99,6 +109,6 @@
       "note": "We don't pass any user data to this string."
     }
   ],
-  "updated": "2021-01-15 21:34:56 +0000",
-  "brakeman_version": "4.10.1"
+  "updated": "2022-10-06 12:04:32 +0100",
+  "brakeman_version": "5.3.1"
 }

--- a/lib/csv_report_generator.rb
+++ b/lib/csv_report_generator.rb
@@ -8,7 +8,7 @@ class CsvReportGenerator
   end
 
   def run!
-    Redis.current.lock("publisher:#{Rails.env}:report_generation_lock", life: 15.minutes) do
+    Redis.new.lock("publisher:#{Rails.env}:report_generation_lock", life: 15.minutes) do
       reports.each do |report|
         Rails.logger.debug "Generating #{path}/#{report.report_name}.csv"
         report.write_csv(path)

--- a/script/mail_fetcher
+++ b/script/mail_fetcher
@@ -37,7 +37,7 @@ handler = FactCheckEmailHandler.new(Publisher::Application.fact_check_config)
 # that long.
 AUTOMATIC_LOCK_EXPIRY = (5 * 60) # seconds
 begin
-  Redis.current.lock("publisher:#{Rails.env}:fact_check_processing_lock", life: AUTOMATIC_LOCK_EXPIRY) do |lock|
+  Redis.new.lock("publisher:#{Rails.env}:fact_check_processing_lock", life: AUTOMATIC_LOCK_EXPIRY) do |lock|
     handler.process do
       lock.extend_life(AUTOMATIC_LOCK_EXPIRY)
     end


### PR DESCRIPTION
Redis.current will be deprecated in Redis 5.0.

As Redis.current ultimately calls Redis.new we can migrate this method now to pave the way for future upgrades.

From Redis changelog from [5.0][1]:

‘Removed Redis.current. You shouldn't assume there is a single global Redis connection, use a connection pool instead, and libaries using Redis should accept a Redis instance (or connection pool) as a config. E.g. MyLibrary.redis = Redis.new(…).’

[Redis.current][2] just calls Redis.new so should just be able to swap methods.

[trello](https://trello.com/c/oGFWhrCO/1551-migrate-away-from-deprecated-redis-method)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
