### PR TITLE
Upload and serve reports from S3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "7.0.4.3"
 
+gem "aws-sdk-s3", "~> 1"
 gem "bootsnap", require: false
 gem "bootstrap-kaminari-views"
 gem "diffy"

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem "whenever", require: false
 group :test do
   gem "capybara-select-2"
   gem "ci_reporter_minitest"
+  gem "climate_control"
   gem "database_cleaner-mongoid"
   gem "factory_bot_rails"
   gem "govuk_schemas"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,7 @@ GEM
     ci_reporter_minitest (1.0.0)
       ci_reporter (~> 2.0)
       minitest (~> 5.0)
+    climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     connection_pool (2.3.0)
@@ -570,6 +571,7 @@ DEPENDENCIES
   bootstrap-kaminari-views
   capybara-select-2
   ci_reporter_minitest
+  climate_control
   database_cleaner-mongoid
   diffy
   erubis

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,22 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.748.0)
+    aws-sdk-core (3.171.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.5)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.63.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.120.1)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.4)
+    aws-sigv4 (1.5.2)
+      aws-eventstream (~> 1, >= 1.0.2)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     bootstrap-kaminari-views (0.0.5)
@@ -218,6 +234,7 @@ GEM
       has_scope (~> 0.6)
       railties (>= 5.2, < 7.1)
       responders (>= 2, < 4)
+    jmespath (1.6.2)
     jquery-rails (4.5.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -548,6 +565,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  aws-sdk-s3 (~> 1)
   bootsnap
   bootstrap-kaminari-views
   capybara-select-2

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,5 +1,3 @@
-require "csv_report_generator"
-
 class ReportsController < ApplicationController
   include ActionView::Helpers::TagHelper
 
@@ -8,55 +6,34 @@ class ReportsController < ApplicationController
   def index; end
 
   def progress
-    send_report "editorial_progress"
+    redirect_to Report.new("editorial_progress").url, allow_other_host: true
   end
 
   def organisation_content
-    send_report "organisation_content"
+    redirect_to Report.new("organisation_content").url, allow_other_host: true
   end
 
   def edition_churn
-    send_report "edition_churn"
+    redirect_to Report.new("edition_churn").url, allow_other_host: true
   end
 
   def content_workflow
-    send_report "content_workflow"
+    redirect_to Report.new("content_workflow").url, allow_other_host: true
   end
 
   def all_urls
-    send_report "all_urls"
+    redirect_to Report.new("all_urls").url, allow_other_host: true
   end
 
 private
 
-  def report_last_updated(report)
-    mtime = mtime_for(report)
-    if mtime
-      tag.span "Generated #{mtime.to_fs(:govuk_date)}", class: "text-muted"
+  def report_last_updated(report_name)
+    last_updated = ::Report.new(report_name).last_updated
+    if last_updated
+      tag.span "Generated #{last_updated.to_fs(:govuk_date)}", class: "text-muted"
     else
       tag.span "Report currently unavailable", class: "text-muted"
     end
   end
   helper_method :report_last_updated
-
-  def mtime_for(report)
-    File.stat(report_location(report)).mtime.in_time_zone(Time.zone)
-  rescue Errno::ENOENT
-    nil
-  end
-
-  def report_location(report)
-    File.join(CsvReportGenerator.csv_path, "#{report}.csv")
-  end
-
-  def send_report(report)
-    if File.exist?(report_location(report))
-      send_file report_location(report),
-                filename: "#{report}-#{mtime_for(report).strftime('%Y%m%d%H%M%S')}.csv",
-                type: "text/csv",
-                disposition: "attachment"
-    else
-      head(:not_found)
-    end
-  end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,0 +1,38 @@
+require "aws-sdk-s3"
+
+class Report
+  def initialize(report_name)
+    @bucket_name = ENV["REPORTS_S3_BUCKET_NAME"]
+    @s3 = Aws::S3::Client.new
+
+    @report_name = report_name
+  end
+
+  def filename
+    "#{@report_name}.csv"
+  end
+
+  def upload_to_s3(body)
+    @s3.put_object(
+      bucket: @bucket_name,
+      key: filename,
+      body:,
+    )
+  end
+
+  def last_updated
+    response = @s3.head_object(bucket: @bucket_name, key: filename)
+    response.last_modified
+  rescue Aws::S3::Errors::NotFound
+    nil
+  end
+
+  def url
+    Aws::S3::Presigner.new.presigned_url(
+      :get_object,
+      bucket: @bucket_name,
+      key: filename,
+      expires_in: 5,
+    )
+  end
+end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,6 +1,29 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "4de24c49b5d87e19ef510a17b4952468eaac4f2bfdcf3d5a67507cf694c25c93",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/reports_controller.rb",
+      "line": 25,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(Report.new(\"all_urls\").url, :allow_other_host => true)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ReportsController",
+        "method": "all_urls"
+      },
+      "user_input": "Report.new(\"all_urls\").url",
+      "confidence": "High",
+      "cwe_id": [
+        601
+      ],
+      "note": "This is a redirect to AWS S3 for file download, unlikely to be dangerous."
+    },
+    {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
       "fingerprint": "73de97a88f3e6fef8a35ced89420323264c5014cde36875b2795a1ac9cf85015",
@@ -35,6 +58,52 @@
       "note": ""
     },
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "814bc0a997725602aa2913dd902c8d77c28de9044d4562f60a898ad250d04b5a",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "lib/csv_report_generator.rb",
+      "line": 6,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Redis.new.lock(\"publisher:#{Rails.env}:report_generation_lock\", :life => 15.minutes)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "CsvReportGenerator",
+        "method": "run!"
+      },
+      "user_input": "Rails.env",
+      "confidence": "Weak",
+      "cwe_id": [
+        89
+      ],
+      "note": "We don't pass any user data to this string."
+    },
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "8a68da1b1484168c425d8ececc95a8768e24993e9eff56e549f233f877ed5628",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/reports_controller.rb",
+      "line": 17,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(Report.new(\"edition_churn\").url, :allow_other_host => true)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ReportsController",
+        "method": "edition_churn"
+      },
+      "user_input": "Report.new(\"edition_churn\").url",
+      "confidence": "High",
+      "cwe_id": [
+        601
+      ],
+      "note": "This is a redirect to AWS S3 for file download, unlikely to be dangerous."
+    },
+    {
       "warning_type": "Remote Code Execution",
       "warning_code": 110,
       "fingerprint": "9ae68e59cfee3e5256c0540dadfeb74e6b72c91997fdb60411063a6e8518144a",
@@ -53,6 +122,29 @@
         502
       ],
       "note": "The params[:list] argument is already checked before the template gets rendered by @presenter.acceptable_list?(@list)."
+    },
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "a4a63bc63305104b5cd40a8d6bd5dd10386b184d04e93294d63f4795f30a7bee",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/reports_controller.rb",
+      "line": 21,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(Report.new(\"content_workflow\").url, :allow_other_host => true)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ReportsController",
+        "method": "content_workflow"
+      },
+      "user_input": "Report.new(\"content_workflow\").url",
+      "confidence": "High",
+      "cwe_id": [
+        601
+      ],
+      "note": "This is a redirect to AWS S3 for file download, unlikely to be dangerous."
     },
     {
       "warning_type": "Dangerous Send",
@@ -86,29 +178,55 @@
       "cwe_id": [
         77
       ],
-      "note": "The params[:list] argument is already checked before the template gets rendered by @presenter.acceptable_list?(@list)."
+      "note": ""
     },
     {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "814bc0a997725602aa2913dd902c8d77c28de9044d4562f60a898ad250d04b5a",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "lib/csv_report_generator.rb",
-      "line": 11,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Redis.new.lock(\"publisher:#{Rails.env}:report_generation_lock\", :life => 15.minutes)",
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "ae27d181beea686b653e71c89ed40293d9b4c7a8866de6894d3f3555d6a12760",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/reports_controller.rb",
+      "line": 13,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(Report.new(\"organisation_content\").url, :allow_other_host => true)",
       "render_path": null,
       "location": {
         "type": "method",
-        "class": "CsvReportGenerator",
-        "method": "run!"
+        "class": "ReportsController",
+        "method": "organisation_content"
       },
-      "user_input": "Rails.env",
-      "confidence": "Weak",
-      "note": "We don't pass any user data to this string."
+      "user_input": "Report.new(\"organisation_content\").url",
+      "confidence": "High",
+      "cwe_id": [
+        601
+      ],
+      "note": "This is a redirect to AWS S3 for file download, unlikely to be dangerous."
+    },
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "b5e56ced685a7fcccc47f90ea76587a75d2ad12f9330058d2ff52d18d7d3d6b6",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/reports_controller.rb",
+      "line": 9,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(Report.new(\"editorial_progress\").url, :allow_other_host => true)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ReportsController",
+        "method": "progress"
+      },
+      "user_input": "Report.new(\"editorial_progress\").url",
+      "confidence": "High",
+      "cwe_id": [
+        601
+      ],
+      "note": "This is a redirect to AWS S3 for file download, unlikely to be dangerous."
     }
   ],
-  "updated": "2022-10-06 12:04:32 +0100",
+  "updated": "2023-04-18 09:48:30 +0100",
   "brakeman_version": "5.3.1"
 }

--- a/lib/csv_report_generator.rb
+++ b/lib/csv_report_generator.rb
@@ -2,26 +2,21 @@ require "redis"
 require "redis-lock"
 
 class CsvReportGenerator
-  def self.csv_path
-    ENV["GOVUK_APP_ROOT"] ||= Rails.root
-    File.join(ENV["GOVUK_APP_ROOT"], "reports")
-  end
-
   def run!
     Redis.new.lock("publisher:#{Rails.env}:report_generation_lock", life: 15.minutes) do
-      reports.each do |report|
-        Rails.logger.debug "Generating #{path}/#{report.report_name}.csv"
-        report.write_csv(path)
-      end
+      presenters.each do |presenter|
+        report = Report.new(presenter.report_name)
 
-      move_temporary_reports_into_place
+        Rails.logger.debug "Uploading #{report.filename} to S3"
+        report.upload_to_s3(presenter.to_csv)
+      end
     end
   rescue Redis::Lock::LockNotAcquired => e
     Rails.logger.debug("Failed to get lock for report generation (#{e.message}). Another process probably got there first.")
   end
 
-  def reports
-    @reports ||= [
+  def presenters
+    @presenters ||= [
       EditorialProgressPresenter.new(
         Edition.not_in(state: %w[archived]),
       ),
@@ -40,23 +35,6 @@ class CsvReportGenerator
         Artefact.where(owning_app: "publisher").not_in(state: %w[archived]),
       ),
     ]
-  end
-
-  def path
-    return @path if @path
-
-    @path = File.join(
-      Dir.tmpdir,
-      "publisher_reports-#{Time.zone.now.strftime('%Y%m%d%H%M%S')}-#{Process.pid}",
-    )
-    FileUtils.mkdir_p(@path)
-    @path
-  end
-
-  def move_temporary_reports_into_place
-    Dir[File.join(path, "*.csv")].each do |file|
-      FileUtils.mv(file, self.class.csv_path, force: true)
-    end
   end
 
   def redis

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -1,0 +1,66 @@
+require "aws-sdk-s3"
+require "test_helper"
+
+class ReportTest < ActiveSupport::TestCase
+  def setup
+    @stubbed_s3_client = Aws::S3::Client.new(stub_responses: true)
+    Aws::S3::Client.stubs(:new).returns(@stubbed_s3_client)
+
+    @bucket_name = "my-test-bucket"
+  end
+
+  context "#filename" do
+    should "return filename with extension" do
+      report = Report.new("example")
+      assert_equal "example.csv", report.filename
+    end
+  end
+
+  context "#upload_to_s3" do
+    should "call put object to S3" do
+      expected_put_object_request = {
+        bucket: @bucket_name,
+        key: "example.csv",
+        body: "body",
+      }
+
+      ClimateControl.modify REPORTS_S3_BUCKET_NAME: @bucket_name do
+        report = Report.new("example")
+        report.upload_to_s3("body")
+      end
+
+      assert_equal 1, @stubbed_s3_client.api_requests.size
+      assert_equal expected_put_object_request, @stubbed_s3_client.api_requests.first[:params]
+    end
+  end
+
+  context "#last_updated" do
+    should "return nil if object not present" do
+      @stubbed_s3_client.stub_responses(:head_object, "NotFound")
+
+      ClimateControl.modify REPORTS_S3_BUCKET_NAME: @bucket_name do
+        report = Report.new("example")
+        assert_nil report.last_updated
+      end
+    end
+
+    should "return with date if object present" do
+      last_modified = Time.zone.local(2023, 12, 12, 1, 1, 1)
+      @stubbed_s3_client.stub_responses(:head_object, { last_modified: })
+
+      ClimateControl.modify REPORTS_S3_BUCKET_NAME: @bucket_name do
+        report = Report.new("example")
+        assert_equal last_modified, report.last_updated
+      end
+    end
+  end
+
+  context "#url" do
+    should "return a presigned URL for the csv" do
+      ClimateControl.modify REPORTS_S3_BUCKET_NAME: @bucket_name do
+        report = Report.new("example")
+        assert report.url.starts_with?("https://#{@bucket_name}.s3.us-stubbed-1.amazonaws.com/example.csv")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Since moving to container based hosting whereby the file system is readonly, the reports functional has broken. This is because the CSVs for reports were written and served from the local filesystem.

This replaces the local filesystem with S3. The hour rake task that generates the CSV report now uploads them to S3. The reports page then redirects users to a signed link valid for 5 mins to download the reports.

PR for Terraform to create bucket:
https://github.com/alphagov/govuk-infrastructure/pull/857

PR to set env var:
https://github.com/alphagov/govuk-helm-charts/pull/1075