### PR TITLE
Transition Downtime Index to the Design System

### DIFF
--- a/app/helpers/downtimes_helper.rb
+++ b/app/helpers/downtimes_helper.rb
@@ -14,4 +14,27 @@ module DowntimesHelper
 
     strings.join(" ").gsub(":00", "").gsub("12pm", "midday").gsub("12am", "midnight")
   end
+
+  def transactions_table_entries(transactions)
+    transactions.map do |transaction|
+      downtime = Downtime.for(transaction.artefact)
+
+      [
+        { text: transaction.title },
+        {
+          text: downtime ? "Scheduled downtime #{downtime_datetime(downtime)}" : "Live",
+        },
+        { text: action_link_for_transaction(transaction) },
+        { text: link_to("View on website", "#{Plek.website_root}/#{transaction.slug}", class: "govuk-link") },
+      ]
+    end
+  end
+
+  def action_link_for_transaction(transaction)
+    if transaction.artefact.downtime
+      link_to "Edit downtime", edit_edition_downtime_path(transaction), class: "govuk-link"
+    else
+      link_to "Add downtime", new_edition_downtime_path(transaction), class: "govuk-link"
+    end
+  end
 end

--- a/app/views/downtimes/index.html.erb
+++ b/app/views/downtimes/index.html.erb
@@ -1,56 +1,30 @@
 <% content_for :page_title, 'Downtime messages' %>
+<% content_for :title, "Downtime messages" %>
 
-<div class="page-title">
-  <h1>Downtime messages</h1>
-  <p class="lead">Show a message on a published transaction start page for a specific time.</p>
+<div class="govuk-grid-column-full">
+
+  <%= render "govuk_publishing_components/components/lead_paragraph", {
+    text: "Show a message on a published transaction start page for a specific time.",
+    margin_bottom: 6
+  } %>  
+
+  <%= render "govuk_publishing_components/components/table", {
+    filterable: true,
+    label: "Filter by service or service status",
+    head: [
+      {
+        text: "Service Start page"
+      },
+      {
+        text: "Service Status",
+      },
+      {
+        text: tag.span("Action", class: "govuk-visually-hidden")
+      },
+      {
+        text: tag.span("Link to view live on GOV.UK", class: "govuk-visually-hidden")
+      }
+    ],
+    rows: transactions_table_entries(@transactions.to_a)
+  } %>
 </div>
-
-<table class="table table-bordered table-striped" data-module="filterable-table">
-  <caption class="h2 remove-top-margin">
-    <h2 class="remove-top-margin remove-bottom-margin">Services</h2>
-  </caption>
-  <thead>
-    <tr class="table-header">
-      <th>Service start page</th>
-      <th>Service status</th>
-      <th>Action</th>
-    </tr>
-    <tr class="if-no-js-hide table-header-secondary">
-      <td colspan="3">
-        <form>
-          <label class="remove-bottom-margin" for="table-filter">Filter services</label>
-          <p class="help-inline">For example ‘driving’ or ‘scheduled downtime’</p>
-          <input id="table-filter" type="text" class="form-control normal js-filter-table-input">
-        </form>
-      </td>
-    </tr>
-  </thead>
-  <tbody>
-    <% @transactions.each do |transaction| %>
-    <tr>
-      <td>
-        <h3 class="publication-table-title">
-          <%= link_to transaction.title, Downtime.for(transaction.artefact).present? ?
-                                          edit_edition_downtime_path(transaction) :
-                                          new_edition_downtime_path(transaction) %>
-        </h3>
-        <%= link_to "/#{transaction.slug}", "#{Plek.website_root}/#{transaction.slug}", class: 'link-muted' %>
-      </td>
-        <% if downtime = Downtime.for(transaction.artefact) %>
-          <td>
-            Scheduled downtime<br />
-            <span class="text-muted"><%= downtime_datetime(downtime) %></span>
-          </td>
-          <td>
-            <%= link_to 'Edit downtime', edit_edition_downtime_path(transaction), class: 'btn btn-info' %>
-          </td>
-        <% else %>
-          <td>Live</td>
-          <td>
-            <%= link_to 'Add downtime', new_edition_downtime_path(transaction), class: 'btn btn-default' %>
-          </td>
-        <% end %>
-    </tr>
-    <% end %>
-  </tbody>
-</table>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -17,26 +17,10 @@
   } %>
 
   <div class="govuk-width-container">
-
     <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
-      <% [:success, :info, :warning, :danger, :notice, :alert].select { |k| flash[k].present? }.each do |k| %>
-        <%
-          case k
-          when :notice
-            alert_class = "success"
-          when :alert
-            alert_class = "danger"
-          else
-            alert_class = k
-          end
-        %>
-        <div class="alert alert-<%= alert_class %>"
-          data-module="auto-track-event"
-          data-track-action="alert-<%= alert_class %>"
-          data-track-label="<%= strip_tags(flash[k]) %>">
-            <%= flash[k] %>
-        </div>
-      <% end %>      
+
+      <%= render "shared/flash", flash: flash %>
+
       <% if yield(:title).present? %>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,0 +1,15 @@
+<% [:success, :info, :warning, :danger, :notice, :alert].select { |k| flash[k].present? }.each do |k| %>
+  <% if k == :warning || k == :danger || k == :alert %>
+    <%= render "govuk_publishing_components/components/error_alert", {
+      message: sanitize(flash[k])
+    } %>
+  <% elsif k == :notice || k == :info %>
+    <%= render "govuk_publishing_components/components/notice", {
+      description: sanitize(flash[k])
+    } %>
+  <% elsif k == :success %>
+    <%= render "govuk_publishing_components/components/success_alert", {
+      message: sanitize(flash[k])
+    } %>
+  <% end %>
+<% end %>

--- a/test/functional/downtimes_controller_test.rb
+++ b/test/functional/downtimes_controller_test.rb
@@ -103,9 +103,9 @@ class DowntimesControllerTest < ActionController::TestCase
       get :index
 
       assert_response :ok
-      assert_select "h3.publication-table-title", count: 0, text: unpublished_transaction_edition.title
+      assert_select ".govuk-table__cell", count: 0, text: unpublished_transaction_edition.title
       transaction_editions.each do |edition|
-        assert_select "h3.publication-table-title", text: edition.title
+        assert_select ".govuk-table__cell", text: edition.title
       end
     end
 

--- a/test/integration/downtime_integration_test.rb
+++ b/test/integration/downtime_integration_test.rb
@@ -24,7 +24,7 @@ class DowntimeIntegrationTest < JavascriptIntegrationTest
 
     visit root_path
     click_link "Downtime"
-    click_link "Apply to become a driving instructor"
+    click_link "Add downtime"
 
     enter_start_time first_of_july_next_year_at_midday_bst
     enter_end_time first_of_july_next_year_at_six_pm_bst

--- a/test/unit/helpers/downtimes_helper_test.rb
+++ b/test/unit/helpers/downtimes_helper_test.rb
@@ -5,6 +5,14 @@ class DowntimesHelperTest < ActionView::TestCase
 
   def setup
     @next_year = 1.year.from_now.year
+    @edition_live = FactoryBot.create(:transaction_edition)
+    @edition_downtime = FactoryBot.create(:transaction_edition)
+    @downtime = FactoryBot.create(
+      :downtime,
+      artefact: @edition_downtime.artefact,
+      start_time: Time.zone.local(@next_year, 10, 10, 15),
+      end_time: Time.zone.local(@next_year, 10, 11, 18),
+    )
   end
 
   test "#downtime_datetime should be a short string representation start and end time" do
@@ -20,5 +28,23 @@ class DowntimesHelperTest < ActionView::TestCase
   test "#downtime_datetime should not repeat date if downtime ends at midnight on next day" do
     downtime = FactoryBot.build(:downtime, start_time: Time.zone.local(@next_year, 10, 10, 21), end_time: Time.zone.local(@next_year, 10, 11, 0))
     assert_equal "9pm to midnight on 10 October", downtime_datetime(downtime)
+  end
+
+  test "#transactions_table_entries should create valid entries for table" do
+    entries = transactions_table_entries([@edition_live, @edition_downtime])
+    assert_equal entries, [
+      [
+        { text: @edition_live.title },
+        { text: "Live" },
+        { text: "<a class=\"govuk-link\" href=\"/editions/#{@edition_live.id}/downtime/new\">Add downtime</a>" },
+        { text: "<a class=\"govuk-link\" href=\"#{Plek.website_root}/#{@edition_live.slug}\">View on website</a>" },
+      ],
+      [
+        { text: @edition_downtime.title },
+        { text: "Scheduled downtime 3pm on 10 October to 6pm on 11 October" },
+        { text: "<a class=\"govuk-link\" href=\"/editions/#{@edition_downtime.id}/downtime/edit\">Edit downtime</a>" },
+        { text: "<a class=\"govuk-link\" href=\"#{Plek.website_root}/#{@edition_downtime.slug}\">View on website</a>" },
+      ],
+    ]
   end
 end


### PR DESCRIPTION
## What

- Use the Table component on the Downtime index page
- Create new helper function to generate entries for the Downtime index table
- Add test for new helper function
- Add flash to design_system.html.erb
- Update existing tests with new changes

## Why

As part of the work to transition Publisher to the Design System from Bootstrap.

[Relevant Trello Card](https://trello.com/c/c1023Flb/620-transition-downtime-hub). https://github.com/alphagov/publisher/pull/2027 Needs to be merged first

## Visual Differences

### Before

![Screenshot 2024-01-31 at 12 06 37](https://github.com/alphagov/publisher/assets/3727504/8ecbfa3c-04b6-424f-b8f7-710ecdee2df1)

![Screenshot 2024-01-31 at 13 58 43](https://github.com/alphagov/publisher/assets/3727504/ac7e5670-679c-47a0-afac-a9951536ff6f)

![Screenshot 2024-01-31 at 13 59 05](https://github.com/alphagov/publisher/assets/3727504/9a34c38f-4e14-4715-96ce-25c4c5a9c3ca)

![Screenshot 2024-01-31 at 13 57 53](https://github.com/alphagov/publisher/assets/3727504/38b90f44-11dd-45fa-9769-1b74a5461f59)


### After

![Screenshot 2024-01-31 at 12 06 06](https://github.com/alphagov/publisher/assets/3727504/92d5ced6-a890-4c4c-ba71-88e28005803d)

![Screenshot 2024-01-31 at 13 55 48](https://github.com/alphagov/publisher/assets/3727504/d3bba143-830c-4b7a-be3d-e5fedb62d55b)

![Screenshot 2024-01-31 at 13 56 17](https://github.com/alphagov/publisher/assets/3727504/369c78e9-67d1-4b32-b981-eae0b2a85c8c)

![Screenshot 2024-01-31 at 13 56 56](https://github.com/alphagov/publisher/assets/3727504/7b73dff0-a692-4a52-878c-66f78e8f5dcd)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
