### PR TITLE
POC Add Flipflop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "bootsnap", require: false
 gem "bootstrap-kaminari-views"
 gem "diffy"
 gem "erubis"
+gem "flipflop"
 gem "gds-api-adapters"
 gem "gds-sso"
 gem "govspeak"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,9 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
     ffi (1.15.5)
+    flipflop (2.7.1)
+      activesupport (>= 4.0)
+      terminal-table (>= 1.8)
     gds-api-adapters (91.1.0)
       addressable
       link_header
@@ -739,6 +742,8 @@ GEM
     statsd-ruby (1.5.0)
     strip_attributes (1.13.0)
       activemodel (>= 3.0, < 8.0)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     terser (1.1.20)
       execjs (>= 0.3.0, < 3)
     thor (1.3.0)
@@ -787,6 +792,7 @@ DEPENDENCIES
   diffy
   erubis
   factory_bot_rails
+  flipflop
   gds-api-adapters
   gds-sso
   govspeak

--- a/app/controllers/legacy_reports_controller.rb
+++ b/app/controllers/legacy_reports_controller.rb
@@ -1,7 +1,7 @@
-class ReportsController < ApplicationController
+class LegacyReportsController < ApplicationController
   include ActionView::Helpers::TagHelper
 
-  before_action :authenticate_user!, :require_design_system_enabled
+  before_action :authenticate_user!
 
   def index; end
 
@@ -44,10 +44,4 @@ private
     end
   end
   helper_method :report_last_updated
-
-  def require_design_system_enabled
-    unless Flipflop.design_system_reports_page?
-      redirect_to legacy_reports_path
-    end
-  end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -3,7 +3,7 @@ require "aws-sdk-s3"
 class Report
   def initialize(report_name)
     @bucket_name = ENV["REPORTS_S3_BUCKET_NAME"]
-    @s3 = Aws::S3::Client.new
+    # @s3 = Aws::S3::Client.new
 
     @report_name = report_name
   end
@@ -21,6 +21,7 @@ class Report
   end
 
   def last_updated
+    return nil
     response = @s3.head_object(bucket: @bucket_name, key: filename)
     response.last_modified
   rescue Aws::S3::Errors::NotFound

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
     <%= nav_link 'Downtime', downtimes_path %>
   <% end %>
 
-  <%= nav_link 'Reports', reports_path %>
+  <%= nav_link 'Reports', legacy_reports_path %>
   <%= nav_link 'Search by user', user_search_path %>
 <% end %>
 

--- a/app/views/legacy_reports/index.html.erb
+++ b/app/views/legacy_reports/index.html.erb
@@ -1,0 +1,35 @@
+<div class="page-header">
+  <h1>CSV Reports</h1>
+  <p>These reports are updated every hour.</p>
+</div>
+
+<p>
+  <strong><%= link_to 'All documents for departmental distribution', legacy_organisation_content_report_path(format: :csv) %></strong><br />
+  <%= report_last_updated("organisation_content")%>
+</p>
+<p>
+  <strong><%= link_to 'Churn in non-archived editions', legacy_edition_churn_report_path(format: :csv) %></strong><br />
+  <%= report_last_updated("edition_churn")%>
+</p>
+<p>
+  <strong><%= link_to 'Churn in all editions', legacy_all_edition_churn_report_path(format: :csv) %></strong><br />
+  <%= report_last_updated("all_edition_churn")%>
+</p>
+<p>
+  <strong><%= link_to 'Progress on all non-archived editions', legacy_progress_report_path(format: :csv) %></strong><br />
+  <%= report_last_updated("editorial_progress")%>
+</p>
+<p>
+  <strong><%= link_to 'Content summary and workflow history for all published editions', legacy_content_workflow_report_path(format: :csv) %></strong><br />
+  <%= report_last_updated("content_workflow")%>
+</p>
+<p>
+  <strong><%= link_to 'Content summary and workflow history for all editions', legacy_all_content_workflow_report_path(format: :csv) %></strong><br />
+  <%= report_last_updated("all_content_workflow")%>
+</p>
+<p>
+  <strong><%= link_to 'All URLs', legacy_all_urls_report_path(format: :csv) %></strong><br />
+  <%= report_last_updated("all_urls")%>
+</p>
+
+<% content_for :page_title, "Reports" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,14 @@ Bundler.require(*Rails.groups)
 
 module Publisher
   class Application < Rails::Application
+    # Before filter for Flipflop dashboard. Replace with a lambda or method name
+    # defined in ApplicationController to implement access control.
+    config.flipflop.dashboard_access_filter = -> { head :forbidden }
+
+    # By default, when set to `nil`, strategy loading errors are suppressed in test
+    # mode. Set to `true` to always raise errors, or `false` to always warn.
+    config.flipflop.raise_strategy_errors = nil
+
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,14 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  # Before filter for Flipflop dashboard. Replace with a lambda or method name
+  # defined in ApplicationController to implement access control.
+  config.flipflop.dashboard_access_filter = nil
+
+  # By default, when set to `nil`, strategy loading errors are suppressed in test
+  # mode. Set to `true` to always raise errors, or `false` to always warn.
+  config.flipflop.raise_strategy_errors = nil
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,14 @@ require "active_support/core_ext/integer/time"
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  # Before filter for Flipflop dashboard. Replace with a lambda or method name
+  # defined in ApplicationController to implement access control.
+  config.flipflop.dashboard_access_filter = nil
+
+  # By default, when set to `nil`, strategy loading errors are suppressed in test
+  # mode. Set to `true` to always raise errors, or `false` to always warn.
+  config.flipflop.raise_strategy_errors = nil
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Turn false under Spring and add config.action_view.cache_template_loading = true.

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,0 +1,26 @@
+Flipflop.configure do
+  # Strategies will be used in the order listed here.
+  strategy :cookie
+  strategy :default
+
+  # Other strategies:
+  #
+  # strategy :sequel
+  # strategy :redis
+  #
+  # strategy :query_string
+  # strategy :session
+  #
+  # strategy :my_strategy do |feature|
+  #   # ... your custom code here; return true/false/nil.
+  # end
+
+  # Declare your features, e.g:
+  #
+  # feature :world_domination,
+  #   default: true,
+  #   description: "Take over the world."
+  feature :design_system_reports_page,
+    description: "Display the reports page using the design system layout",
+    default: false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 # Having a long routes file is not a style violation
 Rails.application.routes.draw do
+  mount Flipflop::Engine => "/flipflop"
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
     GovukHealthcheck::Mongoid,
@@ -53,6 +54,14 @@ Rails.application.routes.draw do
   get "reports/content-workflow" => "reports#content_workflow", as: "content_workflow_report"
   get "reports/all-content-workflow" => "reports#all_content_workflow", as: "all_content_workflow_report"
   get "reports/all-urls" => "reports#all_urls", as: "all_urls_report"
+  get "legacy_reports" => "legacy_reports#index", as: :legacy_reports
+  get "legacy_reports/progress" => "legacy_reports#progress", as: :legacy_progress_report
+  get "legacy_reports/organisation-content" => "legacy_reports#organisation_content", :as => :legacy_organisation_content_report
+  get "legacy_reports/edition-churn" => "legacy_reports#edition_churn", as: "legacy_edition_churn_report"
+  get "legacy_reports/all-edition-churn" => "legacy_reports#all_edition_churn", as: "legacy_all_edition_churn_report"
+  get "legacy_reports/content-workflow" => "legacy_reports#content_workflow", as: "legacy_content_workflow_report"
+  get "legacy_reports/all-content-workflow" => "legacy_reports#all_content_workflow", as: "legacy_all_content_workflow_report"
+  get "legacy_reports/all-urls" => "legacy_reports#all_urls", as: "legacy_all_urls_report"
 
   get "user_search" => "user_search#index"
 

--- a/test/functional/legacy_reports_controller_test.rb
+++ b/test/functional/legacy_reports_controller_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class LegacyReportsControllerTest < ActionController::TestCase
+  setup do
+    login_as_stub_user
+
+    last_modified = Time.zone.local(2023, 12, 12, 1, 1, 1)
+
+    Aws.config[:s3] = {
+      stub_responses: {
+        head_object: { last_modified: },
+      },
+    }
+
+    ENV["REPORTS_S3_BUCKET_NAME"] = "example"
+  end
+
+  teardown do
+    ENV["REPORTS_S3_BUCKET_NAME"] = nil
+  end
+
+  test "it redirects the user to S3" do
+    get :progress
+
+    assert_equal 302, response.status
+  end
+
+  test "shows the last updated time on the index page" do
+    get :index
+
+    assert_match(/Generated 1:01am, 12 December 2023/, response.body)
+  end
+end


### PR DESCRIPTION
Add Flipflop as a dependency for feature-toggling.

As an example, adds a toggle for the /reports page (and reports), with a legacy controller and a non-legacy controller, with access to the non-legacy paths behind a feature toggle.


