### PR TITLE
Handle errors connecting to fact check mailbox

### DIFF
--- a/app/lib/fact_check_email_handler.rb
+++ b/app/lib/fact_check_email_handler.rb
@@ -36,5 +36,10 @@ class FactCheckEmailHandler
     end
 
     GovukStatsd.gauge("unprocessed_emails.count", unprocessed_emails_count)
+  rescue StandardError => e
+    # Occasionally, there is an error when connecting to the mailbox in production.
+    # It seems a very transient error, and since the job is run every few minutes isn't really a problem, but if the
+    # exception is left unhandled a Sentry alert is raised. Log the error and move on.
+    Rails.logger.warn "UnableToProcessError: Failed to connect to mailbox: #{e.message}"
   end
 end

--- a/test/unit/lib/fact_check_email_handler_test.rb
+++ b/test/unit/lib/fact_check_email_handler_test.rb
@@ -20,4 +20,11 @@ class FactCheckEmailHandlerTest < ActiveSupport::TestCase
 
     handler.process
   end
+
+  test "#process does not send count of unprocessed emails to Graphite when emails cannot be retrieved" do
+    Mail.stubs(:all).raises(StandardError)
+    GovukStatsd.expects(:gauge).never
+
+    handler.process
+  end
 end


### PR DESCRIPTION
Occasionally, there is an error when connecting to the mailbox in production. It seems a very transient error, and since the job is run every few minutes isn't really a problem, but if the exception is left unhandled a Sentry alert is raised. Log the error and move on.

We can't determine whether there are any unprocessed emails if we couldn't connect to the mailbox, so don't send any stats to Graphite.

[Trello card](https://trello.com/c/E6NTvtxY)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
