### PR TITLE
Add Claim 2i button on Edit edition page for non-assignee users

### DIFF
--- a/app/views/editions/_reviewer_field.html.erb
+++ b/app/views/editions/_reviewer_field.html.erb
@@ -2,7 +2,7 @@
   <%= f.select :reviewer, User.enabled.order_by([[:name, :asc]]).collect{ |p| [p.name, p.name] }, { :include_blank => true }, { :class => "form-control input-md-3", :disabled => @resource.locked_for_edits?, "data-module" => 'assignee-select'} %>
 <% end %>
 
-<% if current_user.id != edition.assigned_to_id %>
+<% if current_user.id != edition.assigned_to_id && !@resource.reviewer.present? %>
   <%= form_for :edition, url: review_edition_path(edition.id), method: :put do |f| %>
     <%= f.hidden_field :reviewer, value: current_user.name %>
     <%= f.submit "Claim 2i", class: "btn btn-primary claim-2i" %>

--- a/app/views/editions/_reviewer_field.html.erb
+++ b/app/views/editions/_reviewer_field.html.erb
@@ -1,10 +1,13 @@
 <%= form_group(f, :reviewer, label: "Reviewer") do %>
   <%= f.select :reviewer, User.enabled.order_by([[:name, :asc]]).collect{ |p| [p.name, p.name] }, { :include_blank => true }, { :class => "form-control input-md-3", :disabled => @resource.locked_for_edits?, "data-module" => 'assignee-select'} %>
-
-  <% if current_user.id != edition.assigned_to_id %>
-    <%= form_for :edition, url: review_edition_path(edition.id), method: :put do |f| %>
-      <%= f.hidden_field :reviewer, value: current_user.name %>
-      <%= f.submit "Claim 2i", class: "btn btn-primary claim-2i" %>
-    <% end -%>
-  <% end -%>
 <% end %>
+
+<% if current_user.id != edition.assigned_to_id %>
+  <%= form_for :edition, url: review_edition_path(edition.id), method: :put do |f| %>
+    <%= f.hidden_field :reviewer, value: current_user.name %>
+    <%= f.submit "Claim 2i", class: "btn btn-primary claim-2i" %>
+  <% end -%>
+<% end -%>
+
+<br />
+<br />

--- a/app/views/editions/_reviewer_field.html.erb
+++ b/app/views/editions/_reviewer_field.html.erb
@@ -1,3 +1,10 @@
 <%= form_group(f, :reviewer, label: "Reviewer") do %>
   <%= f.select :reviewer, User.enabled.order_by([[:name, :asc]]).collect{ |p| [p.name, p.name] }, { :include_blank => true }, { :class => "form-control input-md-3", :disabled => @resource.locked_for_edits?, "data-module" => 'assignee-select'} %>
+
+  <% if current_user.id != edition.assigned_to_id %>
+    <%= form_for :edition, url: review_edition_path(edition.id), method: :put do |f| %>
+      <%= f.hidden_field :reviewer, value: current_user.name %>
+      <%= f.submit "Claim 2i", class: "btn btn-primary claim-2i" %>
+    <% end -%>
+  <% end -%>
 <% end %>

--- a/app/views/shared/_common_edition_attributes.html.erb
+++ b/app/views/shared/_common_edition_attributes.html.erb
@@ -5,7 +5,7 @@
       <%= f.select :assigned_to_id, enabled_users_select_options, {}, {:class => 'form-control input-md-3', :disabled => @resource.locked_for_edits?, "data-module" => 'assignee-select'} %>
     </div>
   <% end %>
-<%= render partial: 'reviewer_field', locals: { f: f } if @resource.in_review? %>
+<%= render partial: 'reviewer_field', locals: { f: f, edition: @resource } if @resource.in_review? %>
 <%= render partial: 'major_change_fields', locals: { f: f } if @resource.published_edition %>
 
 <%= form_group(f, :title, label: "Title") do %>

--- a/test/integration/edit_artefact_test.rb
+++ b/test/integration/edit_artefact_test.rb
@@ -1,35 +1,86 @@
 require "integration_test_helper"
 
 class EditArtefactTest < ActionDispatch::IntegrationTest
-  setup do
-    setup_users
-    stub_linkables
-    stub_holidays_used_by_fact_check
+  context "edit" do
+    setup do
+      setup_users
+      stub_linkables
+      stub_holidays_used_by_fact_check
+    end
+
+    should "edit a draft artefact" do
+      edition = FactoryBot.create(:edition)
+      visit metadata_edition_path(edition)
+
+      fill_in "Slug", with: ""
+      click_button "Update metadata"
+
+      assert page.has_content?("Enter a slug")
+
+      fill_in "Slug", with: "thingy-mc-thingface"
+
+      UpdateWorker.expects(:perform_async).with(edition.id.to_s)
+      click_button "Update metadata"
+      edition.reload
+
+      assert page.has_content?("Metadata updated")
+      assert edition.artefact.slug == "thingy-mc-thingface"
+    end
+
+    should "not be able to edit metadata for a published edition" do
+      edition = FactoryBot.create(:edition, :published)
+      visit metadata_edition_path(edition)
+
+      assert_not page.has_button?("Update metadata")
+    end
   end
 
-  should "edit a draft artefact" do
-    edition = FactoryBot.create(:edition)
-    visit metadata_edition_path(edition)
+  context "Claim 2i:" do
+    setup do
+      stub_linkables
+      stub_holidays_used_by_fact_check
+    end
 
-    fill_in "Slug", with: ""
-    click_button "Update metadata"
+    should "show 'Claim 2i' button on the Edit page for users who are not the Assignee" do
+      user = FactoryBot.create(:user, :govuk_editor)
+      assignee = FactoryBot.create(:user, :govuk_editor)
+      edition = FactoryBot.create(
+        :guide_edition,
+        title: "XXX",
+        state: "in_review",
+        review_requested_at: Time.zone.now,
+        assigned_to: assignee,
+      )
 
-    assert page.has_content?("Enter a slug")
+      visit edition_path(edition)
 
-    fill_in "Slug", with: "thingy-mc-thingface"
+      within("#edition-form") do
+        find_button("Claim 2i").click
+      end
 
-    UpdateWorker.expects(:perform_async).with(edition.id.to_s)
-    click_button "Update metadata"
-    edition.reload
+      assert edition_url(edition), current_url
+      assert page.has_content?("You are the reviewer of this guide.")
+      assert page.has_select?("Assigned to", selected: assignee.name)
+      assert page.has_select?("Reviewer", selected: user.name)
+    end
 
-    assert page.has_content?("Metadata updated")
-    assert edition.artefact.slug == "thingy-mc-thingface"
-  end
+    should "not show 'Claim 2i' button on the Edit page for the Assignee" do
+      assignee = FactoryBot.create(:user, :govuk_editor)
+      edition = FactoryBot.create(
+        :guide_edition,
+        title: "XXX",
+        state: "in_review",
+        review_requested_at: Time.zone.now,
+        assigned_to: assignee,
+      )
 
-  should "not be able to edit metadata for a published edition" do
-    edition = FactoryBot.create(:edition, :published)
-    visit metadata_edition_path(edition)
+      visit edition_path(edition)
 
-    assert_not page.has_button?("Update metadata")
+      assert edition_url(edition), current_url
+      assert page.has_select?("Assigned to", selected: assignee.name)
+      assert page.has_select?("Reviewer")
+      assert page.has_no_select?("Reviewer", selected: assignee.name)
+      assert page.has_no_css?("input", class: "claim-2i")
+    end
   end
 end

--- a/test/integration/edit_artefact_test.rb
+++ b/test/integration/edit_artefact_test.rb
@@ -82,5 +82,25 @@ class EditArtefactTest < ActionDispatch::IntegrationTest
       assert page.has_no_select?("Reviewer", selected: assignee.name)
       assert page.has_no_css?("input", class: "claim-2i")
     end
+
+    should "not show 'Claim 2i' button on the Edit page if Reviewer is already assigned" do
+      user = FactoryBot.create(:user, :govuk_editor)
+      assignee = FactoryBot.create(:user, :govuk_editor)
+      edition = FactoryBot.create(
+        :guide_edition,
+        title: "XXX",
+        state: "in_review",
+        review_requested_at: Time.zone.now,
+        assigned_to: assignee,
+        reviewer: user,
+      )
+
+      visit edition_path(edition)
+
+      assert edition_url(edition), current_url
+      assert page.has_select?("Assigned to", selected: assignee.name)
+      assert page.has_select?("Reviewer", selected: user.name)
+      assert page.has_no_css?("input", class: "claim-2i")
+    end
   end
 end


### PR DESCRIPTION
## What
Currently, users can be assigned as a reviewer by selecting the “Claim 2i” button on the Publication/Search page. Users can also be assigned as the reviewer by selecting their name in the existing dropdown on the Edit page of an edition.

This PR now adds a "Claim 2i" button on the Edit page so users no longer have to find their name in the dropdown.

[Trello](https://trello.com/c/MpS3mfvX/117-introduce-a-claim-2i-button-next-to-review-dropdown-mainstream)

## Screenshots:
![image](https://github.com/alphagov/publisher/assets/95416755/3954486b-76d4-4b17-91b7-174a7e0b4633)

