### PR TITLE
Document Simple Smart Answers

### DIFF
--- a/docs/simple-smart-answer.md
+++ b/docs/simple-smart-answer.md
@@ -1,0 +1,9 @@
+# Simple Smart Answer
+
+[Simple smart answers](https://docs.publishing.service.gov.uk/document-types/simple_smart_answer.html) work for complex situations with multiple variables and outcomes, where using this format will simplify the user journey.
+A simple smart answer is a series of questions that channels a user to a certain outcome based on their responses. They use simple decision tree logic and don’t involve calculations.
+They differ from standard [smart answers](https://github.com/alphagov/smart-answers), which generally require a developer to maintain.
+
+Examples of Simple Smart Answers:
+- [Contact DVSA](https://www.gov.uk/contact-dvsa)
+- [Find out if you can check someone’s criminal record](https://www.gov.uk/find-out-dbs-check)


### PR DESCRIPTION
A search for "Simple Smart Answers" in the Developer Docs returns nothing relevant to the Simple Smart Answer format:

> ![Screenshot 2023-08-29 at 06 49 51](https://github.com/alphagov/publisher/assets/5111927/fab80b04-86d9-44b0-90fe-29a5df7cd00d)

This commit therefore documents the format. It uses the name of the format for the h1 tag, so should appear at the top of the search results. It's documented close to the code where it is defined, made possible by Developer Doc's "external doc import" mechanism.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
