### PR TITLE
Fix javascript errors

### DIFF
--- a/app/assets/javascripts/legacy-application.js
+++ b/app/assets/javascripts/legacy-application.js
@@ -3,8 +3,9 @@
 //= require moment
 //= require mousetrap
 //= require jquery-ui.custom.min
+//= require ./publications
+//= require ./smart-answers
 //= require_directory ./vendor
-//= require_directory .
 //= require_directory ./legacy_modules
 //= require jquery_nested_form
 

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -1,13 +1,17 @@
 <% environment = GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment %>
 
+<% content_for :head do %>
+  <%= javascript_include_tag "es6-components", type: "module" %>
+<% end %>
+
 <%= render "govuk_publishing_components/components/layout_for_admin", {
   product_title: "Publisher",
   browser_title: yield(:page_title),
-  environment: environment
+  environment: environment,
+  head: yield(:head)
 } do %>
 
   <% render "layouts/google_tag_manager" %>
-  <%= javascript_include_tag "es6-components", type: "module" %>
 
   <%= render "govuk_publishing_components/components/skip_link" %>
 

--- a/test/integration/completed_transactions_create_edit_test.rb
+++ b/test/integration/completed_transactions_create_edit_test.rb
@@ -115,4 +115,18 @@ class CompletedTransactionCreateEditTest < LegacyJavascriptIntegrationTest
     assert page.has_content? "Promote MOT reminders"
     assert page.has_content? "Promote bring photo ID to vote"
   end
+
+  should "warn user when triggering a broken links check with unsaved changes" do
+    # This test checks that the javascript that triggers the modal has been correctly loaded
+    completed_transaction = FactoryBot.create(:completed_transaction_edition)
+    visit_edition completed_transaction
+
+    fill_in "Title", with: "Changed title"
+
+    within(".broken-links-report") do
+      accept_alert("Please save your changes before running a link check.") do
+        click_on "Check for broken links"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolve issues relating to the loading of Javascript in Mainstream Publisher after the [upgrade to version 40](https://github.com/alphagov/publisher/pull/2225) of the `govuk_publishing_components` gem.

[Trello card](https://trello.com/c/iRiqyukz)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
