### PR TITLE
Add Photo ID Promo

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -15,6 +15,7 @@
   left: -9999em;
 }
 
+.promotion-choice-bring-id-to-vote:checked ~ .promotion-choice-opt-in-out-url,
 .promotion-choice-mot-reminder:checked ~ .promotion-choice-opt-in-out-url,
 .promotion-choice-electric-vehicle:checked ~ .promotion-choice-opt-in-out-url {
   position: absolute;

--- a/app/lib/presentation_toggles.rb
+++ b/app/lib/presentation_toggles.rb
@@ -4,7 +4,7 @@ module PresentationToggles
   included do
     field :presentation_toggles, type: Hash, default: default_presentation_toggles
     validates :promotion_choice_url, presence: true, if: :promotes_something?
-    validates :promotion_choice, inclusion: { in: %w[none organ_donor mot_reminder electric_vehicle] }
+    validates :promotion_choice, inclusion: { in: %w[none organ_donor bring_id_to_vote mot_reminder electric_vehicle] }
   end
 
   def promotion_choice=(value)

--- a/app/presenters/formats/completed_transaction_presenter.rb
+++ b/app/presenters/formats/completed_transaction_presenter.rb
@@ -2,7 +2,7 @@ module Formats
   class CompletedTransactionPresenter < EditionFormatPresenter
   private
 
-    PROMOTIONS = %w[organ_donor mot_reminder electric_vehicle].freeze
+    PROMOTIONS = %w[organ_donor bring_id_to_vote mot_reminder electric_vehicle].freeze
 
     def schema_name
       "completed_transaction"

--- a/app/views/completed_transactions/_fields.html.erb
+++ b/app/views/completed_transactions/_fields.html.erb
@@ -35,6 +35,10 @@
           { checked: (f.object.promotion_choice == "organ_donor"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-organ-donor' } %>
         <%= f.label :promotion_choice, "Promote organ donation", value: 'organ_donor' %>
         <br />
+        <%= f.radio_button :promotion_choice, 'bring_id_to_vote',
+          { checked: (f.object.promotion_choice == "bring_id_to_vote"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-bring-id-to-vote' } %>
+        <%= f.label :promotion_choice, "Promote bring photo ID to vote", value: 'bring_id_to_vote' %>
+        <br />
         <%= f.radio_button :promotion_choice, 'mot_reminder',
           { checked: (f.object.promotion_choice == "mot_reminder"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-mot-reminder' } %>
         <%= f.label :promotion_choice, "Promote MOT reminders", value: 'mot_reminder' %>

--- a/test/integration/completed_transactions_create_edit_test.rb
+++ b/test/integration/completed_transactions_create_edit_test.rb
@@ -113,5 +113,6 @@ class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
     assert page.has_content? "Don't promote anything on this page"
     assert page.has_content? "Promote organ donation"
     assert page.has_content? "Promote MOT reminders"
+    assert page.has_content? "Promote bring photo ID to vote"
   end
 end

--- a/test/models/completed_transaction_edition_test.rb
+++ b/test/models/completed_transaction_edition_test.rb
@@ -53,6 +53,13 @@ class CompletedTransactionEditionTest < ActiveSupport::TestCase
     assert_equal "https://www.organdonation.nhs.uk/registration/in/", completed_transaction_edition.promotion_choice_opt_in_url
     assert_equal "https://www.organdonation.nhs.uk/registration/out/", completed_transaction_edition.promotion_choice_opt_out_url
 
+    completed_transaction_edition.promotion_choice = "bring_id_to_vote"
+    completed_transaction_edition.promotion_choice_url = "https://www.gov.uk/how-to-vote/photo-id-youll-need"
+    completed_transaction_edition.save!
+
+    assert_equal "bring_id_to_vote", completed_transaction_edition.reload.promotion_choice
+    assert_equal "https://www.gov.uk/how-to-vote/photo-id-youll-need", completed_transaction_edition.promotion_choice_url
+
     completed_transaction_edition.promotion_choice = "mot_reminder"
     completed_transaction_edition.promotion_choice_url = "https://www.gov.uk/mot-reminder"
     completed_transaction_edition.save!


### PR DESCRIPTION
## What

Add Photo ID promo to list of promos for Completed Transaction pages.

## Why

Request from content team.

