### PR TITLE
Remove Mailer from the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem "inherited_resources"
 gem "jquery-ui-rails"
 gem "kaminari"
 gem "kaminari-mongoid"
-gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mail-notify"
 gem "mlanett-redis-lock"
 gem "momentjs-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -569,7 +569,6 @@ DEPENDENCIES
   kaminari
   kaminari-mongoid
   launchy
-  mail (~> 2.7.1)
   mail-notify
   minitest-reporters
   mlanett-redis-lock


### PR DESCRIPTION
Previously, there was an issue with the mailer gem in release 2.8.0 mikel/mail#1489.

To circumvent this we added it to the Gemfile and pinned it on the 2.7.0 release. Since this has been fixed we can remove it as a direct dependency.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
