### PR TITLE
Handle publishing api errors and save content before publishing

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -21,20 +21,54 @@ class HomepageController < ApplicationController
 
     flash[:success] = "Popular links draft saved.".html_safe
     redirect_to show_popular_links_path
-  rescue StandardError
+  rescue GdsApi::HTTPErrorResponse
+    flash[:danger] = publishing_api_save_error_message.html_safe
+    render "homepage/popular_links/edit"
+  rescue Mongoid::Errors::Validations
+    render "homepage/popular_links/edit"
+  rescue StandardError => e
+    Rails.logger.error "Error #{e.class} #{e.message}"
+    flash[:danger] = "Due to an application error, the edition couldn't be saved."
     render "homepage/popular_links/edit"
   end
 
   def publish
-    @latest_popular_links.publish
+    @latest_popular_links.publish_latest
+
     flash[:success] = "Popular links successfully published.".html_safe
-    render "homepage/popular_links/show"
+  rescue GdsApi::HTTPErrorResponse => e
+    flash[:danger] = rescue_already_published_error(e)
+  rescue StandardError => e
+    Rails.logger.error "Error #{e.class} #{e.message}"
+    flash[:danger] = "Due to an application error, the edition couldn't be published."
+  ensure
+    redirect_to show_popular_links_path
   end
 
 private
 
+  def rescue_already_published_error(error)
+    already_published_error?(JSON.parse(error.http_body)) ? "Popular links publish was unsuccessful, cannot publish an already published content item.".html_safe : publishing_api_publish_error_message
+  end
+
+  def already_published_error?(error_body)
+    error_body["error"] && error_body["error"]["message"] && error_body["error"]["message"].include?("already published content item")
+  end
+
   def fetch_latest_popular_link
     @latest_popular_links = PopularLinksEdition.last
+  end
+
+  def publishing_api_publish_error_message
+    "Popular links publish was unsuccessful due to a service problem. #{try_again_message}".html_safe
+  end
+
+  def publishing_api_save_error_message
+    "Popular links save was unsuccessful due to a service problem. #{try_again_message}".html_safe
+  end
+
+  def try_again_message
+    "Please wait for a few minutes and try again."
   end
 
   def remove_leading_and_trailing_url_spaces(links)

--- a/app/models/popular_links_edition.rb
+++ b/app/models/popular_links_edition.rb
@@ -34,7 +34,7 @@ class PopularLinksEdition < Edition
     popular_links
   end
 
-  def publish
+  def publish_latest
     Services.publishing_api.publish(content_id, update_type, locale:)
     # This publish_popular_links is a new workflow that was introduced for popular links.
     publish_popular_links

--- a/app/models/popular_links_edition.rb
+++ b/app/models/popular_links_edition.rb
@@ -35,6 +35,7 @@ class PopularLinksEdition < Edition
   end
 
   def publish_latest
+    save_draft
     Services.publishing_api.publish(content_id, update_type, locale:)
     # This publish_popular_links is a new workflow that was introduced for popular links.
     publish_popular_links

--- a/test/functional/homepage_controller_test.rb
+++ b/test/functional/homepage_controller_test.rb
@@ -200,6 +200,15 @@ class HomepageControllerTest < ActionController::TestCase
       assert_equal "published", PopularLinksEdition.last.state
     end
 
+    should "save to publishing API before publish" do
+      sequence = sequence(:task_order)
+
+      Services.publishing_api.expects(:put_content).with(@popular_links.content_id, has_entry(:title, "Homepage Popular Links")).in_sequence(sequence)
+      Services.publishing_api.expects(:publish).with(@popular_links.content_id, "major", locale: "en").in_sequence(sequence)
+
+      post :publish, params: { id: @popular_links.id }
+    end
+
     context "database errors" do
       setup do
         PopularLinksEdition.any_instance.stubs(:publish_popular_links).raises(Mongoid::Errors::MongoidError.new)


### PR DESCRIPTION
This commit tries to bring following changes
1. Handle publishing api errors and give user more understandable messages where possible for publishing api errors.
2. Handle database errors.

[Trello](https://trello.com/c/sw3DmXgK/363-update-error-messaging-copy)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
