### PR TITLE
Increase the margin at the bottom of "Add Downtime"

### DIFF
--- a/app/views/downtimes/_form.html.erb
+++ b/app/views/downtimes/_form.html.erb
@@ -77,6 +77,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render "govuk_publishing_components/components/textarea", {
+      margin_bottom: 8,
       label: {
         heading_size: "l",
         text: "Message"


### PR DESCRIPTION
## What

The default bottom margin is 30px for a textarea, but the Figma designs specify 50px.

## Trello

[Trello ticket](https://trello.com/c/0J3X18AA)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
