### PR TITLE
Remove gems that are no longer used

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,8 +29,6 @@ gem "null_logger"
 gem "plek"
 gem "rails_autolink"
 gem "rest-client", require: false
-gem "retriable", require: false
-gem "reverse_markdown", require: false
 gem "sassc-rails"
 gem "select2-rails", "~> 3.5.9" # Updating this will mean updating the styling as 4 & > have a new approach to class names.
 gem "sentry-sidekiq"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -407,9 +407,6 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    retriable (3.1.2)
-    reverse_markdown (2.1.1)
-      nokogiri
     rexml (3.2.5)
     rinku (2.0.6)
     rouge (4.0.0)
@@ -591,8 +588,6 @@ DEPENDENCIES
   rails-controller-testing
   rails_autolink
   rest-client
-  retriable
-  reverse_markdown
   rubocop-govuk
   sassc-rails
   select2-rails (~> 3.5.9)


### PR DESCRIPTION
The Gems: retrievable and reverse markdown were only used by the licence content importer which has now been [removed](https://github.com/alphagov/publisher/pull/1689).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
