### PR TITLE
Disable document actions after marked as retired

### DIFF
--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -25,8 +25,9 @@ module TabsHelper
   def tabs_for(user, resource)
     tabs_to_remove = []
     tabs_to_remove << "admin" unless user.has_editor_permissions?(resource)
+    tabs_to_remove << "admin" if resource.retired_format?
     tabs_to_remove << "unpublish" unless user.govuk_editor?
 
-    tabs.reject { |tab| tabs_to_remove.include?(tab.name) }
+    tabs.reject { |tab| tabs_to_remove.uniq.include?(tab.name) }
   end
 end

--- a/app/views/shared/_related_external_links.html.erb
+++ b/app/views/shared/_related_external_links.html.erb
@@ -18,15 +18,22 @@
             <%= link.label :url, "URL" %>
             <%= link.text_field :url, class: 'form-control' %>
           </div>
-          <%= link.link_to_remove "Remove this URL", class: "remove-row remove-row-related" %>
+          <% unless @resource.retired_format? %>
+            <%= link.link_to_remove "Remove this URL", class: "remove-row remove-row-related" %>
+          <% end %>
         </div>
       </div>
     <% end %>
 
-    <%= f.link_to_add "Add related external link", :external_links, :class => "btn btn-primary" %>
+
+    <% unless @resource.retired_format? %>
+      <%= f.link_to_add "Add related external link", :external_links, :class => "btn btn-primary" %>
+    <% end %>
   </div>
 
-  <br/>
+    <% unless @resource.retired_format? %>
+      <br/>
 
-  <%= f.submit 'Save links', class: "btn btn-success btn-large" %>
+      <%= f.submit 'Save links', class: "btn btn-success btn-large" %>
+    <% end %>
 <% end %>

--- a/app/views/shared/_tagging.html.erb
+++ b/app/views/shared/_tagging.html.erb
@@ -127,6 +127,9 @@
       </div>
     </div>
 
-    <hr/>
-    <%= f.submit 'Update tags', class: "btn btn-success btn-large" %>
+    <% unless @resource.retired_format? %>
+      <hr/>
+
+      <%= f.submit 'Update tags', class: "btn btn-success btn-large" %>
+    <% end %>
 <% end %>

--- a/app/views/shared/_workflow_buttons.html.erb
+++ b/app/views/shared/_workflow_buttons.html.erb
@@ -15,7 +15,7 @@
           <% end %>
           <%= progress_buttons(@resource, skip_disabled_buttons: true) %>
         <% else %>
-          <% if current_user.has_editor_permissions?(@resource) %>
+          <% if current_user.has_editor_permissions?(@resource) && !@resource.retired_format? %>
             <%= f.submit 'Save', id: 'save-edition', class: 'btn btn-success btn-large js-save' %>
           <% end %>
           <%= preview_button(@resource) %>

--- a/test/unit/tabs_helper_test.rb
+++ b/test/unit/tabs_helper_test.rb
@@ -58,5 +58,11 @@ class TabsHelperTest < ActionView::TestCase
       user = FactoryBot.create(:user, :welsh_editor)
       assert_equal %w[admin unpublish], (tabs - tabs_for(user, guide)).map(&:name)
     end
+
+    should "exclude `admin` tab if document retired" do
+      retired_document = FactoryBot.create(:campaign_edition)
+      user = FactoryBot.create(:user, :govuk_editor)
+      assert_equal %w[admin], (tabs - tabs_for(user, retired_document)).map(&:name)
+    end
   end
 end


### PR DESCRIPTION
Previously, retiring a document only disabled creating a brand new
edition and creating a new edition of an existing document. However,
there were a number of POST actions that a user could perform, like
update tagging, change format + saving the document.

If we mark the document type as 'retired' then we don't expect the
inidvidual documents to be modified. All the documents data can be
displayed but not edited + internal notes + unpublish feature (incase a
document needs unpublishing).

Trello:
https://trello.com/c/85Kl4zO7/2092-disable-editing-of-tags-when-marking-publisher-licences-as-retired

## Before

<img width="985" alt="Screenshot 2023-06-29 at 13 00 17" src="https://github.com/alphagov/publisher/assets/24479188/c27a63ed-634b-4a30-ae3b-d187f1d6ee20">
<img width="1219" alt="Screenshot 2023-06-29 at 12 59 12" src="https://github.com/alphagov/publisher/assets/24479188/b45faf53-e356-47f9-acb9-121f53a4e244">
<img width="1075" alt="Screenshot 2023-06-29 at 12 59 59" src="https://github.com/alphagov/publisher/assets/24479188/ccd3f55e-b636-4e51-af61-7d0ecf501138">
<img width="1096" alt="Screenshot 2023-06-29 at 13 00 09" src="https://github.com/alphagov/publisher/assets/24479188/3dc80569-0aee-482b-a1fe-f3e074e3905f">

## After

<img width="1264" alt="Screenshot 2023-07-10 at 13 39 20" src="https://github.com/alphagov/publisher/assets/24479188/8e5eaf48-b5dc-4c77-b864-b444f3f4a076">
<img width="1204" alt="Screenshot 2023-07-10 at 12 58 45" src="https://github.com/alphagov/publisher/assets/24479188/62415b78-9546-4a5c-84cc-6074447ee603">
<img width="1298" alt="Screenshot 2023-07-10 at 12 58 51" src="https://github.com/alphagov/publisher/assets/24479188/321eb2aa-d859-4681-9406-d2b4077f39b2">
<img width="1249" alt="Screenshot 2023-07-10 at 12 59 00" src="https://github.com/alphagov/publisher/assets/24479188/4573328c-399d-491b-be3d-0a6ea548777f">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

