### PR TITLE
fix: correct ordering of content workflow reports and link text

### DIFF
--- a/lib/csv_report_generator.rb
+++ b/lib/csv_report_generator.rb
@@ -33,9 +33,9 @@ class CsvReportGenerator
         Artefact.where(owning_app: "publisher").not_in(state: %w[archived]),
       ),
 
-      ContentWorkflowPresenter.new(Edition.published.order(created_at: :desc)),
+      ContentWorkflowPresenter.new(Edition.all.order(created_at: :desc)),
 
-      AllContentWorkflowPresenter.new(Edition.all.order(created_at: :desc)),
+      AllContentWorkflowPresenter.new(Edition.published.order(created_at: :desc)),
 
       AllUrlsPresenter.new(
         Artefact.where(owning_app: "publisher").not_in(state: %w[archived]),


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
