### PR TITLE
Bug fix for claiming 2i on scheduled publication

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -176,7 +176,7 @@ class EditionsController < InheritedResources::Base
     end
 
     resource.reviewer = params[:edition][:reviewer]
-    if resource.save!
+    if resource.save
       flash[:success] = "You are the reviewer of this #{description(resource).downcase}."
     else
       flash[:danger] = "Something went wrong when attempting to claim 2i."

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -877,6 +877,20 @@ class EditionsControllerTest < ActionController::TestCase
       assert_equal bob.name, @guide.reviewer
     end
 
+    should "not be able to update the reviewer when edition is scheduled for publishing" do
+      bob = FactoryBot.create(:user, name: "bob")
+      edition = FactoryBot.create(:edition, :scheduled_for_publishing)
+
+      put :review,
+          params: {
+            id: edition.id,
+            edition: { reviewer: bob.name },
+          }
+
+      assert_response(302)
+      assert_equal "Something went wrong when attempting to claim 2i.", flash[:danger]
+    end
+
     context "Welsh editors" do
       setup do
         @welsh_guide = FactoryBot.create(:guide_edition, :welsh, :in_review)


### PR DESCRIPTION
Fix exception case when a user tries to claim 2i whilst an edition is scheduled for publishing

[Trello ticket](https://trello.com/c/YMXeGdlK/585-handle-validation-errors-when-assigning-a-reviewer-to-an-edition)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
