### PR TITLE
Fix scheduled last updated at date

### DIFF
--- a/app/workers/scheduled_publisher.rb
+++ b/app/workers/scheduled_publisher.rb
@@ -35,6 +35,7 @@ class ScheduledPublisher
     edition = Edition.find(edition_id)
     edition.publish_anonymously!
 
+    UpdateService.call(edition)
     PublishService.call(edition)
 
     report_state_counts

--- a/test/unit/scheduled_publisher_test.rb
+++ b/test/unit/scheduled_publisher_test.rb
@@ -32,8 +32,12 @@ class ScheduledPublisherTest < ActiveSupport::TestCase
       assert @edition.reload.published?
     end
 
-    should "call downstream publish service" do
-      PublishService.expects(:call).with(@edition)
+    should "update publishing api with latest edition payload before publishing" do
+      sequence = sequence(:task_order)
+
+      UpdateService.expects(:call).with(@edition).in_sequence(sequence)
+      PublishService.expects(:call).with(@edition).in_sequence(sequence)
+
       ScheduledPublisher.new.perform(@edition.id.to_s)
     end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/z6XJSVge/765-scheduled-help-pages-dont-have-their-last-updated-value-set-mainstream-publisher)

This will send the latest edition payload to the publishing api before asking it to publish, which will update the last updated at date when publish is scheduled. 