### PR TITLE
Improvements for the edit and remove downtime page

### DIFF
--- a/app/controllers/downtimes_controller.rb
+++ b/app/controllers/downtimes_controller.rb
@@ -42,7 +42,7 @@ class DowntimesController < ApplicationController
       datetime_validation_errors = datetime_validation_errors(downtime_params, %w[start_time end_time])
       if datetime_validation_errors.empty? && @downtime.update(downtime_params)
         DowntimeScheduler.schedule_publish_and_expiry(@downtime)
-        flash[:success] = "#{edition_link} downtime message re-scheduled (from #{view_context.downtime_datetime(@downtime)})".html_safe
+        flash[:success] = "#{@edition.title} downtime message re-scheduled (from #{view_context.downtime_datetime(@downtime)})".html_safe
         redirect_to downtimes_path
       else
         @downtime.valid? # Make sure the model validations have run
@@ -55,7 +55,7 @@ class DowntimesController < ApplicationController
       end
     else
       DowntimeRemover.destroy_immediately(@downtime)
-      flash[:success] = "#{edition_link} downtime message cancelled".html_safe
+      flash[:success] = "#{@edition.title} downtime message cancelled".html_safe
       redirect_to downtimes_path
     end
   end

--- a/app/views/downtimes/_form.html.erb
+++ b/app/views/downtimes/_form.html.erb
@@ -79,7 +79,7 @@
     <%= render "govuk_publishing_components/components/textarea", {
       margin_bottom: 8,
       label: {
-        heading_size: "l",
+        heading_size: "m",
         text: "Message"
       },
       hint: "Message is auto-generated once a schedule has been made.",

--- a/app/views/downtimes/delete.html.erb
+++ b/app/views/downtimes/delete.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-column-two-thirds">
   <%= render "govuk_publishing_components/components/lead_paragraph", {
-    text: "Are you sure you want to remove the scheduled downtime message for #{@downtime.artefact.name}?",
+    text: "Are you sure you want to remove the scheduled downtime message for \"#{@downtime.artefact.name}\"?",
     margin_bottom: 8
   } %>
 


### PR DESCRIPTION
- Remove link in success message for downtime update and remove
- Add speech marks around the remove downtimes paragraph
- Change heading size of message

[Trello card](https://trello.com/c/i3Jjd1sr/157-upgrade-edit-downtime)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
