### PR TITLE
Transition add downtime page

### DIFF
--- a/app/controllers/downtimes_controller.rb
+++ b/app/controllers/downtimes_controller.rb
@@ -3,6 +3,8 @@ class DowntimesController < ApplicationController
   before_action :load_edition
   before_action :process_params, only: %i[create update]
 
+  layout "design_system"
+
   def new
     @downtime = Downtime.new(artefact: @edition.artefact)
   end

--- a/app/views/downtimes/_form.html.erb
+++ b/app/views/downtimes/_form.html.erb
@@ -2,87 +2,79 @@
 
 <%= render :partial => 'shared/error_summary', locals: { object: @downtime} %>
 
-<div class="downtime-dates">
-  <div class="form-group">
-    <p>This service will be unavailable from</p>
-  </div>
-
-  <div class="row js-start-time">
-    <div class="form-group date col-sm-1">
-      <%= f.label :start_time, "Hour", for: "downtime_start_time_4i" %>
-      <%= select_hour @downtime.start_time&.hour || 1.hour.from_now.beginning_of_hour, { field_name: "start_time(4i)", prefix: "downtime" }, { class: "form-control date" } %>
-    </div>
-
-    <div class="form-group date col-sm-1">
-      <%= f.label :start_time, "Minute", for: "downtime_start_time_5i" %>
-      <%= select_minute @downtime.start_time&.minute, { field_name: "start_time(5i)", prefix: "downtime" }, { class: "form-control date" } %>
-    </div>
-
-    <div class="form-group date col-sm-1">
-      <p class="joining-on">on</p>
-    </div>
-
-    <div class="form-group date col-sm-1">
-      <%= f.label :start_time, "Day", for: "downtime_start_time_3i" %>
-      <%= select_day @downtime.start_time&.day || Date.tomorrow.day, { field_name: "start_time(3i)", prefix: "downtime" }, { class: "form-control date" } %>
-    </div>
-    <div class="form-group date col-sm-1">
-      <%= f.label :start_time, "Month", for: "downtime_start_time_2i" %>
-      <%= select_month@downtime.start_time&.month || Date.tomorrow.month, { field_name: "start_time(2i)", prefix: "downtime" }, { class: "form-control date" } %>
-    </div>
-
-    <div class="form-group date col-sm-1">
-      <%= f.label :start_time, "Year", for: "downtime_start_time_1i" %>
-      <%= select_year @downtime.start_time&.year || Date.tomorrow.year, { field_name: "start_time(1i)", prefix: "downtime" }, { class: "form-control date" } %>
-    </div>
-  </div>
-
-  <div class="form-group">
-    <p>to</p>
-  </div>
-
-  <div class="row js-stop-time">
-
-    <div class="form-group date col-sm-1">
-      <%= f.label :end_time, "Hour", for: "downtime_end_time_4i" %>
-      <%= select_hour @downtime.end_time&.hour || 1.hour.from_now.beginning_of_hour, { field_name: "end_time(4i)", prefix: "downtime" }, { class: "form-control date" } %>
-    </div>
-
-    <div class="form-group date col-sm-1">
-      <%= f.label :end_time, "Minute", for: "downtime_end_time_5i" %>
-      <%= select_minute @downtime.end_time&.minute, { field_name: "end_time(5i)", prefix: "downtime" }, { class: "form-control date" } %>
-    </div>
-
-    <div class="form-group date col-sm-1">
-      <p class="joining-on">on</p>
-    </div>
-
-    <div class="form-group date col-sm-1">
-      <%= f.label :start_time, "Day", for: "downtime_end_time_3i" %>
-      <%= select_day @downtime.end_time&.day || Date.tomorrow.day, { field_name: "end_time(3i)", prefix: "downtime" }, { class: "form-control date" } %>
-    </div>
-
-    <div class="form-group date col-sm-1">
-      <%= f.label :end_time, "Month", for: "downtime_end_time_2i" %>
-      <%= select_month @downtime.end_time&.month || Date.tomorrow.month, { field_name: "end_time(2i)", prefix: "downtime" }, { class: "form-control date" } %>
-    </div>
-
-    <div class="form-group date col-sm-1">
-      <%= f.label :end_time, "Year", for: "downtime_end_time_1i" %>
-      <%= select_year @downtime.end_time&.year || Date.tomorrow.year, { field_name: "end_time(1i)", prefix: "downtime" }, { class: "form-control date" } %>
-    </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/fieldset", {
+      legend_text: "From",
+      heading_size: "l"
+    } do %>
+      <div class="govuk-grid-row govuk-!-padding-left-3">
+        <div class="govuk-grid-column-one-half">
+          <%= render "govuk_publishing_components/components/fieldset", {
+            legend_text: "Date",
+            heading_size: "m"
+          } do %>
+            <%= render "govuk_publishing_components/components/date_input", {
+              hint: "For example, 01 08 2022",
+            } %>
+          <% end %>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <%= render "govuk_publishing_components/components/fieldset", {
+            legend_text: "Time",
+            heading_size: "m"
+          } do %>
+            <%= render "time_input", {
+              hint: "For example, 9:30 or 19:30"
+            } %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
   </div>
 </div>
 
-<hr>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/fieldset", {
+      legend_text: "To",
+      heading_size: "l"
+    } do %>
+      <div class="govuk-grid-row govuk-!-padding-left-3">
+        <div class="govuk-grid-column-one-half">
+          <%= render "govuk_publishing_components/components/fieldset", {
+            legend_text: "Date",
+            heading_size: "m"
+          } do %>
+            <%= render "govuk_publishing_components/components/date_input", {
+              hint: "For example, 01 08 2022",
+            } %>
+          <% end %>
+        </div>
+        <div class="govuk-grid-column-one-half">
+          <%= render "govuk_publishing_components/components/fieldset", {
+            legend_text: "Time",
+            heading_size: "m"
+          } do %>
+            <%= render "time_input", {
+              hint: "For example, 9:30 or 19:30"
+            } %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
 
-<%= form_group(f, :message) do %>
-  <%= f.text_area :message, class: 'form-control input-md-6 js-downtime-message', rows: 5 %>
-<% end %>
-
-<p class="add-bottom-margin help-note">
-  <span class="glyphicon glyphicon-exclamation-sign"></span>
-  <span class="js-schedule-message">Messages appear on the start page one day before the downtime is due.</span>
-</p>
-
-<hr>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/textarea", {
+      label: {
+        heading_size: "l",
+        text: "Message"
+      },
+      hint: "Message is auto-generated once a schedule has been made.",
+      name: "message"
+    } %>
+  </div>
+</div>

--- a/app/views/downtimes/_time_input.html.erb
+++ b/app/views/downtimes/_time_input.html.erb
@@ -1,0 +1,83 @@
+<%
+
+  id ||= "input-#{SecureRandom.hex(4)}"
+  name ||= nil
+  items ||= [
+    { :name => "hour", :width => 2 },
+    { :name => "minute", :width => 2 }
+  ]
+
+  legend_text ||= nil
+  hint ||= nil
+  error_message ||= nil
+  error_items ||= []
+  describedby ||= nil
+  has_error ||= error_message || error_items.any?
+
+  css_classes = %w(gem-c-date-input govuk-date-input)
+  form_group_css_classes = %w(govuk-form-group)
+  form_group_css_classes << "govuk-form-group--error" if has_error
+
+  hint_id = "hint-#{SecureRandom.hex(4)}"
+  error_id = "error-#{SecureRandom.hex(4)}"
+
+  aria_described_by ||= nil
+  if hint || has_error || describedby
+    aria_described_by = []
+    aria_described_by << hint_id if hint
+    aria_described_by << error_id if has_error
+    aria_described_by << describedby if describedby
+    aria_described_by = aria_described_by.join(" ")
+  end
+%>
+
+<%= content_tag :div, class: form_group_css_classes do %>
+  <% fieldset_content = capture do %>
+    <% if hint %>
+      <%= render "govuk_publishing_components/components/hint", {
+        id: hint_id,
+        text: hint,
+        margin_bottom: 2
+      } %>
+    <% end %>
+
+    <% if has_error %>
+      <%= render "govuk_publishing_components/components/error_message", {
+        id:  error_id,
+        text: error_message,
+        items: error_items,
+      } %>
+    <% end %>
+
+    <%= tag.div class: css_classes, id: id do %>
+      <% items.each do |item, index| %>
+        <%= tag.div class: "govuk-date-input__item" do %>
+          <%= render "govuk_publishing_components/components/input", {
+            label: {
+              text: item[:label] || item[:name].capitalize
+            },
+            grouped: true,
+            has_error: has_error,
+            name: name ? (name + "[" + item[:name] + "]") : item[:name],
+            value: item[:value],
+            width: item[:width],
+            id: item[:id],
+            type: "number",
+            data: item[:data]
+          } %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% if legend_text %>
+    <%= render "govuk_publishing_components/components/fieldset", {
+      describedby: aria_described_by,
+      legend_text: legend_text,
+      text: fieldset_content,
+      role: "group"
+    } %>
+  <% else %>
+    <%= fieldset_content %>
+  <% end %>
+<% end %>

--- a/app/views/downtimes/new.html.erb
+++ b/app/views/downtimes/new.html.erb
@@ -1,18 +1,24 @@
 <% content_for :page_title, 'Schedule downtime' %>
+<% content_for :title, 'Add downtime message' %>
+<% content_for :title_context, @downtime.artefact.name %>
 
-<ul class="breadcrumb">
-  <li class="crumb"><%= link_to 'Downtime', downtimes_path %></li>
-  <li class="active"><%= @downtime.artefact.name %></li>
-</ul>
+<div class="govuk-grid-column-two-thirds">
+  <%= render "govuk_publishing_components/components/lead_paragraph", {
+    text: "Downtime message appear on the service's start page one day before the downtime is due to occur.",
+    margin_bottom: 6
+  } %>
 
-<div class="page-title">
-  <h1>
-    <span class="small"><%= @downtime.artefact.name %></span>
-    Schedule a downtime message
-  </h1>
+  <%= form_for @downtime, url: edition_downtime_path(@edition), html: { class: 'form well remove-top-margin', 'data-module' => 'downtime-message' } do |f| %>
+    <%= render 'form', f: f %>
+
+    <div class="govuk-button-group">
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Save",
+        value: "save",
+        name: "save"
+      } %>
+
+      <%= link_to "Cancel", downtimes_path, class: "govuk-link govuk-link--no-visited-state" %>
+    </div>
+  <% end %>
 </div>
-
-<%= form_for @downtime, url: edition_downtime_path(@edition), html: { class: 'form well remove-top-margin', 'data-module' => 'downtime-message' } do |f| %>
-  <%= render 'form', f: f %>
-  <%= f.submit 'Schedule downtime message', class: 'js-submit btn btn-success' %>
-<% end %>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -24,6 +24,7 @@
           <div class="govuk-grid-column-two-thirds">
             <%= render "govuk_publishing_components/components/title", {
               title: yield(:title),
+              context: yield(:title_context),
               margin_top: 0,
               margin_bottom: 6,
             } %>

--- a/test/integration/routes_test.rb
+++ b/test/integration/routes_test.rb
@@ -23,4 +23,18 @@ class RoutesTest < ActionDispatch::IntegrationTest
 
     assert_routing("/editions/#{edition_id}/downtime/edit", controller: "downtimes", action: "edit", edition_id:)
   end
+
+  should "route to new downtimes controller when 'design_system_downtime_new' toggle is enabled" do
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:design_system_downtime_new, true)
+
+    assert_routing("/editions/1/downtime/new", controller: "downtimes", action: "new", edition_id: "1")
+  end
+
+  should "route to legacy downtimes controller when 'design_system_downtime_new' toggle is disabled" do
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:design_system_downtime_new, false)
+
+    assert_routing("/editions/1/downtime/new", controller: "legacy_downtimes", action: "new", edition_id: "1")
+  end
 end


### PR DESCRIPTION
## What

Transition the look and feel of the "Add Downtime" page to the GOV.UK Design System.

Does not include validations/error messages/flash messages.

This breaks the functionality, which will be fixed in a subsequent PR.

## Why

Part of the transition of Mainstream Publisher to the GOV.UK Design System.

## Screenshots

### Before

![publisher integration publishing service gov uk_editions_64380bce51a48c000d211682_downtime_new](https://github.com/alphagov/publisher/assets/138604938/316df269-9a9f-493a-bcae-43ac73a7ba5e)


### After

![publisher dev gov uk_editions_65ba0644e07788001e4e1c37_downtime_new](https://github.com/alphagov/publisher/assets/138604938/66bcdfb8-4269-497c-be29-bfe09acc6189)

## Trello ticket

[Trello ticket](https://trello.com/c/0J3X18AA)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
