### PR TITLE
Preview homepage

### DIFF
--- a/app/assets/stylesheets/popular_links.scss
+++ b/app/assets/stylesheets/popular_links.scss
@@ -6,9 +6,9 @@
   @include govuk-media-query($from: "tablet") {
     position: sticky;
     top: govuk-spacing(3);
-  }
 
-  .sidebar-components {
-    border-top: 2px solid $govuk-brand-colour;
+    .sidebar-components {
+      border-top: 2px solid $govuk-brand-colour;
+    }
   }
 }

--- a/app/helpers/paths_helper.rb
+++ b/app/helpers/paths_helper.rb
@@ -13,6 +13,20 @@ module PathsHelper
     path
   end
 
+  def preview_homepage_path(edition)
+    path = "#{preview_url(edition)}" # rubocop:disable Style/RedundantInterpolation
+
+    if should_have_auth_bypass_id?(edition)
+      path << "?token=#{jwt_token(edition)}"
+    end
+
+    path
+  end
+
+  def view_homepage_path
+    gov_uk_root_url
+  end
+
   def start_work_path(edition)
     send("start_work_edition_path", edition)
   end
@@ -47,6 +61,10 @@ protected
 
   def preview_url(_edition)
     Plek.external_url_for("draft-origin")
+  end
+
+  def gov_uk_root_url
+    Plek.website_root
   end
 
 private

--- a/app/views/homepage/popular_links/_sidebar.html.erb
+++ b/app/views/homepage/popular_links/_sidebar.html.erb
@@ -5,9 +5,19 @@
     padding: true
   } %>
   <% if @latest_popular_links.state == "published" %>
-    <%= primary_button_for(@latest_popular_links, create_popular_links_path, "Create new edition") %>
+    <%= render "govuk_publishing_components/components/list", {
+      items: [
+        primary_button_for(@latest_popular_links, create_popular_links_path, "Create new edition"),
+        link_to("View on GOV.UK (opens in new tab)", view_homepage_path, rel:"noreferrer noopener", target:"_blank", class: "govuk-link")
+      ]
+    } %>
   <% else %>
-    <%= primary_link_button_for(edit_popular_links_path(@latest_popular_links), "Edit popular links") %>
-    <%= secondary_button_for(@latest_popular_links, publish_popular_links_path(@latest_popular_links), "Publish") %>
+    <%= render "govuk_publishing_components/components/list", {
+      items: [
+        primary_link_button_for(edit_popular_links_path(@latest_popular_links), "Edit popular links") ,
+        secondary_button_for(@latest_popular_links, publish_popular_links_path(@latest_popular_links), "Publish"),
+        link_to("Preview (opens in new tab)", preview_homepage_path(@latest_popular_links), rel:"noreferrer noopener", target:"_blank", class: "govuk-link")
+      ]
+    } %>
   <% end %>
 </div>

--- a/test/integration/homepage_popular_links_test.rb
+++ b/test/integration/homepage_popular_links_test.rb
@@ -30,6 +30,10 @@ class HomepagePopularLinksTest < JavascriptIntegrationTest
       assert page.has_css?(".govuk-tag--green")
     end
 
+    should "have link to view 'GOV.UK'" do
+      assert page.has_link?("View on GOV.UK (opens in new tab)", href: Plek.website_root)
+    end
+
     should "have 'Create new edition' button" do
       assert page.has_text?("Create new edition")
     end
@@ -57,6 +61,12 @@ class HomepagePopularLinksTest < JavascriptIntegrationTest
       assert page.has_text?("Draft")
       assert page.has_css?(".govuk-tag--yellow")
       assert page.has_text?("Edit popular links")
+    end
+
+    should "have link to preview on draft-origin" do
+      click_button("Create new edition")
+
+      assert page.has_link?("Preview (opens in new tab)", href: /#{Plek.external_url_for('draft-origin')}/)
     end
 
     should "create a new record with next version and 'draft' status" do


### PR DESCRIPTION
This commit involves changes to 
- Fix sidebar navigation to adjust for mobile devices, (this seems to be a miss from previous discussion).
- Add preview functionality to view popular links on draft frontend and live frontend using 'preview' link and 'View on GOV.UK' link.

[Trello](https://trello.com/c/Vn1ig5N2/353-create-a-preview-link-for-homepage)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
