### PR TITLE
Add task to unpublish licence finder

### DIFF
--- a/lib/tasks/once_off/unpublish_licence_finder.rake
+++ b/lib/tasks/once_off/unpublish_licence_finder.rake
@@ -1,0 +1,27 @@
+namespace :once_off do
+  desc "Archives and unpublishes the licence finder, redirecting to the new one"
+  task unpublish_licence_finder: :environment do
+    licence_finder_edition = Edition.where(state: "published", slug: "licence-finder").last
+    artefact = licence_finder_edition.artefact
+    redirect_url = "/find-licences"
+
+    artefact.assign_attributes(state: "archived", redirect_url:)
+    artefact.save_as_task!("once_off:unpublish_licence_finder")
+
+    Services.publishing_api.unpublish(
+      artefact.content_id,
+      locale: artefact.language,
+      type: "redirect",
+      redirects: [
+        {
+          path: "/#{artefact.slug}",
+          type: "prefix",
+          destination: redirect_url,
+          segments_mode: "ignore",
+        },
+      ],
+      discard_drafts: true,
+    )
+    puts("#{licence_finder_edition.slug} archived, unpublished with redirect to #{redirect_url}")
+  end
+end


### PR DESCRIPTION
- redirects to the new licence finder at /find-licences

This rake task uses a copy of the code from UnpublishService (slightly modified to allow a named task as the user) to perform the unpublish task task.

https://trello.com/c/Wkj80QfI/2062-create-temp-rake-task-to-redirect-the-old-licence-finder

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
