### PR TITLE
Switch from sassc-rails to dartsass-rails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ coverage
 test/reports
 .generators
 .rakeTasks
+/app/assets/builds/*
 
 *.daemonette-dump
 data/local_interactions.csv

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem "rails", "7.0.8.3"
 gem "aws-sdk-s3", "~> 1"
 gem "bootsnap", require: false
 gem "bootstrap-kaminari-views"
+gem "dartsass-rails"
 gem "diffy"
 gem "erubis"
 gem "flipflop"
@@ -33,7 +34,6 @@ gem "null_logger"
 gem "plek"
 gem "rails_autolink"
 gem "rest-client", require: false
-gem "sassc-rails"
 gem "select2-rails", "~> 3.5.9" # Updating this will mean updating the styling as 4 & > have a new approach to class names.
 gem "sentry-sidekiq"
 gem "sprockets-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,9 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
+    dartsass-rails (0.5.0)
+      railties (>= 6.0.0)
+      sass-embedded (~> 1.63)
     database_cleaner-core (2.0.1)
     database_cleaner-mongoid (2.0.1)
       database_cleaner-core (~> 2.0.0)
@@ -709,14 +712,17 @@ GEM
     sanitize (6.1.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    sass-embedded (1.77.8)
+      google-protobuf (~> 4.26)
+      rake (>= 13)
+    sass-embedded (1.77.8-aarch64-linux-gnu)
+      google-protobuf (~> 4.26)
+    sass-embedded (1.77.8-arm64-darwin)
+      google-protobuf (~> 4.26)
+    sass-embedded (1.77.8-x86_64-linux-gnu)
+      google-protobuf (~> 4.26)
     sassc (2.4.0)
       ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     select2-rails (3.5.11)
     selenium-webdriver (4.21.1)
       base64 (~> 0.2)
@@ -777,7 +783,6 @@ GEM
     terser (1.2.3)
       execjs (>= 0.3.0, < 3)
     thor (1.3.1)
-    tilt (2.0.10)
     timecop (0.9.10)
     timeout (0.4.1)
     tzinfo (2.0.6)
@@ -817,6 +822,7 @@ DEPENDENCIES
   capybara-select-2
   ci_reporter_minitest
   climate_control
+  dartsass-rails
   database_cleaner-mongoid
   diffy
   erubis
@@ -857,7 +863,6 @@ DEPENDENCIES
   rails_autolink
   rest-client
   rubocop-govuk
-  sassc-rails
   select2-rails (~> 3.5.9)
   sentry-sidekiq
   shoulda

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server -p 3000
+css: bin/rails dartsass:watch

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,5 @@
 //= link_tree ../images
 //= link_tree ../builds
+//= link legacy-application.css
+//= link legacy-application.js
 

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,6 +1,3 @@
 //= link_tree ../images
-//= link application.js
-//= link application.css
+//= link_tree ../builds
 
-//= link legacy-application.js
-//= link legacy-application.css

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,4 +2,5 @@
 //= link_tree ../builds
 //= link legacy-application.css
 //= link legacy-application.js
+//= link application.js
 

--- a/app/assets/stylesheets/sortable_table.scss
+++ b/app/assets/stylesheets/sortable_table.scss
@@ -21,7 +21,7 @@
 }
 
 th .sortable {
-  background-image: image-url("bg.gif");
+  background-image: url("bg.gif");
   cursor: pointer;
   background-repeat: no-repeat;
   background-position: center right;
@@ -29,12 +29,12 @@ th .sortable {
 }
 
 th .asc {
-  background-image: image-url("asc.gif");
+  background-image: url("asc.gif");
   background-color: #dddddd;
 }
 
 th .desc {
-  background-image: image-url("desc.gif");
+  background-image: url("desc.gif");
   background-color: #dddddd;
 }
 

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+exec foreman start -f Procfile.dev "$@"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -69,7 +69,8 @@ Rails.application.configure do
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.
-  config.assets.digest = true
+  # We turn this off in development so that we can run Sass in watch mode.
+  config.assets.digest = false
 
   # Suppress logger output for asset requests.
   config.assets.quiet = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,9 +36,6 @@ Rails.application.configure do
   # Generate digests for assets URLs.
   config.assets.digest = true
 
-  # Rather than use a CSS compressor, use the SASS style to perform compression.
-  config.sass.style = :compressed
-  config.sass.line_comments = false
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,0 +1,1 @@
+Rails.application.config.dartsass.build_options << " --quiet-deps"


### PR DESCRIPTION
This is an initial stab at tackling this piece of tech debt - https://trello.com/c/CCLlRFxl/90-migrate-publisher-to-dart-sass
[Mainstream team trello card](https://trello.com/c/rtkv3YMZ/348-migrate-mainstream-publisher-to-dart-sass-publisher)

Mostly, this follows the excellent documentation here: https://docs.publishing.service.gov.uk/manual/migrate-to-dart-sass-from-libsass.html

I had to add the legacy-application CSS / JS to the manifest file to stop the app from complaining when running it locally. I've now got it to the point where it runs, but I'm a bit concerned the CSS isn't perfect because the skip link appears at the top of the page:

![image](https://github.com/user-attachments/assets/be3cddcf-8059-460d-8771-17eb272b204d)

Hopefully this is a good start, but I think it might need a bit of care and attention before it's ready to merge.