### PR TITLE
Get Publisher ready for ARM

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
   build-and-publish-image:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     name: Build and publish image
-    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.event.release.tag_name }}
     permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-ARG ruby_version=3.2.2
+ARG ruby_version=3.2
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 
 
-FROM $builder_image AS builder
+FROM --platform=$TARGETPLATFORM $builder_image AS builder
 
 WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
@@ -15,7 +15,7 @@ RUN bootsnap precompile --gemfile .
 RUN rails assets:precompile && rm -fr log node_modules
 
 
-FROM $base_image
+FROM --platform=$TARGETPLATFORM $base_image
 
 ENV GOVUK_APP_NAME=publisher
 


### PR DESCRIPTION
## What?
This gets Publisher ready for ARM.

Changes:

* Allow Docker Build to use latest Ruby 3.2.X
* Switch to the Multi-Arch Build Workflow