### PR TITLE
Make the Change Note Modal wider

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.scss
@@ -101,3 +101,10 @@ legend p {
   font-size: 16px;
   font-weight: bold;
 }
+
+.modal-dialog.modal-dialog--wide {
+  @media only screen and (min-width: 768px) {
+    max-width: 768px;
+    width: 100%;
+  }
+}

--- a/app/views/shared/_history.html.erb
+++ b/app/views/shared/_history.html.erb
@@ -1,5 +1,5 @@
 <div aria-hidden="true" class="modal" id="save-edition-note" role="dialog" tabindex="-1">
-  <div class="modal-dialog">
+  <div class="modal-dialog modal-dialog--wide">
     <div class="modal-content">
       <header class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>


### PR DESCRIPTION
## What

Add new modifier class that can be used to make the length of the modal wider on Desktop screen sizes. Add new class to the modal that is used for specifying the change note.

## Why

It was requested that the change note modal be increased in width.

The modal will (likely) eventually be removed in the change to Design System, so this is a temporary measure until the move has been made.

## Visual Differences

### Before

![image](https://github.com/alphagov/publisher/assets/3727504/dadfdbe2-6830-404f-a196-c7ca7743c73c)


### After

![Screenshot 2024-01-22 at 14 27 25](https://github.com/alphagov/publisher/assets/3727504/cdf38033-eb0f-4463-b1bf-ac96f9d612cf)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
