### PR TITLE
Fix randomly failing Downtime integration test

### DIFF
--- a/test/integration/legacy_downtime_integration_test.rb
+++ b/test/integration/legacy_downtime_integration_test.rb
@@ -14,6 +14,9 @@ class LegacyDowntimeIntegrationTest < JavascriptIntegrationTest
     WebMock.reset!
     stub_any_publishing_api_put_content
     stub_any_publishing_api_publish
+
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:design_system_downtime_index_page, false)
   end
 
   test "Scheduling new downtime" do

--- a/test/integration/legacy_downtime_with_invalid_dates_test.rb
+++ b/test/integration/legacy_downtime_with_invalid_dates_test.rb
@@ -1,6 +1,6 @@
 require "integration_test_helper"
 
-class DowntimeWithInvalidDates < ActionDispatch::IntegrationTest
+class LegacyDowntimeWithInvalidDates < ActionDispatch::IntegrationTest
   setup do
     setup_users
 
@@ -16,7 +16,7 @@ class DowntimeWithInvalidDates < ActionDispatch::IntegrationTest
     stub_any_publishing_api_publish
 
     test_strategy = Flipflop::FeatureSet.current.test!
-    test_strategy.switch!(:design_system_downtime_index_page, true)
+    test_strategy.switch!(:design_system_downtime_index_page, false)
   end
 
   test "Scheduling new downtime with invalid dates" do
@@ -24,7 +24,7 @@ class DowntimeWithInvalidDates < ActionDispatch::IntegrationTest
 
     visit root_path
     click_link "Downtime"
-    click_link "Add downtime"
+    click_link "Apply to become a driving instructor"
 
     enter_start_time 1.day.ago
     enter_end_time 1.day.ago - 1.day


### PR DESCRIPTION
## What

- Add feature toggle to downtime_with_invalid_dates_test
- Create new legacy_downtimes_with_invalid_dates_test
- Add feature toggle to legacy_downtime_integration_test
- Update downtime_with_invalid_dates_test link name
 
## Why

Prevent randomly failing test.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
