### PR TITLE
Revert "Bump mongo from 2.18.2 to 2.19.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,7 +303,7 @@ GEM
       ruby2_keywords (>= 0.0.5)
     momentjs-rails (2.29.4.1)
       railties (>= 3.1)
-    mongo (2.19.0)
+    mongo (2.18.2)
       bson (>= 4.14.1, < 5.0.0)
     mongoid (8.0.4)
       activemodel (>= 5.1, < 7.1, != 7.0.0)


### PR DESCRIPTION
Reverting this change as we believe it [caused an incident](https://docs.google.com/document/d/1ty12B5eBWB9YSfnD9xY1mr5rtTQxdNxRdmEGgibilN0/edit).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
