### PR TITLE
Replace Uglifier with Terser for JS compression

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "sprockets-rails"
 gem "state_machines"
 gem "state_machines-mongoid"
 gem "strip_attributes"
-gem "uglifier"
+gem "terser"
 gem "whenever", require: false
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -739,14 +739,14 @@ GEM
     statsd-ruby (1.5.0)
     strip_attributes (1.13.0)
       activemodel (>= 3.0, < 8.0)
+    terser (1.1.20)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.0)
     tilt (2.0.10)
     timecop (0.9.8)
     timeout (0.4.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
@@ -832,8 +832,8 @@ DEPENDENCIES
   state_machines-graphviz
   state_machines-mongoid
   strip_attributes
+  terser
   timecop
-  uglifier
   webmock
   whenever
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = :terser
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
Uglifier does not support ES6, and Terser is the recommended replacement in the Uglifier README (and is the default option for Rails apps these days).

[Trello card](https://trello.com/c/5Tkk0Ewf)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
