### PR TITLE
add all edition reports for content workflow and edition churn

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -20,7 +20,7 @@ class ReportsController < ApplicationController
   def all_edition_churn
     redirect_to Report.new("all_edition_churn").url, allow_other_host: true
   end
-  
+
   def content_workflow
     redirect_to Report.new("content_workflow").url, allow_other_host: true
   end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -17,8 +17,16 @@ class ReportsController < ApplicationController
     redirect_to Report.new("edition_churn").url, allow_other_host: true
   end
 
+  def all_edition_churn
+    redirect_to Report.new("all_edition_churn").url, allow_other_host: true
+  end
+  
   def content_workflow
     redirect_to Report.new("content_workflow").url, allow_other_host: true
+  end
+
+  def all_content_workflow
+    redirect_to Report.new("all_content_workflow").url, allow_other_host: true
   end
 
   def all_urls

--- a/app/presenters/all_content_workflow_presenter.rb
+++ b/app/presenters/all_content_workflow_presenter.rb
@@ -1,0 +1,39 @@
+class AllContentWorkflowPresenter < CSVPresenter
+  def initialize(scope = Edition.all)
+    super(scope)
+    self.column_headings = %i[
+      content_title
+      content_slug
+      content_url
+      current_status
+      stage
+      format
+      current_assignee
+      created_at
+      date_created
+      time_created
+    ]
+  end
+
+private
+
+  def build_csv(csv)
+    csv << column_headings.collect { |ch| ch.to_s.humanize }
+    scope.each do |item|
+      item.actions.each do |action|
+        csv << [
+          item.title,
+          item.slug,
+          "#{Plek.website_root}/#{item.slug}",
+          item.state,
+          action.request_type,
+          item.format,
+          item.assignee,
+          action.created_at.to_fs(:db),
+          action.created_at.to_date.to_s,
+          action.created_at.to_fs(:time),
+        ]
+      end
+    end
+  end
+end

--- a/app/presenters/all_edition_churn_presenter.rb
+++ b/app/presenters/all_edition_churn_presenter.rb
@@ -1,0 +1,33 @@
+class AllEditionChurnPresenter < CSVPresenter
+  def initialize(scope = Edition.all)
+    super(scope)
+    self.column_headings = %i[
+      id
+      panopticon_id
+      name
+      slug
+      state
+      editioned_on
+      version_number
+      date_created
+      time_created
+    ]
+  end
+
+private
+
+  def get_value(header, edition)
+    case header
+    when :name
+      edition.title
+    when :editioned_on
+      edition.created_at.iso8601
+    when :date_created
+      edition.created_at.to_date.to_s
+    when :time_created
+      edition.created_at.to_fs(:time)
+    else
+      super
+    end
+  end
+end

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -12,12 +12,20 @@
   <%= report_last_updated("edition_churn")%>
 </p>
 <p>
+  <strong><%= link_to 'Churn in all editions', edition_churn_report_path(format: :csv) %></strong><br />
+  <%= report_last_updated("all_edition_churn")%>
+</p>
+<p>
   <strong><%= link_to 'Progress on all non-archived editions', progress_report_path(format: :csv) %></strong><br />
   <%= report_last_updated("editorial_progress")%>
 </p>
 <p>
-  <strong><%= link_to 'Content summary and workflow history', content_workflow_report_path(format: :csv) %></strong><br />
+  <strong><%= link_to 'Content summary and workflow history for all published editions', content_workflow_report_path(format: :csv) %></strong><br />
   <%= report_last_updated("content_workflow")%>
+</p>
+<p>
+  <strong><%= link_to 'Content summary and workflow history for all editions', content_workflow_report_path(format: :csv) %></strong><br />
+  <%= report_last_updated("all_content_workflow")%>
 </p>
 <p>
   <strong><%= link_to 'All URLs', all_urls_report_path(format: :csv) %></strong><br />

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -12,7 +12,7 @@
   <%= report_last_updated("edition_churn")%>
 </p>
 <p>
-  <strong><%= link_to 'Churn in all editions', edition_churn_report_path(format: :csv) %></strong><br />
+  <strong><%= link_to 'Churn in all editions', all_edition_churn_report_path(format: :csv) %></strong><br />
   <%= report_last_updated("all_edition_churn")%>
 </p>
 <p>
@@ -20,7 +20,7 @@
   <%= report_last_updated("editorial_progress")%>
 </p>
 <p>
-  <strong><%= link_to 'Content summary and workflow history for all published editions', content_workflow_report_path(format: :csv) %></strong><br />
+  <strong><%= link_to 'Content summary and workflow history for all published editions', all_content_workflow_report_path(format: :csv) %></strong><br />
   <%= report_last_updated("content_workflow")%>
 </p>
 <p>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,11 +3,34 @@
     {
       "warning_type": "Redirect",
       "warning_code": 18,
+      "fingerprint": "2cb25751c6a39d8b813d792d58ba4f1fe596aa00d263284ffe5ecef8a546c88b",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/reports_controller.rb",
+      "line": 21,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(Report.new(\"all_edition_churn\").url, :allow_other_host => true)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ReportsController",
+        "method": "all_edition_churn"
+      },
+      "user_input": "Report.new(\"all_edition_churn\").url",
+      "confidence": "High",
+      "cwe_id": [
+        601
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
       "fingerprint": "4de24c49b5d87e19ef510a17b4952468eaac4f2bfdcf3d5a67507cf694c25c93",
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/reports_controller.rb",
-      "line": 25,
+      "line": 33,
       "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
       "code": "redirect_to(Report.new(\"all_urls\").url, :allow_other_host => true)",
       "render_path": null,
@@ -22,6 +45,29 @@
         601
       ],
       "note": "This is a redirect to AWS S3 for file download, unlikely to be dangerous."
+    },
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "605ea82aeb307735d184ae89ae7300b2571376340aa1cd7d48c1c79232f6e7d2",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/reports_controller.rb",
+      "line": 29,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(Report.new(\"all_content_workflow\").url, :allow_other_host => true)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ReportsController",
+        "method": "all_content_workflow"
+      },
+      "user_input": "Report.new(\"all_content_workflow\").url",
+      "confidence": "High",
+      "cwe_id": [
+        601
+      ],
+      "note": ""
     },
     {
       "warning_type": "Dynamic Render Path",
@@ -107,7 +153,7 @@
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/reports_controller.rb",
-      "line": 21,
+      "line": 25,
       "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
       "code": "redirect_to(Report.new(\"content_workflow\").url, :allow_other_host => true)",
       "render_path": null,
@@ -204,6 +250,6 @@
       "note": "This is a redirect to AWS S3 for file download, unlikely to be dangerous."
     }
   ],
-  "updated": "2023-04-20 10:50:54 +0100",
-  "brakeman_version": "5.4.0"
+  "updated": "2023-09-07 15:54:38 +0100",
+  "brakeman_version": "5.3.1"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,9 @@ Rails.application.routes.draw do
   get "reports/progress" => "reports#progress", as: :progress_report
   get "reports/organisation-content" => "reports#organisation_content", :as => :organisation_content_report
   get "reports/edition-churn" => "reports#edition_churn", as: "edition_churn_report"
+  get "reports/all-edition-churn" => "reports#all_edition_churn", as: "all_edition_churn_report"
   get "reports/content_workflow" => "reports#content_workflow", as: "content_workflow_report"
+  get "reports/all-content_workflow" => "reports#all_content_workflow", as: "all_content_workflow_report"
   get "reports/all-urls" => "reports#all_urls", as: "all_urls_report"
 
   get "user_search" => "user_search#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,8 +49,8 @@ Rails.application.routes.draw do
   get "reports/organisation-content" => "reports#organisation_content", :as => :organisation_content_report
   get "reports/edition-churn" => "reports#edition_churn", as: "edition_churn_report"
   get "reports/all-edition-churn" => "reports#all_edition_churn", as: "all_edition_churn_report"
-  get "reports/content_workflow" => "reports#content_workflow", as: "content_workflow_report"
-  get "reports/all-content_workflow" => "reports#all_content_workflow", as: "all_content_workflow_report"
+  get "reports/content-workflow" => "reports#content_workflow", as: "content_workflow_report"
+  get "reports/all-content-workflow" => "reports#all_content_workflow", as: "all_content_workflow_report"
   get "reports/all-urls" => "reports#all_urls", as: "all_urls_report"
 
   get "user_search" => "user_search#index"

--- a/lib/csv_report_generator.rb
+++ b/lib/csv_report_generator.rb
@@ -27,7 +27,7 @@ class CsvReportGenerator
 
       AllEditionChurnPresenter.new(
         Edition.all.order(created_at: 1),
-        ),
+      ),
 
       OrganisationContentPresenter.new(
         Artefact.where(owning_app: "publisher").not_in(state: %w[archived]),

--- a/lib/csv_report_generator.rb
+++ b/lib/csv_report_generator.rb
@@ -25,11 +25,17 @@ class CsvReportGenerator
         Edition.not_in(state: %w[archived]).order(created_at: 1),
       ),
 
+      AllEditionChurnPresenter.new(
+        Edition.all.order(created_at: 1),
+        ),
+
       OrganisationContentPresenter.new(
         Artefact.where(owning_app: "publisher").not_in(state: %w[archived]),
       ),
 
       ContentWorkflowPresenter.new(Edition.published.order(created_at: :desc)),
+
+      AllContentWorkflowPresenter.new(Edition.all.order(created_at: :desc)),
 
       AllUrlsPresenter.new(
         Artefact.where(owning_app: "publisher").not_in(state: %w[archived]),

--- a/test/unit/csv_report_generator_test.rb
+++ b/test/unit/csv_report_generator_test.rb
@@ -13,14 +13,16 @@ class CsvReportGeneratorTest < ActiveSupport::TestCase
       @generator.run!
     end
 
-    assert_equal 5, @stubbed_s3_client.api_requests.size
+    assert_equal 7, @stubbed_s3_client.api_requests.size
     assert(@stubbed_s3_client.api_requests.all? { |r| r[:operation_name] == :put_object })
     assert(@stubbed_s3_client.api_requests.all? { |r| r[:params][:bucket] == "example" })
 
     assert_equal "editorial_progress.csv", @stubbed_s3_client.api_requests[0][:params][:key]
     assert_equal "edition_churn.csv", @stubbed_s3_client.api_requests[1][:params][:key]
-    assert_equal "organisation_content.csv", @stubbed_s3_client.api_requests[2][:params][:key]
-    assert_equal "content_workflow.csv", @stubbed_s3_client.api_requests[3][:params][:key]
-    assert_equal "all_urls.csv", @stubbed_s3_client.api_requests[4][:params][:key]
+    assert_equal "all_edition_churn.csv", @stubbed_s3_client.api_requests[2][:params][:key]
+    assert_equal "organisation_content.csv", @stubbed_s3_client.api_requests[3][:params][:key]
+    assert_equal "content_workflow.csv", @stubbed_s3_client.api_requests[4][:params][:key]
+    assert_equal "all_content_workflow.csv", @stubbed_s3_client.api_requests[5][:params][:key]
+    assert_equal "all_urls.csv", @stubbed_s3_client.api_requests[6][:params][:key]
   end
 end


### PR DESCRIPTION
- also with additional time and date created fields split from editioned_at to allow for easier data parsing

Making these changes based on a request by the content improvement team to better understand the rate of change of editions in publisher - they need the historical data, not just that of all current editions, so I'm adding in a couple of extra reports for them.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
