### PR TITLE
Use V2 of GOV.UK Dependabot Merger

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,41 +1,8 @@
-api_version: 1
-auto_merge:
-  - dependency: gds-api-adapters
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: gds-sso
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: govspeak
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: govuk_admin_template
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: govuk_app_config
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: govuk_publishing_components
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: nested_form
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: govuk_sidekiq
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: govuk_test
-    allowed_semver_bumps:
-      - patch
-      - minor
+api_version: 2
+defaults:
+  auto_merge: true
+  update_external_dependencies: false # TODO: enable after verifying that this repo meets the conditions
+overrides:
   - dependency: rubocop-govuk
     allowed_semver_bumps:
       - patch


### PR DESCRIPTION
GOV.UK Dependency Merger configuration changed to allow automatic patching of all dependencies as described in RFC-167 [^1]. Consequently V1 no longer works. This updates the configuration to use the version 2 convention to reinstate the basic functionality of automatic patching of internal dependencies only.

Follow up work will be required to enable automatic patching of external dependencies, which we encourage the team to do.

[^1]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-167-auto-patch-dependencies.md

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
