### PR TITLE
Include locale in call to publishing api to discard draft edition

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -434,7 +434,7 @@ class Edition
   def destroy_publishing_api_draft
     return unless can_destroy?
 
-    Services.publishing_api.discard_draft(content_id)
+    Services.publishing_api.discard_draft(content_id, locale: artefact.language)
   rescue GdsApi::HTTPNotFound
     nil
   rescue GdsApi::HTTPUnprocessableEntity

--- a/test/integration/delete_edition_test.rb
+++ b/test/integration/delete_edition_test.rb
@@ -20,7 +20,7 @@ class DeleteEditionTest < ActionDispatch::IntegrationTest
 
       click_on "Admin"
 
-      Services.publishing_api.expects(:discard_draft).with(artefact.content_id)
+      Services.publishing_api.expects(:discard_draft).with(artefact.content_id, locale: artefact.language)
 
       click_button "Delete this edition – #1"
 
@@ -39,7 +39,7 @@ class DeleteEditionTest < ActionDispatch::IntegrationTest
 
       click_on "Admin"
 
-      Services.publishing_api.expects(:discard_draft).with(artefact.content_id)
+      Services.publishing_api.expects(:discard_draft).with(artefact.content_id, locale: artefact.language)
 
       click_button "Delete this edition – #2"
 

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -41,6 +41,7 @@ FactoryBot.define do
     kind            { Artefact::FORMATS.first }
     owning_app      { "publisher" }
     content_id      { SecureRandom.uuid }
+    language        { "en" }
 
     trait :with_published_edition do
       after(:create) do |object|


### PR DESCRIPTION
There is a bug whereby when an edition with a non-english locale is deleted in Mainstream Publisher, it attempts to discard the draft from the Publishing API. However, this fails because the 'locale' option is not provided, so the Publishing API assumes its an english edition. This commit fixes that by ensuring that the locale is passed to Publishing API for this discard message.

[Trello ticket](https://trello.com/c/1aKN17NQ/1086-mainstream-publisher-doesnt-discard-non-english-editions-properly)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- Adds locale to call to Publishing API to discard draft edition

## Why
At the moment there is a bug where because this locale is not provided, the publishing API assumes its an English edition and then fails to find and discard the appropriate edition.
