### PR TITLE
Remove action buttons if document type is retired

### DIFF
--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -26,7 +26,8 @@ module TabsHelper
     tabs_to_remove = []
     tabs_to_remove << "admin" unless user.has_editor_permissions?(resource)
     tabs_to_remove << "unpublish" unless user.govuk_editor?
+    tabs_to_remove.concat(%w[admin unpublish]) if resource.retired_format?
 
-    tabs.reject { |tab| tabs_to_remove.include?(tab.name) }
+    tabs.reject { |tab| tabs_to_remove.uniq.include?(tab.name) }
   end
 end

--- a/app/views/shared/_related_external_links.html.erb
+++ b/app/views/shared/_related_external_links.html.erb
@@ -23,10 +23,15 @@
       </div>
     <% end %>
 
-    <%= f.link_to_add "Add related external link", :external_links, :class => "btn btn-primary" %>
+
+    <% unless @resource.retired_format? %>
+      <%= f.link_to_add "Add related external link", :external_links, :class => "btn btn-primary" %>
+    <% end %>
   </div>
 
-  <br/>
+    <% unless @resource.retired_format? %>
+      <br/>
 
-  <%= f.submit 'Save links', class: "btn btn-success btn-large" %>
+      <%= f.submit 'Save links', class: "btn btn-success btn-large" %>
+    <% end %>
 <% end %>

--- a/app/views/shared/_tagging.html.erb
+++ b/app/views/shared/_tagging.html.erb
@@ -127,6 +127,9 @@
       </div>
     </div>
 
-    <hr/>
-    <%= f.submit 'Update tags', class: "btn btn-success btn-large" %>
+    <% unless @resource.retired_format? %>
+      <hr/>
+
+      <%= f.submit 'Update tags', class: "btn btn-success btn-large" %>
+    <% end %>
 <% end %>

--- a/app/views/shared/_workflow_buttons.html.erb
+++ b/app/views/shared/_workflow_buttons.html.erb
@@ -15,7 +15,7 @@
           <% end %>
           <%= progress_buttons(@resource, skip_disabled_buttons: true) %>
         <% else %>
-          <% if current_user.has_editor_permissions?(@resource) %>
+          <% if current_user.has_editor_permissions?(@resource) && !@resource.retired_format? %>
             <%= f.submit 'Save', id: 'save-edition', class: 'btn btn-success btn-large js-save' %>
           <% end %>
           <%= preview_button(@resource) %>


### PR DESCRIPTION
## Before

## After

wdfs

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
