### PR TITLE
Transition add downtime page/field level validation messages

### DIFF
--- a/app/controllers/downtimes_controller.rb
+++ b/app/controllers/downtimes_controller.rb
@@ -47,19 +47,11 @@ class DowntimesController < ApplicationController
 private
 
   def downtime_params
-    params[:downtime].permit([
-      "artefact_id",
-      "message",
-      "end_time(1i)",
-      "end_time(2i)",
-      "end_time(3i)",
-      "end_time(4i)",
-      "end_time(5i)",
-      "start_time(1i)",
-      "start_time(2i)",
-      "start_time(3i)",
-      "start_time(4i)",
-      "start_time(5i)",
+    params[:downtime].permit(%w[
+      artefact_id
+      message
+      end_time
+      start_time
     ])
   end
 

--- a/app/controllers/downtimes_controller.rb
+++ b/app/controllers/downtimes_controller.rb
@@ -1,7 +1,7 @@
 class DowntimesController < ApplicationController
   before_action :require_govuk_editor
   before_action :load_edition, except: [:index]
-  before_action :process_params, only: %i[create update]
+  before_action :process_params, only: %i[update]
 
   layout "design_system"
 

--- a/app/helpers/errors_helper.rb
+++ b/app/helpers/errors_helper.rb
@@ -1,0 +1,14 @@
+module ErrorsHelper
+  def errors_for(errors, attribute)
+    return nil if errors.blank?
+
+    errors.filter_map { |error|
+      if error.attribute == attribute
+        {
+          text: error.full_message,
+        }
+      end
+    }
+    .presence
+  end
+end

--- a/app/models/downtime.rb
+++ b/app/models/downtime.rb
@@ -27,10 +27,10 @@ class Downtime
 private
 
   def end_time_is_in_future
-    errors.add(:end_time, "End time must be in the future") if end_time && !end_time.future?
+    errors.add(:end_time, "must be in the future") if end_time && !end_time.future?
   end
 
   def start_time_precedes_end_time
-    errors.add(:start_time, "Start time must be earlier than end time") if start_time && end_time && start_time >= end_time
+    errors.add(:start_time, "must be earlier than end time") if start_time && end_time && start_time >= end_time
   end
 end

--- a/app/views/downtimes/_datetime_fields.html.erb
+++ b/app/views/downtimes/_datetime_fields.html.erb
@@ -2,6 +2,8 @@
   date_legend_text ||= nil
   time_legend_text ||= nil
 
+  error_items ||= nil
+
   year ||= nil
   month ||= nil
   day ||= nil
@@ -29,6 +31,7 @@
           <%= render "govuk_publishing_components/components/date_input", {
             hint: "For example, 01 08 2022",
             items: date_input_items,
+            error_items: error_items,
           } %>
         <% end %>
       </div>
@@ -40,6 +43,7 @@
           <%= render "time_input", {
             hint: "For example, 9:30 or 19:30",
             items: time_input_items,
+            error_items: error_items,
           } %>
         <% end %>
       </div>

--- a/app/views/downtimes/_form.html.erb
+++ b/app/views/downtimes/_form.html.erb
@@ -6,27 +6,32 @@
   year: {
     name: "downtime[start_time(1i)]",
     label: "Year",
+    value: params.dig("downtime", "start_time(1i)"),
     width: 4,
   },
   month: {
     name: "downtime[start_time(2i)]",
     label: "Month",
+    value: params.dig("downtime", "start_time(2i)"),
     width: 2,
   },
   day: {
     id: "downtime_start_time",
     name: "downtime[start_time(3i)]",
     label: "Day",
+    value: params.dig("downtime", "start_time(3i)"),
     width: 2,
   },
   hour: {
     name: "downtime[start_time(4i)]",
     label: "Hour",
+    value: params.dig("downtime", "start_time(4i)"),
     width: 2,
   },
   minute: {
     name: "downtime[start_time(5i)]",
     label: "Minute",
+    value: params.dig("downtime", "start_time(5i)"),
     width: 2,
   },
 } %>
@@ -37,27 +42,32 @@
   year: {
     name: "downtime[end_time(1i)]",
     label: "Year",
+    value: params.dig("downtime", "end_time(1i)"),
     width: 4,
   },
   month: {
     name: "downtime[end_time(2i)]",
     label: "Month",
+    value: params.dig("downtime", "end_time(2i)"),
     width: 2,
   },
   day: {
     id: "downtime_end_time",
     name: "downtime[end_time(3i)]",
     label: "Day",
+    value: params.dig("downtime", "end_time(3i)"),
     width: 2,
   },
   hour: {
     name: "downtime[end_time(4i)]",
     label: "Hour",
+    value: params.dig("downtime", "end_time(4i)"),
     width: 2,
   },
   minute: {
     name: "downtime[end_time(5i)]",
     label: "Minute",
+    value: params.dig("downtime", "end_time(5i)"),
     width: 2,
   },
 } %>
@@ -71,7 +81,8 @@
       },
       hint: "Message is auto-generated once a schedule has been made.",
       id: "downtime_message",
-      name: "downtime[message]"
+      name: "downtime[message]",
+      value: params.dig("downtime", "message"),
     } %>
   </div>
 </div>

--- a/app/views/downtimes/_form.html.erb
+++ b/app/views/downtimes/_form.html.erb
@@ -85,6 +85,7 @@
       id: "downtime_message",
       name: "downtime[message]",
       value: params.dig("downtime", "message"),
+      error_items: errors_for(f.object.errors, :message),
     } %>
   </div>
 </div>

--- a/app/views/downtimes/_form.html.erb
+++ b/app/views/downtimes/_form.html.erb
@@ -3,6 +3,7 @@
 <%= render partial: "downtimes/datetime_fields", locals: {
   date_legend_text: "From date",
   time_legend_text: "From time",
+  error_items: errors_for(f.object.errors, :start_time),
   year: {
     name: "downtime[start_time(1i)]",
     label: "Year",
@@ -39,6 +40,7 @@
 <%= render partial: "downtimes/datetime_fields", locals: {
   date_legend_text: "To date",
   time_legend_text: "To time",
+  error_items: errors_for(f.object.errors, :end_time),
   year: {
     name: "downtime[end_time(1i)]",
     label: "Year",

--- a/app/views/legacy_downtimes/_form.html.erb
+++ b/app/views/legacy_downtimes/_form.html.erb
@@ -1,6 +1,6 @@
 <%= f.hidden_field :artefact_id %>
 
-<%= render :partial => 'shared/legacy_error_summary', locals: { object: @downtime} %>
+<%= render :partial => 'legacy_downtimes_error_summary', locals: { object: @downtime} %>
 
 <div class="downtime-dates">
   <div class="form-group">

--- a/app/views/legacy_downtimes/_legacy_downtimes_error_summary.html.erb
+++ b/app/views/legacy_downtimes/_legacy_downtimes_error_summary.html.erb
@@ -1,0 +1,13 @@
+<% if object.errors.any? %>
+  <div id="error-summary" class="alert alert-danger error-summary">
+    <h2 class="add-bottom-margin">There is a problem</h2>
+    <ul>
+      <% object.errors.each do |error| %>
+      <li>
+        <% model = object.class.superclass.to_s == "Object" ? object.class : object.class.superclass %>
+        <a href="#<%= model.to_s.underscore + "_" + error.attribute.to_s %>"><%= error.full_message %></a>
+      </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/shared/_error_summary.html.erb
+++ b/app/views/shared/_error_summary.html.erb
@@ -4,7 +4,7 @@
     items: object.errors.map do |error|
       model = object.class.superclass.to_s == "Object" ? object.class : object.class.superclass
       {
-        text: error.message,
+        text: error.full_message,
         href: "##{model.to_s.underscore + "_" + error.attribute.to_s}",
       }
     end

--- a/test/integration/downtime_with_invalid_dates_test.rb
+++ b/test/integration/downtime_with_invalid_dates_test.rb
@@ -27,13 +27,25 @@ class DowntimeWithInvalidDates < ActionDispatch::IntegrationTest
     click_link "Downtime"
     click_link "Add downtime"
 
-    enter_from_date_and_time 1.day.ago
-    enter_to_date_and_time 1.day.ago - 1.day
+    start_time = 1.day.ago
+    end_time = start_time - 1.day
+    enter_from_date_and_time start_time
+    enter_to_date_and_time end_time
 
     click_button "Save"
 
     assert page.has_link?("End time must be in the future", href: "#downtime_end_time")
     assert page.has_link?("Start time must be earlier than end time", href: "#downtime_start_time")
+    assert page.has_field?("downtime[start_time(1i)]", with: start_time.year.to_s)
+    assert page.has_field?("downtime[start_time(2i)]", with: start_time.month.to_s)
+    assert page.has_field?("downtime[start_time(3i)]", with: start_time.day.to_s)
+    assert page.has_field?("downtime[start_time(4i)]", with: start_time.hour.to_s)
+    assert page.has_field?("downtime[start_time(5i)]", with: start_time.min.to_s)
+    assert page.has_field?("downtime[end_time(1i)]", with: end_time.year.to_s)
+    assert page.has_field?("downtime[end_time(2i)]", with: end_time.month.to_s)
+    assert page.has_field?("downtime[end_time(3i)]", with: end_time.day.to_s)
+    assert page.has_field?("downtime[end_time(4i)]", with: end_time.hour.to_s)
+    assert page.has_field?("downtime[end_time(5i)]", with: end_time.min.to_s)
   end
 
   def enter_from_date_and_time(start_time)

--- a/test/models/downtime_test.rb
+++ b/test/models/downtime_test.rb
@@ -34,7 +34,7 @@ class DowntimeTest < ActiveSupport::TestCase
       downtime = FactoryBot.build(:downtime, end_time: Time.zone.yesterday)
 
       assert_not downtime.valid?
-      assert_includes downtime.errors[:end_time], "End time must be in the future"
+      assert_includes downtime.errors[:end_time], "must be in the future"
     end
 
     should "validate end time is in future only on create" do
@@ -48,7 +48,7 @@ class DowntimeTest < ActiveSupport::TestCase
       downtime = FactoryBot.build(:downtime, start_time: Time.zone.today + 2, end_time: Time.zone.today + 1)
 
       assert_not downtime.valid?
-      assert_includes downtime.errors[:start_time], "Start time must be earlier than end time"
+      assert_includes downtime.errors[:start_time], "must be earlier than end time"
     end
   end
 

--- a/test/support/downtimes_controller_parameterised_tests.rb
+++ b/test/support/downtimes_controller_parameterised_tests.rb
@@ -1,0 +1,60 @@
+module DowntimesControllerParameterisedTests
+  def test_create_with_invalid_datetime_values
+    [
+      ["start_time", "1", "", "Start time format is invalid"],
+      ["start_time", "2", "", "Start time format is invalid"],
+      ["start_time", "3", "", "Start time format is invalid"],
+      ["start_time", "4", "", "Start time format is invalid"],
+      ["start_time", "5", "", "Start time format is invalid"],
+      ["start_time", "1", "asdf", "Start time format is invalid"],
+      ["start_time", "2", "a", "Start time format is invalid"],
+      ["start_time", "3", "a", "Start time format is invalid"],
+      ["start_time", "4", "a", "Start time format is invalid"],
+      ["start_time", "5", "a", "Start time format is invalid"],
+      ["start_time", "1", "-2024", "Start time format is invalid"],
+      ["start_time", "2", "-1", "Start time format is invalid"],
+      ["start_time", "3", "-1", "Start time format is invalid"],
+      ["start_time", "4", "-1", "Start time format is invalid"],
+      ["start_time", "5", "-1", "Start time format is invalid"],
+      ["start_time", "2", "0", "Start time format is invalid"],
+      ["start_time", "3", "0", "Start time format is invalid"],
+      ["start_time", "1", "10000", "Start time format is invalid"],
+      ["start_time", "2", "13", "Start time format is invalid"],
+      ["start_time", "3", "32", "Start time format is invalid"],
+      ["start_time", "4", "60", "Start time format is invalid"],
+      ["start_time", "5", "60", "Start time format is invalid"],
+      ["end_time", "1", "", "End time format is invalid"],
+      ["end_time", "2", "", "End time format is invalid"],
+      ["end_time", "3", "", "End time format is invalid"],
+      ["end_time", "4", "", "End time format is invalid"],
+      ["end_time", "5", "", "End time format is invalid"],
+      ["end_time", "1", "asdf", "End time format is invalid"],
+      ["end_time", "2", "a", "End time format is invalid"],
+      ["end_time", "3", "a", "End time format is invalid"],
+      ["end_time", "4", "a", "End time format is invalid"],
+      ["end_time", "5", "a", "End time format is invalid"],
+      ["end_time", "1", "-2024", "End time format is invalid"],
+      ["end_time", "2", "-1", "End time format is invalid"],
+      ["end_time", "3", "-1", "End time format is invalid"],
+      ["end_time", "4", "-1", "End time format is invalid"],
+      ["end_time", "5", "-1", "End time format is invalid"],
+      ["end_time", "2", "0", "End time format is invalid"],
+      ["end_time", "3", "0", "End time format is invalid"],
+      ["end_time", "1", "10000", "End time format is invalid"],
+      ["end_time", "2", "13", "End time format is invalid"],
+      ["end_time", "3", "32", "End time format is invalid"],
+      ["end_time", "4", "60", "End time format is invalid"],
+      ["end_time", "5", "60", "End time format is invalid"],
+    ].each do |param_base_name, param_sub_ordinal, param_value, expected_message|
+      should "display a validation error when the '#{param_base_name}' sub-param '#{param_sub_ordinal}' is '#{param_value}'" do
+        params = downtime_params.merge("#{param_base_name}(#{param_sub_ordinal}i)": param_value)
+
+        post :create, params: { edition_id: edition.id, downtime: params }
+
+        assert_select "div.govuk-error-summary" do
+          assert_select "a", expected_message
+        end
+      end
+    end
+  end
+end

--- a/test/unit/helpers/errors_helper_test.rb
+++ b/test/unit/helpers/errors_helper_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class ErrorsHelperTest < ActionView::TestCase
+  setup do
+    @object_with_no_errors = ErrorTestObject.new("title", Time.zone.today)
+    @object_with_errors = ErrorTestObject.new(nil, nil)
+    @object_with_unrelated_errors = ErrorTestObject.new("title", nil)
+    @object_with_errors.validate
+    @object_with_unrelated_errors.validate
+    @flash = ActionDispatch::Flash::FlashHash.new
+  end
+
+  context "#errors_for" do
+    should "return nil when there are no error messages" do
+      assert_nil errors_for(@object_with_no_errors.errors, :title)
+    end
+
+    should "return errors for the attribute passed in" do
+      assert_equal errors_for(@object_with_errors.errors, :title), [{ text: "Title can't be blank" }]
+    end
+
+    should "format the error message when there are multiple errors on a field" do
+      assert_equal errors_for(@object_with_errors.errors, :date), [{ text: "Date can't be blank" }, { text: "Date is invalid" }]
+    end
+
+    should "return nil when object only has unrelated errors" do
+      assert_nil errors_for(@object_with_unrelated_errors.errors, :title)
+    end
+  end
+
+  class ErrorTestObject
+    include ActiveModel::Model
+    attr_accessor :title, :date
+
+    validates :title, :date, presence: true
+    validate :date_is_a_date
+
+    def initialize(title, date)
+      @title = title
+      @date = date
+    end
+
+    def date_is_a_date
+      errors.add(:date, :invalid) unless date.is_a?(Date)
+    end
+  end
+end


### PR DESCRIPTION
## What

- Update validations on the "Add downtime" page now that we're using text fields for all of the input fields.
- When there are validation errors, populate the fields with the values that were submitted.
- Make model validation error messages consistent (so the `message` does not include the field name at the start, which is prepended when using `full_message`).

## Why

Part of the transition of Mainstream Publisher to the GOV.UK Design System.

## Trello

[Trello ticket](https://trello.com/c/0J3X18AA)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
