### PR TITLE
Skip unpublishing one smokey licence

### DIFF
--- a/lib/tasks/once_off/unpublish_licences.rake
+++ b/lib/tasks/once_off/unpublish_licences.rake
@@ -17,10 +17,14 @@ PATHS_NOT_TO_MIGRATE = [
   "pet-shop-licence-wales-scotland",
 ].freeze
 
+PATH_NOT_TO_UNPUBLISH = "busking-licence".freeze
+
 namespace :once_off do
   desc "Archives and unpublishes licences after they've been migrated to Specialist Publisher"
   task unpublish_licences: :environment do
     LicenceEdition.where(state: "published").each do |licence_edition|
+      next if licence_edition.slug == PATH_NOT_TO_UNPUBLISH
+
       if licence_edition.exact_route?
         puts("WARNING: #{licence_edition.slug} skipped as it unexpectedly has an exact route")
         next


### PR DESCRIPTION
busking-licence is used in our smoke tests but Smokey can't be deployed currently due to chromedriver version issues. This means that we can't update smokey to point at the new busking-licence path (/find-licences/busking-licence) and thus Smokey would start failing if we unpublished the original licence. Temporary fix to leave the busking licence published while unpublishing all other licence.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
