### PR TITLE
Update application content

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -187,7 +187,7 @@ class EditionsController < InheritedResources::Base
   def destroy
     if resource.can_destroy?
       destroy! do
-        flash[:success] = "#{description(resource)} destroyed"
+        flash[:success] = "Edition deleted"
         redirect_to root_url
         return
       end

--- a/app/helpers/edition_activity_buttons_helper.rb
+++ b/app/helpers/edition_activity_buttons_helper.rb
@@ -13,15 +13,15 @@ module EditionActivityButtonsHelper
     buttons = []
     if current_user.has_editor_permissions?(edition)
       buttons << build_review_button(edition, "request_amendments", "Needs more work")
-      buttons << build_review_button(edition, "approve_review", "OK for publication")
+      buttons << build_review_button(edition, "approve_review", "No changes needed")
     end
     buttons.join("\n").html_safe
   end
 
   def fact_check_buttons(edition)
     [
-      ["Needs major changes", "request_amendments"],
-      ["Minor or no changes required", "approve_fact_check"],
+      ["Needs more work", "request_amendments"],
+      ["No more work needed", "approve_fact_check"],
     ].map { |title, activity|
       build_review_button(edition, activity, title)
     }.join("\n").html_safe

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -87,7 +87,7 @@ class Edition
     request_review: "Send to 2nd pair of eyes",
     schedule_for_publishing: "Schedule for publishing",
     publish: "Send to publish",
-    approve_review: "OK for publication",
+    approve_review: "No changes needed",
     request_amendments: "Request amendments",
     approve_fact_check: "Approve fact check",
     skip_review: "Skip review",

--- a/app/views/editions/_major_change_fields.html.erb
+++ b/app/views/editions/_major_change_fields.html.erb
@@ -1,11 +1,11 @@
-<%= form_group(f, :change_note, label: "Summary of changes to this edition", attributes: { id: "edition_change_note_input" }) do %>
+<%= form_group(f, :change_note, label: "Public change note", help: "Only use this to alert the public that the content has been updated or to change the ‘last updated’ date.", attributes: { id: "edition_change_note_input" }) do %>
   <%= f.text_area :change_note, rows: 3, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
 <% end %>
 
 <div class="form-group emphasised-field add-bottom-margin checkbox">
   <span class="form-wrapper">
     <%= f.label :major_change, class: "control-label" do %>
-      <%= f.check_box :major_change, disabled: @resource.locked_for_edits?, class: "input-md-7" %>
+      <%= f.check_box :major_change, disabled: @resource.locked_for_edits?, class: "input-md-7", help: "The change note will be emailed to users subscribed to email alerts and the ‘last updated’ date will change." %>
       Alert the public to this change
     <% end %>
   </span>

--- a/app/views/editions/_major_change_fields.html.erb
+++ b/app/views/editions/_major_change_fields.html.erb
@@ -5,8 +5,9 @@
 <div class="form-group emphasised-field add-bottom-margin checkbox">
   <span class="form-wrapper">
     <%= f.label :major_change, class: "control-label" do %>
-      <%= f.check_box :major_change, disabled: @resource.locked_for_edits?, class: "input-md-7", help: "The change note will be emailed to users subscribed to email alerts and the ‘last updated’ date will change." %>
+      <%= f.check_box :major_change, disabled: @resource.locked_for_edits?, class: "input-md-7" %>
       Alert the public to this change
     <% end %>
+    <span class='help-block'>The change note will be emailed to users subscribed to email alerts and the ‘last updated’ date will change.</span>
   </span>
 </div>

--- a/app/views/shared/_edition_activity_fields.html.erb
+++ b/app/views/shared/_edition_activity_fields.html.erb
@@ -12,6 +12,13 @@
       <% if activity == :skip_review %>
         <p class="alert alert-warning">You should only skip review in exceptional circumstances, for example if you're the only person responding to an emergency out of hours call.</p>
       <% end %>
+      
+      <% if activity == :request_review %>
+        <p class="help-block">Explain what changes you did or did not make and why. <% if current_user.govuk_editor? %>Include a link to the relevant Zendesk ticket and Trello card.<% end %> If you’ve added an edition note already, you do not need to add another one.</p>
+        <% if current_user.govuk_editor? %>
+          <p class="help-block">Read the <a href="https://gov-uk.atlassian.net/l/cp/dwn06raQ" rel="noreferrer noopener" target="_blank">guidance on writing good change notes on the GOV.UK wiki (opens in a new tab)</a>.</p>
+        <% end %>
+      <% end %>
 
       <% if activity == :send_fact_check %>
         <div class="form-group">

--- a/app/views/shared/_history.html.erb
+++ b/app/views/shared/_history.html.erb
@@ -9,14 +9,17 @@
         <fieldset class="inputs">
           <%= hidden_field_tag :edition_id, resource.id %>
           <div class="modal-body">
+            <p class="help-block">Explain what changes you did or did not make and why. <% if current_user.govuk_editor? %>Include a link to the relevant Zendesk ticket and Trello card.<% end %> You can also add an edition note when you send the edition for review (2nd pair of eyes).</p>
+            <% if current_user.govuk_editor? %>
+              <p class="help-block">Read the <a href="https://gov-uk.atlassian.net/l/cp/dwn06raQ" rel="noreferrer noopener" target="_blank">guidance on writing good change notes on the GOV.UK wiki (opens in a new tab)</a>.</p>
+            <% end %>
             <div class="form-group">
               <span class="form-label">
-                <%= f.label :comment, "Note" %>
+                <%= f.label :comment, "Edition note" %>
               </span>
               <span class="form-wrapper">
                 <%= f.text_area :comment, rows: 6, cols: 120, class: "form-control" %>
               </span>
-              <p class="help-block">Summarise your changes, and briefly explain why if you didn't make any requested changes.</p>
             </div>
           </div>
           <footer class="modal-footer remove-top-margin">

--- a/app/views/shared/_metadata.html.erb
+++ b/app/views/shared/_metadata.html.erb
@@ -7,7 +7,7 @@
         <%= f.hidden_field :id, value: @artefact.id %>
 
         <%= form_group(f, :slug) do %>
-          <%= f.text_field :slug, class: "form-control input-md-6" %>
+          <%= f.text_field :slug, class: "form-control input-md-6", help: "If you change the slug of a published page, the old slug will automatically redirect to the new one." %>
         <% end %>
 
         <%= form_group(f, :language) do %>

--- a/app/views/shared/_metadata.html.erb
+++ b/app/views/shared/_metadata.html.erb
@@ -6,8 +6,8 @@
       <div class="col-md-12">
         <%= f.hidden_field :id, value: @artefact.id %>
 
-        <%= form_group(f, :slug) do %>
-          <%= f.text_field :slug, class: "form-control input-md-6", help: "If you change the slug of a published page, the old slug will automatically redirect to the new one." %>
+        <%= form_group(f, :slug, help: "If you change the slug of a published page, the old slug will automatically redirect to the new one.") do %>
+          <%= f.text_field :slug, class: "form-control input-md-6" %>
         <% end %>
 
         <%= form_group(f, :language) do %>

--- a/app/views/shared/_review.html.erb
+++ b/app/views/shared/_review.html.erb
@@ -6,7 +6,7 @@
         <p><%= build_review_button(@resource, "skip_review", "Skip review").html_safe %></p>
       <% end %>
     <% else %>
-    <p><%= @resource.latest_status_action(Action::REQUEST_REVIEW).requester.name %> has sent this edition to be reviewed.</p>
+      <p><%= @resource.latest_status_action(Action::REQUEST_REVIEW).requester.name %> has sent this edition to be reviewed.</p>
       <div class="workflow-buttons">
         <%= review_buttons(@resource)%>
       </div>

--- a/app/views/shared/_review.html.erb
+++ b/app/views/shared/_review.html.erb
@@ -1,12 +1,12 @@
 <div class="alert alert-info">
   <% if @resource.latest_status_action(Action::REQUEST_REVIEW) %>
-    <p><%= @resource.latest_status_action(Action::REQUEST_REVIEW).requester.name %> has requested this edition be reviewed.</p>
     <% if @resource.latest_status_action.requester == current_user %>
-      <p>That&rsquo;s you! You'll get an email when it has been reviewed.</p>
+      <p>You’ve sent this edition to be reviewed.</p>
       <% if skip_review? %>
         <p><%= build_review_button(@resource, "skip_review", "Skip review").html_safe %></p>
       <% end %>
     <% else %>
+    <p><%= @resource.latest_status_action(Action::REQUEST_REVIEW).requester.name %> has sent this edition to be reviewed.</p>
       <div class="workflow-buttons">
         <%= review_buttons(@resource)%>
       </div>
@@ -15,7 +15,7 @@
       <% end %>
     <% end %>
   <% else %>
-    <p>We're having trouble accessing the action data. This Edition has been requested to be reviewed.</p>
+    <p>We're having trouble accessing the action data. This edition has been sent to be reviewed.</p>
     <div class="workflow-buttons">
       <%= review_buttons(@resource)%>
     </div>

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -986,7 +986,7 @@ class EditionsControllerTest < ActionController::TestCase
         end
 
         assert_redirected_to(:controller => "root", "action" => "index")
-        assert_equal "Guide destroyed", flash[:success]
+        assert_equal "Edition deleted", flash[:success]
       end
     end
   end

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -566,7 +566,7 @@ class EditionsControllerTest < ActionController::TestCase
         post :update,
              params: {
                id: welsh_edition.id,
-               commit: "OK for publication",
+               commit: "No changes needed",
                edition: {
                  activity_approve_review_attributes: {
                    request_type: :approve_review,
@@ -589,7 +589,7 @@ class EditionsControllerTest < ActionController::TestCase
         post :update,
              params: {
                id: edition.id,
-               commit: "OK for publication",
+               commit: "No changes needed",
                edition: {
                  activity_approve_review_attributes: {
                    request_type: :approve_review,

--- a/test/integration/delete_edition_test.rb
+++ b/test/integration/delete_edition_test.rb
@@ -25,7 +25,7 @@ class DeleteEditionTest < ActionDispatch::IntegrationTest
       click_button "Delete this edition – #1"
 
       within(".alert-success") do
-        assert page.has_content?("Guide destroyed")
+        assert page.has_content?("Edition deleted")
       end
     end
   end
@@ -44,7 +44,7 @@ class DeleteEditionTest < ActionDispatch::IntegrationTest
       click_button "Delete this edition – #2"
 
       within(".alert-success") do
-        assert page.has_content?("Guide destroyed")
+        assert page.has_content?("Edition deleted")
       end
     end
   end

--- a/test/integration/edition_history_test.rb
+++ b/test/integration/edition_history_test.rb
@@ -197,7 +197,7 @@ class EditionHistoryTest < JavascriptIntegrationTest
         click_on "Add edition note"
 
         within "#save-edition-note" do
-          fill_in "Note", with: "A simple Welsh note"
+          fill_in "Edition note", with: "A simple Welsh note"
           click_on "Save edition note"
         end
 

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -374,7 +374,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     guide.save!(validate: false)
 
     visit_edition guide
-    send_action guide, "No changes needed", "OK for publication", "Yup, looks good"
+    send_action guide, "No changes needed", "No changes needed", "Yup, looks good"
     assert page.has_content?("updated")
 
     filter_for_all_users

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -295,7 +295,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     assert page.has_content?("updated")
 
     assert page.has_selector?(".alert-info")
-    assert has_no_link? "OK for publication"
+    assert has_no_link? "No changes needed"
   end
 
   test "cannot be the guide reviewer and assignee" do
@@ -351,7 +351,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     visit_edition guide
     assert page.has_selector?(".alert-info")
     assert has_link? "Needs more work"
-    assert has_link? "OK for publication"
+    assert has_link? "No changes needed"
   end
 
   test "review failed" do
@@ -374,7 +374,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     guide.save!(validate: false)
 
     visit_edition guide
-    send_action guide, "OK for publication", "OK for publication", "Yup, looks good"
+    send_action guide, "No changes needed", "OK for publication", "Yup, looks good"
     assert page.has_content?("updated")
 
     filter_for_all_users
@@ -406,7 +406,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     guide.update!(state: "fact_check_received")
 
     visit_edition guide
-    send_action guide, "Minor or no changes required", "Approve fact check", "Hurrah!"
+    send_action guide, "No more work needed", "Approve fact check", "Hurrah!"
     assert page.has_content?("updated")
 
     filter_for_all_users
@@ -587,8 +587,8 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     visit_edition edition
 
     assert page.has_content?("We have received a fact check response for this edition")
-    assert_not page.has_css?(".btn.btn-info", text: "Needs major changes")
-    assert_not page.has_css?(".btn.btn-info", text: "Minor or no changes required")
+    assert_not page.has_css?(".btn.btn-info", text: "Needs more work")
+    assert_not page.has_css?(".btn.btn-info", text: "No more work needed")
   end
 
   test "Welsh editors may see buttons to respond to fact checks for Welsh editions" do
@@ -598,8 +598,8 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     visit_edition edition
 
     assert page.has_content?("We have received a fact check response for this edition")
-    assert page.has_css?(".btn.btn-info", text: "Needs major changes")
-    assert page.has_css?(".btn.btn-info", text: "Minor or no changes required")
+    assert page.has_css?(".btn.btn-info", text: "Needs more work")
+    assert page.has_css?(".btn.btn-info", text: "No more work needed")
   end
 
   test "Welsh editors may not request more work for fact checked edition" do
@@ -689,7 +689,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     visit_edition edition
 
     assert_not page.has_link?("Needs more work", href: "#request_amendments_form")
-    assert_not page.has_link?("OK for publication", href: "#approve_review_form")
+    assert_not page.has_link?("No changes needed", href: "#approve_review_form")
   end
 
   test "Welsh editors can see review buttons for Welsh editions" do
@@ -699,7 +699,7 @@ class EditionWorkflowTest < JavascriptIntegrationTest
     visit_edition edition
 
     assert page.has_link?("Needs more work", href: "#request_amendments_form")
-    assert page.has_link?("OK for publication", href: "#approve_review_form")
+    assert page.has_link?("No changes needed", href: "#approve_review_form")
   end
 
   test "Welsh editors cannot see buttons to request a review for non-Welsh editions" do


### PR DESCRIPTION
This PR includes several commits updating content in Mainstream Publisher to make actions and steps in the workflow clearer for content designers using the application.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
