### PR TITLE
Raise exceptions when updates fail

### DIFF
--- a/app/models/artefact.rb
+++ b/app/models/artefact.rb
@@ -251,7 +251,7 @@ class Artefact
   end
 
   def update_from_edition(edition)
-    update(
+    update!(
       state: state_from_edition(edition),
       description: edition.overview,
       public_timestamp: edition.public_updated_at,


### PR DESCRIPTION
In 000fbeeb we fixed a data issue which was causing two artefacts in publisher's database to fail to update.

There was effectively no visibility of this situation from the developers' perspective - only the user saw the error. We didn't get an error in sentry, a log message in logit, or even a 500 in the metrics.

The [update](https://www.mongodb.com/docs/mongoid/master/api/Mongoid/Persistable/Updatable.html#update-instance_method) method in mongoid returns false if the record can't be updated because it's not valid. We weren't checking the result and logging anything, so the failure was effectively silent.

Switching to [update!](https://www.mongodb.com/docs/mongoid/master/api/Mongoid/Persistable/Updatable.html#update!-instance_method) will raise Errors::Validations if the record being updated is not valid. This will result in the user seeing a 500 / Something went wrong error page, instead of an validation-style message they can't do anything about. It will also mean we get an error in Sentry, and in logit, and there will be a 500 in our metrics.

Alternatively we could check the return value of `update` and log a warning, but I think this situation is genuinely an error, and it's better to raise.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
