### PR TITLE
Add double-locks

### DIFF
--- a/lib/csv_report_generator.rb
+++ b/lib/csv_report_generator.rb
@@ -4,11 +4,13 @@ require "redis-lock"
 class CsvReportGenerator
   def run!
     Redis.new.lock("publisher:#{Rails.env}:report_generation_lock", life: 900) do
-      presenters.each do |presenter|
-        report = Report.new(presenter.report_name)
+      Redis.new.lock("publisher:report_generation_lock", life: 900) do
+        presenters.each do |presenter|
+          report = Report.new(presenter.report_name)
 
-        Rails.logger.debug "Uploading #{report.filename} to S3"
-        report.upload_to_s3(presenter.to_csv)
+          Rails.logger.debug "Uploading #{report.filename} to S3"
+          report.upload_to_s3(presenter.to_csv)
+        end
       end
     end
   rescue Redis::Lock::LockNotAcquired => e

--- a/script/mail_fetcher
+++ b/script/mail_fetcher
@@ -40,7 +40,7 @@ begin
   Redis.new.lock("publisher:#{Rails.env}:fact_check_processing_lock", life: AUTOMATIC_LOCK_EXPIRY) do |lock|
     Redis.new.lock("publisher:fact_check_processing_lock", life: AUTOMATIC_LOCK_EXPIRY) do |inner_lock|
       handler.process do
-        inner_lock.exception(AUTOMATIC_LOCK_EXPIRY)
+        inner_lock.extend_life(AUTOMATIC_LOCK_EXPIRY)
         lock.extend_life(AUTOMATIC_LOCK_EXPIRY)
       end
     end

--- a/script/mail_fetcher
+++ b/script/mail_fetcher
@@ -38,8 +38,11 @@ handler = FactCheckEmailHandler.new(Publisher::Application.fact_check_config)
 AUTOMATIC_LOCK_EXPIRY = (5 * 60) # seconds
 begin
   Redis.new.lock("publisher:#{Rails.env}:fact_check_processing_lock", life: AUTOMATIC_LOCK_EXPIRY) do |lock|
-    handler.process do
-      lock.extend_life(AUTOMATIC_LOCK_EXPIRY)
+    Redis.new.lock("publisher:fact_check_processing_lock", life: AUTOMATIC_LOCK_EXPIRY) do |inner_lock|
+      handler.process do
+        inner_lock.exception(AUTOMATIC_LOCK_EXPIRY)
+        lock.extend_life(AUTOMATIC_LOCK_EXPIRY)
+      end
     end
   end
 rescue Redis::Lock::LockNotAcquired => e


### PR DESCRIPTION
Adds a second lock inside the current lock in the CsvReportGenerator#run! method and inside the mail_fetcher script.

This is a first step to cleaning up a little tech debt. We want to remove the environment from the lock name (not necessary because all environments have their own redis anyway, and undesirable because it requires a brakeman ignore).

However, these scripts are run by cron jobs (the mail_fetcher script is run every 5 minutes, and the reports:generate task - which uses CsvReportGenerator - is run on the hour), so it's not necessarily possible to ensure that the job won't be running when the app is deployed. This means if we just change the lock name there's a possibility two instances will try to run the task, one with the old lock, one with the new one. So here we require both locks. Once this is deployed and two hours have passed we can deploy with the new lock only, safe in the knowledge that if we deploy during a rake run it'll already be locking the new lock.

https://trello.com/c/84yWQ0NJ/1662-ps-15-clean-up-brakeman-errors-following-on-from-rediscurrent-redisnew-updates

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
