### PR TITLE
Add downtime update view

### DIFF
--- a/app/views/downtimes/_form.html.erb
+++ b/app/views/downtimes/_form.html.erb
@@ -12,6 +12,7 @@
         } do %>
           <%= render "govuk_publishing_components/components/date_input", {
             hint: "For example, 01 08 2022",
+            name: "from-date"
           } %>
         <% end %>
       </div>
@@ -21,7 +22,8 @@
           heading_size: "l"
         } do %>
           <%= render "time_input", {
-            hint: "For example, 9:30 or 19:30"
+            hint: "For example, 9:30 or 19:30",
+            name: "from-time"
           } %>
         <% end %>
       </div>
@@ -39,6 +41,7 @@
         } do %>
           <%= render "govuk_publishing_components/components/date_input", {
             hint: "For example, 01 08 2022",
+            name: "to-date"
           } %>
         <% end %>
       </div>
@@ -48,7 +51,8 @@
           heading_size: "l"
         } do %>
           <%= render "time_input", {
-            hint: "For example, 9:30 or 19:30"
+            hint: "For example, 9:30 or 19:30",
+            name: "to-time"
           } %>
         <% end %>
       </div>

--- a/app/views/downtimes/_form.html.erb
+++ b/app/views/downtimes/_form.html.erb
@@ -4,65 +4,55 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render "govuk_publishing_components/components/fieldset", {
-      legend_text: "From",
-      heading_size: "l"
-    } do %>
-      <div class="govuk-grid-row govuk-!-padding-left-3">
-        <div class="govuk-grid-column-one-half">
-          <%= render "govuk_publishing_components/components/fieldset", {
-            legend_text: "Date",
-            heading_size: "m"
-          } do %>
-            <%= render "govuk_publishing_components/components/date_input", {
-              hint: "For example, 01 08 2022",
-            } %>
-          <% end %>
-        </div>
-        <div class="govuk-grid-column-one-half">
-          <%= render "govuk_publishing_components/components/fieldset", {
-            legend_text: "Time",
-            heading_size: "m"
-          } do %>
-            <%= render "time_input", {
-              hint: "For example, 9:30 or 19:30"
-            } %>
-          <% end %>
-        </div>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half">
+        <%= render "govuk_publishing_components/components/fieldset", {
+          legend_text: "From date",
+          heading_size: "l"
+        } do %>
+          <%= render "govuk_publishing_components/components/date_input", {
+            hint: "For example, 01 08 2022",
+          } %>
+        <% end %>
       </div>
-    <% end %>
+      <div class="govuk-grid-column-one-half">
+        <%= render "govuk_publishing_components/components/fieldset", {
+          legend_text: "From time",
+          heading_size: "l"
+        } do %>
+          <%= render "time_input", {
+            hint: "For example, 9:30 or 19:30"
+          } %>
+        <% end %>
+      </div>
+    </div>
   </div>
 </div>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render "govuk_publishing_components/components/fieldset", {
-      legend_text: "To",
-      heading_size: "l"
-    } do %>
-      <div class="govuk-grid-row govuk-!-padding-left-3">
-        <div class="govuk-grid-column-one-half">
-          <%= render "govuk_publishing_components/components/fieldset", {
-            legend_text: "Date",
-            heading_size: "m"
-          } do %>
-            <%= render "govuk_publishing_components/components/date_input", {
-              hint: "For example, 01 08 2022",
-            } %>
-          <% end %>
-        </div>
-        <div class="govuk-grid-column-one-half">
-          <%= render "govuk_publishing_components/components/fieldset", {
-            legend_text: "Time",
-            heading_size: "m"
-          } do %>
-            <%= render "time_input", {
-              hint: "For example, 9:30 or 19:30"
-            } %>
-          <% end %>
-        </div>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half">
+        <%= render "govuk_publishing_components/components/fieldset", {
+          legend_text: "To date",
+          heading_size: "l"
+        } do %>
+          <%= render "govuk_publishing_components/components/date_input", {
+            hint: "For example, 01 08 2022",
+          } %>
+        <% end %>
       </div>
-    <% end %>
+      <div class="govuk-grid-column-one-half">
+        <%= render "govuk_publishing_components/components/fieldset", {
+          legend_text: "To time",
+          heading_size: "l"
+        } do %>
+          <%= render "time_input", {
+            hint: "For example, 9:30 or 19:30"
+          } %>
+        <% end %>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/app/views/downtimes/_form.html.erb
+++ b/app/views/downtimes/_form.html.erb
@@ -8,7 +8,7 @@
       <div class="govuk-grid-column-one-half">
         <%= render "govuk_publishing_components/components/fieldset", {
           legend_text: "From date",
-          heading_size: "l"
+          heading_size: "m"
         } do %>
           <%= render "govuk_publishing_components/components/date_input", {
             hint: "For example, 01 08 2022",
@@ -19,7 +19,7 @@
       <div class="govuk-grid-column-one-half">
         <%= render "govuk_publishing_components/components/fieldset", {
           legend_text: "From time",
-          heading_size: "l"
+          heading_size: "m"
         } do %>
           <%= render "time_input", {
             hint: "For example, 9:30 or 19:30",
@@ -37,7 +37,7 @@
       <div class="govuk-grid-column-one-half">
         <%= render "govuk_publishing_components/components/fieldset", {
           legend_text: "To date",
-          heading_size: "l"
+          heading_size: "m"
         } do %>
           <%= render "govuk_publishing_components/components/date_input", {
             hint: "For example, 01 08 2022",
@@ -48,7 +48,7 @@
       <div class="govuk-grid-column-one-half">
         <%= render "govuk_publishing_components/components/fieldset", {
           legend_text: "To time",
-          heading_size: "l"
+          heading_size: "m"
         } do %>
           <%= render "time_input", {
             hint: "For example, 9:30 or 19:30",


### PR DESCRIPTION
## What

- Avoid the use of nested fieldsets and rename the remaining fieldsets to "From date"/"From time" and "To date"/To time". This should work better with assistive technologies; update the legend size to "m".
- Customise the date and time input names so that we can differentiate between the two sets.

[Trello ticket](https://trello.com/c/0J3X18AA)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
