### PR TITLE
Set downtime upgrade switch to true

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -10,14 +10,14 @@ Flipflop.configure do
   end
 
   feature :design_system_downtime_new,
-          default: false,
+          default: true,
           description: "A transition of the add downtime page to use the GOV.UK Design System"
 
   feature :design_system_downtime_edit,
-          default: false,
+          default: true,
           description: "A transition of the edit downtime page to the GOV.UK Design System"
 
   feature :design_system_downtime_index_page,
-          default: false,
+          default: true,
           description: "A transition of the downtime index page to use the GOV.UK Design System"
 end

--- a/test/integration/legacy_downtime_integration_test.rb
+++ b/test/integration/legacy_downtime_integration_test.rb
@@ -18,6 +18,7 @@ class LegacyDowntimeIntegrationTest < JavascriptIntegrationTest
     test_strategy = Flipflop::FeatureSet.current.test!
     test_strategy.switch!(:design_system_downtime_index_page, false)
     test_strategy.switch!(:design_system_downtime_new, false)
+    test_strategy.switch!(:design_system_downtime_edit, false)
   end
 
   test "Scheduling new downtime" do

--- a/test/integration/legacy_downtime_with_invalid_dates_test.rb
+++ b/test/integration/legacy_downtime_with_invalid_dates_test.rb
@@ -17,6 +17,8 @@ class LegacyDowntimeWithInvalidDates < ActionDispatch::IntegrationTest
 
     test_strategy = Flipflop::FeatureSet.current.test!
     test_strategy.switch!(:design_system_downtime_index_page, false)
+    test_strategy.switch!(:design_system_downtime_new, false)
+    test_strategy.switch!(:design_system_downtime_edit, false)
   end
 
   test "Scheduling new downtime with invalid dates" do


### PR DESCRIPTION
[Trello card](https://trello.com/c/QSEpDCa1/184-toggle-on-new-version-of-downtime-pages-monday-18th-march)

This will make the default use the design system for downtime hub, edit and new.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
