### PR TITLE
Remove original lock now a safe time has passed

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -24,29 +24,6 @@
       "note": "This is a redirect to AWS S3 for file download, unlikely to be dangerous."
     },
     {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "56a132f8b3538ac32e889d8c251c856723b1a5ef7ca6fa0dcc3c684a6ae317a4",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "lib/csv_report_generator.rb",
-      "line": 6,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Redis.new.lock(\"publisher:#{Rails.env}:report_generation_lock\", :life => 900)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "CsvReportGenerator",
-        "method": "run!"
-      },
-      "user_input": "Rails.env",
-      "confidence": "Weak",
-      "cwe_id": [
-        89
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
       "fingerprint": "73de97a88f3e6fef8a35ced89420323264c5014cde36875b2795a1ac9cf85015",

--- a/lib/csv_report_generator.rb
+++ b/lib/csv_report_generator.rb
@@ -3,14 +3,12 @@ require "redis-lock"
 
 class CsvReportGenerator
   def run!
-    Redis.new.lock("publisher:#{Rails.env}:report_generation_lock", life: 900) do
-      Redis.new.lock("publisher:report_generation_lock", life: 900) do
-        presenters.each do |presenter|
-          report = Report.new(presenter.report_name)
+    Redis.new.lock("publisher:report_generation_lock", life: 900) do
+      presenters.each do |presenter|
+        report = Report.new(presenter.report_name)
 
-          Rails.logger.debug "Uploading #{report.filename} to S3"
-          report.upload_to_s3(presenter.to_csv)
-        end
+        Rails.logger.debug "Uploading #{report.filename} to S3"
+        report.upload_to_s3(presenter.to_csv)
       end
     end
   rescue Redis::Lock::LockNotAcquired => e

--- a/script/mail_fetcher
+++ b/script/mail_fetcher
@@ -37,12 +37,9 @@ handler = FactCheckEmailHandler.new(Publisher::Application.fact_check_config)
 # that long.
 AUTOMATIC_LOCK_EXPIRY = (5 * 60) # seconds
 begin
-  Redis.new.lock("publisher:#{Rails.env}:fact_check_processing_lock", life: AUTOMATIC_LOCK_EXPIRY) do |lock|
-    Redis.new.lock("publisher:fact_check_processing_lock", life: AUTOMATIC_LOCK_EXPIRY) do |inner_lock|
-      handler.process do
-        inner_lock.extend_life(AUTOMATIC_LOCK_EXPIRY)
-        lock.extend_life(AUTOMATIC_LOCK_EXPIRY)
-      end
+  Redis.new.lock("publisher:fact_check_processing_lock", life: AUTOMATIC_LOCK_EXPIRY) do |lock|
+    handler.process do
+      lock.extend_life(AUTOMATIC_LOCK_EXPIRY)
     end
   end
 rescue Redis::Lock::LockNotAcquired => e


### PR DESCRIPTION
Removes the original lock, moving us to the simplified lock name added here: https://github.com/alphagov/publisher/pull/1815

Can be merged once a safe period of time has passed (min 2 hours after original pull merged, so any time on Friday 19th May or later would be reasonable)

https://trello.com/c/84yWQ0NJ/1662-ps-15-clean-up-brakeman-errors-following-on-from-rediscurrent-redisnew-updates

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
