### PR TITLE
Bump mongo from 2.18.2 to 2.18.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,7 +316,7 @@ GEM
       ruby2_keywords (>= 0.0.5)
     momentjs-rails (2.29.4.1)
       railties (>= 3.1)
-    mongo (2.18.2)
+    mongo (2.18.3)
       bson (>= 4.14.1, < 5.0.0)
     mongoid (8.1.2)
       activemodel (>= 5.1, < 7.1, != 7.0.0)


### PR DESCRIPTION
This is a manual dependency bump, as we cannot currently upgrade the ruby mongo library to 2.19.* due to it causing the app to break.

## 2.18.3

[This is a patch release](https://github.com/mongodb/mongo-ruby-driver/releases/tag/v2.18.3) that fixes the following issue:

[RUBY-3332 Tailable cursors do no work](https://jira.mongodb.org/browse/RUBY-3332)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
