### PR TITLE
Readd admin tab to retired documents

### DIFF
--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -25,9 +25,8 @@ module TabsHelper
   def tabs_for(user, resource)
     tabs_to_remove = []
     tabs_to_remove << "admin" unless user.has_editor_permissions?(resource)
-    tabs_to_remove << "admin" if resource.retired_format?
     tabs_to_remove << "unpublish" unless user.govuk_editor?
 
-    tabs.reject { |tab| tabs_to_remove.uniq.include?(tab.name) }
+    tabs.reject { |tab| tabs_to_remove.include?(tab.name) }
   end
 end

--- a/test/unit/tabs_helper_test.rb
+++ b/test/unit/tabs_helper_test.rb
@@ -58,11 +58,5 @@ class TabsHelperTest < ActionView::TestCase
       user = FactoryBot.create(:user, :welsh_editor)
       assert_equal %w[admin unpublish], (tabs - tabs_for(user, guide)).map(&:name)
     end
-
-    should "exclude `admin` tab if document retired" do
-      retired_document = FactoryBot.create(:campaign_edition)
-      user = FactoryBot.create(:user, :govuk_editor)
-      assert_equal %w[admin], (tabs - tabs_for(user, retired_document)).map(&:name)
-    end
   end
 end


### PR DESCRIPTION
This was originally removed as you can change document format from this tab but the tab also houses the delete draft feature which we need.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
