### PR TITLE
Add temp rake task to fix data integrity issues

### DIFF
--- a/lib/tasks/tmp_zendesk_5819067.rake
+++ b/lib/tasks/tmp_zendesk_5819067.rake
@@ -1,0 +1,20 @@
+namespace :tmp_zendesk_5819067 do
+  desc "Fix a couple of artefacts which have the wrong 'kind'"
+  task fix_artefact_kinds: :environment do
+    eco = Artefact.find_by(slug: "energy-company-obligation")
+    if eco.latest_edition.instance_of?(AnswerEdition) && eco.kind != "answer"
+      eco.kind = "answer"
+      eco.save!
+    else
+      puts "Skipping energy-company-obligation - had kind #{eco.kind} and latest edition class #{eco.latest_edition.class}"
+    end
+
+    mytc = Artefact.find_by(slug: "manage-your-tax-credits")
+    if mytc.latest_edition.instance_of?(TransactionEdition) && mytc.kind != "transaction"
+      mytc.kind = "transaction"
+      mytc.save!
+    else
+      puts "Skipping manage-your-tax-credits - had kind #{mytc.kind} and latest edition class #{mytc.latest_edition.class}"
+    end
+  end
+end


### PR DESCRIPTION
Somehow energy-company-obligation and manage-your-tax-credits have ended up with Artefacts with kind "completed_transaction", even though their editions are Answer and Transaction (note _not_ CompletedTransaction).

This prevents the editions from being published, because the artefacts are not valid because their slugs don't begin with "done/"

We ran equivalent code to this rake task in integration which appears to have fixed the issues. We'll test again in staging before running in production.

https://govuk.zendesk.com/agent/tickets/5819067

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
