### PR TITLE
Improve testing of simple smart answer flowchart rendering 

### DIFF
--- a/test/integration/large_SA_mermaid_code.txt
+++ b/test/integration/large_SA_mermaid_code.txt
@@ -1,0 +1,1068 @@
+
+    %%{ init: {
+'theme': 'base',
+'themeVariables': {
+    'background': '#FFFFFF',
+    'primaryTextColor': '#0B0C0C',
+    'lineColor': '#0b0c0c',
+    'fontSize': '23.75px' } } }%%
+flowchart TD
+accTitle: Work out your VAT fuel scale charge
+accDescr: A flowchart for the Work out your VAT fuel scale charge smart answer
+AA[Start]:::start
+AA---Q1
+Q1["`Q1. Which period do you want to calculate the fuel scale charge for?`"]:::question
+Q1---Q1A1
+Q1A1(["`A1. 1 May 2021 to 30 April 2022`"]):::answer
+Q1A1-->Q3
+
+Q1---Q1A2
+Q1A2(["`A2. 1 May 2022 to 30 April 2023`"]):::answer
+Q1A2-->Q2
+
+Q1---Q1A3
+Q1A3(["`A3. 1 May 2023 to 30 April 2024`"]):::answer
+Q1A3-->Q10
+
+Q2["`Q2. What accounting period do you want to calculate it for?`"]:::question
+Q2---Q2A1
+Q2A1(["`A1. 1 month (monthly)`"]):::answer
+Q2A1-->Q4
+
+Q2---Q2A2
+Q2A2(["`A2. 3 months (quarterly)`"]):::answer
+Q2A2-->Q5
+
+Q2---Q2A3
+Q2A3(["`A3. 12 months (annual)`"]):::answer
+Q2A3-->Q6
+
+Q3["`Q3. What accounting period do you want to calculate it for?`"]:::question
+Q3---Q3A1
+Q3A1(["`A1. 1 month (monthly)`"]):::answer
+Q3A1-->Q7
+
+Q3---Q3A2
+Q3A2(["`A2. 3 months (quarterly)`"]):::answer
+Q3A2-->Q8
+
+Q3---Q3A3
+Q3A3(["`A3. 12 months (annual)`"]):::answer
+Q3A3-->Q9
+
+Q4["`Q4. What is your car's CO2 emissions band?`"]:::question
+Q4---Q4A1
+Q4A1(["`A1. 124 or less`"]):::answer
+Q4A1-->O1
+
+Q4---Q4A2
+Q4A2(["`A2. 125 to 129`"]):::answer
+Q4A2-->O2
+
+Q4---Q4A3
+Q4A3(["`A3. 130 to 134`"]):::answer
+Q4A3-->O3
+
+Q4---Q4A4
+Q4A4(["`A4. 135 to 139`"]):::answer
+Q4A4-->O4
+
+Q4---Q4A5
+Q4A5(["`A5. 140 to 144`"]):::answer
+Q4A5-->O5
+
+Q4---Q4A6
+Q4A6(["`A6. 145 to 149`"]):::answer
+Q4A6-->O6
+
+Q4---Q4A7
+Q4A7(["`A7. 150 to 154`"]):::answer
+Q4A7-->O7
+
+Q4---Q4A8
+Q4A8(["`A8. 155 to 159`"]):::answer
+Q4A8-->O8
+
+Q4---Q4A9
+Q4A9(["`A9. 160 to 164`"]):::answer
+Q4A9-->O9
+
+Q4---Q4A10
+Q4A10(["`A10. 165 to 169`"]):::answer
+Q4A10-->O10
+
+Q4---Q4A11
+Q4A11(["`A11. 170 to 174`"]):::answer
+Q4A11-->O11
+
+Q4---Q4A12
+Q4A12(["`A12. 175 to 179`"]):::answer
+Q4A12-->O12
+
+Q4---Q4A13
+Q4A13(["`A13. 180 to 184`"]):::answer
+Q4A13-->O13
+
+Q4---Q4A14
+Q4A14(["`A14. 185 to 189`"]):::answer
+Q4A14-->O14
+
+Q4---Q4A15
+Q4A15(["`A15. 190 to 194`"]):::answer
+Q4A15-->O15
+
+Q4---Q4A16
+Q4A16(["`A16. 195 to 199`"]):::answer
+Q4A16-->O16
+
+Q4---Q4A17
+Q4A17(["`A17. 200 to 204`"]):::answer
+Q4A17-->O17
+
+Q4---Q4A18
+Q4A18(["`A18. 205 to 209`"]):::answer
+Q4A18-->O18
+
+Q4---Q4A19
+Q4A19(["`A19. 210 to 214`"]):::answer
+Q4A19-->O19
+
+Q4---Q4A20
+Q4A20(["`A20. 215 to 219`"]):::answer
+Q4A20-->O20
+
+Q4---Q4A21
+Q4A21(["`A21. 220 to 224`"]):::answer
+Q4A21-->O21
+
+Q4---Q4A22
+Q4A22(["`A22. 225 or more`"]):::answer
+Q4A22-->O22
+
+Q5["`Q5. What is your car's CO2 emissions band?`"]:::question
+Q5---Q5A1
+Q5A1(["`A1. 124 or less`"]):::answer
+Q5A1-->O23
+
+Q5---Q5A2
+Q5A2(["`A2. 125 to 129`"]):::answer
+Q5A2-->O24
+
+Q5---Q5A3
+Q5A3(["`A3. 130 to 134`"]):::answer
+Q5A3-->O25
+
+Q5---Q5A4
+Q5A4(["`A4. 135 to 139`"]):::answer
+Q5A4-->O26
+
+Q5---Q5A5
+Q5A5(["`A5. 140 to 144`"]):::answer
+Q5A5-->O27
+
+Q5---Q5A6
+Q5A6(["`A6. 145 to 149`"]):::answer
+Q5A6-->O28
+
+Q5---Q5A7
+Q5A7(["`A7. 150 to 154`"]):::answer
+Q5A7-->O29
+
+Q5---Q5A8
+Q5A8(["`A8. 155 to 159`"]):::answer
+Q5A8-->O30
+
+Q5---Q5A9
+Q5A9(["`A9. 160 to 164`"]):::answer
+Q5A9-->O31
+
+Q5---Q5A10
+Q5A10(["`A10. 165 to 169`"]):::answer
+Q5A10-->O32
+
+Q5---Q5A11
+Q5A11(["`A11. 170 to 174`"]):::answer
+Q5A11-->O33
+
+Q5---Q5A12
+Q5A12(["`A12. 175 to 179`"]):::answer
+Q5A12-->O34
+
+Q5---Q5A13
+Q5A13(["`A13. 180 to 184`"]):::answer
+Q5A13-->O35
+
+Q5---Q5A14
+Q5A14(["`A14. 185 to 189`"]):::answer
+Q5A14-->O36
+
+Q5---Q5A15
+Q5A15(["`A15. 190 to 194`"]):::answer
+Q5A15-->O37
+
+Q5---Q5A16
+Q5A16(["`A16. 195 to 199`"]):::answer
+Q5A16-->O38
+
+Q5---Q5A17
+Q5A17(["`A17. 200 to 204`"]):::answer
+Q5A17-->O39
+
+Q5---Q5A18
+Q5A18(["`A18. 205 to 209`"]):::answer
+Q5A18-->O40
+
+Q5---Q5A19
+Q5A19(["`A19. 210 to 214`"]):::answer
+Q5A19-->O41
+
+Q5---Q5A20
+Q5A20(["`A20. 215 to 219`"]):::answer
+Q5A20-->O42
+
+Q5---Q5A21
+Q5A21(["`A21. 220 to 224`"]):::answer
+Q5A21-->O43
+
+Q5---Q5A22
+Q5A22(["`A22. 225 or more`"]):::answer
+Q5A22-->O44
+
+Q6["`Q6. What is your car's CO2 emissions band?`"]:::question
+Q6---Q6A1
+Q6A1(["`A1. 124 or less`"]):::answer
+Q6A1-->O45
+
+Q6---Q6A2
+Q6A2(["`A2. 125 to 129`"]):::answer
+Q6A2-->O46
+
+Q6---Q6A3
+Q6A3(["`A3. 130 to 134`"]):::answer
+Q6A3-->O47
+
+Q6---Q6A4
+Q6A4(["`A4. 135 to 139`"]):::answer
+Q6A4-->O48
+
+Q6---Q6A5
+Q6A5(["`A5. 140 to 144`"]):::answer
+Q6A5-->O49
+
+Q6---Q6A6
+Q6A6(["`A6. 145 to 149`"]):::answer
+Q6A6-->O50
+
+Q6---Q6A7
+Q6A7(["`A7. 150 to 154`"]):::answer
+Q6A7-->O51
+
+Q6---Q6A8
+Q6A8(["`A8. 155 to 159`"]):::answer
+Q6A8-->O52
+
+Q6---Q6A9
+Q6A9(["`A9. 160 to 164`"]):::answer
+Q6A9-->O53
+
+Q6---Q6A10
+Q6A10(["`A10. 165 to 169`"]):::answer
+Q6A10-->O54
+
+Q6---Q6A11
+Q6A11(["`A11. 170 to 174`"]):::answer
+Q6A11-->O55
+
+Q6---Q6A12
+Q6A12(["`A12. 175 to 179`"]):::answer
+Q6A12-->O56
+
+Q6---Q6A13
+Q6A13(["`A13. 180 to 184`"]):::answer
+Q6A13-->O57
+
+Q6---Q6A14
+Q6A14(["`A14. 185 to 189`"]):::answer
+Q6A14-->O58
+
+Q6---Q6A15
+Q6A15(["`A15. 190 to 194`"]):::answer
+Q6A15-->O59
+
+Q6---Q6A16
+Q6A16(["`A16. 195 to 199`"]):::answer
+Q6A16-->O60
+
+Q6---Q6A17
+Q6A17(["`A17. 200 to 204`"]):::answer
+Q6A17-->O61
+
+Q6---Q6A18
+Q6A18(["`A18. 205 to 209`"]):::answer
+Q6A18-->O62
+
+Q6---Q6A19
+Q6A19(["`A19. 210 to 214`"]):::answer
+Q6A19-->O63
+
+Q6---Q6A20
+Q6A20(["`A20. 215 to 219`"]):::answer
+Q6A20-->O64
+
+Q6---Q6A21
+Q6A21(["`A21. 220 to 224`"]):::answer
+Q6A21-->O65
+
+Q6---Q6A22
+Q6A22(["`A22. 225 or more`"]):::answer
+Q6A22-->O66
+
+Q7["`Q7. What is your car's CO2 emissions band?`"]:::question
+Q7---Q7A1
+Q7A1(["`A1. 124 or less`"]):::answer
+Q7A1-->O67
+
+Q7---Q7A2
+Q7A2(["`A2. 125 to 129`"]):::answer
+Q7A2-->O68
+
+Q7---Q7A3
+Q7A3(["`A3. 130 to 134`"]):::answer
+Q7A3-->O69
+
+Q7---Q7A4
+Q7A4(["`A4. 135 to 139`"]):::answer
+Q7A4-->O70
+
+Q7---Q7A5
+Q7A5(["`A5. 140 to 144`"]):::answer
+Q7A5-->O71
+
+Q7---Q7A6
+Q7A6(["`A6. 145 to 149`"]):::answer
+Q7A6-->O72
+
+Q7---Q7A7
+Q7A7(["`A7. 150 to 154`"]):::answer
+Q7A7-->O73
+
+Q7---Q7A8
+Q7A8(["`A8. 155 to 159`"]):::answer
+Q7A8-->O74
+
+Q7---Q7A9
+Q7A9(["`A9. 160 to 164`"]):::answer
+Q7A9-->O75
+
+Q7---Q7A10
+Q7A10(["`A10. 165 to 169`"]):::answer
+Q7A10-->O76
+
+Q7---Q7A11
+Q7A11(["`A11. 170 to 174`"]):::answer
+Q7A11-->O77
+
+Q7---Q7A12
+Q7A12(["`A12. 175 to 179`"]):::answer
+Q7A12-->O78
+
+Q7---Q7A13
+Q7A13(["`A13. 180 to 184`"]):::answer
+Q7A13-->O79
+
+Q7---Q7A14
+Q7A14(["`A14. 185 to 189`"]):::answer
+Q7A14-->O80
+
+Q7---Q7A15
+Q7A15(["`A15. 190 to 194`"]):::answer
+Q7A15-->O81
+
+Q7---Q7A16
+Q7A16(["`A16. 195 to 199`"]):::answer
+Q7A16-->O82
+
+Q7---Q7A17
+Q7A17(["`A17. 200 to 204`"]):::answer
+Q7A17-->O83
+
+Q7---Q7A18
+Q7A18(["`A18. 205 to 209`"]):::answer
+Q7A18-->O84
+
+Q7---Q7A19
+Q7A19(["`A19. 210 to 214`"]):::answer
+Q7A19-->O85
+
+Q7---Q7A20
+Q7A20(["`A20. 215 to 219`"]):::answer
+Q7A20-->O86
+
+Q7---Q7A21
+Q7A21(["`A21. 220 to 224`"]):::answer
+Q7A21-->O87
+
+Q7---Q7A22
+Q7A22(["`A22. 225 or more`"]):::answer
+Q7A22-->O88
+
+Q8["`Q8. What is your car's CO2 emissions band?`"]:::question
+Q8---Q8A1
+Q8A1(["`A1. 124 or less`"]):::answer
+Q8A1-->O89
+
+Q8---Q8A2
+Q8A2(["`A2. 125 to 129`"]):::answer
+Q8A2-->O90
+
+Q8---Q8A3
+Q8A3(["`A3. 130 to 134`"]):::answer
+Q8A3-->O91
+
+Q8---Q8A4
+Q8A4(["`A4. 135 to 139`"]):::answer
+Q8A4-->O92
+
+Q8---Q8A5
+Q8A5(["`A5. 140 to 144`"]):::answer
+Q8A5-->O93
+
+Q8---Q8A6
+Q8A6(["`A6. 145 to 149`"]):::answer
+Q8A6-->O94
+
+Q8---Q8A7
+Q8A7(["`A7. 150 to 154`"]):::answer
+Q8A7-->O95
+
+Q8---Q8A8
+Q8A8(["`A8. 155 to 159`"]):::answer
+Q8A8-->O96
+
+Q8---Q8A9
+Q8A9(["`A9. 160 to 164`"]):::answer
+Q8A9-->O97
+
+Q8---Q8A10
+Q8A10(["`A10. 165 to 169`"]):::answer
+Q8A10-->O98
+
+Q8---Q8A11
+Q8A11(["`A11. 170 to 174`"]):::answer
+Q8A11-->O99
+
+Q8---Q8A12
+Q8A12(["`A12. 175 to 179`"]):::answer
+Q8A12-->O100
+
+Q8---Q8A13
+Q8A13(["`A13. 180 to 184`"]):::answer
+Q8A13-->O101
+
+Q8---Q8A14
+Q8A14(["`A14. 185 to 189`"]):::answer
+Q8A14-->O102
+
+Q8---Q8A15
+Q8A15(["`A15. 190 to 194`"]):::answer
+Q8A15-->O103
+
+Q8---Q8A16
+Q8A16(["`A16. 195 to 199`"]):::answer
+Q8A16-->O104
+
+Q8---Q8A17
+Q8A17(["`A17. 200 to 204`"]):::answer
+Q8A17-->O105
+
+Q8---Q8A18
+Q8A18(["`A18. 205 to 209`"]):::answer
+Q8A18-->O106
+
+Q8---Q8A19
+Q8A19(["`A19. 210 to 214`"]):::answer
+Q8A19-->O107
+
+Q8---Q8A20
+Q8A20(["`A20. 215 to 219`"]):::answer
+Q8A20-->O108
+
+Q8---Q8A21
+Q8A21(["`A21. 220 to 224`"]):::answer
+Q8A21-->O109
+
+Q8---Q8A22
+Q8A22(["`A22. 225 or more`"]):::answer
+Q8A22-->O110
+
+Q9["`Q9. What is your car's CO2 emissions band?`"]:::question
+Q9---Q9A1
+Q9A1(["`A1. 124 or less`"]):::answer
+Q9A1-->O111
+
+Q9---Q9A2
+Q9A2(["`A2. 125 to 129`"]):::answer
+Q9A2-->O112
+
+Q9---Q9A3
+Q9A3(["`A3. 130 to 134`"]):::answer
+Q9A3-->O113
+
+Q9---Q9A4
+Q9A4(["`A4. 135 to 139`"]):::answer
+Q9A4-->O114
+
+Q9---Q9A5
+Q9A5(["`A5. 140 to 144`"]):::answer
+Q9A5-->O115
+
+Q9---Q9A6
+Q9A6(["`A6. 145 to 149`"]):::answer
+Q9A6-->O116
+
+Q9---Q9A7
+Q9A7(["`A7. 150 to 154`"]):::answer
+Q9A7-->O117
+
+Q9---Q9A8
+Q9A8(["`A8. 155 to 159`"]):::answer
+Q9A8-->O118
+
+Q9---Q9A9
+Q9A9(["`A9. 160 to 164`"]):::answer
+Q9A9-->O119
+
+Q9---Q9A10
+Q9A10(["`A10. 165 to 169`"]):::answer
+Q9A10-->O120
+
+Q9---Q9A11
+Q9A11(["`A11. 170 to 174`"]):::answer
+Q9A11-->O121
+
+Q9---Q9A12
+Q9A12(["`A12. 175 to 179`"]):::answer
+Q9A12-->O122
+
+Q9---Q9A13
+Q9A13(["`A13. 180 to 184`"]):::answer
+Q9A13-->O123
+
+Q9---Q9A14
+Q9A14(["`A14. 185 to 189`"]):::answer
+Q9A14-->O124
+
+Q9---Q9A15
+Q9A15(["`A15. 190 to 194`"]):::answer
+Q9A15-->O125
+
+Q9---Q9A16
+Q9A16(["`A16. 195 to 199`"]):::answer
+Q9A16-->O126
+
+Q9---Q9A17
+Q9A17(["`A17. 200 to 204`"]):::answer
+Q9A17-->O127
+
+Q9---Q9A18
+Q9A18(["`A18. 205 to 209`"]):::answer
+Q9A18-->O128
+
+Q9---Q9A19
+Q9A19(["`A19. 210 to 214`"]):::answer
+Q9A19-->O129
+
+Q9---Q9A20
+Q9A20(["`A20. 215 to 219`"]):::answer
+Q9A20-->O130
+
+Q9---Q9A21
+Q9A21(["`A21. 220 to 224`"]):::answer
+Q9A21-->O131
+
+Q9---Q9A22
+Q9A22(["`A22. 225 or more`"]):::answer
+Q9A22-->O132
+
+Q10["`Q10. What accounting period do you want to calculate it for?`"]:::question
+Q10---Q10A1
+Q10A1(["`A1. 1 month (monthly)`"]):::answer
+Q10A1-->Q11
+
+Q10---Q10A2
+Q10A2(["`A2. 3 months (quarterly)`"]):::answer
+Q10A2-->Q12
+
+Q10---Q10A3
+Q10A3(["`A3. 12 months (annual)`"]):::answer
+Q10A3-->Q13
+
+Q11["`Q11. What is your car's CO2 emissions band?`"]:::question
+Q11---Q11A1
+Q11A1(["`A1. 124 or less`"]):::answer
+Q11A1-->O133
+
+Q11---Q11A2
+Q11A2(["`A2. 125 to 129`"]):::answer
+Q11A2-->O134
+
+Q11---Q11A3
+Q11A3(["`A3. 130 to 134`"]):::answer
+Q11A3-->O135
+
+Q11---Q11A4
+Q11A4(["`A4. 135 to 139`"]):::answer
+Q11A4-->O136
+
+Q11---Q11A5
+Q11A5(["`A5. 140 to 144`"]):::answer
+Q11A5-->O137
+
+Q11---Q11A6
+Q11A6(["`A6. 145 to 149`"]):::answer
+Q11A6-->O138
+
+Q11---Q11A7
+Q11A7(["`A7. 150 to 154`"]):::answer
+Q11A7-->O139
+
+Q11---Q11A8
+Q11A8(["`A8. 155 to 159`"]):::answer
+Q11A8-->O140
+
+Q11---Q11A9
+Q11A9(["`A9. 160 to 164`"]):::answer
+Q11A9-->O141
+
+Q11---Q11A10
+Q11A10(["`A10. 165 to 169`"]):::answer
+Q11A10-->O142
+
+Q11---Q11A11
+Q11A11(["`A11. 170 to 174`"]):::answer
+Q11A11-->O143
+
+Q11---Q11A12
+Q11A12(["`A12. 175 to 179`"]):::answer
+Q11A12-->O144
+
+Q11---Q11A13
+Q11A13(["`A13. 180 to 184`"]):::answer
+Q11A13-->O145
+
+Q11---Q11A14
+Q11A14(["`A14. 185 to 189`"]):::answer
+Q11A14-->O146
+
+Q11---Q11A15
+Q11A15(["`A15. 190 to 194`"]):::answer
+Q11A15-->O147
+
+Q11---Q11A16
+Q11A16(["`A16. 195 to 199`"]):::answer
+Q11A16-->O148
+
+Q11---Q11A17
+Q11A17(["`A17. 200 to 204`"]):::answer
+Q11A17-->O149
+
+Q11---Q11A18
+Q11A18(["`A18. 205 to 209`"]):::answer
+Q11A18-->O150
+
+Q11---Q11A19
+Q11A19(["`A19. 210 to 214`"]):::answer
+Q11A19-->O151
+
+Q11---Q11A20
+Q11A20(["`A20. 215 to 219`"]):::answer
+Q11A20-->O152
+
+Q11---Q11A21
+Q11A21(["`A21. 220 to 224`"]):::answer
+Q11A21-->O153
+
+Q11---Q11A22
+Q11A22(["`A22. 225 or more`"]):::answer
+Q11A22-->O154
+
+Q12["`Q12. What is your car's CO2 emissions band?`"]:::question
+Q12---Q12A1
+Q12A1(["`A1. 124 or less`"]):::answer
+Q12A1-->O155
+
+Q12---Q12A2
+Q12A2(["`A2. 125 to 129`"]):::answer
+Q12A2-->O156
+
+Q12---Q12A3
+Q12A3(["`A3. 130 to 134`"]):::answer
+Q12A3-->O157
+
+Q12---Q12A4
+Q12A4(["`A4. 135 to 139`"]):::answer
+Q12A4-->O158
+
+Q12---Q12A5
+Q12A5(["`A5. 140 to 144`"]):::answer
+Q12A5-->O159
+
+Q12---Q12A6
+Q12A6(["`A6. 145 to 149`"]):::answer
+Q12A6-->O160
+
+Q12---Q12A7
+Q12A7(["`A7. 150 to 154`"]):::answer
+Q12A7-->O161
+
+Q12---Q12A8
+Q12A8(["`A8. 155 to 159`"]):::answer
+Q12A8-->O162
+
+Q12---Q12A9
+Q12A9(["`A9. 160 to 164`"]):::answer
+Q12A9-->O163
+
+Q12---Q12A10
+Q12A10(["`A10. 165 to 169`"]):::answer
+Q12A10-->O164
+
+Q12---Q12A11
+Q12A11(["`A11. 170 to 174`"]):::answer
+Q12A11-->O165
+
+Q12---Q12A12
+Q12A12(["`A12. 175 to 179`"]):::answer
+Q12A12-->O166
+
+Q12---Q12A13
+Q12A13(["`A13. 180 to 184`"]):::answer
+Q12A13-->O167
+
+Q12---Q12A14
+Q12A14(["`A14. 185 to 189`"]):::answer
+Q12A14-->O168
+
+Q12---Q12A15
+Q12A15(["`A15. 190 to 194`"]):::answer
+Q12A15-->O169
+
+Q12---Q12A16
+Q12A16(["`A16. 195 to 199`"]):::answer
+Q12A16-->O170
+
+Q12---Q12A17
+Q12A17(["`A17. 200 to 204`"]):::answer
+Q12A17-->O171
+
+Q12---Q12A18
+Q12A18(["`A18. 205 to 209`"]):::answer
+Q12A18-->O172
+
+Q12---Q12A19
+Q12A19(["`A19. 210 to 214`"]):::answer
+Q12A19-->O173
+
+Q12---Q12A20
+Q12A20(["`A20. 215 to 219`"]):::answer
+Q12A20-->O174
+
+Q12---Q12A21
+Q12A21(["`A21. 220 to 224`"]):::answer
+Q12A21-->O175
+
+Q12---Q12A22
+Q12A22(["`A22. 225 or more`"]):::answer
+Q12A22-->O176
+
+Q13["`Q13. What is your car's CO2 emissions band?`"]:::question
+Q13---Q13A1
+Q13A1(["`A1. 124 or less`"]):::answer
+Q13A1-->O177
+
+Q13---Q13A2
+Q13A2(["`A2. 125 to 129`"]):::answer
+Q13A2-->O178
+
+Q13---Q13A3
+Q13A3(["`A3. 130 to 134`"]):::answer
+Q13A3-->O179
+
+Q13---Q13A4
+Q13A4(["`A4. 135 to 139`"]):::answer
+Q13A4-->O180
+
+Q13---Q13A5
+Q13A5(["`A5. 140 to 144`"]):::answer
+Q13A5-->O181
+
+Q13---Q13A6
+Q13A6(["`A6. 145 to 149`"]):::answer
+Q13A6-->O182
+
+Q13---Q13A7
+Q13A7(["`A7. 150 to 154`"]):::answer
+Q13A7-->O183
+
+Q13---Q13A8
+Q13A8(["`A8. 155 to 159`"]):::answer
+Q13A8-->O184
+
+Q13---Q13A9
+Q13A9(["`A9. 160 to 164`"]):::answer
+Q13A9-->O185
+
+Q13---Q13A10
+Q13A10(["`A10. 165 to 169`"]):::answer
+Q13A10-->O186
+
+Q13---Q13A11
+Q13A11(["`A11. 170 to 174`"]):::answer
+Q13A11-->O187
+
+Q13---Q13A12
+Q13A12(["`A12. 175 to 179`"]):::answer
+Q13A12-->O188
+
+Q13---Q13A13
+Q13A13(["`A13. 180 to 184`"]):::answer
+Q13A13-->O189
+
+Q13---Q13A14
+Q13A14(["`A14. 185 to 189`"]):::answer
+Q13A14-->O190
+
+Q13---Q13A15
+Q13A15(["`A15. 190 to 194`"]):::answer
+Q13A15-->O191
+
+Q13---Q13A16
+Q13A16(["`A16. 195 to 199`"]):::answer
+Q13A16-->O192
+
+Q13---Q13A17
+Q13A17(["`A17. 200 to 204`"]):::answer
+Q13A17-->O193
+
+Q13---Q13A18
+Q13A18(["`A18. 205 to 209`"]):::answer
+Q13A18-->O194
+
+Q13---Q13A19
+Q13A19(["`A19. 210 to 214`"]):::answer
+Q13A19-->O195
+
+Q13---Q13A20
+Q13A20(["`A20. 215 to 219`"]):::answer
+Q13A20-->O196
+
+Q13---Q13A21
+Q13A21(["`A21. 220 to 224`"]):::answer
+Q13A21-->O197
+
+Q13---Q13A22
+Q13A22(["`A22. 225 or more`"]):::answer
+Q13A22-->O198
+
+O1{{"`O1. Your car's fuel scale charge for 2022 to 2023 is £58.00 a month`"}}:::outcome
+O2{{"`O2. Your car's fuel scale charge for 2022 to 2023 is £87.00 a month`"}}:::outcome
+O3{{"`O3. Your car's fuel scale charge for 2022 to 2023 is £92.00 a month`"}}:::outcome
+O4{{"`O4. Your car's fuel scale charge for 2022 to 2023 is £98.00 a month`"}}:::outcome
+O5{{"`O5. Your car's fuel scale charge for 2022 to 2023 is £104.00 a month`"}}:::outcome
+O6{{"`O6. Your car's fuel scale charge for 2022 to 2023 is £110.00 a month`"}}:::outcome
+O7{{"`O7. Your car's fuel scale charge for 2022 to 2023 is £116.00 a month`"}}:::outcome
+O8{{"`O8. Your car's fuel scale charge for 2022 to 2023 is £122.00 a month`"}}:::outcome
+O9{{"`O9. Your car's fuel scale charge for 2022 to 2023 is £127.00 a month`"}}:::outcome
+O10{{"`O10. Your car's fuel scale charge for 2022 to 2023 is £133.00 a month`"}}:::outcome
+O11{{"`O11. Your car's fuel scale charge for 2022 to 2023 is £139.00 a month`"}}:::outcome
+O12{{"`O12. Your car's fuel scale charge for 2022 to 2023 is £145.00 a month`"}}:::outcome
+O13{{"`O13. Your car's fuel scale charge for 2022 to 2023 is £151.00 a month`"}}:::outcome
+O14{{"`O14. Your car's fuel scale charge for 2022 to 2023 is £156.00 a month`"}}:::outcome
+O15{{"`O15. Your car's fuel scale charge for 2022 to 2023 is £163.00 a month`"}}:::outcome
+O16{{"`O16. Your car's fuel scale charge for 2022 to 2023 is £169.00 a month`"}}:::outcome
+O17{{"`O17. Your car's fuel scale charge for 2022 to 2023 is £174.00 a month`"}}:::outcome
+O18{{"`O18. Your car's fuel scale charge for 2022 to 2023 is £180.00 a month`"}}:::outcome
+O19{{"`O19. Your car's fuel scale charge for 2022 to 2023 is £185.00 a month`"}}:::outcome
+O20{{"`O20. Your car's fuel scale charge for 2022 to 2023 is £192.00 a month`"}}:::outcome
+O21{{"`O21. Your car's fuel scale charge for 2022 to 2023 is £198.00 a month`"}}:::outcome
+O22{{"`O22. Your car's fuel scale charge for 2022 to 2023 is £203.00 a month`"}}:::outcome
+O23{{"`O23. Your car's fuel scale charge for 2022 to 2023 is £174.00 a quarter`"}}:::outcome
+O24{{"`O24. Your car's fuel scale charge for 2022 to 2023 is £262.00 a quarter`"}}:::outcome
+O25{{"`O25. Your car's fuel scale charge for 2022 to 2023 is £279.00 a quarter`"}}:::outcome
+O26{{"`O26. Your car's fuel scale charge for 2022 to 2023 is £296.00 a quarter`"}}:::outcome
+O27{{"`O27. Your car's fuel scale charge for 2022 to 2023 is £314.00 a quarter`"}}:::outcome
+O28{{"`O28. Your car's fuel scale charge for 2022 to 2023 is £332.00 a quarter`"}}:::outcome
+O29{{"`O29. Your car's fuel scale charge for 2022 to 2023 is £349.00 a quarter`"}}:::outcome
+O30{{"`O30. Your car's fuel scale charge for 2022 to 2023 is £367.00 a quarter`"}}:::outcome
+O31{{"`O31. Your car's fuel scale charge for 2022 to 2023 is £385.00 a quarter`"}}:::outcome
+O32{{"`O32. Your car's fuel scale charge for 2022 to 2023 is £402.00 a quarter`"}}:::outcome
+O33{{"`O33. Your car's fuel scale charge for 2022 to 2023 is £419.00 a quarter`"}}:::outcome
+O34{{"`O34. Your car's fuel scale charge for 2022 to 2023 is £437.00 a quarter`"}}:::outcome
+O35{{"`O35. Your car's fuel scale charge for 2022 to 2023 is £454.00 a quarter`"}}:::outcome
+O36{{"`O36. Your car's fuel scale charge for 2022 to 2023 is £472.00 a quarter`"}}:::outcome
+O37{{"`O37. Your car's fuel scale charge for 2022 to 2023 is £490.00 a quarter`"}}:::outcome
+O38{{"`O38. Your car's fuel scale charge for 2022 to 2023 is £507.00 a quarter`"}}:::outcome
+O39{{"`O39. Your car's fuel scale charge for 2022 to 2023 is £525.00 a quarter`"}}:::outcome
+O40{{"`O40. Your car's fuel scale charge for 2022 to 2023 is £543.00 a quarter`"}}:::outcome
+O41{{"`O41. Your car's fuel scale charge for 2022 to 2023 is £559.00 a quarter`"}}:::outcome
+O42{{"`O42. Your car's fuel scale charge for 2022 to 2023 is £577.00 a quarter`"}}:::outcome
+O43{{"`O43.  Your car's fuel scale charge for 2022 to 2023 is £595.00 a quarter`"}}:::outcome
+O44{{"`O44. Your car's fuel scale charge for 2022 to 2023 is £612.00 a quarter`"}}:::outcome
+O45{{"`O45. Your car's annual fuel scale charge for 2022 to 2023 is £700.00`"}}:::outcome
+O46{{"`O46. Your car's annual fuel scale charge for 2022 to 2023 is £1,048.00`"}}:::outcome
+O47{{"`O47. Your car's annual fuel scale charge for 2022 to 2023 is £1,121.00`"}}:::outcome
+O48{{"`O48. Your car's annual fuel scale charge for 2022 to 2023 is £1,188.00`"}}:::outcome
+O49{{"`O49. Your car's annual fuel scale charge for 2022 to 2023 is £1,261.00`"}}:::outcome
+O50{{"`O50. Your car's annual fuel scale charge for 2022 to 2023 is £1,329.00`"}}:::outcome
+O51{{"`O51. Your car's annual fuel scale charge for 2022 to 2023 is £1,401.00`"}}:::outcome
+O52{{"`O52. Your car's annual fuel scale charge for 2022 to 2023 is £1,469.00`"}}:::outcome
+O53{{"`O53. Your car's annual fuel scale charge for 2022 to 2023 is £1,542.00`"}}:::outcome
+O54{{"`O54. Your car's annual fuel scale charge for 2022 to 2023 is £1,609.00`"}}:::outcome
+O55{{"`O55. Your car's annual fuel scale charge for 2022 to 2023 is £1,682.00`"}}:::outcome
+O56{{"`O56. Your car's annual fuel scale charge for 2022 to 2023 is £1,749.00`"}}:::outcome
+O57{{"`O57. Your car's annual fuel scale charge for 2022 to 2023 is £1,822.00`"}}:::outcome
+O58{{"`O58. Your car's annual fuel scale charge for 2022 to 2023 is £1,889.00`"}}:::outcome
+O59{{"`O59. Your car's annual fuel scale charge for 2022 to 2023 is £1,962.00`"}}:::outcome
+O60{{"`O60. Your car's annual fuel scale charge for 2022 to 2023 is £2,030.00`"}}:::outcome
+O61{{"`O61. Your car's annual fuel scale charge for 2022 to 2023 is £2,102.00`"}}:::outcome
+O62{{"`O62. Your car's annual fuel scale charge for 2022 to 2023 is £2,170.00`"}}:::outcome
+O63{{"`O63. Your car's annual fuel scale charge for 2022 to 2023 is £2,242.00`"}}:::outcome
+O64{{"`O64. Your car's annual fuel scale charge for 2022 to 2023 is £2,310.00`"}}:::outcome
+O65{{"`O65. Your car's annual fuel scale charge for 2022 to 2023 is £2,383.00`"}}:::outcome
+O66{{"`O66. Your car's annual fuel scale charge for 2022 to 2023 is £2,450.00`"}}:::outcome
+O67{{"`O67. Your car's fuel scale charge for 2021 to 2022 is £48.00 a month`"}}:::outcome
+O68{{"`O68. Your car's fuel scale charge for 2021 to 2022 is £72.00 a month`"}}:::outcome
+O69{{"`O69. Your car's fuel scale charge for 2021 to 2022 is £77.00 a month`"}}:::outcome
+O70{{"`O70. Your car's fuel scale charge for 2021 to 2022 is £82.00 a month`"}}:::outcome
+O71{{"`O71. Your car's fuel scale charge for 2021 to 2022 is £87.00 a month`"}}:::outcome
+O72{{"`O72. Your car's fuel scale charge for 2021 to 2022 is £91.00 a month`"}}:::outcome
+O73{{"`O73. Your car's fuel scale charge for 2021 to 2022 is £97.00 a month`"}}:::outcome
+O74{{"`O74. Your car's fuel scale charge for 2021 to 2022 is £102.00 a month`"}}:::outcome
+O75{{"`O75. Your car's fuel scale charge for 2021 to 2022 is £106.00 a month`"}}:::outcome
+O76{{"`O76. Your car's fuel scale charge for 2021 to 2022 is £111.00 a month`"}}:::outcome
+O77{{"`O77. Your car's fuel scale charge for 2021 to 2022 is £116.00 a month`"}}:::outcome
+O78{{"`O78. Your car's fuel scale charge for 2021 to 2022 is £121.00 a month`"}}:::outcome
+O79{{"`O79. Your car's fuel scale charge for 2021 to 2022 is £126.00 a month`"}}:::outcome
+O80{{"`O80. Your car's fuel scale charge for 2021 to 2022 is £130.00 a month`"}}:::outcome
+O81{{"`O81. Your car's fuel scale charge for 2021 to 2022 is £136.00 a month`"}}:::outcome
+O82{{"`O82. Your car's fuel scale charge for 2021 to 2022 is £141.00 a month`"}}:::outcome
+O83{{"`O83. Your car's fuel scale charge for 2021 to 2022 is £145.00 a month`"}}:::outcome
+O84{{"`O84. Your car's fuel scale charge for 2021 to 2022 is £150.00 a month`"}}:::outcome
+O85{{"`O85. Your car's fuel scale charge for 2021 to 2022 is £155.00 a month`"}}:::outcome
+O86{{"`O86. Your car's fuel scale charge for 2021 to 2022 is £160.00 a month`"}}:::outcome
+O87{{"`O87. Your car's fuel scale charge for 2021 to 2022 is £165.00 a month`"}}:::outcome
+O88{{"`O88. Your car's fuel scale charge for 2021 to 2022 is £169.00 a month`"}}:::outcome
+O89{{"`O89. Your car’s fuel surcharge for 2021 to 2022 is £145.00 a quarter`"}}:::outcome
+O90{{"`O90. Your car’s fuel surcharge for 2021 to 2022 is £219.00 a quarter`"}}:::outcome
+O91{{"`O91. Your car’s fuel surcharge for 2021 to 2022 is £233.00 a quarter`"}}:::outcome
+O92{{"`O92. Your car’s fuel surcharge for 2021 to 2022 is £247.00 a quarter`"}}:::outcome
+O93{{"`O93. Your car’s fuel surcharge for 2021 to 2022 is £262.00 a quarter`"}}:::outcome
+O94{{"`O94. Your car’s fuel surcharge for 2021 to 2022 is £277.00 a quarter`"}}:::outcome
+O95{{"`O95. Your car’s fuel surcharge for 2021 to 2022 is £292.00 a quarter`"}}:::outcome
+O96{{"`O96. Your car’s fuel surcharge for 2021 to 2022 is £306.00 a quarter`"}}:::outcome
+O97{{"`O97. Your car’s fuel surcharge for 2021 to 2022 is £321.00 a quarter`"}}:::outcome
+O98{{"`O98. Your car’s fuel surcharge for 2021 to 2022 is £336.00 a quarter`"}}:::outcome
+O99{{"`O99. Your car’s fuel surcharge for 2021 to 2022 is £350.00 a quarter`"}}:::outcome
+O100{{"`O100. Your car’s fuel surcharge for 2021 to 2022 is £364.00 a quarter`"}}:::outcome
+O101{{"`O101. Your car’s fuel surcharge for 2021 to 2022 is £379.00 a quarter`"}}:::outcome
+O102{{"`O102. Your car’s fuel surcharge for 2021 to 2022 is £394.00 a quarter`"}}:::outcome
+O103{{"`O103. Your car’s fuel surcharge for 2021 to 2022 is £409.00 a quarter`"}}:::outcome
+O104{{"`O104. Your car’s fuel surcharge for 2021 to 2022 is £423.00 a quarter`"}}:::outcome
+O105{{"`O105. Your car’s fuel surcharge for 2021 to 2022 is £438.00 a quarter`"}}:::outcome
+O106{{"`O106. Your car’s fuel surcharge for 2021 to 2022 is £453.00 a quarter`"}}:::outcome
+O107{{"`O107. Your car’s fuel surcharge for 2021 to 2022 is £467.00 a quarter`"}}:::outcome
+O108{{"`O108. Your car’s fuel surcharge for 2021 to 2022 is £481.00 a quarter`"}}:::outcome
+O109{{"`O109. Your car’s fuel surcharge for 2021 to 2022 is £496.00 a quarter`"}}:::outcome
+O110{{"`O110. Your car’s fuel surcharge for 2021 to 2022 is £511.00 a quarter`"}}:::outcome
+O111{{"`O111. Your car's annual fuel scale charge for 2021 to 2022 is £585.00`"}}:::outcome
+O112{{"`O112. Your car's annual fuel scale charge for 2021 to 2022 is £875.00`"}}:::outcome
+O113{{"`O113. Your car's annual fuel scale charge for 2021 to 2022 is £936.00`"}}:::outcome
+O114{{"`O114. Your car's annual fuel scale charge for 2021 to 2022 is £992.00`"}}:::outcome
+O115{{"`O115. Your car's annual fuel scale charge for 2021 to 2022 is £1,053.00`"}}:::outcome
+O116{{"`O116. Your car's annual fuel scale charge for 2021 to 2022 is £1,109.00`"}}:::outcome
+O117{{"`O117. Your car's annual fuel scale charge for 2021 to 2022 is £1,170.00`"}}:::outcome
+O118{{"`O118. Your car's annual fuel scale charge for 2021 to 2022 is £1,226.00`"}}:::outcome
+O119{{"`O119. Your car's annual fuel scale charge for 2021 to 2022 is £1,287.00`"}}:::outcome
+O120{{"`O120. Your car's annual fuel scale charge for 2021 to 2022 is £1,343.00`"}}:::outcome
+O121{{"`O121. Your car's annual fuel scale charge for 2021 to 2022 is £1,404.00`"}}:::outcome
+O122{{"`O122. Your car's annual fuel scale charge for 2021 to 2022 is £1,460.00`"}}:::outcome
+O123{{"`O123. Your car's annual fuel scale charge for 2021 to 2022 is £1,521.00`"}}:::outcome
+O124{{"`O124. Your car's annual fuel scale charge for 2021 to 2022 is £1,577.00`"}}:::outcome
+O125{{"`O125. Your car's annual fuel scale charge for 2021 to 2022 is £1,638.00`"}}:::outcome
+O126{{"`O126. Your car's annual fuel scale charge for 2021 to 2022 is £1,694.00`"}}:::outcome
+O127{{"`O127. Your car's annual fuel scale charge for 2021 to 2022 is £1,755.00`"}}:::outcome
+O128{{"`O128. Your car's annual fuel scale charge for 2021 to 2022 is £1,811.00`"}}:::outcome
+O129{{"`O129. Your car's annual fuel scale charge for 2021 to 2022 is £1,872.00`"}}:::outcome
+O130{{"`O130. Your car's annual fuel scale charge for 2021 to 2022 is £1928.00`"}}:::outcome
+O131{{"`O131. Your car's annual fuel scale charge for 2021 to 2022 is £1989.00`"}}:::outcome
+O132{{"`O132. Your car's annual fuel scale charge for 2021 to 2022 is £2,045,00`"}}:::outcome
+O133{{"`O133. Your car's fuel scale charge for 2023 to 2024 is £61.00 a month`"}}:::outcome
+O134{{"`O134. Your car's fuel scale charge for 2023 to 2024 is £91.00 a month`"}}:::outcome
+O135{{"`O135. Your car's fuel scale charge for 2023 to 2024 is £97.00 a month`"}}:::outcome
+O136{{"`O136. Your car's fuel scale charge for 2023 to 2024 is £103.00 a month`"}}:::outcome
+O137{{"`O137. Your car's fuel scale charge for 2023 to 2024 is £110.00 a month`"}}:::outcome
+O138{{"`O138. Your car's fuel scale charge for 2023 to 2024 is £115.00 a month`"}}:::outcome
+O139{{"`O139. Your car's fuel scale charge for 2023 to 2024 is £122.00 a month`"}}:::outcome
+O140{{"`O140. Your car's fuel scale charge for 2023 to 2024 is £128.00 a month`"}}:::outcome
+O141{{"`O141. Your car's fuel scale charge for 2023 to 2024 is £134.00 a month`"}}:::outcome
+O142{{"`O142. Your car's fuel scale charge for 2023 to 2024 is £140.00 a month`"}}:::outcome
+O143{{"`O143. Your car's fuel scale charge for 2023 to 2024 is £146.00 a month`"}}:::outcome
+O144{{"`O144. Your car's fuel scale charge for 2023 to 2024 is £152.00 a month`"}}:::outcome
+O145{{"`O145. Your car's fuel scale charge for 2023 to 2024 is £159.00 a month`"}}:::outcome
+O146{{"`O146. Your car's fuel scale charge for 2023 to 2024 is £164.00 a month`"}}:::outcome
+O147{{"`O147. Your car's fuel scale charge for 2023 to 2024 is £171.00 a month`"}}:::outcome
+O148{{"`O148. Your car's fuel scale charge for 2023 to 2024 is £178.00 a month`"}}:::outcome
+O149{{"`O149. Your car's fuel scale charge for 2023 to 2024 is £183.00 a month`"}}:::outcome
+O150{{"`O150. Your car's fuel scale charge for 2023 to 2024 is £190.00 a month`"}}:::outcome
+O151{{"`O151. Your car's fuel scale charge for 2023 to 2024 is £195.00 a month`"}}:::outcome
+O152{{"`O152. Your car's fuel scale charge for 2023 to 2024 is £202.00 a month`"}}:::outcome
+O153{{"`O153. Your car's fuel scale charge for 2023 to 2024 is £208.00 a month`"}}:::outcome
+O154{{"`O154. Your car's fuel scale charge for 2023 to 2024 is £214.00 a month`"}}:::outcome
+O155{{"`O155. Your car's fuel scale charge for 2023 to 2024 is £183.00 a quarter`"}}:::outcome
+O156{{"`O156. Your car's fuel scale charge for 2023 to 2024 is £276.00 a quarter`"}}:::outcome
+O157{{"`O157. Your car's fuel scale charge for 2023 to 2024 is £293.00 a quarter`"}}:::outcome
+O158{{"`O158. Your car's fuel scale charge for 2023 to 2024 is £312.00 a quarter`"}}:::outcome
+O159{{"`O159. Your car's fuel scale charge for 2023 to 2024 is £331.00 a quarter`"}}:::outcome
+O160{{"`O160. Your car's fuel scale charge for 2023 to 2024 is £349.00 a quarter`"}}:::outcome
+O161{{"`O161. Your car's fuel scale charge for 2023 to 2024 is £368.00 a quarter`"}}:::outcome
+O162{{"`O162. Your car's fuel scale charge for 2023 to 2024 is £386.00 a quarter`"}}:::outcome
+O163{{"`O163. Your car's fuel scale charge for 2023 to 2024 is £405.00 a quarter`"}}:::outcome
+O164{{"`O164. Your car's fuel scale charge for 2023 to 2024 is £423.00 a quarter`"}}:::outcome
+O165{{"`O165. Your car's fuel scale charge for 2023 to 2024 is £441.00 a quarter`"}}:::outcome
+O166{{"`O166. Your car's fuel scale charge for 2023 to 2024 is £459.00 a quarter`"}}:::outcome
+O167{{"`O167. Your car's fuel scale charge for 2023 to 2024 is £478.00 a quarter`"}}:::outcome
+O168{{"`O168. Your car's fuel scale charge for 2023 to 2024 is £497.00 a quarter`"}}:::outcome
+O169{{"`O169. Your car's fuel scale charge for 2023 to 2024 is £515.00 a quarter`"}}:::outcome
+O170{{"`O170. Your car's fuel scale charge for 2023 to 2024 is £534.00 a quarter`"}}:::outcome
+O171{{"`O171. Your car's fuel scale charge for 2023 to 2024 is £552.00 a quarter`"}}:::outcome
+O172{{"`O172. Your car's fuel scale charge for 2023 to 2024 is £571.00 a quarter`"}}:::outcome
+O173{{"`O173. Your car's fuel scale charge for 2023 to 2024 is £588.00 a quarter`"}}:::outcome
+O174{{"`O174. Your car's fuel scale charge for 2023 to 2024 is £607.00 a quarter`"}}:::outcome
+O175{{"`O175. Your car's fuel scale charge for 2023 to 2024 is £626.00 a quarter`"}}:::outcome
+O176{{"`O176. Your car's fuel scale charge for 2023 to 2024 is £644.00 a quarter`"}}:::outcome
+O177{{"`O177. Your car's annual fuel scale charge for 2023 to 2024 is £737.00`"}}:::outcome
+O178{{"`O178. Your car's annual fuel scale charge for 2023 to 2024 is £1,103.00`"}}:::outcome
+O179{{"`O179. Your car's annual fuel scale charge for 2023 to 2024 is £1,179.00`"}}:::outcome
+O180{{"`O180. Your car's annual fuel scale charge for 2023 to 2024 is £1,250.00`"}}:::outcome
+O181{{"`O181. Your car's annual fuel scale charge for 2023 to 2024 is £1,327.00`"}}:::outcome
+O182{{"`O182. Your car's annual fuel scale charge for 2023 to 2024 is £1,398.00`"}}:::outcome
+O183{{"`O183. Your car's annual fuel scale charge for 2023 to 2024 is £1,474.00`"}}:::outcome
+O184{{"`O184. Your car's annual fuel scale charge for 2023 to 2024 is £1,545.00`"}}:::outcome
+O185{{"`O185. Your car's annual fuel scale charge for 2023 to 2024 is £1,622.00`"}}:::outcome
+O186{{"`O186. Your car's annual fuel scale charge for 2023 to 2024 is £1,693.00`"}}:::outcome
+O187{{"`O187. Your car's annual fuel scale charge for 2023 to 2024 is £1,769.00`"}}:::outcome
+O188{{"`O188. Your car's annual fuel scale charge for 2023 to 2024 is £1,840.00`"}}:::outcome
+O189{{"`O189. Your car's annual fuel scale charge for 2023 to 2024 is £1,917.00`"}}:::outcome
+O190{{"`O190. Your car's annual fuel scale charge for 2023 to 2024 is £1,988.00`"}}:::outcome
+O191{{"`O191. Your car's annual fuel scale charge for 2023 to 2024 is £2,064.00`"}}:::outcome
+O192{{"`O192. Your car's annual fuel scale charge for 2023 to 2024 is £2,135.00`"}}:::outcome
+O193{{"`O193. Your car's annual fuel scale charge for 2023 to 2024 is £2,212.00`"}}:::outcome
+O194{{"`O194. Your car's annual fuel scale charge for 2023 to 2024 is £2,283.00`"}}:::outcome
+O195{{"`O195. Your car's annual fuel scale charge for 2023 to 2024 is £2,359.00`"}}:::outcome
+O196{{"`O196. Your car's annual fuel scale charge for 2023 to 2024 is £2,430.00`"}}:::outcome
+O197{{"`O197. Your car's annual fuel scale charge for 2023 to 2024 is £2,507.00`"}}:::outcome
+O198{{"`O198. Your car's annual fuel scale charge for 2023 to 2024 is £2,578.00`"}}:::outcome
+classDef answer fill: #F3F2F1, stroke:#505A5F;
+classDef outcome fill: #6FA4D2
+classDef question fill: #B1B4B6, stroke:#505A5F;
+classDef start fill:#00703c,color: #ffffff

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -589,4 +589,36 @@ class SimpleSmartAnswersTest < JavascriptIntegrationTest
       end
     end
   end
+
+  context "mermaid:" do
+    setup do
+      @edition = FactoryBot.build(
+        :simple_smart_answer_edition,
+        title: "Can I get a driving licence?",
+        panopticon_id: @artefact.id,
+        slug: "can-i-get-a-driving-licence",
+        )
+      @edition.nodes.build(
+        slug: "question-1",
+        order: 1,
+        title: "To be or not to be?",
+        kind: "question",
+        options_attributes: [
+          { label: "That is the question", next_node: "outcome-1" },
+          { label: "That is not the question", next_node: "outcome-2" },
+        ],
+        )
+      @edition.nodes.build(slug: "outcome-1", order: 2, title: "Outcome One", kind: "outcome")
+      @edition.nodes.build(slug: "outcome-2", order: 3, title: "Outcome Two", kind: "outcome")
+      @edition.save!
+    end
+
+    should "render small smart-answer flowchart successfully" do
+      visit "/editions/#{@edition.to_param}/diagram"
+
+      within ".nodes" do
+        assert page.has_content? "Q1. To be or not to be?"
+      end
+    end
+  end
 end

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -597,7 +597,7 @@ class SimpleSmartAnswersTest < JavascriptIntegrationTest
         title: "Can I get a driving licence?",
         panopticon_id: @artefact.id,
         slug: "can-i-get-a-driving-licence",
-        )
+      )
       @edition.nodes.build(
         slug: "question-1",
         order: 1,
@@ -607,7 +607,7 @@ class SimpleSmartAnswersTest < JavascriptIntegrationTest
           { label: "That is the question", next_node: "outcome-1" },
           { label: "That is not the question", next_node: "outcome-2" },
         ],
-        )
+      )
       @edition.nodes.build(slug: "outcome-1", order: 2, title: "Outcome One", kind: "outcome")
       @edition.nodes.build(slug: "outcome-2", order: 3, title: "Outcome Two", kind: "outcome")
       @edition.save!
@@ -618,6 +618,20 @@ class SimpleSmartAnswersTest < JavascriptIntegrationTest
 
       within ".nodes" do
         assert page.has_content? "Q1. To be or not to be?"
+      end
+    end
+
+    should "render large smart-answer flowchart with 421 'edges' (i.e lines/arrows) successfully" do
+      file = File.open(Rails.root.join("test/integration/large_SA_mermaid_code.txt").to_s)
+
+      mermaid_code = file.read
+
+      SimpleSmartAnswerEdition.any_instance.stubs(:generate_mermaid).returns(mermaid_code)
+
+      visit "/editions/#{@edition.to_param}/diagram"
+
+      within ".nodes" do
+        assert page.has_content? "Q1. Which period do you want to calculate the fuel scale charge for?"
       end
     end
   end


### PR DESCRIPTION
As described in ticket [#600](https://trello.com/c/0iriT8Ow/600-bug-ssa-visualization-fails-with-mermaid-upgrade), it was identified that when mermaid.js released version [10.6.0](https://github.com/mermaid-js/mermaid/releases/tag/v10.6.0), they added a limitation to the max number of of edges (i.e number of lines and arrows between nodes) a diagram can have(280). 

This was only picked up manually when looking at the ["Work out your VAT fuel scale charge"](https://publisher.publishing.service.gov.uk/editions/6450cb324aa60b000d4172d6/diagram) smart-answer, as it failed to load. 

To avoid future instances of this happening tests have been added, to check that both small and large smart answers flowcharts are render successfully. 
