### PR TITLE
Remove redundant govuk_admin_template config

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,7 +34,7 @@ class ApplicationController < ActionController::Base
 
   def notify_bad_request(exception)
     # TODO: control this via the log level rather than an environment variable
-    if %w[integration staging].include?(ENV["GOVUK_ENVIRONMENT_NAME"]) && exception.message =~ /team-only API key/
+    if %w[integration staging].include?(ENV["GOVUK_ENVIRONMENT"]) && exception.message =~ /team-only API key/
       # in production we care about all errors
       # in staging and integration the team-only error may be encountered by
       # end-users who should see a more helpful error message

--- a/config/initializers/govuk_admin_template.rb
+++ b/config/initializers/govuk_admin_template.rb
@@ -2,6 +2,3 @@ GovukAdminTemplate.configure do |c|
   c.app_title = "GOV.UK Publisher"
   c.show_signout = true
 end
-
-GovukAdminTemplate.environment_label = ENV.fetch("GOVUK_ENVIRONMENT_NAME", "development").titleize
-GovukAdminTemplate.environment_style = ENV["GOVUK_ENVIRONMENT_NAME"] == "production" ? "production" : "preview"


### PR DESCRIPTION
As of version 7.0, the config is now the default gem behaviour.

https://github.com/alphagov/govuk_admin_template/blob/06d93749b4482f062e721ce300ff9509d08c4c0b/lib/govuk_admin_template.rb#L10