### PR TITLE
Add `$govuk-page-width` to application.scss

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,2 +1,4 @@
+$govuk-page-width: 1140px;
+
 // GOVUK Design System
 @import "govuk_publishing_components/all_components";


### PR DESCRIPTION
## What

Increase the size of `$govuk-page-width` to `1140px` on appplication.scss, the stylesheet used by the `design_system.html.erb` layout for the pages transitioning to the Design System.

## Why

Request from designer, based on feedback from Whitehall transition. As part of the work to transition to the Design System. [Relevant Trello Card](https://trello.com/c/FDWSNsdX/606-transition-the-navbar-and-footer).

## Visual Differences

### Before

![Screenshot 2024-01-29 at 10 59 14](https://github.com/alphagov/publisher/assets/3727504/4da818f9-4cd3-42d0-8ce0-6908a6b07d8f)


### After

![Screenshot 2024-01-29 at 10 59 22](https://github.com/alphagov/publisher/assets/3727504/1881557e-5c5f-4e31-9ce4-2e441ebb0d6c)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
