### PR TITLE
Change completed_transactions rendering app

### DIFF
--- a/app/presenters/formats/completed_transaction_presenter.rb
+++ b/app/presenters/formats/completed_transaction_presenter.rb
@@ -16,6 +16,10 @@ module Formats
       optional_details.merge(required_details)
     end
 
+    def rendering_app
+      "feedback"
+    end
+
     def required_details
       { external_related_links: }
     end

--- a/test/unit/presenters/formats/completed_transaction_presenter_test.rb
+++ b/test/unit/presenters/formats/completed_transaction_presenter_test.rb
@@ -86,6 +86,10 @@ class CompletedTransactionPresenterTest < ActiveSupport::TestCase
 
       assert_equal expected, result[:details][:external_related_links]
     end
+
+    should "[:rendering_app]" do
+      assert_equal "feedback", result[:rendering_app]
+    end
   end
 
   should "[:routes]" do


### PR DESCRIPTION
[Trello](https://trello.com/c/VHZ1R1zY/262-no-form-validation-on-service-feedback-forms-l)

This needs to be deployed along with two other PRS in [Feedback](https://github.com/alphagov/feedback/pull/1601) and [Frontend](https://github.com/alphagov/frontend/pull/3534).

# What? 
This changes the rendering app for completed transactions from Frontend to Feedback. For more information about this change, [see this PR](https://github.com/alphagov/feedback/pull/1601).

When the various PRs are deployed, the completed transactions will need to be republished. Hence do not merge as things will need to happen in a set order!

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
