### PR TITLE
fix(workflow) update artefact before 'publishing' edition state

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -31,7 +31,7 @@ module Workflow
         edition.reviewer = nil
       end
 
-      after_transition on: :publish do |edition, _transition|
+      before_transition on: :publish do |edition, _transition|
         edition.was_published
       end
 

--- a/test/models/workflow_test.rb
+++ b/test/models/workflow_test.rb
@@ -532,7 +532,7 @@ class WorkflowTest < ActiveSupport::TestCase
       edition = FactoryBot.create(:edition, state: "ready")
       raise_exception = -> { raise "something went wrong with the publish transition" }
       edition.stub :was_published, raise_exception do
-        assert_raises(ArgumentError) { publish(@user, edition, "this should fail") }
+        assert_raises(RuntimeError) { publish(@user, edition, "this should fail") }
       end
       assert_equal "ready", edition.state
     end

--- a/test/models/workflow_test.rb
+++ b/test/models/workflow_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "minitest/autorun"
 
 class WorkflowTest < ActiveSupport::TestCase
   def setup
@@ -519,6 +520,21 @@ class WorkflowTest < ActiveSupport::TestCase
         schedule_for_publishing(@user, edition, @activity_details)
       end
       assert_equal "schedule_for_publishing", edition.actions.last.request_type
+    end
+  end
+
+  context "#publish" do
+    setup do
+      @user = FactoryBot.create(:user, :govuk_editor)
+    end
+
+    should "not be in published state if the transition fails" do
+      edition = FactoryBot.create(:edition, state: "ready")
+      raise_exception = -> { raise ArgumentError.new }
+      edition.stub :was_published, raise_exception do
+        assert_raises(ArgumentError) { publish(@user, edition, "this should fail") }
+      end
+      assert_equal "ready", edition.state
     end
   end
 end

--- a/test/models/workflow_test.rb
+++ b/test/models/workflow_test.rb
@@ -530,7 +530,7 @@ class WorkflowTest < ActiveSupport::TestCase
 
     should "not be in published state if the transition fails" do
       edition = FactoryBot.create(:edition, state: "ready")
-      raise_exception = -> { raise ArgumentError.new }
+      raise_exception = -> { raise "something went wrong with the publish transition" }
       edition.stub :was_published, raise_exception do
         assert_raises(ArgumentError) { publish(@user, edition, "this should fail") }
       end


### PR DESCRIPTION
Seeing several issues where an edition has gotten into an incorrect state because of errors raised _after_publish_ breaking, but once the state has been moved to "published" then it is unable to rerun that code without manually changing the status.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
