### PR TITLE
Show popular links

### DIFF
--- a/app/assets/stylesheets/_summary-card.scss
+++ b/app/assets/stylesheets/_summary-card.scss
@@ -1,0 +1,13 @@
+.app-c-summary-card {
+  .govuk-summary-list__key {
+    vertical-align: top;
+  }
+
+  img {
+    display: block;
+  }
+
+  .govuk-summary-card__action:not(:first-child):not(:last-child) {
+    padding-left: govuk-spacing(2);
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,3 +3,4 @@ $govuk-page-width: 1140px;
 // GOVUK Design System
 @import "govuk_publishing_components/all_components";
 @import "downtimes";
+@import "summary-card";

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -1,0 +1,8 @@
+class HomepageController < ApplicationController
+  layout "design_system"
+
+  def show
+    @latest_popular_links = PopularLinksEdition.last
+    render "homepage/popular_links/show"
+  end
+end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -47,8 +47,11 @@ private
 
   def build_presenter(user_filter, current_page = nil)
     user_filter, user = process_user_filter(user_filter)
+
     editions = filtered_editions.order_by([sort_column, sort_direction])
     editions = editions.page(current_page).per(ITEMS_PER_PAGE)
+    editions = editions.where.not(_type: "PopularLinksEdition")
+
     [PrimaryListingPresenter.new(editions, user), user_filter]
   end
 

--- a/app/helpers/popular_links_helper.rb
+++ b/app/helpers/popular_links_helper.rb
@@ -1,0 +1,8 @@
+module PopularLinksHelper
+  def popular_link_rows(item)
+    rows = []
+    rows << { key: "Title", value: item[:title] }
+    rows << { key: "URL", value: item[:url] }
+    rows.compact
+  end
+end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -118,10 +118,10 @@ class Edition
   ].freeze
 
   validates :title, presence: { message: "Enter a title" }
-  validates :version_number, presence: true, uniqueness: { scope: :panopticon_id }
-  validates :panopticon_id, presence: true
-  validates_with SafeHtml
-  validates_with LinkValidator, on: :update, unless: :archived?
+  validates :version_number, presence: true, uniqueness: { scope: :panopticon_id }, unless: :popular_links_edition?
+  validates :panopticon_id, presence: true, unless: :popular_links_edition?
+  validates_with SafeHtml, unless: :popular_links_edition?
+  validates_with LinkValidator, on: :update, unless: :archived? || :popular_links_edition?
   validates_with ReviewerValidator
   validates :change_note, presence: { if: :major_change }
 
@@ -514,5 +514,9 @@ private
 
   def common_type_specific_field_keys(target_class)
     ((fields.keys & target_class.fields.keys) - Edition.fields.keys).map(&:to_sym)
+  end
+
+  def popular_links_edition?
+    instance_of?(::PopularLinksEdition)
   end
 end

--- a/app/models/popular_links_edition.rb
+++ b/app/models/popular_links_edition.rb
@@ -1,0 +1,16 @@
+class PopularLinksEdition < Edition
+  field :link_items, type: Array
+  validate :six_link_items_present?
+  validate :all_urls_and_titles_are_present?
+
+  def six_link_items_present?
+    errors.add(:link_items, "6 links are required") if link_items.count != 6
+  end
+
+  def all_urls_and_titles_are_present?
+    link_items.each_with_index do |item, index|
+      errors.add(:item, "A URL is required for Link #{index + 1}") unless item.key?(:url)
+      errors.add(:item, "A Title is required for Link #{index + 1}") unless item.key?(:title)
+    end
+  end
+end

--- a/app/views/homepage/popular_links/_link.html.erb
+++ b/app/views/homepage/popular_links/_link.html.erb
@@ -1,0 +1,4 @@
+<%= render "shared/summary_card", {
+  title: "Link #{index +1}" ,
+  rows: popular_link_rows(item),
+} %>

--- a/app/views/homepage/popular_links/_version_and_status.html.erb
+++ b/app/views/homepage/popular_links/_version_and_status.html.erb
@@ -1,0 +1,15 @@
+<% status_tags = { :published=> "govuk-tag--green", :draft => "govuk-tag--yellow" } %>
+<% status_tag = tag.strong status.capitalize, class: ["govuk-tag",status_tags[status.to_sym]] %>
+
+<%= render "govuk_publishing_components/components/summary_list", {
+  items: [
+    {
+      field: "Edition",
+      value: version
+    },
+    {
+      field: "Status",
+      value: status_tag
+    }
+  ]
+} %>

--- a/app/views/homepage/popular_links/show.html.erb
+++ b/app/views/homepage/popular_links/show.html.erb
@@ -1,0 +1,9 @@
+<% content_for :page_title, 'Popular on GOV.UK' %>
+<% content_for :title, 'Popular on GOV.UK' %>
+<% content_for :title_context, 'Homepage' %>
+<div class="govuk-grid-column-two-thirds">
+  <%= render "homepage/popular_links/version_and_status", version: @latest_popular_links.version_number, status: @latest_popular_links.state %>
+  <% @latest_popular_links.link_items.each_with_index do |item, index| %>
+    <%= render "homepage/popular_links/link", item:, index: %>
+  <% end %>
+</div>

--- a/app/views/shared/_summary_card.html.erb
+++ b/app/views/shared/_summary_card.html.erb
@@ -1,0 +1,47 @@
+<%
+  id ||= nil
+  data_attributes ||= {}
+  summary_card_actions ||= []
+  rows ||=[]
+%>
+<%= tag.div class: "app-c-summary-card", id: id, data: data_attributes do %>
+  <div class="govuk-summary-card">
+    <div class="govuk-summary-card__title-wrapper">
+      <h2 class="govuk-summary-card__title"><%= title %></h2>
+      <ul class="govuk-summary-card__actions">
+        <% summary_card_actions.each do |action| %>
+          <li class="govuk-summary-card__action">
+            <%= link_to sanitize(action[:label] + tag.span(" #{title}", class: "govuk-visually-hidden")), action[:href], class: "govuk-link govuk-link--no-visited-state #{"gem-link--destructive govuk-!-font-weight-bold" if action[:destructive]}".strip %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+    <% if rows.present? %>
+      <div class="govuk-summary-card__content">
+        <dl class="govuk-summary-list">
+          <% rows.each do |row| %>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                <%= row[:key] %>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <%= row[:value] %>
+              </dd>
+              <% if row[:actions].present? %>
+                <dd class="govuk-summary-list__actions">
+                  <% row[:actions].each do |action| %>
+                    <% if action[:opens_in_new_tab] %>
+                      <%= link_to sanitize(action[:label] + tag.span(" #{row[:key]} (opens in new tab)", class: "govuk-visually-hidden")), action[:href], class: "govuk-link govuk-link--no-visited-state govuk-!-margin-left-2", rel: "noreferrer noopener", target: "_blank" %>
+                    <% else %>
+                      <%= link_to sanitize(action[:label] + tag.span(" #{row[:key]}", class: "govuk-visually-hidden")), action[:href], class: "govuk-link govuk-link--no-visited-state govuk-!-margin-left-2 #{"gem-link--destructive" if action[:destructive]}".strip %>
+                    <% end %>
+                  <% end %>
+                </dd>
+              <% end %>
+            </div>
+          <% end %>
+        </dl>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,8 @@ Rails.application.routes.draw do
 
   get "/govuk-sitemap.xml" => "sitemap#index"
 
+  get "/homepage/popular-links" => "homepage#show"
+
   mount GovukAdminTemplate::Engine, at: "/style-guide"
   mount Flipflop::Engine => "/flipflop"
 end

--- a/test/functional/homepage_controller_test.rb
+++ b/test/functional/homepage_controller_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class HomepageControllerTest < ActionController::TestCase
+  setup do
+    login_as_stub_user
+  end
+
+  context "#show" do
+    setup do
+      @popular_links = FactoryBot.create(:popular_links)
+    end
+
+    should "render show template" do
+      get :show
+
+      assert_response :ok
+      assert_template "homepage/popular_links/show"
+    end
+  end
+end

--- a/test/integration/homepage_popular_links_test.rb
+++ b/test/integration/homepage_popular_links_test.rb
@@ -1,0 +1,35 @@
+require "integration_test_helper"
+
+class HomepagePopularLinksTest < JavascriptIntegrationTest
+  setup do
+    setup_users
+    @popular_links = FactoryBot.create(:popular_links)
+    visit_popular_links
+  end
+
+  should "show page title" do
+    assert_title "Popular on GOV.UK"
+  end
+
+  should "show 'Homepage' as a page title context" do
+    assert page.has_content?("Homepage")
+  end
+
+  should "have 6 links with title and url" do
+    assert page.has_css?(".govuk-summary-card__title", count: 6)
+    assert page.has_text?("Title", count: 6)
+    assert page.has_text?("URL", count: 6)
+  end
+
+  should "have popular links version and status" do
+    assert page.has_text?("Edition")
+    assert page.has_text?(@popular_links.version_number)
+    assert page.has_text?("Status")
+    assert page.has_text?("DRAFT")
+    assert page.has_css?(".govuk-tag--yellow")
+  end
+
+  def visit_popular_links
+    visit "/homepage/popular-links"
+  end
+end

--- a/test/integration/root_overview_test.rb
+++ b/test/integration/root_overview_test.rb
@@ -300,4 +300,20 @@ class RootOverviewTest < ActionDispatch::IntegrationTest
 
     assert page.has_link?("/test-slug", href: "#{Plek.website_root}/test-slug")
   end
+
+  test "should not render popular links edition" do
+    FactoryBot.create(:user, :govuk_editor)
+    FactoryBot.create(:guide_edition, title: "Draft guide")
+    FactoryBot.create(:transaction_edition, title: "Draft transaction")
+    FactoryBot.create(:popular_links, title: "Popular links edition")
+
+    visit "/"
+
+    filter_by_user("All")
+
+    assert page.has_content?("Draft guide")
+    assert page.has_content?("Draft transaction")
+    assert page.has_content?("Draft guide")
+    assert page.has_no_content?("Popular links edition")
+  end
 end

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -234,6 +234,8 @@ class EditionTest < ActiveSupport::TestCase
 
   # test cloning into different edition types
   Edition.subclasses.permutation(2).each do |source_class, destination_class|
+    next if source_class.instance_of?(PopularLinksEdition.class) || destination_class.instance_of?(PopularLinksEdition.class)
+
     test "it should be possible to clone from a #{source_class} to a #{destination_class}" do
       # Note that the new edition won't necessarily be valid - for example the
       # new type might have required fields that the old just doesn't have.
@@ -469,7 +471,7 @@ class EditionTest < ActiveSupport::TestCase
 
   test "should scope publications by assignee" do
     stub_request(:get, %r{http://panopticon\.test\.gov\.uk/artefacts/.*\.js})
-        .to_return(status: 200, body: "{}", headers: {})
+      .to_return(status: 200, body: "{}", headers: {})
 
     a, b = 2.times.map { FactoryBot.create(:guide_edition, panopticon_id: @artefact.id) }
 
@@ -567,7 +569,7 @@ class EditionTest < ActiveSupport::TestCase
 
   test "should scope publications assigned to nobody" do
     stub_request(:get, %r{http://panopticon\.test\.gov\.uk/artefacts/.*\.js})
-        .to_return(status: 200, body: "{}", headers: {})
+      .to_return(status: 200, body: "{}", headers: {})
 
     a, b = 2.times.map { |_i| FactoryBot.create(:guide_edition, panopticon_id: @artefact.id) }
 
@@ -947,8 +949,10 @@ class EditionTest < ActiveSupport::TestCase
     assert_nil published_edition.reload.sibling_in_progress
   end
 
-  test "all subclasses should provide a working whole_body method for diffing" do
+  test "all subclasses except popular links should provide a working whole_body method for diffing" do
     Edition.subclasses.each do |klass|
+      next if klass.instance_of?(PopularLinksEdition.class)
+
       assert klass.instance_methods.include?(:whole_body), "#{klass} doesn't provide a whole_body"
       assert_nothing_raised do
         klass.new.whole_body

--- a/test/models/popular_links_edition_test.rb
+++ b/test/models/popular_links_edition_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class PopularLinksEditionTest < ActiveSupport::TestCase
+  should "save" do
+    popular_links = FactoryBot.build(:popular_links)
+    assert popular_links.save
+  end
+
+  should "validate 6 links are present" do
+    link_items = [{ url: "url1", title: "title1" }]
+    popular_links = FactoryBot.build(:popular_links, link_items:)
+
+    assert_not popular_links.valid?
+    assert popular_links.errors[:link_items].any?
+  end
+
+  should "validate all links have url" do
+    link_items = [{ title: "title1" },
+                  { url: "url2", title: "title2" },
+                  { url: "url3", title: "title3" },
+                  { url: "url4", title: "title4" },
+                  { url: "url5", title: "title5" },
+                  { url: "url6", title: "title6" }]
+    popular_links = FactoryBot.build(:popular_links, link_items:)
+
+    assert_not popular_links.valid?
+    assert_equal popular_links.errors[:item][0], "A URL is required for Link 1"
+  end
+
+  should "validate all links have title" do
+    link_items = [{ url: "url1" },
+                  { url: "url2", title: "title2" },
+                  { url: "url3", title: "title3" },
+                  { url: "url4", title: "title4" },
+                  { url: "url5", title: "title5" },
+                  { url: "url6", title: "title6" }]
+    popular_links = FactoryBot.build(:popular_links, link_items:)
+
+    assert_not popular_links.valid?
+    assert_equal popular_links.errors[:item][0], "A Title is required for Link 1"
+  end
+end

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -181,6 +181,11 @@ FactoryBot.define do
     sequence(:title) { |n| "Test guide #{n}" }
   end
 
+  factory :popular_links, class: "PopularLinksEdition" do
+    title { "Homepage Popular Links" }
+    link_items { [{ url: "url1", title: "title1" }, { url: "url2", title: "title2" }, { url: "url3", title: "title3" }, { url: "url4", title: "title4" }, { url: "url5", title: "title5" }, { url: "url6", title: "title6" }] }
+  end
+
   factory :programme_edition, parent: :edition, class: "ProgrammeEdition" do
     sequence(:title) { |n| "Test programme #{n}" }
   end


### PR DESCRIPTION
[Trello card](https://trello.com/c/6xb4YYE7/299-create-a-page-to-show-popular-links)

We want the ability to view the latest published popular links within Mainstream Publisher.

In order to be able to do that, this is the first story to allow us to navigate to popular links page and view the last version of popular links. The ability to view the popular links will be provided by subsequent tickets. In order to be able to view we needed to create the model so that we can insert the very first record. 