### PR TITLE
Backend filtering support for the new publications page (root controller)

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -20,7 +20,7 @@ class RootController < ApplicationController
     states_filter_params = filter_params_hash[:states_filter]
     sanitised_states_filter_params = states_filter_params&.select { |fp| PERMITTED_FILTER_STATES.include?(fp) }
     assignee_filter = filter_params_hash[:assignee_filter]
-    @presenter = FilteredEditionsPresenter.new(sanitised_states_filter_params, assignee_filter)
+    @presenter = FilteredEditionsPresenter.new(sanitised_states_filter_params, assignee_filter, nil)
   end
 
 private

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -3,7 +3,27 @@
 class RootController < ApplicationController
   layout "design_system"
 
+  PERMITTED_FILTER_STATES = %w[
+    draft
+    amends_needed
+    in_review
+    fact_check
+    fact_check_received
+    ready
+    scheduled_for_publishing
+    published
+    archived
+  ].freeze
+
   def index
-    @presenter = FilteredEditionsPresenter.new
+    states_filter_params = filter_params.to_h[:states_filter]
+    sanitised_states_filter_params = states_filter_params&.select { |fp| PERMITTED_FILTER_STATES.include?(fp) }
+    @presenter = FilteredEditionsPresenter.new(sanitised_states_filter_params)
+  end
+
+private
+
+  def filter_params
+    params.permit(states_filter: [])
   end
 end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -21,12 +21,13 @@ class RootController < ApplicationController
     sanitised_states_filter_params = states_filter_params&.select { |fp| PERMITTED_FILTER_STATES.include?(fp) }
     assignee_filter = filter_params_hash[:assignee_filter]
     format_filter = filter_params_hash[:format_filter]
-    @presenter = FilteredEditionsPresenter.new(sanitised_states_filter_params, assignee_filter, format_filter, nil)
+    title_filter = filter_params_hash[:title_filter]
+    @presenter = FilteredEditionsPresenter.new(sanitised_states_filter_params, assignee_filter, format_filter, title_filter)
   end
 
 private
 
   def filter_params
-    params.permit(:assignee_filter, :format_filter, states_filter: [])
+    params.permit(:assignee_filter, :format_filter, :title_filter, states_filter: [])
   end
 end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -20,12 +20,13 @@ class RootController < ApplicationController
     states_filter_params = filter_params_hash[:states_filter]
     sanitised_states_filter_params = states_filter_params&.select { |fp| PERMITTED_FILTER_STATES.include?(fp) }
     assignee_filter = filter_params_hash[:assignee_filter]
-    @presenter = FilteredEditionsPresenter.new(sanitised_states_filter_params, assignee_filter, nil)
+    format_filter = filter_params_hash[:format_filter]
+    @presenter = FilteredEditionsPresenter.new(sanitised_states_filter_params, assignee_filter, format_filter)
   end
 
 private
 
   def filter_params
-    params.permit(:assignee_filter, states_filter: [])
+    params.permit(:assignee_filter, :format_filter, states_filter: [])
   end
 end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -22,7 +22,12 @@ class RootController < ApplicationController
     assignee_filter = filter_params_hash[:assignee_filter]
     format_filter = filter_params_hash[:format_filter]
     title_filter = filter_params_hash[:title_filter]
-    @presenter = FilteredEditionsPresenter.new(sanitised_states_filter_params, assignee_filter, format_filter, title_filter)
+    @presenter = FilteredEditionsPresenter.new(
+      states_filter: sanitised_states_filter_params,
+      assigned_to_filter: assignee_filter,
+      format_filter:,
+      title_filter:,
+    )
   end
 
 private

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -16,14 +16,16 @@ class RootController < ApplicationController
   ].freeze
 
   def index
-    states_filter_params = filter_params.to_h[:states_filter]
+    filter_params_hash = filter_params.to_h
+    states_filter_params = filter_params_hash[:states_filter]
     sanitised_states_filter_params = states_filter_params&.select { |fp| PERMITTED_FILTER_STATES.include?(fp) }
-    @presenter = FilteredEditionsPresenter.new(sanitised_states_filter_params, nil)
+    assignee_filter = filter_params_hash[:assignee_filter]
+    @presenter = FilteredEditionsPresenter.new(sanitised_states_filter_params, assignee_filter)
   end
 
 private
 
   def filter_params
-    params.permit(states_filter: [])
+    params.permit(:assignee_filter, states_filter: [])
   end
 end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -18,7 +18,7 @@ class RootController < ApplicationController
   def index
     states_filter_params = filter_params.to_h[:states_filter]
     sanitised_states_filter_params = states_filter_params&.select { |fp| PERMITTED_FILTER_STATES.include?(fp) }
-    @presenter = FilteredEditionsPresenter.new(sanitised_states_filter_params)
+    @presenter = FilteredEditionsPresenter.new(sanitised_states_filter_params, nil)
   end
 
 private

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -21,7 +21,7 @@ class RootController < ApplicationController
     sanitised_states_filter_params = states_filter_params&.select { |fp| PERMITTED_FILTER_STATES.include?(fp) }
     assignee_filter = filter_params_hash[:assignee_filter]
     format_filter = filter_params_hash[:format_filter]
-    @presenter = FilteredEditionsPresenter.new(sanitised_states_filter_params, assignee_filter, format_filter)
+    @presenter = FilteredEditionsPresenter.new(sanitised_states_filter_params, assignee_filter, format_filter, nil)
   end
 
 private

--- a/app/helpers/editions_helper.rb
+++ b/app/helpers/editions_helper.rb
@@ -24,8 +24,17 @@ module EditionsHelper
     possible_target_formats.map { |format_name| [format_name.humanize, format_name] }
   end
 
-  def format_filter_selection_options
+  def legacy_format_filter_selection_options
     [%w[All edition]] +
+      Artefact::FORMATS_BY_DEFAULT_OWNING_APP["publisher"].map do |format_name|
+        displayed_format_name = format_name.humanize
+        displayed_format_name += " (Retired)" if Artefact::RETIRED_FORMATS.include?(format_name)
+        [displayed_format_name, format_name]
+      end
+  end
+
+  def format_filter_selection_options
+    [%w[All all]] +
       Artefact::FORMATS_BY_DEFAULT_OWNING_APP["publisher"].map do |format_name|
         displayed_format_name = format_name.humanize
         displayed_format_name += " (Retired)" if Artefact::RETIRED_FORMATS.include?(format_name)

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -82,6 +82,11 @@ class Edition
   scope :draft_in_publishing_api, -> { where(state: { "$in" => PUBLISHING_API_DRAFT_STATES }) }
 
   scope :in_states, ->(states) { where(state: { "$in" => states }) }
+  scope :title_contains,
+        lambda { |term|
+          regex = ::Regexp.new(::Regexp.escape(term), true) # case-insensitive
+          where({ title: regex })
+        }
 
   ACTIONS = {
     send_fact_check: "Send to Fact check",

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -81,6 +81,8 @@ class Edition
   scope :published, -> { where(state: "published") }
   scope :draft_in_publishing_api, -> { where(state: { "$in" => PUBLISHING_API_DRAFT_STATES }) }
 
+  scope :in_states, ->(states) { where(state: { "$in" => states }) }
+
   ACTIONS = {
     send_fact_check: "Send to Fact check",
     resend_fact_check: "Resend fact check email",

--- a/app/presenters/filtered_editions_presenter.rb
+++ b/app/presenters/filtered_editions_presenter.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class FilteredEditionsPresenter
-  def initialize(states_filter, assigned_to_filter, format_filter)
+  def initialize(states_filter, assigned_to_filter, format_filter, title_filter)
     @states_filter = states_filter || []
     @assigned_to_filter = assigned_to_filter
     @format_filter = format_filter
+    @title_filter = title_filter
   end
 
   def available_users
@@ -14,7 +15,8 @@ class FilteredEditionsPresenter
   def editions
     result = editions_by_format
     result = apply_states_filter(result)
-    apply_assigned_to_filter(result)
+    result = apply_assigned_to_filter(result)
+    apply_title_filter(result)
   end
 
 private
@@ -47,5 +49,11 @@ private
     editions
   end
 
-  attr_reader :states_filter, :assigned_to_filter, :format_filter
+  def apply_title_filter(editions)
+    return editions if title_filter.blank?
+
+    editions.title_contains(title_filter)
+  end
+
+  attr_reader :states_filter, :assigned_to_filter, :format_filter, :title_filter
 end

--- a/app/presenters/filtered_editions_presenter.rb
+++ b/app/presenters/filtered_editions_presenter.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class FilteredEditionsPresenter
-  def initialize(states_filter, assigned_to_filter)
+  def initialize(states_filter, assigned_to_filter, format_filter)
     @states_filter = states_filter || []
     @assigned_to_filter = assigned_to_filter
+    @format_filter = format_filter
   end
 
   def available_users
@@ -11,12 +12,18 @@ class FilteredEditionsPresenter
   end
 
   def editions
-    result = Edition.all
+    result = editions_by_format
     result = apply_states_filter(result)
     apply_assigned_to_filter(result)
   end
 
 private
+
+  def editions_by_format
+    return Edition.all unless format_filter && format_filter != "all"
+
+    Edition.where(_type: "#{format_filter.camelcase}Edition")
+  end
 
   def apply_states_filter(editions)
     return editions if states_filter.empty?
@@ -40,5 +47,5 @@ private
     editions
   end
 
-  attr_reader :states_filter, :assigned_to_filter
+  attr_reader :states_filter, :assigned_to_filter, :format_filter
 end

--- a/app/presenters/filtered_editions_presenter.rb
+++ b/app/presenters/filtered_editions_presenter.rb
@@ -1,7 +1,17 @@
 # frozen_string_literal: true
 
 class FilteredEditionsPresenter
-  def editions
-    Edition.all
+  def initialize(states_filter)
+    @states_filter = states_filter || []
   end
+
+  def editions
+    result = Edition.all
+    result = result.in_states(states_filter) unless states_filter.empty?
+    result
+  end
+
+private
+
+  attr_reader :states_filter
 end

--- a/app/presenters/filtered_editions_presenter.rb
+++ b/app/presenters/filtered_editions_presenter.rb
@@ -1,17 +1,44 @@
 # frozen_string_literal: true
 
 class FilteredEditionsPresenter
-  def initialize(states_filter)
+  def initialize(states_filter, assigned_to_filter)
     @states_filter = states_filter || []
+    @assigned_to_filter = assigned_to_filter
+  end
+
+  def available_users
+    User.enabled.alphabetized
   end
 
   def editions
     result = Edition.all
-    result = result.in_states(states_filter) unless states_filter.empty?
-    result
+    result = apply_states_filter(result)
+    apply_assigned_to_filter(result)
   end
 
 private
 
-  attr_reader :states_filter
+  def apply_states_filter(editions)
+    return editions if states_filter.empty?
+
+    editions.in_states(states_filter)
+  end
+
+  def apply_assigned_to_filter(editions)
+    return editions unless assigned_to_filter
+
+    if assigned_to_filter == "nobody"
+      editions = editions.assigned_to(nil)
+    else
+      begin
+        assigned_user = User.find(assigned_to_filter)
+        editions = editions.assigned_to(assigned_user) if assigned_user
+      rescue Mongoid::Errors::DocumentNotFound
+        Rails.logger.warn "An attempt was made to filter by an unknown user ID: '#{assigned_to_filter}'"
+      end
+    end
+    editions
+  end
+
+  attr_reader :states_filter, :assigned_to_filter
 end

--- a/app/presenters/filtered_editions_presenter.rb
+++ b/app/presenters/filtered_editions_presenter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class FilteredEditionsPresenter
-  def initialize(states_filter, assigned_to_filter, format_filter, title_filter)
+  def initialize(states_filter: [], assigned_to_filter: nil, format_filter: nil, title_filter: nil)
     @states_filter = states_filter || []
     @assigned_to_filter = assigned_to_filter
     @format_filter = format_filter

--- a/app/views/legacy_root/index.html.erb
+++ b/app/views/legacy_root/index.html.erb
@@ -40,7 +40,7 @@
 
             <label for="format_filter" class="add-top-margin nav-header">Format</label>
             <%= select_tag("format_filter", options_for_select(
-              format_filter_selection_options,
+              legacy_format_filter_selection_options,
               params[:format_filter]
             ), class: 'form-control') %>
             <input class="add-top-margin btn btn-default" type="submit" value="Filter publications">

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -3,7 +3,14 @@
 
 <div class="govuk-grid-column-one-third">
   <p>[replace with filter controls]</p>
+  <%= form_with url: root_path, method: :get do |form| %>
+    <%= form.label :states_filter_draft, "Draft" %>
+    <%= check_box_tag "states_filter[]", "draft", false, {id: "states_filter_draft"} %>
+    <%= form.label :states_filter_published, "Published" %>
+    <%= check_box_tag "states_filter[]", "published", false, :id => "states_filter_published" %>
+    <%= form.submit %>
+  <% end %>
 </div>
 <div class="govuk-grid-column-two-thirds">
-  <p>[replace with publications table]</p>
+  <h2><%= @presenter.editions.count %> document(s)</h2>
 </div>

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -2,14 +2,16 @@
 <% content_for :title, "Publications" %>
 
 <div class="govuk-grid-column-one-third">
-  <p>[replace with filter controls]</p>
   <%= form_with url: root_path, method: :get do |form| %>
+    <%= form.label :format_filter, "Format" %>
+    <%= select_tag :format_filter,
+                   options_for_select(format_filter_selection_options) %>
     <%= form.label :assignee_filter, "Assignee" %>
     <%= select_tag :assignee_filter,
                    options_for_select([%w[Nobody nobody]]) <<
-                   options_from_collection_for_select(@presenter.available_users, "id", "name") %>
+                     options_from_collection_for_select(@presenter.available_users, "id", "name") %>
     <%= form.label :states_filter_draft, "Draft" %>
-    <%= check_box_tag "states_filter[]", "draft", false, {id: "states_filter_draft"} %>
+    <%= check_box_tag "states_filter[]", "draft", false, { id: "states_filter_draft" } %>
     <%= form.label :states_filter_published, "Published" %>
     <%= check_box_tag "states_filter[]", "published", false, :id => "states_filter_published" %>
     <%= form.submit %>

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -4,6 +4,10 @@
 <div class="govuk-grid-column-one-third">
   <p>[replace with filter controls]</p>
   <%= form_with url: root_path, method: :get do |form| %>
+    <%= form.label :assignee_filter, "Assignee" %>
+    <%= select_tag :assignee_filter,
+                   options_for_select([%w[Nobody nobody]]) <<
+                   options_from_collection_for_select(@presenter.available_users, "id", "name") %>
     <%= form.label :states_filter_draft, "Draft" %>
     <%= check_box_tag "states_filter[]", "draft", false, {id: "states_filter_draft"} %>
     <%= form.label :states_filter_published, "Published" %>

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -3,6 +3,8 @@
 
 <div class="govuk-grid-column-one-third">
   <%= form_with url: root_path, method: :get do |form| %>
+    <%= form.label :title_filter, "Title" %>
+    <%= text_field_tag :title_filter %>
     <%= form.label :format_filter, "Format" %>
     <%= select_tag :format_filter,
                    options_for_select(format_filter_selection_options) %>

--- a/app/views/user_search/index.html.erb
+++ b/app/views/user_search/index.html.erb
@@ -17,7 +17,7 @@
 
           <label for="format_filter" class="add-top-margin nav-header">Format</label>
           <%= select_tag("format_filter", options_for_select(
-            format_filter_selection_options,
+            legacy_format_filter_selection_options,
             params[:format_filter]
           ), class: 'form-control') %>
           <input class="add-top-margin btn btn-default" type="submit" value="Filter publications">

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -13,6 +13,16 @@ class RootControllerTest < ActionController::TestCase
       assert_template "root/index"
     end
 
+    should "filter publications by state" do
+      FactoryBot.create(:guide_edition, state: "draft")
+      FactoryBot.create(:guide_edition, state: "published")
+
+      get :index, params: { states_filter: %w[draft] }
+
+      assert_response :ok
+      assert_select "h2", "1 document(s)"
+    end
+
     should "ignore unrecognised filter states" do
       FilteredEditionsPresenter.expects(:new).with(%w[draft]).returns(stub(editions: []))
 

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -43,6 +43,16 @@ class RootControllerTest < ActionController::TestCase
       assert_select "h2", "1 document(s)"
     end
 
+    should "filter publications by title text" do
+      FactoryBot.create(:guide_edition, title: "How to train your dragon")
+      FactoryBot.create(:guide_edition, title: "What to do in the event of a zombie apocalypse")
+
+      get :index, params: { title_filter: "zombie" }
+
+      assert_response :ok
+      assert_select "h2", "1 document(s)"
+    end
+
     should "ignore unrecognised filter states" do
       FilteredEditionsPresenter.expects(:new).with(%w[draft], anything, anything, anything)
                                .returns(stub(editions: [], available_users: []))

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -24,7 +24,7 @@ class RootControllerTest < ActionController::TestCase
     end
 
     should "ignore unrecognised filter states" do
-      FilteredEditionsPresenter.expects(:new).with(%w[draft]).returns(stub(editions: []))
+      FilteredEditionsPresenter.expects(:new).with(%w[draft], anything).returns(stub(editions: []))
 
       get :index, params: { states_filter: %w[draft not_a_real_state] }
     end

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -54,8 +54,10 @@ class RootControllerTest < ActionController::TestCase
     end
 
     should "ignore unrecognised filter states" do
-      FilteredEditionsPresenter.expects(:new).with(%w[draft], anything, anything, anything)
-                               .returns(stub(editions: [], available_users: []))
+      FilteredEditionsPresenter
+        .expects(:new)
+        .with(states_filter: %w[draft], assigned_to_filter: anything, format_filter: anything, title_filter: anything)
+        .returns(stub(editions: [], available_users: []))
 
       get :index, params: { states_filter: %w[draft not_a_real_state] }
     end

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -12,5 +12,11 @@ class RootControllerTest < ActionController::TestCase
       assert_response :ok
       assert_template "root/index"
     end
+
+    should "ignore unrecognised filter states" do
+      FilteredEditionsPresenter.expects(:new).with(%w[draft]).returns(stub(editions: []))
+
+      get :index, params: { states_filter: %w[draft not_a_real_state] }
+    end
   end
 end

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -33,6 +33,16 @@ class RootControllerTest < ActionController::TestCase
       assert_select "h2", "1 document(s)"
     end
 
+    should "filter publications by format" do
+      FactoryBot.create(:guide_edition)
+      FactoryBot.create(:completed_transaction_edition)
+
+      get :index, params: { format_filter: "guide" }
+
+      assert_response :ok
+      assert_select "h2", "1 document(s)"
+    end
+
     should "ignore unrecognised filter states" do
       FilteredEditionsPresenter.expects(:new).with(%w[draft], anything, anything)
                                .returns(stub(editions: [], available_users: []))

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -34,7 +34,7 @@ class RootControllerTest < ActionController::TestCase
     end
 
     should "ignore unrecognised filter states" do
-      FilteredEditionsPresenter.expects(:new).with(%w[draft], anything)
+      FilteredEditionsPresenter.expects(:new).with(%w[draft], anything, anything)
                                .returns(stub(editions: [], available_users: []))
 
       get :index, params: { states_filter: %w[draft not_a_real_state] }

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -23,8 +23,19 @@ class RootControllerTest < ActionController::TestCase
       assert_select "h2", "1 document(s)"
     end
 
+    should "filter publications by assignee" do
+      anna = FactoryBot.create(:user, name: "Anna")
+      FactoryBot.create(:guide_edition)
+
+      get :index, params: { assignee_filter: [anna.id] }
+
+      assert_response :ok
+      assert_select "h2", "1 document(s)"
+    end
+
     should "ignore unrecognised filter states" do
-      FilteredEditionsPresenter.expects(:new).with(%w[draft], anything).returns(stub(editions: []))
+      FilteredEditionsPresenter.expects(:new).with(%w[draft], anything)
+                               .returns(stub(editions: [], available_users: []))
 
       get :index, params: { states_filter: %w[draft not_a_real_state] }
     end

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -44,7 +44,7 @@ class RootControllerTest < ActionController::TestCase
     end
 
     should "ignore unrecognised filter states" do
-      FilteredEditionsPresenter.expects(:new).with(%w[draft], anything, anything)
+      FilteredEditionsPresenter.expects(:new).with(%w[draft], anything, anything, anything)
                                .returns(stub(editions: [], available_users: []))
 
       get :index, params: { states_filter: %w[draft not_a_real_state] }

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -482,6 +482,13 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal [b], Edition.assigned_to(bob).to_a
   end
 
+  test "should scope publications by state" do
+    draft_guide = FactoryBot.create(:guide_edition, state: "draft")
+    FactoryBot.create(:guide_edition, state: "published")
+
+    assert_equal [draft_guide], Edition.in_states(%w[draft]).to_a
+  end
+
   test "cannot delete a publication that has been published" do
     dummy_answer = template_published_answer
     loaded_answer = AnswerEdition.where(slug: "childcare").first

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -489,6 +489,20 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal [draft_guide], Edition.in_states(%w[draft]).to_a
   end
 
+  test "should scope publications by partial title match" do
+    guide = FactoryBot.create(:guide_edition, title: "Hitchhiker's Guide to the Galaxy")
+    FactoryBot.create(:guide_edition)
+
+    assert_equal [guide], Edition.title_contains("Galaxy").to_a
+  end
+
+  test "should scope publications by case-insensitive title match" do
+    guide = FactoryBot.create(:guide_edition, title: "Hitchhiker's Guide to the Galaxy")
+    FactoryBot.create(:guide_edition)
+
+    assert_equal [guide], Edition.title_contains("Hitchhiker's gUIDE to the Galaxy").to_a
+  end
+
   test "cannot delete a publication that has been published" do
     dummy_answer = template_published_answer
     loaded_answer = AnswerEdition.where(slug: "childcare").first

--- a/test/unit/presenters/filtered_editions_presenter_test.rb
+++ b/test/unit/presenters/filtered_editions_presenter_test.rb
@@ -8,7 +8,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       draft_guide = FactoryBot.create(:guide_edition, state: "draft")
       published_guide = FactoryBot.create(:guide_edition, state: "published")
 
-      filtered_editions = FilteredEditionsPresenter.new(nil, nil).editions
+      filtered_editions = FilteredEditionsPresenter.new(nil, nil, nil).editions
 
       assert_equal(2, filtered_editions.count)
       assert_equal(draft_guide, filtered_editions[0])
@@ -19,7 +19,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       draft_guide = FactoryBot.create(:guide_edition, state: "draft")
       FactoryBot.create(:guide_edition, state: "published")
 
-      filtered_editions = FilteredEditionsPresenter.new(%w[draft], nil).editions
+      filtered_editions = FilteredEditionsPresenter.new(%w[draft], nil, nil).editions
 
       assert_equal(1, filtered_editions.count)
       assert_equal(draft_guide, filtered_editions[0])
@@ -30,7 +30,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       assigned_to_anna = FactoryBot.create(:guide_edition, assigned_to: anna.id)
       FactoryBot.create(:guide_edition)
 
-      filtered_editions = FilteredEditionsPresenter.new(nil, anna.id).editions.to_a
+      filtered_editions = FilteredEditionsPresenter.new(nil, anna.id, nil).editions.to_a
 
       assert_equal([assigned_to_anna], filtered_editions)
     end
@@ -40,7 +40,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       FactoryBot.create(:guide_edition, assigned_to: anna.id)
       not_assigned = FactoryBot.create(:guide_edition)
 
-      filtered_editions = FilteredEditionsPresenter.new(nil, "nobody").editions.to_a
+      filtered_editions = FilteredEditionsPresenter.new(nil, "nobody", nil).editions.to_a
 
       assert_equal([not_assigned], filtered_editions)
     end
@@ -51,7 +51,25 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       FactoryBot.create(:guide_edition)
 
       filtered_editions =
-        FilteredEditionsPresenter.new(nil, "not a valid user id").editions
+        FilteredEditionsPresenter.new(nil, "not a valid user id", nil).editions
+
+      assert_equal(2, filtered_editions.count)
+    end
+
+    should "filter by format" do
+      guide = FactoryBot.create(:guide_edition)
+      FactoryBot.create(:completed_transaction_edition)
+
+      filtered_editions = FilteredEditionsPresenter.new(nil, nil, "guide").editions
+
+      assert_equal([guide], filtered_editions)
+    end
+
+    should "return all formats when specified by the format filter" do
+      FactoryBot.create(:guide_edition)
+      FactoryBot.create(:completed_transaction_edition)
+
+      filtered_editions = FilteredEditionsPresenter.new(nil, nil, "all").editions
 
       assert_equal(2, filtered_editions.count)
     end
@@ -63,7 +81,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       charlie = FactoryBot.create(:user, name: "Charlie")
       anna = FactoryBot.create(:user, name: "Anna")
 
-      users = FilteredEditionsPresenter.new(nil, nil).available_users.to_a
+      users = FilteredEditionsPresenter.new(nil, nil, nil).available_users.to_a
 
       assert_equal([anna, bob, charlie], users)
     end
@@ -72,7 +90,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       enabled_user = FactoryBot.create(:user, name: "enabled user")
       FactoryBot.create(:user, name: "disabled user", disabled: true)
 
-      users = FilteredEditionsPresenter.new(nil, nil).available_users.to_a
+      users = FilteredEditionsPresenter.new(nil, nil, nil).available_users.to_a
 
       assert_equal(users, [enabled_user])
     end

--- a/test/unit/presenters/filtered_editions_presenter_test.rb
+++ b/test/unit/presenters/filtered_editions_presenter_test.rb
@@ -8,7 +8,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       draft_guide = FactoryBot.create(:guide_edition, state: "draft")
       published_guide = FactoryBot.create(:guide_edition, state: "published")
 
-      filtered_editions = FilteredEditionsPresenter.new(nil).editions
+      filtered_editions = FilteredEditionsPresenter.new(nil, nil).editions
 
       assert_equal(2, filtered_editions.count)
       assert_equal(draft_guide, filtered_editions[0])
@@ -19,10 +19,62 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       draft_guide = FactoryBot.create(:guide_edition, state: "draft")
       FactoryBot.create(:guide_edition, state: "published")
 
-      filtered_editions = FilteredEditionsPresenter.new(%w[draft]).editions
+      filtered_editions = FilteredEditionsPresenter.new(%w[draft], nil).editions
 
       assert_equal(1, filtered_editions.count)
       assert_equal(draft_guide, filtered_editions[0])
+    end
+
+    should "filter by 'assigned to'" do
+      anna = FactoryBot.create(:user, name: "Anna")
+      assigned_to_anna = FactoryBot.create(:guide_edition, assigned_to: anna.id)
+      FactoryBot.create(:guide_edition)
+
+      filtered_editions = FilteredEditionsPresenter.new(nil, anna.id).editions.to_a
+
+      assert_equal([assigned_to_anna], filtered_editions)
+    end
+
+    should "filter by 'not assigned'" do
+      anna = FactoryBot.create(:user, name: "Anna")
+      FactoryBot.create(:guide_edition, assigned_to: anna.id)
+      not_assigned = FactoryBot.create(:guide_edition)
+
+      filtered_editions = FilteredEditionsPresenter.new(nil, "nobody").editions.to_a
+
+      assert_equal([not_assigned], filtered_editions)
+    end
+
+    should "ignore invalid 'assigned to'" do
+      anna = FactoryBot.create(:user, name: "Anna")
+      FactoryBot.create(:guide_edition, assigned_to: anna.id)
+      FactoryBot.create(:guide_edition)
+
+      filtered_editions =
+        FilteredEditionsPresenter.new(nil, "not a valid user id").editions
+
+      assert_equal(2, filtered_editions.count)
+    end
+  end
+
+  context "#available_users" do
+    should "return users in alphabetical order" do
+      bob = FactoryBot.create(:user, name: "Bob")
+      charlie = FactoryBot.create(:user, name: "Charlie")
+      anna = FactoryBot.create(:user, name: "Anna")
+
+      users = FilteredEditionsPresenter.new(nil, nil).available_users.to_a
+
+      assert_equal([anna, bob, charlie], users)
+    end
+
+    should "not include disabled users" do
+      enabled_user = FactoryBot.create(:user, name: "enabled user")
+      FactoryBot.create(:user, name: "disabled user", disabled: true)
+
+      users = FilteredEditionsPresenter.new(nil, nil).available_users.to_a
+
+      assert_equal(users, [enabled_user])
     end
   end
 end

--- a/test/unit/presenters/filtered_editions_presenter_test.rb
+++ b/test/unit/presenters/filtered_editions_presenter_test.rb
@@ -8,7 +8,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       draft_guide = FactoryBot.create(:guide_edition, state: "draft")
       published_guide = FactoryBot.create(:guide_edition, state: "published")
 
-      filtered_editions = FilteredEditionsPresenter.new(nil, nil, nil, nil).editions
+      filtered_editions = FilteredEditionsPresenter.new.editions
 
       assert_equal(2, filtered_editions.count)
       assert_equal(draft_guide, filtered_editions[0])
@@ -19,7 +19,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       draft_guide = FactoryBot.create(:guide_edition, state: "draft")
       FactoryBot.create(:guide_edition, state: "published")
 
-      filtered_editions = FilteredEditionsPresenter.new(%w[draft], nil, nil, nil).editions
+      filtered_editions = FilteredEditionsPresenter.new(states_filter: %w[draft]).editions
 
       assert_equal(1, filtered_editions.count)
       assert_equal(draft_guide, filtered_editions[0])
@@ -30,7 +30,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       assigned_to_anna = FactoryBot.create(:guide_edition, assigned_to: anna.id)
       FactoryBot.create(:guide_edition)
 
-      filtered_editions = FilteredEditionsPresenter.new(nil, anna.id, nil, nil).editions.to_a
+      filtered_editions = FilteredEditionsPresenter.new(assigned_to_filter: anna.id).editions.to_a
 
       assert_equal([assigned_to_anna], filtered_editions)
     end
@@ -40,7 +40,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       FactoryBot.create(:guide_edition, assigned_to: anna.id)
       not_assigned = FactoryBot.create(:guide_edition)
 
-      filtered_editions = FilteredEditionsPresenter.new(nil, "nobody", nil, nil).editions.to_a
+      filtered_editions = FilteredEditionsPresenter.new(assigned_to_filter: "nobody").editions.to_a
 
       assert_equal([not_assigned], filtered_editions)
     end
@@ -51,7 +51,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       FactoryBot.create(:guide_edition)
 
       filtered_editions =
-        FilteredEditionsPresenter.new(nil, "not a valid user id", nil, nil).editions
+        FilteredEditionsPresenter.new(assigned_to_filter: "not a valid user id").editions
 
       assert_equal(2, filtered_editions.count)
     end
@@ -60,7 +60,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       guide = FactoryBot.create(:guide_edition)
       FactoryBot.create(:completed_transaction_edition)
 
-      filtered_editions = FilteredEditionsPresenter.new(nil, nil, "guide", nil).editions
+      filtered_editions = FilteredEditionsPresenter.new(format_filter: "guide").editions
 
       assert_equal([guide], filtered_editions)
     end
@@ -69,7 +69,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       FactoryBot.create(:guide_edition)
       FactoryBot.create(:completed_transaction_edition)
 
-      filtered_editions = FilteredEditionsPresenter.new(nil, nil, "all", nil).editions
+      filtered_editions = FilteredEditionsPresenter.new(format_filter: "all").editions
 
       assert_equal(2, filtered_editions.count)
     end
@@ -78,7 +78,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       guide_fawkes = FactoryBot.create(:guide_edition, title: "Guide Fawkes")
       FactoryBot.create(:guide_edition, title: "Hitchhiker's Guide")
 
-      filtered_editions = FilteredEditionsPresenter.new(nil, nil, nil, "Fawkes").editions
+      filtered_editions = FilteredEditionsPresenter.new(title_filter: "Fawkes").editions
 
       assert_equal([guide_fawkes], filtered_editions)
     end
@@ -90,7 +90,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       charlie = FactoryBot.create(:user, name: "Charlie")
       anna = FactoryBot.create(:user, name: "Anna")
 
-      users = FilteredEditionsPresenter.new(nil, nil, nil, nil).available_users.to_a
+      users = FilteredEditionsPresenter.new.available_users.to_a
 
       assert_equal([anna, bob, charlie], users)
     end
@@ -99,7 +99,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       enabled_user = FactoryBot.create(:user, name: "enabled user")
       FactoryBot.create(:user, name: "disabled user", disabled: true)
 
-      users = FilteredEditionsPresenter.new(nil, nil, nil, nil).available_users.to_a
+      users = FilteredEditionsPresenter.new.available_users.to_a
 
       assert_equal(users, [enabled_user])
     end

--- a/test/unit/presenters/filtered_editions_presenter_test.rb
+++ b/test/unit/presenters/filtered_editions_presenter_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FilteredEditionsPresenterTest < ActiveSupport::TestCase
+  context "#editions" do
+    should "return all editions when no filters are specified" do
+      draft_guide = FactoryBot.create(:guide_edition, state: "draft")
+      published_guide = FactoryBot.create(:guide_edition, state: "published")
+
+      filtered_editions = FilteredEditionsPresenter.new(nil).editions
+
+      assert_equal(2, filtered_editions.count)
+      assert_equal(draft_guide, filtered_editions[0])
+      assert_equal(published_guide, filtered_editions[1])
+    end
+
+    should "filter by state" do
+      draft_guide = FactoryBot.create(:guide_edition, state: "draft")
+      FactoryBot.create(:guide_edition, state: "published")
+
+      filtered_editions = FilteredEditionsPresenter.new(%w[draft]).editions
+
+      assert_equal(1, filtered_editions.count)
+      assert_equal(draft_guide, filtered_editions[0])
+    end
+  end
+end

--- a/test/unit/presenters/filtered_editions_presenter_test.rb
+++ b/test/unit/presenters/filtered_editions_presenter_test.rb
@@ -8,7 +8,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       draft_guide = FactoryBot.create(:guide_edition, state: "draft")
       published_guide = FactoryBot.create(:guide_edition, state: "published")
 
-      filtered_editions = FilteredEditionsPresenter.new(nil, nil, nil).editions
+      filtered_editions = FilteredEditionsPresenter.new(nil, nil, nil, nil).editions
 
       assert_equal(2, filtered_editions.count)
       assert_equal(draft_guide, filtered_editions[0])
@@ -19,7 +19,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       draft_guide = FactoryBot.create(:guide_edition, state: "draft")
       FactoryBot.create(:guide_edition, state: "published")
 
-      filtered_editions = FilteredEditionsPresenter.new(%w[draft], nil, nil).editions
+      filtered_editions = FilteredEditionsPresenter.new(%w[draft], nil, nil, nil).editions
 
       assert_equal(1, filtered_editions.count)
       assert_equal(draft_guide, filtered_editions[0])
@@ -30,7 +30,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       assigned_to_anna = FactoryBot.create(:guide_edition, assigned_to: anna.id)
       FactoryBot.create(:guide_edition)
 
-      filtered_editions = FilteredEditionsPresenter.new(nil, anna.id, nil).editions.to_a
+      filtered_editions = FilteredEditionsPresenter.new(nil, anna.id, nil, nil).editions.to_a
 
       assert_equal([assigned_to_anna], filtered_editions)
     end
@@ -40,7 +40,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       FactoryBot.create(:guide_edition, assigned_to: anna.id)
       not_assigned = FactoryBot.create(:guide_edition)
 
-      filtered_editions = FilteredEditionsPresenter.new(nil, "nobody", nil).editions.to_a
+      filtered_editions = FilteredEditionsPresenter.new(nil, "nobody", nil, nil).editions.to_a
 
       assert_equal([not_assigned], filtered_editions)
     end
@@ -51,7 +51,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       FactoryBot.create(:guide_edition)
 
       filtered_editions =
-        FilteredEditionsPresenter.new(nil, "not a valid user id", nil).editions
+        FilteredEditionsPresenter.new(nil, "not a valid user id", nil, nil).editions
 
       assert_equal(2, filtered_editions.count)
     end
@@ -60,7 +60,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       guide = FactoryBot.create(:guide_edition)
       FactoryBot.create(:completed_transaction_edition)
 
-      filtered_editions = FilteredEditionsPresenter.new(nil, nil, "guide").editions
+      filtered_editions = FilteredEditionsPresenter.new(nil, nil, "guide", nil).editions
 
       assert_equal([guide], filtered_editions)
     end
@@ -69,9 +69,18 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       FactoryBot.create(:guide_edition)
       FactoryBot.create(:completed_transaction_edition)
 
-      filtered_editions = FilteredEditionsPresenter.new(nil, nil, "all").editions
+      filtered_editions = FilteredEditionsPresenter.new(nil, nil, "all", nil).editions
 
       assert_equal(2, filtered_editions.count)
+    end
+
+    should "filter by a partially-matching title" do
+      guide_fawkes = FactoryBot.create(:guide_edition, title: "Guide Fawkes")
+      FactoryBot.create(:guide_edition, title: "Hitchhiker's Guide")
+
+      filtered_editions = FilteredEditionsPresenter.new(nil, nil, nil, "Fawkes").editions
+
+      assert_equal([guide_fawkes], filtered_editions)
     end
   end
 
@@ -81,7 +90,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       charlie = FactoryBot.create(:user, name: "Charlie")
       anna = FactoryBot.create(:user, name: "Anna")
 
-      users = FilteredEditionsPresenter.new(nil, nil, nil).available_users.to_a
+      users = FilteredEditionsPresenter.new(nil, nil, nil, nil).available_users.to_a
 
       assert_equal([anna, bob, charlie], users)
     end
@@ -90,7 +99,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       enabled_user = FactoryBot.create(:user, name: "enabled user")
       FactoryBot.create(:user, name: "disabled user", disabled: true)
 
-      users = FilteredEditionsPresenter.new(nil, nil, nil).available_users.to_a
+      users = FilteredEditionsPresenter.new(nil, nil, nil, nil).available_users.to_a
 
       assert_equal(users, [enabled_user])
     end


### PR DESCRIPTION
Update the new root controller, which uses the GOV.UK Design System layout template, to accept various submitted filter parameters, which are then used to make a filtered list of editions available to the rendered view, via a presenter.

There is a very basic, unstyled UI, (using basic rails controls rather than Design System components) for the purposes of demonstrating that the filters work / manual testing. This UI is simply there for test purposes and will be replaced by the separate ongoing work that will create the filter component and the results table component.

The controller is behind a feature flag, and so none of this is visible to general users.

[Trello ticket](https://trello.com/c/wucvIcYg)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
