### PR TITLE
Update govuk_publishing_components to resolve Plek warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,7 @@ GEM
     govuk_personalisation (0.12.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (31.0.0)
+    govuk_publishing_components (31.1.2)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -271,7 +271,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
-    mini_portile2 (2.6.1)
+    mini_portile2 (2.8.0)
     minitest (5.16.3)
     minitest-reporters (1.5.0)
       ansi
@@ -304,8 +304,14 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.12.0)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.13.9)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
+    nokogiri (1.13.9-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.13.9-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.9-x86_64-linux)
       racc (~> 1.4)
     notifications-ruby-client (5.3.0)
       jwt (>= 1.5, < 3)


### PR DESCRIPTION
This resolves the "Plek.current is deprecated and will be removed. Use Plek.new or Plek.find instead." warning on initialisation.

This gem doesn't get updated automatically by dependabot as it's an indirect dependency through Govspeak.

As part of this `bundle update` nokogiri is updated, which seems to add in platform gems that I'd have expected to be there in: https://github.com/alphagov/publisher/commit/f9418c57751ed50134cf0bf1c59e3b4b062e3633 🤔.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
