### PR TITLE
Publish popular links

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -16,8 +16,8 @@ class HomepageController < ApplicationController
   end
 
   def update
-    update_link_items
-    UpdateWorker.perform_async(@latest_popular_links.id.to_s, update_action_is_publish?)
+    @latest_popular_links.link_items = remove_leading_and_trailing_url_spaces(params[:popular_links].values)
+    @latest_popular_links.save_draft
 
     flash[:success] = "Popular links draft saved.".html_safe
     redirect_to show_popular_links_path
@@ -26,7 +26,8 @@ class HomepageController < ApplicationController
   end
 
   def publish
-    publish_latest_popular_links
+    @latest_popular_links.publish
+    flash[:success] = "Popular links successfully published.".html_safe
     render "homepage/popular_links/show"
   end
 
@@ -36,11 +37,6 @@ private
     @latest_popular_links = PopularLinksEdition.last
   end
 
-  def update_link_items
-    @latest_popular_links.link_items = remove_leading_and_trailing_url_spaces(params[:popular_links].values)
-    @latest_popular_links.save!
-  end
-
   def remove_leading_and_trailing_url_spaces(links)
     link_items = []
     links.each do |link|
@@ -48,17 +44,5 @@ private
       link_items << link
     end
     link_items
-  end
-
-  def publish_latest_popular_links
-    @latest_popular_links.publish_popular_links
-  end
-
-  def update_action_is_publish?
-    attempted_activity == :publish
-  end
-
-  def attempted_activity
-    Edition::ACTIONS.invert[params[:commit]]
   end
 end

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -17,6 +17,8 @@ class HomepageController < ApplicationController
 
   def update
     update_link_items
+    UpdateWorker.perform_async(@latest_popular_links.id.to_s, update_action_is_publish?)
+
     flash[:success] = "Popular links draft saved.".html_safe
     redirect_to show_popular_links_path
   rescue StandardError
@@ -50,5 +52,13 @@ private
 
   def publish_latest_popular_links
     @latest_popular_links.publish_popular_links
+  end
+
+  def update_action_is_publish?
+    attempted_activity == :publish
+  end
+
+  def attempted_activity
+    Edition::ACTIONS.invert[params[:commit]]
   end
 end

--- a/app/models/popular_links_edition.rb
+++ b/app/models/popular_links_edition.rb
@@ -34,7 +34,28 @@ class PopularLinksEdition < Edition
     popular_links
   end
 
+  def publish
+    Services.publishing_api.publish(content_id, update_type, locale:)
+    # This publish_popular_links is a new workflow that was introduced for popular links.
+    publish_popular_links
+  end
+
+  def save_draft
+    UpdateService.call(self)
+    save!
+  end
+
   def content_id
     "ad7968d0-0339-40b2-80bc-3ea1db8ef1b7".freeze
+  end
+
+  # PopularLinks updates are going to be a major update
+  # as there is no real reason for having a minor update
+  def update_type
+    "major".freeze
+  end
+
+  def locale
+    "en".freeze
   end
 end

--- a/app/models/popular_links_edition.rb
+++ b/app/models/popular_links_edition.rb
@@ -33,4 +33,8 @@ class PopularLinksEdition < Edition
     popular_links.save!
     popular_links
   end
+
+  def content_id
+    "ad7968d0-0339-40b2-80bc-3ea1db8ef1b7".freeze
+  end
 end

--- a/app/presenters/formats/popular_links_presenter.rb
+++ b/app/presenters/formats/popular_links_presenter.rb
@@ -1,0 +1,46 @@
+module Formats
+  class PopularLinksPresenter
+    # Unlike presenters for other models which inherit from editions model,
+    # PopularLinksPresenter does not inherit from EditionFormatPresenter
+    # This is because Edition presenter has dependency on Artefact and
+    # Popular links are not coupled with Artefact unlike any other models.
+    # Hence the difference
+    def initialize(popular_links_edition)
+      @popular_links_edition = popular_links_edition
+    end
+
+    def render_for_publishing_api(*)
+      required_fields.merge optional_fields
+    end
+
+  private
+
+    attr_reader :popular_links_edition
+
+    def required_fields
+      {
+        title: popular_links_edition.title,
+        schema_name: "link_collection",
+        document_type: "link_collection",
+        publishing_app: "publisher",
+        rendering_app: "frontend",
+        details:,
+      }
+    end
+
+    def details
+      {
+        link_items: popular_links_edition.link_items,
+      }
+    end
+
+    def optional_fields
+      access_limited = { auth_bypass_ids: [popular_links_edition.auth_bypass_id] }
+      { access_limited:, public_updated_at: public_updated_at.rfc3339(3) }
+    end
+
+    def public_updated_at
+      popular_links_edition.updated_at
+    end
+  end
+end

--- a/app/services/edition_presenter_factory.rb
+++ b/app/services/edition_presenter_factory.rb
@@ -24,6 +24,8 @@ class EditionPresenterFactory
         "Formats::SimpleSmartAnswerPresenter"
       when "TransactionEdition"
         "Formats::TransactionPresenter"
+      when "PopularLinksEdition"
+        "Formats::PopularLinksPresenter"
       else
         "Formats::GenericEditionPresenter"
       end

--- a/test/functional/homepage_controller_test.rb
+++ b/test/functional/homepage_controller_test.rb
@@ -58,8 +58,6 @@ class HomepageControllerTest < ActionController::TestCase
     end
 
     should "update latest PopularLinksEdition with changed title and url" do
-      UpdateWorker.stubs(:perform_async)
-
       assert_equal "title1", @popular_links.link_items[0][:title]
       assert_equal "https://www.url1.com", @popular_links.link_items[0][:url]
 
@@ -79,22 +77,19 @@ class HomepageControllerTest < ActionController::TestCase
     end
 
     should "update publishing API" do
-      Sidekiq::Testing.inline! do
-        Services.publishing_api.expects(:put_content)
+      Services.publishing_api.expects(:put_content).with(@popular_links.content_id, has_entry(:title, "Homepage Popular Links"))
 
-        patch :update, params: { id: @popular_links.id,
-                                 "popular_links" =>
-                                   { "1" => { "title" => "title", "url" => "url.com" },
-                                     "2" => { "title" => "title2", "url" => "https://www.url2.com" },
-                                     "3" => { "title" => "title3", "url" => "https://www.url3.com" },
-                                     "4" => { "title" => "title4", "url" => "https://www.url4.com" },
-                                     "5" => { "title" => "title5", "url" => "https://www.url5.com" },
-                                     "6" => { "title" => "title6", "url" => "https://www.url6.com" } } }
-      end
+      patch :update, params: { id: @popular_links.id,
+                               "popular_links" =>
+                                 { "1" => { "title" => "title", "url" => "url.com" },
+                                   "2" => { "title" => "title2", "url" => "https://www.url2.com" },
+                                   "3" => { "title" => "title3", "url" => "https://www.url3.com" },
+                                   "4" => { "title" => "title4", "url" => "https://www.url4.com" },
+                                   "5" => { "title" => "title5", "url" => "https://www.url5.com" },
+                                   "6" => { "title" => "title6", "url" => "https://www.url6.com" } } }
     end
 
     should "redirect to show path on success" do
-      UpdateWorker.stubs(:perform_async)
       new_title = "title has changed"
 
       patch :update, params: { id: @popular_links.id,
@@ -131,6 +126,12 @@ class HomepageControllerTest < ActionController::TestCase
       assert_response :ok
       assert_template "homepage/popular_links/show"
       assert_equal "published", PopularLinksEdition.last.state
+    end
+
+    should "publish to publishing API" do
+      Services.publishing_api.expects(:publish).with(@popular_links.content_id, "major", locale: "en")
+
+      post :publish, params: { id: @popular_links.id }
     end
   end
 end

--- a/test/integration/homepage_popular_links_test.rb
+++ b/test/integration/homepage_popular_links_test.rb
@@ -135,6 +135,19 @@ class HomepagePopularLinksTest < JavascriptIntegrationTest
     end
   end
 
+  context "#publish" do
+    setup do
+      click_button("Create new edition")
+    end
+
+    should "publish latest edition when 'Publish' is clicked" do
+      click_button("Publish")
+
+      assert page.has_text?("PUBLISHED")
+      assert page.has_text?("Popular links successfully published.")
+    end
+  end
+
   def visit_popular_links
     visit "/homepage/popular-links"
   end

--- a/test/unit/presenters/formats/popular_links_presenter_test.rb
+++ b/test/unit/presenters/formats/popular_links_presenter_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class PopularLinksPresenterTest < ActiveSupport::TestCase
+  def subject
+    updated_at_time = Time.parse("Thu, 11 Jul 2024 10:47:27.397934771 UTC")
+    Formats::PopularLinksPresenter.new(FactoryBot.create(:popular_links, updated_at: updated_at_time))
+  end
+
+  context "#render_for_publishing_api" do
+    setup do
+      @result = subject.render_for_publishing_api
+    end
+
+    should "be valid against schema" do
+      assert_valid_against_publisher_schema(@result, "link_collection")
+    end
+
+    should "have expected required fields" do
+      assert_equal "Homepage Popular Links", @result[:title]
+      assert_equal "link_collection", @result[:schema_name]
+      assert_equal "link_collection", @result[:document_type]
+      assert_equal "publisher", @result[:publishing_app]
+      assert_equal "frontend", @result[:rendering_app]
+      assert_equal ({ link_items: [{ url: "https://www.url1.com", title: "title1" },
+                                   { url: "https://www.url2.com", title: "title2" },
+                                   { url: "https://www.url3.com", title: "title3" },
+                                   { url: "https://www.url4.com", title: "title4" },
+                                   { url: "https://www.url5.com", title: "title5" },
+                                   { url: "https://www.url6.com", title: "title6" }] }),
+                   @result[:details]
+    end
+
+    should "have expected optional fields" do
+      assert_not_empty @result[:access_limited]
+      assert_not_empty @result[:public_updated_at]
+    end
+  end
+end

--- a/test/unit/services/edition_presenter_factory_test.rb
+++ b/test/unit/services/edition_presenter_factory_test.rb
@@ -51,6 +51,11 @@ class EditionPresenterFactoryTest < ActiveSupport::TestCase
       assert result == "Formats::TransactionPresenter"
     end
 
+    should "return a presenter for PopularLinks" do
+      result = EditionPresenterFactory.presenter_class("PopularLinksEdition")
+      assert result == "Formats::PopularLinksPresenter"
+    end
+
     should "return default presenter for other pages" do
       result = EditionPresenterFactory.presenter_class("any_other_format")
       assert result == "Formats::GenericEditionPresenter"


### PR DESCRIPTION
This PR does the following:

- Calls publishing api to store the updated popular links content to draft content store when an edit and save action is performed on popular links.
- Calls publishing api to store the published popular links content to content store when a publish action is performed on popular links.

[trello](https://trello.com/c/szYiEKlQ/298-enable-publishing-of-popular-links)


