### PR TITLE
Handle error from publishing-api when unpublishing edition

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -230,7 +230,7 @@ class EditionsController < InheritedResources::Base
       flash[:notice] = notice
       redirect_to root_path
     else
-      flash[:alert] = artefact.errors.full_messages.join("\n")
+      flash[:alert] = "Due to a service problem, the edition couldn't be unpublished"
       redirect_to unpublish_edition_path(edition)
     end
   end

--- a/app/services/unpublish_service.rb
+++ b/app/services/unpublish_service.rb
@@ -1,9 +1,11 @@
 class UnpublishService
   class << self
     def call(artefact, user, redirect_url = "")
-      if update_artefact_in_shared_db(artefact, user, redirect_url)
-        unpublish_in_publishing_api artefact, redirect_url
-      end
+      unpublish_in_publishing_api(artefact, redirect_url)
+      update_artefact_in_shared_db artefact, user, redirect_url
+    rescue StandardError => e
+      Rails.logger.error "Encountered error #{e.message} while trying to unpublish #{artefact.slug}"
+      nil
     end
 
   private

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -1124,8 +1124,18 @@ class EditionsControllerTest < ActionController::TestCase
       @redirect_url = "https://www.example.com/somewhere_else"
     end
 
-    should "update publishing API upon unpublishing an edition" do
-      UnpublishService.expects(:call).with(@guide.artefact, @user, @redirect_url).returns(true)
+    should "update publishing API upon unpublishing" do
+      UnpublishService.expects(:call).with(@guide.artefact, @user, @redirect_url)
+
+      post :process_unpublish,
+           params: {
+             id: @guide.id,
+             redirect_url: @redirect_url,
+           }
+    end
+
+    should "redirect and display success message after successful unpublish" do
+      UnpublishService.stubs(:call).with(@guide.artefact, @user, @redirect_url).returns(true)
 
       post :process_unpublish,
            params: {
@@ -1145,6 +1155,18 @@ class EditionsControllerTest < ActionController::TestCase
            }
 
       assert_equal "Redirect path is invalid. Guide has not been unpublished.", flash[:danger]
+    end
+
+    should "alert if unable to unpublish" do
+      UnpublishService.stubs(:call).with(@guide.artefact, @user, @redirect_url).returns(nil)
+
+      post :process_unpublish,
+           params: {
+             id: @guide.id,
+             redirect_url: @redirect_url,
+           }
+
+      assert_equal "Due to a service problem, the edition couldn't be unpublished", flash[:alert]
     end
 
     context "Welsh editors" do

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -1137,6 +1137,16 @@ class EditionsControllerTest < ActionController::TestCase
       assert_equal "Content unpublished and redirected", flash[:notice]
     end
 
+    should "not be able to unpublish with invalid redirect url" do
+      post :process_unpublish,
+           params: {
+             id: @guide.id,
+             redirect_url: "invalid redirect url",
+           }
+
+      assert_equal "Redirect path is invalid. Guide has not been unpublished.", flash[:danger]
+    end
+
     context "Welsh editors" do
       setup do
         login_as_welsh_editor

--- a/test/unit/services/unpublish_service_test.rb
+++ b/test/unit/services/unpublish_service_test.rb
@@ -2,107 +2,109 @@ require "test_helper"
 
 class UnpublishServiceTest < ActiveSupport::TestCase
   setup do
+    @user = stub
     @content_id = "foo"
     @artefact = stub(update_as: true, content_id: @content_id, slug: "foo", state: "live", language: "en", exact_route?: true)
-    @user = stub
-    @publishing_api = stub(unpublish: true)
-
-    Services.stubs(:publishing_api).returns(@publishing_api)
   end
 
-  context "when an invalid redirect URL is provided" do
-    should "Publishing API is not called" do
-      @artefact.expects(:update_as).returns(false)
-      @publishing_api.expects(:unpublish).never
+  context "when publishing API returns an error" do
+    setup do
+      stub_any_publishing_api_unpublish.to_return(status: 422)
+    end
 
+    should "not update artefact" do
+      @artefact.expects(:update_as).never
       UnpublishService.call(@artefact, @user)
     end
 
     should "return nil" do
-      @artefact.expects(:update_as).returns(false)
-
       result = UnpublishService.call(@artefact, @user)
       assert result.nil?
     end
   end
 
-  context "when no redirect URL is provided" do
-    should "archive the artefact" do
+  context "when publishing API is successful" do
+    should "update artefact" do
       @artefact.expects(:update_as)
-        .with(@user, state: "archived", redirect_url: "")
-        .returns(true)
-
       UnpublishService.call(@artefact, @user)
     end
 
-    should "tell the publishing API about the change" do
-      @publishing_api.expects(:unpublish)
-        .with(@content_id,
-              locale: "en",
-              type: "gone",
-              discard_drafts: true)
-        .returns(true)
+    context "when no redirect URL is provided" do
+      should "archive the artefact in DB" do
+        @artefact.expects(:update_as)
+                 .with(@user, state: "archived", redirect_url: "")
 
-      UnpublishService.call(@artefact, @user)
-    end
+        UnpublishService.call(@artefact, @user)
+      end
 
-    should "return true" do
-      @artefact.expects(:update_as).returns(true)
-
-      assert UnpublishService.call(@artefact, @user)
-    end
-  end
-
-  context "when a valid redirect URL is provided" do
-    context "for an artefact with prefix routes" do
       should "tell the publishing API about the change" do
-        @artefact.expects(:exact_route?).returns(false)
+        Services.publishing_api.expects(:unpublish)
+                .with(@content_id,
+                      locale: "en",
+                      type: "gone",
+                      discard_drafts: true)
 
-        @publishing_api.expects(:unpublish)
-          .with(@content_id,
-                locale: "en",
-                type: "redirect",
-                redirects: [
-                  {
-                    path: "/foo",
-                    type: "prefix",
-                    destination: "/bar",
-                    segments_mode: "ignore",
-                  },
-                ],
-                discard_drafts: true)
-          .returns(true)
+        UnpublishService.call(@artefact, @user)
+      end
 
-        UnpublishService.call(@artefact, @user, "/bar")
+      should "return true" do
+        @artefact.stubs(:update_as).returns(true)
+        assert UnpublishService.call(@artefact, @user)
       end
     end
 
-    context "for an artefact with exact routes" do
-      should "tell the publishing API about the change" do
-        @publishing_api.expects(:unpublish)
-          .with(@content_id,
-                locale: "en",
-                type: "redirect",
-                alternative_path: "/bar",
-                discard_drafts: true)
-          .returns(true)
+    context "when a valid redirect URL is provided" do
+      context "for an artefact with prefix routes" do
+        setup do
+          @artefact.stubs(:exact_route?).returns(false)
+        end
+        should "tell the publishing API about the change" do
+          Services.publishing_api.expects(:unpublish)
+                  .with(@content_id,
+                        locale: "en",
+                        type: "redirect",
+                        redirects: [
+                          {
+                            path: "/foo",
+                            type: "prefix",
+                            destination: "/bar",
+                            segments_mode: "ignore",
+                          },
+                        ],
+                        discard_drafts: true)
+
+          UnpublishService.call(@artefact, @user, "/bar")
+        end
+      end
+
+      context "for an artefact with exact routes" do
+        setup do
+          @artefact.expects(:exact_route?).returns(true)
+        end
+        should "tell the publishing API about the change" do
+          Services.publishing_api.expects(:unpublish)
+                  .with(@content_id,
+                        locale: "en",
+                        type: "redirect",
+                        alternative_path: "/bar",
+                        discard_drafts: true)
+
+          UnpublishService.call(@artefact, @user, "/bar")
+        end
+      end
+
+      should "allow a redirect_url to be passed in" do
+        @artefact.expects(:update_as)
+                 .with(@user, state: "archived", redirect_url: "/bar")
 
         UnpublishService.call(@artefact, @user, "/bar")
       end
-    end
 
-    should "allow a redirect_url to be passed in" do
-      @artefact.expects(:update_as)
-        .with(@user, state: "archived", redirect_url: "/bar")
-        .returns(true)
+      should "return true" do
+        @artefact.stubs(:update_as).returns(true)
 
-      UnpublishService.call(@artefact, @user, "/bar")
-    end
-
-    should "return true" do
-      @artefact.expects(:update_as).returns(true)
-
-      assert UnpublishService.call(@artefact, @user, "/bar")
+        assert UnpublishService.call(@artefact, @user, "/bar")
+      end
     end
   end
 end


### PR DESCRIPTION
The changes in this PR is to solve the issue that arises when inconsistency happens between publishing-api and artefact db because of publishing api error happening after artefact db is already updated. The solution is documented in [the ADR](https://github.com/alphagov/publisher/pull/2139/files).

[Trello card](https://trello.com/c/Vx4ZTIwU/72-handle-error-from-publishing-api-when-unpublishing-edition)

