### PR TITLE
Include necessary scripts in the container image.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,7 +12,7 @@ docs
 features
 log
 node_modules
-script
+script/cucumber
 spec
 test
 tmp


### PR DESCRIPTION
The mail-fetcher cronjob was failing because it needs `script/mail_fetcher`.

This only affects the container image; no change to the EC2/Puppet deployment.