### PR TITLE
Turn toggle on for reports page to use design system

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -10,7 +10,7 @@ Flipflop.configure do
   end
 
   feature :design_system_reports_page,
-          default: false,
+          default: true,
           description: "A transition of the reports page to use the GOV.UK Design System"
 
   feature :design_system_downtime_new,


### PR DESCRIPTION
[Trello card](https://trello.com/c/erOwzh02/607-transition-reports-page-to-the-govuk-design-system)

This will make the feature available to all users.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
