### PR TITLE
Migrate the Reports page to GOV.UK Design System

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -38,12 +38,17 @@ class ReportsController < ApplicationController
 private
 
   def report_last_updated(report_name)
-    last_updated = ::Report.new(report_name).last_updated
-    if last_updated
-      tag.span "Generated #{last_updated.to_fs(:govuk_date)}", class: "text-muted"
-    else
-      tag.span "Report currently unavailable", class: "text-muted"
-    end
+    ::Report.new(report_name).last_updated
   end
   helper_method :report_last_updated
+
+  def report_generated_time_message(report_name)
+    last_updated = report_last_updated(report_name)
+    if last_updated
+      "Generated #{last_updated.strftime('%-l:%M%#p')}"
+    else
+      "Report currently unavailable"
+    end
+  end
+  helper_method :report_generated_time_message
 end

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -18,7 +18,22 @@
 
   <div class="govuk-width-container">
     <main class="govuk-main-wrapper" id="main-content" role="main">
-      <%= yield %>
+
+      <% if yield(:title).present? %>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <%= render "govuk_publishing_components/components/title", {
+              title: yield(:title),
+              margin_top: 0,
+              margin_bottom: 6,
+            } %>
+          </div>
+        </div>
+      <% end %>
+
+      <div class="govuk-grid-row">
+        <%= yield %>
+      </div>
     </main>
   </div>
 

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,35 +1,86 @@
-<div class="page-header">
-  <h1>CSV Reports</h1>
-  <p>These reports are updated every hour.</p>
-</div>
-
-<p>
-  <strong><%= link_to 'All documents for departmental distribution', organisation_content_report_path(format: :csv) %></strong><br />
-  <%= report_last_updated("organisation_content")%>
-</p>
-<p>
-  <strong><%= link_to 'Churn in non-archived editions', edition_churn_report_path(format: :csv) %></strong><br />
-  <%= report_last_updated("edition_churn")%>
-</p>
-<p>
-  <strong><%= link_to 'Churn in all editions', all_edition_churn_report_path(format: :csv) %></strong><br />
-  <%= report_last_updated("all_edition_churn")%>
-</p>
-<p>
-  <strong><%= link_to 'Progress on all non-archived editions', progress_report_path(format: :csv) %></strong><br />
-  <%= report_last_updated("editorial_progress")%>
-</p>
-<p>
-  <strong><%= link_to 'Content summary and workflow history for all published editions', content_workflow_report_path(format: :csv) %></strong><br />
-  <%= report_last_updated("content_workflow")%>
-</p>
-<p>
-  <strong><%= link_to 'Content summary and workflow history for all editions', all_content_workflow_report_path(format: :csv) %></strong><br />
-  <%= report_last_updated("all_content_workflow")%>
-</p>
-<p>
-  <strong><%= link_to 'All URLs', all_urls_report_path(format: :csv) %></strong><br />
-  <%= report_last_updated("all_urls")%>
-</p>
-
 <% content_for :page_title, "Reports" %>
+<% content_for :title, "CSV Reports" %>
+
+<div class="govuk-grid-column-two-thirds">
+  <%= render "govuk_publishing_components/components/lead_paragraph", {
+    text: "These reports are updated every hour.",
+    margin_bottom: 6
+  } %>
+
+  <%= render "govuk_publishing_components/components/document_list", {
+    margin_bottom: 6,
+    items: [
+      {
+        link: {
+          text: "All documents for departmental distribution",
+          path: organisation_content_report_path(format: :csv)
+        },
+        metadata: {
+          updated_at_time: report_generated_time_message("organisation_content"),
+          public_updated_at: report_last_updated("organisation_content"),
+        }
+      },
+      {
+        link: {
+          text: "Churn in non-archived editions",
+          path: edition_churn_report_path(format: :csv)
+        },
+        metadata: {
+          updated_at_time: report_generated_time_message("edition_churn"),
+          public_updated_at: report_last_updated("edition_churn"),
+        }
+      },
+      {
+        link: {
+          text: "Churn in all editions",
+          path: all_edition_churn_report_path(format: :csv)
+        },
+        metadata: {
+          updated_at_time: report_generated_time_message("all_edition_churn"),
+          public_updated_at: report_last_updated("all_edition_churn"),
+        }
+      },
+      {
+        link: {
+          text: "Progress on all non-archived editions",
+          path: progress_report_path(format: :csv)
+        },
+        metadata: {
+          updated_at_time: report_generated_time_message("editorial_progress"),
+          public_updated_at: report_last_updated("editorial_progress"),
+        }
+      },
+      {
+        link: {
+          text: "Content summary and workflow history for all published editions",
+          path: content_workflow_report_path(format: :csv)
+        },
+        metadata: {
+          updated_at_time: report_generated_time_message("content_workflow"),
+          public_updated_at: report_last_updated("content_workflow"),
+        }
+      },
+      {
+        link: {
+          text: "Content summary and workflow history for all editions",
+          path: all_content_workflow_report_path(format: :csv)
+        },
+        metadata: {
+          updated_at_time: report_generated_time_message("all_content_workflow"),
+          public_updated_at: report_last_updated("all_content_workflow"),
+        }
+      },
+      {
+        link: {
+          text: "All URLs",
+          path: all_urls_report_path(format: :csv)
+        },
+        metadata: {
+          updated_at_time: report_generated_time_message("all_urls"),
+          public_updated_at: report_last_updated("all_urls"),
+        }
+      },
+    ]
+  } %>
+
+</div>

--- a/test/functional/reports_controller_test.rb
+++ b/test/functional/reports_controller_test.rb
@@ -1,33 +1,74 @@
 require "test_helper"
 
 class ReportsControllerTest < ActionController::TestCase
-  setup do
-    login_as_stub_user
+  context "When reports are available" do
+    setup do
+      login_as_stub_user
 
-    last_modified = Time.zone.local(2023, 12, 12, 1, 1, 1)
+      last_modified = Time.zone.local(2023, 12, 12, 1, 2, 3)
 
-    Aws.config[:s3] = {
-      stub_responses: {
-        head_object: { last_modified: },
-      },
-    }
+      Aws.config[:s3] = {
+        stub_responses: {
+          head_object: { last_modified: },
+        },
+      }
 
-    ENV["REPORTS_S3_BUCKET_NAME"] = "example"
+      ENV["REPORTS_S3_BUCKET_NAME"] = "example"
+    end
+
+    teardown do
+      ENV["REPORTS_S3_BUCKET_NAME"] = nil
+    end
+
+    should "redirect the user to S3 when following report links" do
+      %i[
+        progress
+        organisation_content
+        edition_churn
+        all_edition_churn
+        content_workflow
+        all_content_workflow
+        all_urls
+      ].each do |action|
+        get action
+
+        assert_equal 302, response.status
+      end
+    end
+
+    should "show the last updated time on the index page" do
+      get :index
+
+      assert_select "ul.gem-c-document-list__item-metadata" do
+        assert_select "li.gem-c-document-list__attribute", { count: 7, text: "Generated 1:02am" }
+        assert_select "li.gem-c-document-list__attribute", { count: 7, text: "12 December 2023" }
+      end
+    end
   end
 
-  teardown do
-    ENV["REPORTS_S3_BUCKET_NAME"] = nil
-  end
+  context "When reports are not available" do
+    setup do
+      login_as_stub_user
 
-  test "it redirects the user to S3" do
-    get :progress
+      Aws.config[:s3] = {
+        stub_responses: {
+          head_object: "NotFound",
+        },
+      }
 
-    assert_equal 302, response.status
-  end
+      ENV["REPORTS_S3_BUCKET_NAME"] = "example"
+    end
 
-  test "shows the last updated time on the index page" do
-    get :index
+    teardown do
+      ENV["REPORTS_S3_BUCKET_NAME"] = nil
+    end
 
-    assert_match(/Generated 1:01am, 12 December 2023/, response.body)
+    should "indicate that reports are not available on the index page" do
+      get :index
+
+      assert_select "ul.gem-c-document-list__item-metadata" do
+        assert_select "li.gem-c-document-list__attribute", { count: 7, text: "Report currently unavailable" }
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

Transitions the content of the reports page to the GOV.UK Design System.

- Adds use of the [Page Title](https://components.publishing.service.gov.uk/component-guide/title) component to `app/views/layouts/design_system.html.erb` to ensure transitioned pages use consistent formatting for the page title.
- Updates the reports index view to use the [Document List](https://components.publishing.service.gov.uk/component-guide/document_list) component.
- Improves the test coverage around the reports controller.

Since the transitioned design splits the generated message into two separate pieces of metadata (one for the time and one for the date), there will now be twice the calls to S3 to fetch that data. This could be optimised if it becomes a problem, but this page is not used much so that is left as a potential future optimisation.

**Feature toggle**: `design_system_reports_page`

## Why

Part of transitioning all pages in Mainstream Publisher to using the GOV.UK Design System.

## Screenshots

### Toggled off

<img width="1150" alt="image" src="https://github.com/alphagov/publisher/assets/138604938/d2cc98cb-a095-4cfe-92df-2ded9067255d">

<img width="1167" alt="image" src="https://github.com/alphagov/publisher/assets/138604938/51d944d0-bab6-49e9-9d71-c8cd5f244ddb">

### Toggled on

![publisher dev gov uk_reports](https://github.com/alphagov/publisher/assets/138604938/d4d4056d-7ecf-45e2-8197-116495f8117d)

![publisher integration publishing service gov uk_reports](https://github.com/alphagov/publisher/assets/138604938/25bb4867-83b4-4e39-81d3-96c390a59735)


[Trello ticket](https://trello.com/c/erOwzh02)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
