### PR TITLE
Revert "Bump mermaid from 10.5.1 to 10.6.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "stylelint-config-gds": "^1.1.0"
   },
   "dependencies": {
-    "mermaid": "10.6.1",
+    "mermaid": "10.5.1",
     "paste-html-to-govspeak": "^0.4.0"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2296,10 +2296,10 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-mermaid@10.6.1:
-  version "10.6.1"
-  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-10.6.1.tgz#701f4160484137a417770ce757ce1887a98c00fc"
-  integrity sha512-Hky0/RpOw/1il9X8AvzOEChfJtVvmXm+y7JML5C//ePYMy0/9jCEmW1E1g86x9oDfW9+iVEdTV/i+M6KWRNs4A==
+mermaid@10.5.1:
+  version "10.5.1"
+  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-10.5.1.tgz#b6ee7356e3b79515bc87406763e258ca49b5cca9"
+  integrity sha512-+4mkGW5PptHDSae4YZ/Jw1pEOf0irrB/aCL6BwZcJPhr5+84UJBrQnHTvyPqCUz67tXkrDvSzWv4B+J2hLO78g==
   dependencies:
     "@braintree/sanitize-url" "^6.0.1"
     "@types/d3-scale" "^4.0.3"


### PR DESCRIPTION
Reverts alphagov/publisher#1995 because of this https://trello.com/c/0iriT8Ow/600-bug-ssa-visualization-fails-with-mermaid-upgrade