### PR TITLE
Add an error summary to the design system layout

### DIFF
--- a/app/views/downtimes/_form.html.erb
+++ b/app/views/downtimes/_form.html.erb
@@ -1,7 +1,5 @@
 <%= f.hidden_field :artefact_id %>
 
-<%= render :partial => 'shared/legacy_error_summary', locals: { object: @downtime} %>
-
 <%= render partial: "downtimes/datetime_fields", locals: {
   date_legend_text: "From date",
   time_legend_text: "From time",
@@ -16,6 +14,7 @@
     width: 2,
   },
   day: {
+    id: "downtime_start_time",
     name: "downtime[start_time(3i)]",
     label: "Day",
     width: 2,
@@ -46,6 +45,7 @@
     width: 2,
   },
   day: {
+    id: "downtime_end_time",
     name: "downtime[end_time(3i)]",
     label: "Day",
     width: 2,
@@ -70,6 +70,7 @@
         text: "Message"
       },
       hint: "Message is auto-generated once a schedule has been made.",
+      id: "downtime_message",
       name: "downtime[message]"
     } %>
   </div>

--- a/app/views/downtimes/new.html.erb
+++ b/app/views/downtimes/new.html.erb
@@ -1,6 +1,9 @@
 <% content_for :page_title, 'Schedule downtime' %>
 <% content_for :title, 'Add downtime message' %>
 <% content_for :title_context, @downtime.artefact.name %>
+<% unless @downtime.errors.empty? %>
+  <% content_for :error_summary, render("shared/error_summary", { object: @downtime })  %>
+<% end %>
 
 <div class="govuk-grid-column-two-thirds">
   <%= render "govuk_publishing_components/components/lead_paragraph", {

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -21,6 +21,14 @@
 
       <%= render "shared/flash", flash: flash %>
 
+      <% if content_for?(:error_summary) %>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <%= yield(:error_summary) %>
+          </div>
+        </div>
+      <% end %>
+
       <% if yield(:title).present? %>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">

--- a/app/views/shared/_error_summary.html.erb
+++ b/app/views/shared/_error_summary.html.erb
@@ -1,0 +1,12 @@
+<% if object.errors.any? %>
+  <%= render "govuk_publishing_components/components/error_summary", {
+    title: "There is a problem",
+    items: object.errors.map do |error|
+      model = object.class.superclass.to_s == "Object" ? object.class : object.class.superclass
+      {
+        text: error.message,
+        href: "##{model.to_s.underscore + "_" + error.attribute.to_s}",
+      }
+    end
+  } %>
+<% end %>


### PR DESCRIPTION
## What

Replace the use of the legacy error summary on the "Add downtime" view with one from the design system layout.

Add ids to relevant form inputs so that the links in the error summary link to the expected input.

The new error summary partial is a like-for-like replacement of the legacy one, just making use of the `error_summary` component from the GOV.UK Design System. This means that the title, error message text and link generation is exactly the same.

## Why

This is part of the transition of Mainstream Publisher to the GOV.UK Design System.

## Trello

[Trello ticket](https://trello.com/c/0J3X18AA)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
