### PR TITLE
Enable minor rubocop-govuk gem update automerges

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -2,7 +2,3 @@ api_version: 2
 defaults:
   auto_merge: true
   update_external_dependencies: false # TODO: enable after verifying that this repo meets the conditions
-overrides:
-  - dependency: rubocop-govuk
-    allowed_semver_bumps:
-      - patch


### PR DESCRIPTION
Allow the GOV.UK dependabot merger bot to automatically merge minor
 version updates to the rubocop-govuk dependency. This was
 unintentionally restricted to only allow patch updates.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
