### PR TITLE
Increase rows of Body Textarea in Smart Answer Edit

### DIFF
--- a/app/views/simple_smart_answers/_fields.html.erb
+++ b/app/views/simple_smart_answers/_fields.html.erb
@@ -9,7 +9,7 @@
       <div class="row">
         <div class="col-md-10">
           <%= form_group(f, :body) do %>
-            <%= f.text_area :body, rows: 5, disabled: @resource.locked_for_edits?, class: "form-control", data: {
+            <%= f.text_area :body, rows: 20, disabled: @resource.locked_for_edits?, class: "form-control", data: {
               module: "paste-html-to-govspeak"
             } %>
           <% end %>


### PR DESCRIPTION
## What

Change the numbers of rows in the "Body" textarea of the Smart Answer edit view.

## Why

It was shorter than all the other textareas.

## Visual Differences

### Before

![image](https://github.com/alphagov/publisher/assets/3727504/c4c83cfc-0e20-44d7-bc17-5dc1b8eb268c)


### After

![Screenshot 2024-01-16 at 15 28 23](https://github.com/alphagov/publisher/assets/3727504/98cfa563-15f5-40a5-b5c6-5d468d32edc9)


[Relevant Trello Card](https://trello.com/c/tUoohEu2/592-window-for-editing-simple-smart-answer-start-page-body-text-not-large-enough)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
