### PR TITLE
Add extra rows to Edition notes textarea

### DIFF
--- a/app/views/shared/_history.html.erb
+++ b/app/views/shared/_history.html.erb
@@ -18,7 +18,7 @@
                 <%= f.label :comment, "Edition note" %>
               </span>
               <span class="form-wrapper">
-                <%= f.text_area :comment, rows: 6, cols: 120, class: "form-control" %>
+                <%= f.text_area :comment, rows: 20, cols: 120, class: "form-control" %>
               </span>
             </div>
           </div>


### PR DESCRIPTION
## What

Change the numbers of rows in the change note textarea modal.

## Why

The edition note box is not big enough, meaning Content Designers cannot easily compose or work with the note in Publisher.

## Visual Differences

### Before

![image](https://github.com/alphagov/publisher/assets/3727504/af061d28-296e-4305-bc40-9d2348273258)


### After

![Screenshot 2024-01-16 at 16 03 29](https://github.com/alphagov/publisher/assets/3727504/bb443174-cd56-4abc-9d26-b1763e0b0d2a)

[Relevant Trello Card](https://trello.com/c/cExM15Xj/593-edition-notes-box-size)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
