### PR TITLE
fix: correct ordering of content workflow reports and link text

### DIFF
--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -20,11 +20,11 @@
   <%= report_last_updated("editorial_progress")%>
 </p>
 <p>
-  <strong><%= link_to 'Content summary and workflow history for all published editions', all_content_workflow_report_path(format: :csv) %></strong><br />
+  <strong><%= link_to 'Content summary and workflow history for all published editions', content_workflow_report_path(format: :csv) %></strong><br />
   <%= report_last_updated("content_workflow")%>
 </p>
 <p>
-  <strong><%= link_to 'Content summary and workflow history for all editions', content_workflow_report_path(format: :csv) %></strong><br />
+  <strong><%= link_to 'Content summary and workflow history for all editions', all_content_workflow_report_path(format: :csv) %></strong><br />
   <%= report_last_updated("all_content_workflow")%>
 </p>
 <p>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
