### PR TITLE
Changes to Downtimes table

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,3 +2,4 @@ $govuk-page-width: 1140px;
 
 // GOVUK Design System
 @import "govuk_publishing_components/all_components";
+@import "downtimes";

--- a/app/assets/stylesheets/downtimes.scss
+++ b/app/assets/stylesheets/downtimes.scss
@@ -1,0 +1,15 @@
+.downtimes__table-title-column {
+  display: block;
+  max-width: 600px;
+}
+
+.downtimes__table-state-column {
+  display: block;
+  max-width: 350px;
+}
+
+.downtimes__table-link {
+  @include govuk-media-query($from: "tablet") {
+    white-space: nowrap;  
+  }
+}

--- a/app/helpers/downtimes_helper.rb
+++ b/app/helpers/downtimes_helper.rb
@@ -20,21 +20,21 @@ module DowntimesHelper
       downtime = Downtime.for(transaction.artefact)
 
       [
-        { text: transaction.title },
+        { text: tag.span(transaction.title, class: "downtimes__table-title-column") },
         {
-          text: downtime ? "Scheduled downtime #{downtime_datetime(downtime)}" : "Live",
+          text: tag.span(downtime ? "Scheduled downtime #{downtime_datetime(downtime)}" : "Live", class: "downtimes__table-state-column"),
         },
         { text: action_link_for_transaction(transaction) },
-        { text: link_to("View on website", "#{Plek.website_root}/#{transaction.slug}", class: "govuk-link") },
+        { text: link_to("View on website", "#{Plek.website_root}/#{transaction.slug}", class: "govuk-link downtimes__table-link") },
       ]
     end
   end
 
   def action_link_for_transaction(transaction)
     if transaction.artefact.downtime
-      link_to "Edit downtime", edit_edition_downtime_path(transaction), class: "govuk-link"
+      link_to "Edit downtime", edit_edition_downtime_path(transaction), class: "govuk-link downtimes__table-link"
     else
-      link_to "Add downtime", new_edition_downtime_path(transaction), class: "govuk-link"
+      link_to "Add downtime", new_edition_downtime_path(transaction), class: "govuk-link downtimes__table-link"
     end
   end
 end

--- a/app/views/downtimes/index.html.erb
+++ b/app/views/downtimes/index.html.erb
@@ -13,7 +13,7 @@
     label: "Filter by service or service status",
     head: [
       {
-        text: "Service Start page"
+        text: "Service",
       },
       {
         text: "Service Status",

--- a/test/unit/helpers/downtimes_helper_test.rb
+++ b/test/unit/helpers/downtimes_helper_test.rb
@@ -34,16 +34,16 @@ class DowntimesHelperTest < ActionView::TestCase
     entries = transactions_table_entries([@edition_live, @edition_downtime])
     assert_equal entries, [
       [
-        { text: @edition_live.title },
-        { text: "Live" },
-        { text: "<a class=\"govuk-link\" href=\"/editions/#{@edition_live.id}/downtime/new\">Add downtime</a>" },
-        { text: "<a class=\"govuk-link\" href=\"#{Plek.website_root}/#{@edition_live.slug}\">View on website</a>" },
+        { text: "<span class=\"downtimes__table-title-column\">#{@edition_live.title}</span>" },
+        { text: "<span class=\"downtimes__table-state-column\">Live</span>" },
+        { text: "<a class=\"govuk-link downtimes__table-link\" href=\"/editions/#{@edition_live.id}/downtime/new\">Add downtime</a>" },
+        { text: "<a class=\"govuk-link downtimes__table-link\" href=\"#{Plek.website_root}/#{@edition_live.slug}\">View on website</a>" },
       ],
       [
-        { text: @edition_downtime.title },
-        { text: "Scheduled downtime 3pm on 10 October to 6pm on 11 October" },
-        { text: "<a class=\"govuk-link\" href=\"/editions/#{@edition_downtime.id}/downtime/edit\">Edit downtime</a>" },
-        { text: "<a class=\"govuk-link\" href=\"#{Plek.website_root}/#{@edition_downtime.slug}\">View on website</a>" },
+        { text: "<span class=\"downtimes__table-title-column\">#{@edition_downtime.title}</span>" },
+        { text: "<span class=\"downtimes__table-state-column\">Scheduled downtime 3pm on 10 October to 6pm on 11 October</span>" },
+        { text: "<a class=\"govuk-link downtimes__table-link\" href=\"/editions/#{@edition_downtime.id}/downtime/edit\">Edit downtime</a>" },
+        { text: "<a class=\"govuk-link downtimes__table-link\" href=\"#{Plek.website_root}/#{@edition_downtime.slug}\">View on website</a>" },
       ],
     ]
   end


### PR DESCRIPTION
## What

- Create new stylesheet for Downtimes
- Add max width to the title of the service in the Downtimes index page table
- Add max width to the state of the service in the Downtimes index page table
- Prevent the links from breaking to multiple lines (on Desktop screen sizes)

## Why

Make the table resemble more closely what it looks like in the design.

## Visual Differences

### Before

![Screenshot 2024-02-06 at 14 10 02](https://github.com/alphagov/publisher/assets/3727504/1dc6564b-7d07-4d23-91ce-56bf74c69bee)

### After

![Screenshot 2024-02-06 at 14 15 01](https://github.com/alphagov/publisher/assets/3727504/ded91929-e3ea-40d3-b795-5ddfd6d88f1f)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
