### PR TITLE
fix(editions) prevent calling method on nil

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -332,15 +332,12 @@ protected
   def update_assignment(edition, assignee)
     return if edition.assigned_to == assignee
 
-    unless assignee.has_editor_permissions?(resource)
-      flash[:danger] = "Chosen assignee does not have correct editor permissions."
-      return
-    end
-
-    if assignee
+    if !assignee
+      current_user.unassign(edition)
+    elsif assignee.has_editor_permissions?(resource)
       current_user.assign(edition, assignee)
     else
-      current_user.unassign(edition)
+      flash[:danger] = "Chosen assignee does not have correct editor permissions."
     end
   end
 

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -314,6 +314,17 @@ class EditionsControllerTest < ActionController::TestCase
       assert_equal bob, @guide.assigned_to
     end
 
+    should "clear assignment if no assignment is passed" do
+      post :update,
+           params: {
+             id: @guide.id,
+             edition: {},
+           }
+
+      @guide.reload
+      assert_nil @guide.assigned_to
+    end
+
     should "not create a new action if the assignment is unchanged" do
       bob = FactoryBot.create(:user, :govuk_editor)
       @user.assign(@guide, bob)


### PR DESCRIPTION
- when a request is sent without an assigned_to param to update an edition, an error was being thrown as the update_assignment function expected a value to always be passed

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
