### PR TITLE
Transition downtime message Javascript

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,2 +1,4 @@
+//= require_directory ./modules
+
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/all_components

--- a/app/assets/javascripts/legacy_modules/legacy_downtime_message.js
+++ b/app/assets/javascripts/legacy_modules/legacy_downtime_message.js
@@ -2,7 +2,7 @@
 
 (function (Modules) {
   'use strict'
-  Modules.DowntimeMessage = function () {
+  Modules.LegacyDowntimeMessage = function () {
     this.start = function (element) {
       var $startTimeFields = element.find('.js-start-time select')
       var $stopTimeFields = element.find('.js-stop-time select')

--- a/app/assets/javascripts/modules/downtime_message.js
+++ b/app/assets/javascripts/modules/downtime_message.js
@@ -1,0 +1,97 @@
+//= require govuk_publishing_components/vendor/polyfills/closest
+
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function DowntimeMessage ($module) {
+    this.module = $module
+  }
+
+  DowntimeMessage.prototype.init = function () {
+    const form = this.module
+
+    form.addEventListener('change', updateMessage)
+
+    function updateMessage () {
+      const fromDate = getDate('from')
+      const toDate = getDate('to')
+
+      let message = ''
+      if (isValidSchedule(fromDate, toDate)) {
+        message = downtimeMessage(fromDate, toDate)
+      }
+      form.elements.message.value = message
+    }
+
+    function getDate (selector) {
+      const day = form.elements[`${selector}-date[day]`].value
+      const month = form.elements[`${selector}-date[month]`].value
+      const year = form.elements[`${selector}-date[year]`].value
+      const hours = form.elements[`${selector}-time[hour]`].value
+      const minutes = form.elements[`${selector}-time[minute]`].value
+
+      // The Date class treats 1 as February, but in the UI we expect 1 to be January
+      const zeroIndexedMonth = parseInt(month) - 1
+      return new Date(year, zeroIndexedMonth, day, hours, minutes)
+    }
+
+    function isValidSchedule (fromDate, toDate) {
+      return toDate.getTime() > fromDate.getTime()
+    }
+
+    function downtimeMessage (fromDate, toDate) {
+      let message = 'This service will be unavailable from'
+      const fromDayText = getDayText(fromDate)
+      const fromTime = getTime(fromDate)
+      const toTime = getTime(toDate)
+      const toDayText = getDayText(toDate)
+      const sameDay = isSameDay(fromDate, toDate)
+
+      if (!isValidSchedule(fromDate, toDate)) {
+        return ''
+      }
+
+      if (sameDay) {
+        message = `${message} ${fromTime} to ${toTime} on ${fromDayText}.`
+      } else {
+        message = `${message} ${fromTime} on ${fromDayText} to ${toTime} on ${toDayText}.`
+      }
+
+      return message
+    }
+
+    function getTime (date) {
+      const time = date.toLocaleString(
+        'en-GB',
+        { hour: 'numeric', minute: 'numeric', hourCycle: 'h12' })
+      return time.replace(/:00/, '')
+        .replace(/ am/, 'am')
+        .replace(/ pm/, 'pm')
+        .replace(/12am/, 'midnight')
+        .replace(/12pm/, 'midday')
+    }
+
+    function getDayText (date) {
+      const dayText = date.toLocaleDateString(
+        'en-GB',
+        { weekday: 'long', month: 'long', day: 'numeric' }
+      )
+      return dayText.replace(/,/, '')
+    }
+
+    function isSameDay (fromDate, toDate) {
+      // Treat a midnight stop date as being on the same day as
+      // the hours before it. eg
+      // Unavailable from 10pm to midnight on Thursday 8 January
+      const toDateOneMinuteEarlier = new Date(toDate.valueOf())
+      toDateOneMinuteEarlier.setMinutes(toDate.getMinutes() - 1)
+
+      return fromDate.getFullYear() === toDateOneMinuteEarlier.getFullYear() &&
+        fromDate.getMonth() === toDateOneMinuteEarlier.getMonth() &&
+        fromDate.getDate() === toDateOneMinuteEarlier.getDate()
+    }
+  }
+
+  Modules.DowntimeMessage = DowntimeMessage
+})(window.GOVUK.Modules)

--- a/app/views/legacy_downtimes/edit.html.erb
+++ b/app/views/legacy_downtimes/edit.html.erb
@@ -12,7 +12,7 @@
   </h1>
 </div>
 
-<%= form_for @downtime, url: edition_downtime_path(@edition), html: { class: 'form well remove-top-margin', 'data-module': 'downtime-message' } do |f| %>
+<%= form_for @downtime, url: edition_downtime_path(@edition), html: { class: 'form well remove-top-margin', 'data-module': 'legacy-downtime-message' } do |f| %>
   <%= render 'form', f: f %>
   <%= f.submit 'Re-schedule downtime message', class: 'js-submit btn btn-success' %>
   <%= f.submit 'Cancel downtime', class: 'add-left-margin btn btn-danger' %>

--- a/app/views/legacy_downtimes/new.html.erb
+++ b/app/views/legacy_downtimes/new.html.erb
@@ -12,7 +12,7 @@
   </h1>
 </div>
 
-<%= form_for @downtime, url: edition_downtime_path(@edition), html: { class: 'form well remove-top-margin', 'data-module' => 'downtime-message' } do |f| %>
+<%= form_for @downtime, url: edition_downtime_path(@edition), html: { class: 'form well remove-top-margin', 'data-module' => 'legacy-downtime-message' } do |f| %>
   <%= render 'form', f: f %>
   <%= f.submit 'Schedule downtime message', class: 'js-submit btn btn-success' %>
 <% end %>

--- a/spec/javascripts/spec/downtime_message.spec.js
+++ b/spec/javascripts/spec/downtime_message.spec.js
@@ -1,0 +1,316 @@
+/* global GOVUK */
+
+describe('A downtime message module', function () {
+  'use strict'
+
+  let downtimeMessage, form
+
+  const formHtml = `<form class="form well remove-top-margin" id="new_downtime" data-module="downtime-message"
+      action="/editions/65ba0644e07788001e4e1c37/downtime" accept-charset="UTF-8" method="post"><input type="hidden"
+                                                                                                       name="authenticity_token"
+                                                                                                       value="lK-eQ7wGdDt5vMmzdL2WoPTIoSGtvld-eAQDlrao4zN4G6EIfwrGonmtOJSsiUxyNt9RN7hiBgpFaD9t-7WSZA"
+                                                                                                       autocomplete="off">
+    <input autocomplete="off" type="hidden" value="65ba0643e07788001e4e1c35" name="downtime[artefact_id]"
+           id="downtime_artefact_id">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-one-half">
+                    <div class="gem-c-fieldset govuk-form-group">
+                        <fieldset class="govuk-fieldset">
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">From date</legend>
+                            <div class="govuk-form-group">
+                                <div id="hint-da6b7017" class="gem-c-hint govuk-hint govuk-!-margin-bottom-2">
+                                    For example, 01 08 2022
+                                </div>
+                                <div class="gem-c-date-input govuk-date-input" id="input-7eba3d5d">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label for="input-4e6660ad" class="gem-c-label govuk-label">Day</label>
+                                            <input class="gem-c-input govuk-input govuk-input--width-2"
+                                                   id="input-4e6660ad"
+                                                   inputmode="numeric" name="from-date[day]" spellcheck="false"
+                                                   type="text">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label for="input-dd278c71" class="gem-c-label govuk-label">Month</label>
+                                            <input class="gem-c-input govuk-input govuk-input--width-2"
+                                                   id="input-dd278c71"
+                                                   inputmode="numeric" name="from-date[month]" spellcheck="false"
+                                                   type="text">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label for="input-c655ec58" class="gem-c-label govuk-label">Year</label>
+                                            <input class="gem-c-input govuk-input govuk-input--width-4"
+                                                   id="input-c655ec58"
+                                                   inputmode="numeric" name="from-date[year]" spellcheck="false"
+                                                   type="text">
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                </div>
+                <div class="govuk-grid-column-one-half">
+                    <div class="gem-c-fieldset govuk-form-group">
+                        <fieldset class="govuk-fieldset">
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">From time</legend>
+                            <div class="govuk-form-group">
+                                <div id="hint-5e9f4628" class="gem-c-hint govuk-hint govuk-!-margin-bottom-2">
+                                    For example, 9:30 or 19:30
+                                </div>
+                                <div class="gem-c-date-input govuk-date-input" id="input-7d260dea">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label for="input-7a3a41a1" class="gem-c-label govuk-label">Hour</label>
+                                            <input class="gem-c-input govuk-input govuk-input--width-2"
+                                                   id="input-7a3a41a1"
+                                                   inputmode="numeric" name="from-time[hour]" spellcheck="false"
+                                                   type="text">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label for="input-662f9f21" class="gem-c-label govuk-label">Minute</label>
+                                            <input class="gem-c-input govuk-input govuk-input--width-2"
+                                                   id="input-662f9f21"
+                                                   inputmode="numeric" name="from-time[minute]" spellcheck="false"
+                                                   type="text">
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-one-half">
+                    <div class="gem-c-fieldset govuk-form-group">
+                        <fieldset class="govuk-fieldset">
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">To date</legend>
+                            <div class="govuk-form-group">
+                                <div id="hint-cecadea2" class="gem-c-hint govuk-hint govuk-!-margin-bottom-2">
+                                    For example, 01 08 2022
+                                </div>
+                                <div class="gem-c-date-input govuk-date-input" id="input-291f5da5">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label for="input-16a32f90" class="gem-c-label govuk-label">Day</label>
+                                            <input class="gem-c-input govuk-input govuk-input--width-2"
+                                                   id="input-16a32f90" inputmode="numeric" name="to-date[day]"
+                                                   spellcheck="false" type="text">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label for="input-8d7d5a30" class="gem-c-label govuk-label">Month</label>
+                                            <input class="gem-c-input govuk-input govuk-input--width-2"
+                                                   id="input-8d7d5a30" inputmode="numeric" name="to-date[month]"
+                                                   spellcheck="false" type="text">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label for="input-3d609a01" class="gem-c-label govuk-label">Year</label>
+                                            <input class="gem-c-input govuk-input govuk-input--width-4"
+                                                   id="input-3d609a01" inputmode="numeric" name="to-date[year]"
+                                                   spellcheck="false" type="text">
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                </div>
+                <div class="govuk-grid-column-one-half">
+                    <div class="gem-c-fieldset govuk-form-group">
+                        <fieldset class="govuk-fieldset">
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">To time</legend>
+                            <div class="govuk-form-group">
+                                <div id="hint-b056facb" class="gem-c-hint govuk-hint govuk-!-margin-bottom-2">
+                                    For example, 9:30 or 19:30
+                                </div>
+                                <div class="gem-c-date-input govuk-date-input" id="input-6449ba0b">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label for="input-f956661e" class="gem-c-label govuk-label">Hour</label>
+                                            <input class="gem-c-input govuk-input govuk-input--width-2"
+                                                   id="input-f956661e" inputmode="numeric" name="to-time[hour]"
+                                                   spellcheck="false" type="text">
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <label for="input-d1cdd592" class="gem-c-label govuk-label">Minute</label>
+                                            <input class="gem-c-input govuk-input govuk-input--width-2"
+                                                   id="input-d1cdd592" inputmode="numeric" name="to-time[minute]"
+                                                   spellcheck="false" type="text">
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div class="gem-c-textarea govuk-form-group govuk-!-margin-bottom-6">
+                <label for="textarea-30759358" class="gem-c-label govuk-label govuk-label--l">Message</label>
+                <div id="hint-2d54afbc" class="gem-c-hint govuk-hint">
+                    Message is auto-generated once a schedule has been made.
+                </div>
+                <textarea name="message" class="govuk-textarea" id="textarea-30759358" rows="5" spellcheck="true"
+                          aria-describedby="hint-2d54afbc">starting message</textarea>
+            </div>
+        </div>
+    </div>
+    <div class="govuk-button-group">
+        <button class="gem-c-button govuk-button" type="submit" name="save" value="save">Save</button>
+        <a class="govuk-link govuk-link--no-visited-state" href="/downtimes">Cancel</a>
+    </div>
+</form>`
+
+  beforeEach(function () {
+    form = document.createElement('form')
+    form.innerHTML = formHtml
+    document.body.appendChild(form)
+
+    downtimeMessage = new GOVUK.Modules.DowntimeMessage(form)
+    downtimeMessage.init(form)
+  })
+
+  afterEach(function () {
+    form.remove()
+  })
+
+  describe('when initialising', function () {
+    it('leaves any existing downtime message alone', function () {
+      expectDowntimeMessageToMatch('starting message')
+    })
+  })
+
+  describe('when entering dates', function () {
+    it('generates a downtime message', function () {
+      enterFromDate()
+      enterToDate({ hour: '02' })
+      expectDowntimeMessageToMatch('This service will be unavailable from 1am to 2am on Thursday 1 January.')
+
+      enterToDate({ hour: '03' })
+      expectDowntimeMessageToMatch('from 1am to 3am on Thursday 1 January.')
+    })
+
+    describe('that are the same', function () {
+      beforeEach(function () {
+        enterFromDate()
+        enterToDate()
+      })
+
+      it('sets an empty message', function () {
+        expectDowntimeMessageToBe('')
+      })
+    })
+
+    describe('with a stop date before the start date', function () {
+      beforeEach(function () {
+        enterFromDate({ hour: '03' })
+        enterToDate({ hour: '01' })
+      })
+
+      it('sets an empty message', function () {
+        expectDowntimeMessageToBe('')
+      })
+    })
+
+    describe('the generated messages', function () {
+      it('use a 12 hour clock', function () {
+        enterFromDate({ hour: '11' })
+        enterToDate({ hour: '15' })
+        expectDowntimeMessageToMatch('from 11am to 3pm on Thursday 1 January.')
+      })
+
+      it('use midnight instead of 12am', function () {
+        enterFromDate({ hour: '00' })
+        enterToDate({ hour: '02' })
+        expectDowntimeMessageToMatch('from midnight to 2am on Thursday 1 January.')
+      })
+
+      it('use midday instead of 12pm', function () {
+        enterFromDate({ hour: '12' })
+        enterToDate({ hour: '14' })
+        expectDowntimeMessageToMatch('from midday to 2pm on Thursday 1 January.')
+      })
+
+      it('includes minutes when they are not 0', function () {
+        enterFromDate({ hour: '00', minutes: '15' })
+        enterToDate({ hour: '02', minutes: '45' })
+        expectDowntimeMessageToMatch('from 12:15am to 2:45am on Thursday 1 January.')
+      })
+
+      it('includes both dates when they differ', function () {
+        enterFromDate()
+        enterToDate({ day: '2', hour: '03' })
+        expectDowntimeMessageToMatch('from 1am on Thursday 1 January to 3am on Friday 2 January.')
+      })
+
+      it('treats midnight on the next consecutive day as the same date', function () {
+        enterFromDate({ hour: '22', day: '1' })
+        enterToDate({ hour: '00', day: '2' })
+        expectDowntimeMessageToMatch('from 10pm to midnight on Thursday 1 January.')
+      })
+
+      it('handles incorrect dates in the same way as rails', function () {
+        enterFromDate({ day: '29', month: '2' })
+        enterToDate({ day: '5', month: '3' })
+        expectDowntimeMessageToMatch('from 1am on Sunday 1 March to 1am on Thursday 5 March.')
+      })
+    })
+  })
+
+  function expectDowntimeMessageToMatch (text) {
+    expect(form.elements.message.value).toMatch(text)
+  }
+
+  function expectDowntimeMessageToBe (text) {
+    expect(form.elements.message.value).toBe(text)
+  }
+
+  function enterFromDate (dateObj) {
+    enterDate('from', dateObj)
+  }
+
+  function enterToDate (dateObj) {
+    enterDate('to', dateObj)
+  }
+
+  function enterDate (selector, dateObj) {
+    const day = form.elements[`${selector}-date[day]`]
+    const month = form.elements[`${selector}-date[month]`]
+    const year = form.elements[`${selector}-date[year]`]
+    const hour = form.elements[`${selector}-time[hour]`]
+    const minute = form.elements[`${selector}-time[minute]`]
+
+    dateObj = dateObj || {}
+
+    day.value = dateObj.day || '1'
+    month.value = dateObj.month || '1'
+    year.value = dateObj.year || '2015'
+    hour.value = dateObj.hour || '1'
+    minute.value = dateObj.minutes || '0'
+
+    const event = new Event('change')
+    form.dispatchEvent(event)
+  }
+})

--- a/spec/javascripts/spec/legacy_downtime_message.spec.js
+++ b/spec/javascripts/spec/legacy_downtime_message.spec.js
@@ -101,7 +101,7 @@ describe('A downtime message module', function () {
 
     $('body').append(form)
 
-    downtimeMessage = new GOVUKAdmin.Modules.DowntimeMessage()
+    downtimeMessage = new GOVUKAdmin.Modules.LegacyDowntimeMessage()
     downtimeMessage.start(form)
   })
 


### PR DESCRIPTION
## What

Create a new Javascript module that generates the downtime message when adding/editing downtime for a publication, that works with the new add/edit downtime form components.

## Why

The old page used dropdown lists for selecting the date components, whereas the transitioned page uses text inputs.

The old code disabled the form, which is not accessible, so the new code does not do this.

Furthermore, the old code generated two messages that appeared in slightly different places on the form, whereas the new page only has one message to display.

## Trello ticket

[Trello card](https://trello.com/c/0J3X18AA).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
