### PR TITLE
Initial work for Downtime Index page transition to Design System

### DIFF
--- a/app/controllers/downtimes_controller.rb
+++ b/app/controllers/downtimes_controller.rb
@@ -1,9 +1,13 @@
 class DowntimesController < ApplicationController
   before_action :require_govuk_editor
-  before_action :load_edition
+  before_action :load_edition, except: [:index]
   before_action :process_params, only: %i[create update]
 
   layout "design_system"
+
+  def index
+    @transactions = TransactionEdition.published.order_by(%i[title asc])
+  end
 
   def new
     @downtime = Downtime.new(artefact: @edition.artefact)

--- a/app/views/downtimes/index.html.erb
+++ b/app/views/downtimes/index.html.erb
@@ -1,0 +1,56 @@
+<% content_for :page_title, 'Downtime messages' %>
+
+<div class="page-title">
+  <h1>Downtime messages</h1>
+  <p class="lead">Show a message on a published transaction start page for a specific time.</p>
+</div>
+
+<table class="table table-bordered table-striped" data-module="filterable-table">
+  <caption class="h2 remove-top-margin">
+    <h2 class="remove-top-margin remove-bottom-margin">Services</h2>
+  </caption>
+  <thead>
+    <tr class="table-header">
+      <th>Service start page</th>
+      <th>Service status</th>
+      <th>Action</th>
+    </tr>
+    <tr class="if-no-js-hide table-header-secondary">
+      <td colspan="3">
+        <form>
+          <label class="remove-bottom-margin" for="table-filter">Filter services</label>
+          <p class="help-inline">For example ‘driving’ or ‘scheduled downtime’</p>
+          <input id="table-filter" type="text" class="form-control normal js-filter-table-input">
+        </form>
+      </td>
+    </tr>
+  </thead>
+  <tbody>
+    <% @transactions.each do |transaction| %>
+    <tr>
+      <td>
+        <h3 class="publication-table-title">
+          <%= link_to transaction.title, Downtime.for(transaction.artefact).present? ?
+                                          edit_edition_downtime_path(transaction) :
+                                          new_edition_downtime_path(transaction) %>
+        </h3>
+        <%= link_to "/#{transaction.slug}", "#{Plek.website_root}/#{transaction.slug}", class: 'link-muted' %>
+      </td>
+        <% if downtime = Downtime.for(transaction.artefact) %>
+          <td>
+            Scheduled downtime<br />
+            <span class="text-muted"><%= downtime_datetime(downtime) %></span>
+          </td>
+          <td>
+            <%= link_to 'Edit downtime', edit_edition_downtime_path(transaction), class: 'btn btn-info' %>
+          </td>
+        <% else %>
+          <td>Live</td>
+          <td>
+            <%= link_to 'Add downtime', new_edition_downtime_path(transaction), class: 'btn btn-default' %>
+          </td>
+        <% end %>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -17,8 +17,26 @@
   } %>
 
   <div class="govuk-width-container">
-    <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
 
+    <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+      <% [:success, :info, :warning, :danger, :notice, :alert].select { |k| flash[k].present? }.each do |k| %>
+        <%
+          case k
+          when :notice
+            alert_class = "success"
+          when :alert
+            alert_class = "danger"
+          else
+            alert_class = k
+          end
+        %>
+        <div class="alert alert-<%= alert_class %>"
+          data-module="auto-track-event"
+          data-track-action="alert-<%= alert_class %>"
+          data-track-label="<%= strip_tags(flash[k]) %>">
+            <%= flash[k] %>
+        </div>
+      <% end %>      
       <% if yield(:title).present? %>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">

--- a/config/features.rb
+++ b/config/features.rb
@@ -20,4 +20,8 @@ Flipflop.configure do
   feature :design_system_downtime_edit,
           default: false,
           description: "A transition of the edit downtime page to the GOV.UK Design System"
+
+  feature :design_system_downtime_index_page,
+          default: false,
+          description: "A transition of the downtime index page to use the GOV.UK Design System"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
     put "resolve", on: :member
   end
 
+  constraints FeatureConstraint.new("design_system_downtime_index_page") do
+    get "downtimes" => "downtimes#index"
+  end
   get "downtimes" => "legacy_downtimes#index"
 
   resources :artefacts, only: %i[new create update]

--- a/test/functional/downtimes_controller_test.rb
+++ b/test/functional/downtimes_controller_test.rb
@@ -95,6 +95,31 @@ class DowntimesControllerTest < ActionController::TestCase
     end
   end
 
+  context "#index" do
+    should "list all published transaction editions" do
+      unpublished_transaction_edition = FactoryBot.create(:transaction_edition)
+      transaction_editions = FactoryBot.create_list(:transaction_edition, 2, :published)
+
+      get :index
+
+      assert_response :ok
+      assert_select "h3.publication-table-title", count: 0, text: unpublished_transaction_edition.title
+      transaction_editions.each do |edition|
+        assert_select "h3.publication-table-title", text: edition.title
+      end
+    end
+
+    should "redirect to root page if welsh_editor" do
+      login_as_welsh_editor
+
+      get :index
+
+      assert_response :redirect
+      assert_redirected_to controller: "root", action: "index"
+      assert_includes flash[:danger], "do not have permission"
+    end
+  end
+
   def edition
     @edition ||= FactoryBot.create(:transaction_edition)
   end

--- a/test/integration/legacy_downtime_integration_test.rb
+++ b/test/integration/legacy_downtime_integration_test.rb
@@ -1,6 +1,6 @@
 require "integration_test_helper"
 
-class DowntimeIntegrationTest < JavascriptIntegrationTest
+class LegacyDowntimeIntegrationTest < JavascriptIntegrationTest
   setup do
     setup_users
 
@@ -14,9 +14,6 @@ class DowntimeIntegrationTest < JavascriptIntegrationTest
     WebMock.reset!
     stub_any_publishing_api_put_content
     stub_any_publishing_api_publish
-
-    test_strategy = Flipflop::FeatureSet.current.test!
-    test_strategy.switch!(:design_system_downtime_index_page, true)
   end
 
   test "Scheduling new downtime" do

--- a/test/integration/routes_test.rb
+++ b/test/integration/routes_test.rb
@@ -37,4 +37,18 @@ class RoutesTest < ActionDispatch::IntegrationTest
 
     assert_routing("/editions/1/downtime/new", controller: "legacy_downtimes", action: "new", edition_id: "1")
   end
+
+  should "route to new downtimes controller index action when 'design_system_downtime_index_page' toggle is enabled" do
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:design_system_downtime_index_page, true)
+
+    assert_routing("/downtimes", controller: "downtimes", action: "index")
+  end
+
+  should "route to legacy downtimes controller index action when 'design_system_downtime_index_page' toggle is disabled" do
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:design_system_downtime_index_page, false)
+
+    assert_routing("/downtimes", controller: "legacy_downtimes", action: "index")
+  end
 end


### PR DESCRIPTION
## What

- Add new feature `design_system_downtime_pages` to the FlipFlop config.
- Update the routes with new constraint.
- Duplicate the controllers, views and test of Downtimes and append the `legacy_` prefix to them.
- Add new test in the routes integration test for the new feature.
- Add new test for legacy views in integration for Downtimes.
- Make the new Downtimes index page use the Design System layout.
- Add flash back to the Design System layout for integration tests (and also for future work to flash success/failure messages).

## Why

As part of the work to transition Publisher to the Design System from Bootstrap.

## Visual Differences (behind a feature flag toggle)

### Before

![Screenshot 2024-01-29 at 16 16 37](https://github.com/alphagov/publisher/assets/3727504/d3804ebc-43ae-4fcb-8760-222b177c564b)


### After

![Screenshot 2024-01-29 at 16 15 42](https://github.com/alphagov/publisher/assets/3727504/bbe829f7-d22d-4f73-93f8-b1073f94370b)

[Relevant Trello Card](https://trello.com/c/c1023Flb/620-transition-downtime-hub)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
