### PR TITLE
Remove Register to Vote Promo

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -15,7 +15,6 @@
   left: -9999em;
 }
 
-.promotion-choice-register-to-vote:checked ~ .promotion-choice-opt-in-out-url,
 .promotion-choice-mot-reminder:checked ~ .promotion-choice-opt-in-out-url,
 .promotion-choice-electric-vehicle:checked ~ .promotion-choice-opt-in-out-url {
   position: absolute;

--- a/app/lib/presentation_toggles.rb
+++ b/app/lib/presentation_toggles.rb
@@ -4,7 +4,7 @@ module PresentationToggles
   included do
     field :presentation_toggles, type: Hash, default: default_presentation_toggles
     validates :promotion_choice_url, presence: true, if: :promotes_something?
-    validates :promotion_choice, inclusion: { in: %w[none organ_donor register_to_vote mot_reminder electric_vehicle] }
+    validates :promotion_choice, inclusion: { in: %w[none organ_donor mot_reminder electric_vehicle] }
   end
 
   def promotion_choice=(value)

--- a/app/presenters/formats/completed_transaction_presenter.rb
+++ b/app/presenters/formats/completed_transaction_presenter.rb
@@ -2,7 +2,7 @@ module Formats
   class CompletedTransactionPresenter < EditionFormatPresenter
   private
 
-    PROMOTIONS = %w[organ_donor register_to_vote mot_reminder electric_vehicle].freeze
+    PROMOTIONS = %w[organ_donor mot_reminder electric_vehicle].freeze
 
     def schema_name
       "completed_transaction"

--- a/app/views/completed_transactions/_fields.html.erb
+++ b/app/views/completed_transactions/_fields.html.erb
@@ -35,10 +35,6 @@
           { checked: (f.object.promotion_choice == "organ_donor"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-organ-donor' } %>
         <%= f.label :promotion_choice, "Promote organ donation", value: 'organ_donor' %>
         <br />
-        <%= f.radio_button :promotion_choice, 'register_to_vote',
-          { checked: (f.object.promotion_choice == "register_to_vote"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-register-to-vote' } %>
-        <%= f.label :promotion_choice, "Promote register to vote", value: 'register_to_vote' %>
-        <br />
         <%= f.radio_button :promotion_choice, 'mot_reminder',
           { checked: (f.object.promotion_choice == "mot_reminder"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-mot-reminder' } %>
         <%= f.label :promotion_choice, "Promote MOT reminders", value: 'mot_reminder' %>

--- a/test/integration/completed_transactions_create_edit_test.rb
+++ b/test/integration/completed_transactions_create_edit_test.rb
@@ -90,18 +90,18 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
 
   should "only allow one promotion to be displayed at once" do
     edition = FactoryBot.create(:completed_transaction_edition, panopticon_id: @artefact.id)
-    register_to_vote_promotion_url = "https://gov.uk/register-to-vote"
+    mot_promotion_url = "https://www.gov.uk/mot-reminder"
 
     visit_edition edition
 
-    assert page.has_unchecked_field? "Promote register to vote"
+    assert page.has_unchecked_field? "Promote MOT reminders"
 
-    choose "Promote register to vote"
-    fill_in "Promotion choice URL", with: register_to_vote_promotion_url
+    choose "Promote MOT reminders"
+    fill_in "Promotion choice URL", with: mot_promotion_url
     save_edition_and_assert_success
 
-    assert page.has_checked_field? "Promote register to vote"
-    assert page.has_field? "Promotion choice URL", with: register_to_vote_promotion_url
+    assert page.has_checked_field? "Promote MOT reminders"
+    assert page.has_field? "Promotion choice URL", with: mot_promotion_url
     assert page.has_unchecked_field? "Promote organ donation"
   end
 
@@ -112,7 +112,6 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
 
     assert page.has_content? "Don't promote anything on this page"
     assert page.has_content? "Promote organ donation"
-    assert page.has_content? "Promote register to vote"
     assert page.has_content? "Promote MOT reminders"
   end
 end

--- a/test/models/completed_transaction_edition_test.rb
+++ b/test/models/completed_transaction_edition_test.rb
@@ -53,13 +53,6 @@ class CompletedTransactionEditionTest < ActiveSupport::TestCase
     assert_equal "https://www.organdonation.nhs.uk/registration/in/", completed_transaction_edition.promotion_choice_opt_in_url
     assert_equal "https://www.organdonation.nhs.uk/registration/out/", completed_transaction_edition.promotion_choice_opt_out_url
 
-    completed_transaction_edition.promotion_choice = "register_to_vote"
-    completed_transaction_edition.promotion_choice_url = "https://www.gov.uk/register-to-vote"
-    completed_transaction_edition.save!
-
-    assert_equal "register_to_vote", completed_transaction_edition.reload.promotion_choice
-    assert_equal "https://www.gov.uk/register-to-vote", completed_transaction_edition.promotion_choice_url
-
     completed_transaction_edition.promotion_choice = "mot_reminder"
     completed_transaction_edition.promotion_choice_url = "https://www.gov.uk/mot-reminder"
     completed_transaction_edition.save!


### PR DESCRIPTION
## What

Remove the Register to Vote promo option from Publisher.

## Why

Requested to be removed.

[Relevant Trello Card](https://trello.com/c/NpANWWTr/223-remove-promote-register-to-vote-option-when-editing-completed-transactions-in-publisher)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
