### PR TITLE
Use current user as assignee

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -66,7 +66,7 @@ class EditionsController < InheritedResources::Base
     if !resource.can_create_new_edition?
       flash[:warning] = "Another person has created a newer edition"
       redirect_to edition_path(resource)
-    elsif command.duplicate(target_edition_class_name, new_assignee)
+    elsif command.duplicate(target_edition_class_name, current_user)
       new_edition = command.new_edition
       UpdateWorker.perform_async(new_edition.id.to_s)
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -337,6 +337,7 @@ class Edition
       panopticon_id: metadata.id,
       slug: metadata.slug,
       title: metadata.name,
+      assigned_to_id: importing_user.id,
     )
   end
 

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -427,6 +427,24 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal artefact.id.to_s, publication.panopticon_id.to_s
   end
 
+  test "should create a publication with the current user as the assignee" do
+    artefact = FactoryBot.create(
+      :artefact,
+      slug: "foo-bar",
+      kind: "answer",
+      name: "Foo bar",
+      owning_app: "publisher",
+    )
+    artefact.save!
+
+    Artefact.find(artefact.id)
+    user = FactoryBot.create(:user, :govuk_editor)
+
+    publication = Edition.find_or_create_from_panopticon_data(artefact.id, user)
+
+    assert_equal user.id.to_s, publication.assigned_to_id.to_s
+  end
+
   test "should not change edition metadata if archived" do
     artefact = FactoryBot.create(
       :artefact,


### PR DESCRIPTION
Previously, a publisher would need to manually assign themselves as the
assignee when creating an edition. We now assign the user that
created the edition as the assignee. This can be still be modified from
the UI if the assignee is different from the creator, but for the
majority of cases this should be the expected behaviour.

Feature verified in integration by Keith Emmerson.

Trello:
https://trello.com/c/3zzF4dKj/37-auto-assign-ownership-in-mainstream-publisher

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
