### PR TITLE
Restructure integration tests

### DIFF
--- a/test/integration/add_artefact_test.rb
+++ b/test/integration/add_artefact_test.rb
@@ -1,6 +1,6 @@
 require "integration_test_helper"
 
-class AddArtefactTest < ActionDispatch::IntegrationTest
+class AddArtefactTest < PublisherIntegrationTest
   setup do
     setup_users
     stub_linkables

--- a/test/integration/add_artefact_test.rb
+++ b/test/integration/add_artefact_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class AddArtefactTest < PublisherIntegrationTest
+class AddArtefactTest < LegacyPublisherIntegrationTest
   setup do
     setup_users
     stub_linkables

--- a/test/integration/add_artefact_test.rb
+++ b/test/integration/add_artefact_test.rb
@@ -1,6 +1,6 @@
 require "legacy_integration_test_helper"
 
-class AddArtefactTest < LegacyPublisherIntegrationTest
+class AddArtefactTest < LegacyIntegrationTest
   setup do
     setup_users
     stub_linkables

--- a/test/integration/adding_parts_to_guides_test.rb
+++ b/test/integration/adding_parts_to_guides_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class AddingPartsToGuidesTest < JavascriptIntegrationTest
+class AddingPartsToGuidesTest < LegacyJavascriptIntegrationTest
   setup do
     setup_users
     stub_linkables

--- a/test/integration/adding_variants_to_transactions_test.rb
+++ b/test/integration/adding_variants_to_transactions_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class AddingVariantsToTransactionsTest < JavascriptIntegrationTest
+class AddingVariantsToTransactionsTest < LegacyJavascriptIntegrationTest
   setup do
     setup_users
     stub_linkables

--- a/test/integration/change_edition_type_test.rb
+++ b/test/integration/change_edition_type_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class ChangeEditionTypeTest < JavascriptIntegrationTest
+class ChangeEditionTypeTest < LegacyJavascriptIntegrationTest
   setup do
     stub_linkables
     FactoryBot.create(:user, :govuk_editor)

--- a/test/integration/completed_transactions_create_edit_test.rb
+++ b/test/integration/completed_transactions_create_edit_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class CompletedTransactionCreateEditTest < JavascriptIntegrationTest
+class CompletedTransactionCreateEditTest < LegacyJavascriptIntegrationTest
   setup do
     @artefact = FactoryBot.create(
       :artefact,

--- a/test/integration/delete_edition_test.rb
+++ b/test/integration/delete_edition_test.rb
@@ -1,6 +1,6 @@
 require "legacy_integration_test_helper"
 
-class DeleteEditionTest < LegacyPublisherIntegrationTest
+class DeleteEditionTest < LegacyIntegrationTest
   setup do
     setup_users
     stub_linkables

--- a/test/integration/delete_edition_test.rb
+++ b/test/integration/delete_edition_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class DeleteEditionTest < PublisherIntegrationTest
+class DeleteEditionTest < LegacyPublisherIntegrationTest
   setup do
     setup_users
     stub_linkables

--- a/test/integration/delete_edition_test.rb
+++ b/test/integration/delete_edition_test.rb
@@ -1,6 +1,6 @@
 require "integration_test_helper"
 
-class DeleteEditionTest < ActionDispatch::IntegrationTest
+class DeleteEditionTest < PublisherIntegrationTest
   setup do
     setup_users
     stub_linkables

--- a/test/integration/downtime_integration_test.rb
+++ b/test/integration/downtime_integration_test.rb
@@ -1,6 +1,6 @@
-require "legacy_integration_test_helper"
+require "integration_test_helper"
 
-class DowntimeIntegrationTest < LegacyJavascriptIntegrationTest
+class DowntimeIntegrationTest < JavascriptIntegrationTest
   setup do
     setup_users
 

--- a/test/integration/downtime_integration_test.rb
+++ b/test/integration/downtime_integration_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class DowntimeIntegrationTest < JavascriptIntegrationTest
+class DowntimeIntegrationTest < LegacyJavascriptIntegrationTest
   setup do
     setup_users
 

--- a/test/integration/downtime_with_invalid_dates_test.rb
+++ b/test/integration/downtime_with_invalid_dates_test.rb
@@ -1,6 +1,6 @@
 require "integration_test_helper"
 
-class DowntimeWithInvalidDates < PublisherIntegrationTest
+class DowntimeWithInvalidDates < IntegrationTest
   setup do
     setup_users
 

--- a/test/integration/downtime_with_invalid_dates_test.rb
+++ b/test/integration/downtime_with_invalid_dates_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class DowntimeWithInvalidDates < PublisherIntegrationTest
+class DowntimeWithInvalidDates < LegacyPublisherIntegrationTest
   setup do
     setup_users
 

--- a/test/integration/downtime_with_invalid_dates_test.rb
+++ b/test/integration/downtime_with_invalid_dates_test.rb
@@ -1,6 +1,6 @@
 require "integration_test_helper"
 
-class DowntimeWithInvalidDates < ActionDispatch::IntegrationTest
+class DowntimeWithInvalidDates < PublisherIntegrationTest
   setup do
     setup_users
 

--- a/test/integration/downtime_with_invalid_dates_test.rb
+++ b/test/integration/downtime_with_invalid_dates_test.rb
@@ -1,6 +1,6 @@
-require "legacy_integration_test_helper"
+require "integration_test_helper"
 
-class DowntimeWithInvalidDates < LegacyPublisherIntegrationTest
+class DowntimeWithInvalidDates < PublisherIntegrationTest
   setup do
     setup_users
 

--- a/test/integration/edit_artefact_test.rb
+++ b/test/integration/edit_artefact_test.rb
@@ -1,6 +1,6 @@
 require "integration_test_helper"
 
-class EditArtefactTest < ActionDispatch::IntegrationTest
+class EditArtefactTest < PublisherIntegrationTest
   setup do
     setup_users
     stub_linkables

--- a/test/integration/edit_artefact_test.rb
+++ b/test/integration/edit_artefact_test.rb
@@ -1,6 +1,6 @@
 require "legacy_integration_test_helper"
 
-class EditArtefactTest < LegacyPublisherIntegrationTest
+class EditArtefactTest < LegacyIntegrationTest
   setup do
     setup_users
     stub_linkables

--- a/test/integration/edit_artefact_test.rb
+++ b/test/integration/edit_artefact_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class EditArtefactTest < PublisherIntegrationTest
+class EditArtefactTest < LegacyPublisherIntegrationTest
   setup do
     setup_users
     stub_linkables

--- a/test/integration/edition_history_test.rb
+++ b/test/integration/edition_history_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class EditionHistoryTest < JavascriptIntegrationTest
+class EditionHistoryTest < LegacyJavascriptIntegrationTest
   setup do
     setup_users
     stub_linkables

--- a/test/integration/edition_link_check_test.rb
+++ b/test/integration/edition_link_check_test.rb
@@ -1,7 +1,7 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 require "gds_api/test_helpers/link_checker_api"
 
-class EditionLinkCheckTest < JavascriptIntegrationTest
+class EditionLinkCheckTest < LegacyJavascriptIntegrationTest
   include GdsApi::TestHelpers::LinkCheckerApi
 
   setup do

--- a/test/integration/edition_major_change_test.rb
+++ b/test/integration/edition_major_change_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class EditionMajorChangeTest < JavascriptIntegrationTest
+class EditionMajorChangeTest < LegacyJavascriptIntegrationTest
   setup do
     setup_users
     stub_linkables

--- a/test/integration/edition_scheduled_publishing_test.rb
+++ b/test/integration/edition_scheduled_publishing_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class EditionScheduledPublishingTest < JavascriptIntegrationTest
+class EditionScheduledPublishingTest < LegacyJavascriptIntegrationTest
   setup do
     setup_users
     stub_linkables

--- a/test/integration/edition_tab_test.rb
+++ b/test/integration/edition_tab_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class EditionTabTest < JavascriptIntegrationTest
+class EditionTabTest < LegacyJavascriptIntegrationTest
   setup do
     setup_users
     stub_linkables

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -1,7 +1,7 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 require "gds_api/test_helpers/calendars"
 
-class EditionWorkflowTest < JavascriptIntegrationTest
+class EditionWorkflowTest < LegacyJavascriptIntegrationTest
   include GdsApi::TestHelpers::Calendars
   attr_reader :alice, :bob, :guide
 

--- a/test/integration/fact_check_email_test.rb
+++ b/test/integration/fact_check_email_test.rb
@@ -1,6 +1,6 @@
 require "legacy_integration_test_helper"
 
-class FactCheckEmailTest < LegacyPublisherIntegrationTest
+class FactCheckEmailTest < LegacyIntegrationTest
   def fact_check_mail_for(edition, attrs = {})
     message = Mail.new do
       from    attrs.fetch(:from,    "foo@example.com")

--- a/test/integration/fact_check_email_test.rb
+++ b/test/integration/fact_check_email_test.rb
@@ -1,6 +1,6 @@
 require "integration_test_helper"
 
-class FactCheckEmailTest < ActionDispatch::IntegrationTest
+class FactCheckEmailTest < PublisherIntegrationTest
   def fact_check_mail_for(edition, attrs = {})
     message = Mail.new do
       from    attrs.fetch(:from,    "foo@example.com")

--- a/test/integration/fact_check_email_test.rb
+++ b/test/integration/fact_check_email_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class FactCheckEmailTest < PublisherIntegrationTest
+class FactCheckEmailTest < LegacyPublisherIntegrationTest
   def fact_check_mail_for(edition, attrs = {})
     message = Mail.new do
       from    attrs.fetch(:from,    "foo@example.com")

--- a/test/integration/guide_create_edit_test.rb
+++ b/test/integration/guide_create_edit_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class GuideCreateEditTest < JavascriptIntegrationTest
+class GuideCreateEditTest < LegacyJavascriptIntegrationTest
   setup do
     setup_users
     stub_linkables

--- a/test/integration/healthcheck_test.rb
+++ b/test/integration/healthcheck_test.rb
@@ -1,6 +1,6 @@
 require "legacy_integration_test_helper"
 
-class HealthcheckTest < LegacyPublisherIntegrationTest
+class HealthcheckTest < LegacyIntegrationTest
   def json
     JSON.parse(response.body)
   end

--- a/test/integration/healthcheck_test.rb
+++ b/test/integration/healthcheck_test.rb
@@ -1,6 +1,6 @@
-require "test_helper"
+require "integration_test_helper"
 
-class HealthcheckTest < ActionDispatch::IntegrationTest
+class HealthcheckTest < PublisherIntegrationTest
   def json
     JSON.parse(response.body)
   end

--- a/test/integration/healthcheck_test.rb
+++ b/test/integration/healthcheck_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class HealthcheckTest < PublisherIntegrationTest
+class HealthcheckTest < LegacyPublisherIntegrationTest
   def json
     JSON.parse(response.body)
   end

--- a/test/integration/help_page_create_edit_test.rb
+++ b/test/integration/help_page_create_edit_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class HelpPageCreateEditTest < JavascriptIntegrationTest
+class HelpPageCreateEditTest < LegacyJavascriptIntegrationTest
   setup do
     @artefact = FactoryBot.create(
       :artefact,

--- a/test/integration/homepage_popular_links_test.rb
+++ b/test/integration/homepage_popular_links_test.rb
@@ -1,6 +1,6 @@
-require "legacy_integration_test_helper"
+require "integration_test_helper"
 
-class HomepagePopularLinksTest < LegacyJavascriptIntegrationTest
+class HomepagePopularLinksTest < JavascriptIntegrationTest
   setup do
     setup_users
     @popular_links = FactoryBot.create(:popular_links, state: "published")

--- a/test/integration/homepage_popular_links_test.rb
+++ b/test/integration/homepage_popular_links_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class HomepagePopularLinksTest < JavascriptIntegrationTest
+class HomepagePopularLinksTest < LegacyJavascriptIntegrationTest
   setup do
     setup_users
     @popular_links = FactoryBot.create(:popular_links, state: "published")

--- a/test/integration/legacy_redirect_test.rb
+++ b/test/integration/legacy_redirect_test.rb
@@ -1,6 +1,6 @@
 require "legacy_integration_test_helper"
 
-class LegacyRedirect < LegacyPublisherIntegrationTest
+class LegacyRedirect < LegacyIntegrationTest
   should "redirect requests for the old index to the new one" do
     get "/admin"
     assert_response :redirect

--- a/test/integration/legacy_redirect_test.rb
+++ b/test/integration/legacy_redirect_test.rb
@@ -1,6 +1,6 @@
 require "integration_test_helper"
 
-class LegacyRedirect < ActionDispatch::IntegrationTest
+class LegacyRedirect < PublisherIntegrationTest
   should "redirect requests for the old index to the new one" do
     get "/admin"
     assert_response :redirect

--- a/test/integration/legacy_redirect_test.rb
+++ b/test/integration/legacy_redirect_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class LegacyRedirect < PublisherIntegrationTest
+class LegacyRedirect < LegacyPublisherIntegrationTest
   should "redirect requests for the old index to the new one" do
     get "/admin"
     assert_response :redirect

--- a/test/integration/legacy_root_overview_test.rb
+++ b/test/integration/legacy_root_overview_test.rb
@@ -1,8 +1,11 @@
 require_relative "../legacy_integration_test_helper"
 
-class RootOverviewTest < LegacyPublisherIntegrationTest
+class LegacyRootOverviewTest < LegacyPublisherIntegrationTest
   setup do
     stub_holidays_used_by_fact_check
+
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:design_system_publications_filter, false)
   end
 
   test "filtering by assigned user" do

--- a/test/integration/legacy_root_overview_test.rb
+++ b/test/integration/legacy_root_overview_test.rb
@@ -1,6 +1,6 @@
 require_relative "../legacy_integration_test_helper"
 
-class LegacyRootOverviewTest < LegacyPublisherIntegrationTest
+class LegacyRootOverviewTest < LegacyIntegrationTest
   setup do
     stub_holidays_used_by_fact_check
 

--- a/test/integration/local_transaction_create_edit_test.rb
+++ b/test/integration/local_transaction_create_edit_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class LocalTransactionCreateEditTest < JavascriptIntegrationTest
+class LocalTransactionCreateEditTest < LegacyJavascriptIntegrationTest
   setup do
     LocalService.create!(lgsl_code: 1, providing_tier: %w[county unitary])
 

--- a/test/integration/mark_edition_in_beta_test.rb
+++ b/test/integration/mark_edition_in_beta_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class MarkEditionInBetaTest < JavascriptIntegrationTest
+class MarkEditionInBetaTest < LegacyJavascriptIntegrationTest
   setup do
     setup_users
     stub_linkables

--- a/test/integration/previous_edition_differences_test.rb
+++ b/test/integration/previous_edition_differences_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class PreviousEditionDifferencesTest < JavascriptIntegrationTest
+class PreviousEditionDifferencesTest < LegacyJavascriptIntegrationTest
   setup do
     stub_register_published_content
     setup_users

--- a/test/integration/request_tracing_test.rb
+++ b/test/integration/request_tracing_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class RequestTracingTest < PublisherIntegrationTest
+class RequestTracingTest < LegacyPublisherIntegrationTest
   setup do
     setup_users
     stub_register_published_content

--- a/test/integration/request_tracing_test.rb
+++ b/test/integration/request_tracing_test.rb
@@ -1,6 +1,6 @@
 require "legacy_integration_test_helper"
 
-class RequestTracingTest < LegacyPublisherIntegrationTest
+class RequestTracingTest < LegacyIntegrationTest
   setup do
     setup_users
     stub_register_published_content

--- a/test/integration/request_tracing_test.rb
+++ b/test/integration/request_tracing_test.rb
@@ -1,6 +1,6 @@
 require "integration_test_helper"
 
-class RequestTracingTest < ActionDispatch::IntegrationTest
+class RequestTracingTest < PublisherIntegrationTest
   setup do
     setup_users
     stub_register_published_content

--- a/test/integration/root_overview_test.rb
+++ b/test/integration/root_overview_test.rb
@@ -1,6 +1,6 @@
 require_relative "../integration_test_helper"
 
-class RootOverviewTest < ActionDispatch::IntegrationTest
+class RootOverviewTest < PublisherIntegrationTest
   setup do
     stub_holidays_used_by_fact_check
   end

--- a/test/integration/root_overview_test.rb
+++ b/test/integration/root_overview_test.rb
@@ -1,6 +1,6 @@
-require_relative "../integration_test_helper"
+require_relative "../legacy_integration_test_helper"
 
-class RootOverviewTest < PublisherIntegrationTest
+class RootOverviewTest < LegacyPublisherIntegrationTest
   setup do
     stub_holidays_used_by_fact_check
   end

--- a/test/integration/routes_test.rb
+++ b/test/integration/routes_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class RoutesTest < PublisherIntegrationTest
+class RoutesTest < LegacyPublisherIntegrationTest
   should "route to downtimes controller for edit downtime" do
     edition = FactoryBot.create(:edition)
     edition_id = edition.id.to_s

--- a/test/integration/routes_test.rb
+++ b/test/integration/routes_test.rb
@@ -1,6 +1,6 @@
 require "integration_test_helper"
 
-class RoutesTest < ActionDispatch::IntegrationTest
+class RoutesTest < PublisherIntegrationTest
   should "route to downtimes controller for edit downtime" do
     edition = FactoryBot.create(:edition)
     edition_id = edition.id.to_s

--- a/test/integration/routes_test.rb
+++ b/test/integration/routes_test.rb
@@ -1,6 +1,6 @@
 require "legacy_integration_test_helper"
 
-class RoutesTest < LegacyPublisherIntegrationTest
+class RoutesTest < LegacyIntegrationTest
   should "route to downtimes controller for edit downtime" do
     edition = FactoryBot.create(:edition)
     edition_id = edition.id.to_s

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class SimpleSmartAnswersTest < JavascriptIntegrationTest
+class SimpleSmartAnswersTest < LegacyJavascriptIntegrationTest
   setup do
     @artefact = FactoryBot.create(
       :artefact,

--- a/test/integration/skip_review_test.rb
+++ b/test/integration/skip_review_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class SkipReviewTest < JavascriptIntegrationTest
+class SkipReviewTest < LegacyJavascriptIntegrationTest
   setup do
     @permitted_user = FactoryBot.create(
       :user,

--- a/test/integration/tagging_test.rb
+++ b/test/integration/tagging_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class TaggingTest < JavascriptIntegrationTest
+class TaggingTest < LegacyJavascriptIntegrationTest
   setup do
     setup_users
     stub_linkables

--- a/test/integration/transaction_create_edit_test.rb
+++ b/test/integration/transaction_create_edit_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class TransactionCreateEditTest < JavascriptIntegrationTest
+class TransactionCreateEditTest < LegacyJavascriptIntegrationTest
   setup do
     @artefact = FactoryBot.create(
       :artefact,

--- a/test/integration/unpublish_test.rb
+++ b/test/integration/unpublish_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class UnpublishTest < PublisherIntegrationTest
+class UnpublishTest < LegacyPublisherIntegrationTest
   setup do
     @artefact = FactoryBot.create(
       :artefact,

--- a/test/integration/unpublish_test.rb
+++ b/test/integration/unpublish_test.rb
@@ -1,6 +1,6 @@
 require "legacy_integration_test_helper"
 
-class UnpublishTest < LegacyPublisherIntegrationTest
+class UnpublishTest < LegacyIntegrationTest
   setup do
     @artefact = FactoryBot.create(
       :artefact,

--- a/test/integration/unpublish_test.rb
+++ b/test/integration/unpublish_test.rb
@@ -1,6 +1,6 @@
 require "integration_test_helper"
 
-class UnpublishTest < ActionDispatch::IntegrationTest
+class UnpublishTest < PublisherIntegrationTest
   setup do
     @artefact = FactoryBot.create(
       :artefact,

--- a/test/integration/user_search_test.rb
+++ b/test/integration/user_search_test.rb
@@ -1,6 +1,6 @@
 require_relative "../legacy_integration_test_helper"
 
-class UserSearchTest < LegacyPublisherIntegrationTest
+class UserSearchTest < LegacyIntegrationTest
   setup do
     alice = FactoryBot.create(:user, name: "Alice", uid: "alice")
     GDS::SSO.test_user = alice

--- a/test/integration/user_search_test.rb
+++ b/test/integration/user_search_test.rb
@@ -1,6 +1,6 @@
-require_relative "../integration_test_helper"
+require_relative "../legacy_integration_test_helper"
 
-class UserSearchTest < PublisherIntegrationTest
+class UserSearchTest < LegacyPublisherIntegrationTest
   setup do
     alice = FactoryBot.create(:user, name: "Alice", uid: "alice")
     GDS::SSO.test_user = alice

--- a/test/integration/user_search_test.rb
+++ b/test/integration/user_search_test.rb
@@ -1,6 +1,6 @@
 require_relative "../integration_test_helper"
 
-class UserSearchTest < ActionDispatch::IntegrationTest
+class UserSearchTest < PublisherIntegrationTest
   setup do
     alice = FactoryBot.create(:user, name: "Alice", uid: "alice")
     GDS::SSO.test_user = alice

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -3,7 +3,7 @@ require "capybara/rails"
 require "capybara-select-2"
 require "support/govuk_test"
 
-class PublisherIntegrationTest < ActionDispatch::IntegrationTest
+class IntegrationTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
   include CapybaraSelect2
   include CapybaraSelect2::Helpers
@@ -29,7 +29,7 @@ class PublisherIntegrationTest < ActionDispatch::IntegrationTest
   end
 end
 
-class JavascriptIntegrationTest < PublisherIntegrationTest
+class JavascriptIntegrationTest < IntegrationTest
   setup do
     Capybara.current_driver = Capybara.javascript_driver
   end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -3,7 +3,7 @@ require "capybara/rails"
 require "capybara-select-2"
 require "support/govuk_test"
 
-class ActionDispatch::IntegrationTest
+class PublisherIntegrationTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
   include CapybaraSelect2
   include CapybaraSelect2::Helpers
@@ -95,7 +95,7 @@ class ActionDispatch::IntegrationTest
   end
 end
 
-class JavascriptIntegrationTest < ActionDispatch::IntegrationTest
+class JavascriptIntegrationTest < PublisherIntegrationTest
   setup do
     Capybara.current_driver = Capybara.javascript_driver
   end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+require "capybara/rails"
+require "capybara-select-2"
+require "support/govuk_test"
+
+class PublisherIntegrationTest < ActionDispatch::IntegrationTest
+  include Capybara::DSL
+  include CapybaraSelect2
+  include CapybaraSelect2::Helpers
+  include Warden::Test::Helpers
+
+  teardown do
+    Capybara.reset_sessions! # Forget the (simulated) browser state
+    Capybara.use_default_driver # Revert Capybara.current_driver to Capybara.default_driver
+    GDS::SSO.test_user = nil
+  end
+
+  def setup_users
+    # This may not be the right way to do things. We rely on the gds-sso
+    # having a strategy that uses the first user. We probably want some
+    # tests that cover the oauth interaction properly
+    @author = FactoryBot.create(:user, :govuk_editor, name: "Author", email: "test@example.com")
+    @reviewer = FactoryBot.create(:user, :govuk_editor, name: "Reviewer", email: "test@example.com")
+  end
+
+  def login_as(user)
+    GDS::SSO.test_user = user
+    super(user)
+  end
+end
+
+class JavascriptIntegrationTest < PublisherIntegrationTest
+  setup do
+    Capybara.current_driver = Capybara.javascript_driver
+  end
+
+  # Get a single user by their name. If the user doesn't exist, return nil.
+  def get_user(name)
+    User.where(name:).first
+  end
+
+  # Set the given user to be the current user
+  # Accepts either a User object or a user's name
+  def login_as(user)
+    unless user.is_a?(User)
+      user = get_user(user)
+    end
+    clear_cookies
+    GDS::SSO.test_user = user
+  end
+
+  def clear_cookies
+    browser = Capybara.current_session.driver.browser
+    if browser.respond_to?(:clear_cookies)
+      # Rack::MockSession
+      browser.clear_cookies
+    elsif browser.respond_to?(:manage) && browser.manage.respond_to?(:delete_all_cookies)
+      # Selenium::WebDriver
+      browser.manage.delete_all_cookies
+    end
+  end
+end

--- a/test/legacy_integration_test_helper.rb
+++ b/test/legacy_integration_test_helper.rb
@@ -3,7 +3,7 @@ require "capybara/rails"
 require "capybara-select-2"
 require "support/govuk_test"
 
-class LegacyPublisherIntegrationTest < ActionDispatch::IntegrationTest
+class LegacyIntegrationTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
   include CapybaraSelect2
   include CapybaraSelect2::Helpers
@@ -95,7 +95,7 @@ class LegacyPublisherIntegrationTest < ActionDispatch::IntegrationTest
   end
 end
 
-class LegacyJavascriptIntegrationTest < LegacyPublisherIntegrationTest
+class LegacyJavascriptIntegrationTest < LegacyIntegrationTest
   setup do
     Capybara.current_driver = Capybara.javascript_driver
   end

--- a/test/legacy_integration_test_helper.rb
+++ b/test/legacy_integration_test_helper.rb
@@ -3,7 +3,7 @@ require "capybara/rails"
 require "capybara-select-2"
 require "support/govuk_test"
 
-class PublisherIntegrationTest < ActionDispatch::IntegrationTest
+class LegacyPublisherIntegrationTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
   include CapybaraSelect2
   include CapybaraSelect2::Helpers
@@ -95,7 +95,7 @@ class PublisherIntegrationTest < ActionDispatch::IntegrationTest
   end
 end
 
-class JavascriptIntegrationTest < PublisherIntegrationTest
+class LegacyJavascriptIntegrationTest < LegacyPublisherIntegrationTest
   setup do
     Capybara.current_driver = Capybara.javascript_driver
   end

--- a/test/unit/edition_churn_presenter_test.rb
+++ b/test/unit/edition_churn_presenter_test.rb
@@ -1,6 +1,6 @@
-require "integration_test_helper"
+require "legacy_integration_test_helper"
 
-class EditionChurnPresenterTest < PublisherIntegrationTest
+class EditionChurnPresenterTest < LegacyPublisherIntegrationTest
   should "provide a CSV export of the churn in editions" do
     document = FactoryBot.create(
       :artefact,

--- a/test/unit/edition_churn_presenter_test.rb
+++ b/test/unit/edition_churn_presenter_test.rb
@@ -1,6 +1,6 @@
-require "test_helper"
+require "integration_test_helper"
 
-class EditionChurnPresenterTest < ActionDispatch::IntegrationTest
+class EditionChurnPresenterTest < PublisherIntegrationTest
   should "provide a CSV export of the churn in editions" do
     document = FactoryBot.create(
       :artefact,

--- a/test/unit/edition_churn_presenter_test.rb
+++ b/test/unit/edition_churn_presenter_test.rb
@@ -1,6 +1,6 @@
 require "legacy_integration_test_helper"
 
-class EditionChurnPresenterTest < LegacyPublisherIntegrationTest
+class EditionChurnPresenterTest < LegacyIntegrationTest
   should "provide a CSV export of the churn in editions" do
     document = FactoryBot.create(
       :artefact,


### PR DESCRIPTION
Prepare for integration test helpers that are useful for pages transitioned to the GOV.UK Design System.

The classes in the integration test helper file contain lots of methods tightly-coupled to the old, bootstrap UI, structure. Rename those classes to have a "legacy" prefix, and create new (for now, minimal) ones for use by transitioned pages (currently only the downtime and popular link editing pages have integration tests and are using the GOV.UK Design System).

By keeping the old and new helpers completely separate, it will make cleanup at the end (once all pages have been transitioned, and are using the new helper classes) a lot easier, as we can simply delete the legacy integration test helper file.

This PR also addresses a weird implementation quirk, where the `ActionDispatch::IntegrationTest` class was being redefined, rather than extended from. I can't see any reason why that would have been done, and so have corrected it to be implemented more normally.

[Trello card](https://trello.com/c/wucvIcYg)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
