### PR TITLE
Use GOVUK_ENVIRONMENT instead of GOVUK_ENVIRONMENT_NAME

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,7 +34,7 @@ class ApplicationController < ActionController::Base
 
   def notify_bad_request(exception)
     # TODO: control this via the log level rather than an environment variable
-    if %w[integration staging].include?(ENV["GOVUK_ENVIRONMENT_NAME"]) && exception.message =~ /team-only API key/
+    if %w[integration staging].include?(ENV["GOVUK_ENVIRONMENT"]) && exception.message =~ /team-only API key/
       # in production we care about all errors
       # in staging and integration the team-only error may be encountered by
       # end-users who should see a more helpful error message

--- a/config/initializers/govuk_admin_template.rb
+++ b/config/initializers/govuk_admin_template.rb
@@ -3,5 +3,5 @@ GovukAdminTemplate.configure do |c|
   c.show_signout = true
 end
 
-GovukAdminTemplate.environment_label = ENV.fetch("GOVUK_ENVIRONMENT_NAME", "development").titleize
-GovukAdminTemplate.environment_style = ENV["GOVUK_ENVIRONMENT_NAME"] == "production" ? "production" : "preview"
+GovukAdminTemplate.environment_label = ENV.fetch("GOVUK_ENVIRONMENT", "development").titleize
+GovukAdminTemplate.environment_style = ENV["GOVUK_ENVIRONMENT"] == "production" ? "production" : "preview"


### PR DESCRIPTION
Both environment variables are set to the same value. GOVUK_ENVIRONMENT is used more frequently, renaming for consistency.