### PR TITLE
Log a warning on DocumentNotFound

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,8 @@ class ApplicationController < ActionController::Base
     prepend_view_path template_folder_for(publication)
   end
 
-  def record_not_found
+  def record_not_found(exception)
+    Rails.logger.warn "Error loading document: #{exception.message}"
     render body: { 'raw': "404 Not Found" }, status: :not_found
   end
 


### PR DESCRIPTION
Log a warning when a `Mongoid::Errors::DocumentNotFound` error is raised in a controller. These errors were being silently swallowed by the application.

The error occurs when an attempt is made to load a document that doesn't exist, which can happen when the overnight DB replication from prod->integration fails. It will also happen if the edition ID is manipulated in the URL (e.g. in URLs of the form
 `/editions/[edition-id]`), so it's not _necessarily_ an error when it happens.

### Example log

<img width="1027" alt="image" src="https://github.com/user-attachments/assets/ac242a52-8a0f-4b41-9309-ff6b0e8ea527">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
