### PR TITLE
Remove specialist topic code

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -396,7 +396,6 @@ private
       :previous_version,
       :parent,
       mainstream_browse_pages: [],
-      topics: [],
       organisations: [],
       meets_user_needs: [],
       ordered_related_items: [],

--- a/app/lib/tagging/linkables.rb
+++ b/app/lib/tagging/linkables.rb
@@ -8,10 +8,6 @@
 # to use `content_id`, we may move this functionality into a gem.
 module Tagging
   class Linkables
-    def topics
-      @topics ||= for_nested_document_type("topic")
-    end
-
     def taxons
       @taxons ||= for_document_type("taxon")
     end

--- a/app/lib/tagging/tagging_update_form.rb
+++ b/app/lib/tagging/tagging_update_form.rb
@@ -1,7 +1,7 @@
 module Tagging
   class TaggingUpdateForm
     include ActiveModel::Model
-    attr_accessor :content_id, :previous_version, :topics, :organisations, :meets_user_needs, :mainstream_browse_pages, :ordered_related_items, :parent
+    attr_accessor :content_id, :previous_version, :organisations, :meets_user_needs, :mainstream_browse_pages, :ordered_related_items, :parent
 
     validate :ordered_related_items_paths_exist
 
@@ -11,7 +11,6 @@ module Tagging
       new(
         content_id:,
         previous_version: link_set.version,
-        topics: link_set.links["topics"],
         organisations: link_set.links["organisations"],
         meets_user_needs: link_set.links["meets_user_needs"],
         mainstream_browse_pages: link_set.links["mainstream_browse_pages"],
@@ -30,7 +29,6 @@ module Tagging
 
     def links_payload
       {
-        topics: clean_content_ids(topics),
         organisations: clean_content_ids(organisations),
         meets_user_needs: clean_content_ids(meets_user_needs),
         mainstream_browse_pages: clean_content_ids(mainstream_browse_pages),

--- a/app/presenters/organisation_content_presenter.rb
+++ b/app/presenters/organisation_content_presenter.rb
@@ -8,7 +8,6 @@ class OrganisationContentPresenter < CSVPresenter
       slug
       state
       browse_pages
-      topics
       organisations
     ]
   end
@@ -27,8 +26,6 @@ private
     case header
     when :browse_pages
       expanded_links(content_id, %w[mainstream_browse_pages base_path], /\/browse\//)
-    when :topics
-      expanded_links(content_id, %w[topics base_path], /\/topic\//)
     when :organisations
       expanded_links(content_id, %w[organisations title])
     when :format

--- a/app/views/shared/_tagging.html.erb
+++ b/app/views/shared/_tagging.html.erb
@@ -43,24 +43,6 @@
           </p>
         </div>
 
-        <div class="form-group" id="edition_topics_input">
-          <%= f.label :topics, "Specialist topic pages", class: 'control-label' %>
-          <%= f.select :topics, @linkables.topics,
-                       {},
-                       { multiple: true,
-                         class: 'select2',
-                         data: { placeholder: 'Choose Topics…' } } %>
-
-          <p class='help-block'>
-            Specialist topic pages live under <a href="https://www.gov.uk/topic">/topic</a>.
-            They contain collections of pages on GOV.UK. Example:
-            <a href="https://www.gov.uk/topic/business-tax">Business Tax</a> or
-            <a href="https://www.gov.uk/topic/animal-welfare/pets">Animal Welfare / Pets</a>.
-            Tagging a page to a specialist topic will send out an
-            <a href="https://www.gov.uk/topic/business-tax/vat/email-signup">email alert to subscribers</a>.
-          </p>
-        </div>
-
         <div class="form-group" id="edition_organisations_input">
           <%= f.label :organisations, "Organisations", class: 'control-label' %>
           <%= f.select :organisations, @linkables.organisations,

--- a/test/integration/tagging_test.rb
+++ b/test/integration/tagging_test.rb
@@ -24,31 +24,9 @@ class TaggingTest < JavascriptIntegrationTest
       assert_publishing_api_patch_links(
         @content_id,
         links: {
-          topics: [],
           organisations: [],
           meets_user_needs: [],
           mainstream_browse_pages: %w[CONTENT-ID-RTI CONTENT-ID-VAT],
-          ordered_related_items: [],
-          parent: [],
-        },
-        previous_version: 0,
-      )
-    end
-
-    should "tag to topics" do
-      visit_edition @edition
-      switch_tab "Tagging"
-
-      select2 "Oil and Gas / Fields", "Oil and Gas / Distillation (draft)", from: "Specialist topic pages"
-
-      save_tags_and_assert_success
-      assert_publishing_api_patch_links(
-        @content_id,
-        links: {
-          topics: %w[CONTENT-ID-DISTILL CONTENT-ID-FIELDS],
-          organisations: [],
-          meets_user_needs: [],
-          mainstream_browse_pages: [],
           ordered_related_items: [],
           parent: [],
         },
@@ -66,7 +44,6 @@ class TaggingTest < JavascriptIntegrationTest
       assert_publishing_api_patch_links(
         @content_id,
         links: {
-          topics: [],
           organisations: %w[9a9111aa-1db8-4025-8dd2-e08ec3175e72],
           meets_user_needs: [],
           mainstream_browse_pages: [],
@@ -87,7 +64,6 @@ class TaggingTest < JavascriptIntegrationTest
       assert_publishing_api_patch_links(
         @edition.artefact.content_id,
         links: {
-          topics: [],
           organisations: [],
           meets_user_needs: %w[CONTENT-ID-USER-NEED],
           mainstream_browse_pages: [],
@@ -147,7 +123,6 @@ class TaggingTest < JavascriptIntegrationTest
       assert_publishing_api_patch_links(
         @content_id,
         links: {
-          topics: [],
           organisations: [],
           meets_user_needs: [],
           mainstream_browse_pages: [],
@@ -178,7 +153,6 @@ class TaggingTest < JavascriptIntegrationTest
       assert_publishing_api_patch_links(
         @content_id,
         links: {
-          topics: [],
           organisations: [],
           meets_user_needs: [],
           mainstream_browse_pages: [],
@@ -196,13 +170,6 @@ class TaggingTest < JavascriptIntegrationTest
                    body: {
                      "content_id" => @content_id,
                      "expanded_links" => {
-                       "topics" => [
-                         {
-                           "content_id" => "CONTENT-ID-WELLS",
-                           "base_path" => "/topic/oil-and-gas/wells",
-                           "internal_name" => "Oil and Gas / Wells",
-                         },
-                       ],
                        "mainstream_browse_pages" => [
                          {
                            "content_id" => "CONTENT-ID-RTI",
@@ -226,14 +193,12 @@ class TaggingTest < JavascriptIntegrationTest
       select2 "Tax / RTI (draft)", "Tax / VAT", from: "Mainstream browse pages"
 
       select2 "Tax / Capital Gains Tax", from: "Breadcrumb"
-      select2 "Oil and Gas / Fields", from: "Specialist topic pages"
 
       save_tags_and_assert_success
 
       assert_publishing_api_patch_links(
         @content_id,
         links: {
-          topics: %w[CONTENT-ID-FIELDS CONTENT-ID-WELLS],
           organisations: [],
           meets_user_needs: [],
           mainstream_browse_pages: %w[CONTENT-ID-RTI CONTENT-ID-VAT],
@@ -248,7 +213,6 @@ class TaggingTest < JavascriptIntegrationTest
       stub_publishing_api_has_links(
         "content_id" => @content_id,
         "links" => {
-          topics: %w[CONTENT-ID-WELLS],
           mainstream_browse_pages: %w[CONTENT-ID-RTI],
           parent: %w[CONTENT-ID-RTI],
         },
@@ -258,7 +222,7 @@ class TaggingTest < JavascriptIntegrationTest
 
       switch_tab "Tagging"
 
-      select2 "Oil and Gas / Fields", from: "Specialist topic pages"
+      select2 "Tax / RTI", from: "Mainstream browse pages"
 
       stub_request(:patch, "#{PUBLISHING_API_V2_ENDPOINT}/links/#{@content_id}")
         .to_return(status: 409)

--- a/test/unit/all_urls_presenter_test.rb
+++ b/test/unit/all_urls_presenter_test.rb
@@ -18,11 +18,6 @@ class AllUrlsPresenterTest < ActiveSupport::TestCase
             "title" => "HMRC",
           },
         ],
-        "topics" => [
-          {
-            "base_path" => "/topic/business-tax/vat",
-          },
-        ],
       },
     }
   end
@@ -50,7 +45,6 @@ class AllUrlsPresenterTest < ActiveSupport::TestCase
     assert_equal "Important document", data[0]["Name"]
     assert_equal "answer", data[0]["Format"]
     assert_equal "HMRC", data[0]["Organisations"]
-    assert_equal "business-tax/vat", data[0]["Topics"]
     assert_equal "business/support,tax/vat", data[0]["Browse pages"]
   end
 

--- a/test/unit/organisation_content_presenter_test.rb
+++ b/test/unit/organisation_content_presenter_test.rb
@@ -18,11 +18,6 @@ class OrganisationContentPresenterTest < ActiveSupport::TestCase
             "title" => "HMRC",
           },
         ],
-        "topics" => [
-          {
-            "base_path" => "/topic/business-tax/vat",
-          },
-        ],
       },
     }
   end
@@ -50,7 +45,6 @@ class OrganisationContentPresenterTest < ActiveSupport::TestCase
     assert_equal "Important document", data[0]["Name"]
     assert_equal "answer", data[0]["Format"]
     assert_equal "HMRC", data[0]["Organisations"]
-    assert_equal "business-tax/vat", data[0]["Topics"]
     assert_equal "business/support,tax/vat", data[0]["Browse pages"]
   end
 

--- a/test/unit/tagging/linkables_test.rb
+++ b/test/unit/tagging/linkables_test.rb
@@ -5,19 +5,6 @@ class LinkablesTest < ActiveSupport::TestCase
     stub_linkables
   end
 
-  test "returns sorted topics" do
-    assert_equal(
-      {
-        "Oil and Gas" => [
-          ["Oil and Gas / Distillation (draft)", "CONTENT-ID-DISTILL"],
-          ["Oil and Gas / Fields", "CONTENT-ID-FIELDS"],
-          ["Oil and Gas / Wells", "CONTENT-ID-WELLS"],
-        ],
-      },
-      Tagging::Linkables.new.topics,
-    )
-  end
-
   test "returns sorted browse pages" do
     assert_equal(
       {


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Ticket: https://trello.com/c/f6QxCh5o/2380-remove-specialist-topic-code-from-publisher-m


## What
[Publisher](https://github.com/alphagov/publisher) is an app used by internal [gov.uk](http://gov.uk/) content designers to publish mainstream content to [GOV.UK](http://gov.uk/). You can access the [Publisher UI](https://publisher.integration.publishing.service.gov.uk/) via signon. Publisher supports tagging content to Specialist topics. As we are retiring specialist topics, we need to remove the the specialist topic tagging form from the tagging UI, as well as clear up any associated code.

## Why
To prevent old code hanging around leading to bugs and confusion. Ie if we don’t tidy up we will be leave a big pile of tech debt.

## When
This card can be picked up now. It is not dependent on completing the epic to retire all specialist topics.
