### PR TITLE
Erb lint update

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,40 @@
+---
+EnableDefaultLinters: false
+glob: "**/*.{html,text,js}{+*,}.erb"
+exclude:
+  - '**/vendor/**/*'
+  - '**/node_modules/**/*'
+linters:
+  SpaceAroundErbTag:
+    enabled: true
+  Rubocop:
+    enabled: true
+    exclude:
+      - "**/vendor/**/*"
+      - "**/vendor/**/.*"
+      - "bin/**"
+      - "db/**/*"
+      - "spec/**/*"
+      - "config/**/*"
+      - "node_modules/**/*"
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
+      AllCops:
+        DisabledByDefault: true
+      Layout/InitialIndentation:
+        Enabled: false
+      Layout/TrailingEmptyLines:
+        Enabled: false
+      Layout/TrailingWhitespace:
+        Enabled: false
+      Naming/FileName:
+        Enabled: false
+      Style/FrozenStringLiteralComment:
+        Enabled: false
+      Layout/LineLength:
+        Enabled: false
+      Lint/UselessAssignment:
+        Enabled: false
+      Layout/FirstHashElementIndentation:
+        Enabled: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,10 @@ jobs:
     name: Lint Ruby
     uses: alphagov/govuk-infrastructure/.github/workflows/rubocop.yml@main
 
+  lint-erb:
+    name: Lint Ruby
+    uses: alphagov/govuk-infrastructure/.github/workflows/erblint.yml@main
+
   test-javascript:
     name: Test JavaScript
     uses: alphagov/govuk-infrastructure/.github/workflows/jasmine.yml@main

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "aws-sdk-s3", "~> 1"
 gem "bootsnap", require: false
 gem "bootstrap-kaminari-views"
 gem "diffy"
+gem "erb_lint"
 gem "erubis"
 gem "flipflop"
 gem "gds-api-adapters"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,13 @@ GEM
     aws-sigv4 (1.9.1)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
+    better_html (2.1.1)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bigdecimal (3.1.8)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
@@ -143,6 +150,13 @@ GEM
     diffy (3.4.2)
     docile (1.4.0)
     domain_name (0.6.20240107)
+    erb_lint (0.6.0)
+      activesupport
+      better_html (>= 2.0.1)
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop (>= 1)
+      smart_properties
     erubi (1.13.0)
     erubis (2.7.0)
     execjs (2.9.1)
@@ -748,6 +762,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    smart_properties (1.17.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -819,6 +834,7 @@ DEPENDENCIES
   climate_control
   database_cleaner-mongoid
   diffy
+  erb_lint
   erubis
   factory_bot_rails
   flipflop

--- a/app/views/answers/_fields.html.erb
+++ b/app/views/answers/_fields.html.erb
@@ -5,15 +5,15 @@
         <h2 class="remove-top-margin add-bottom-margin h3">Edit Answer</h2>
       </legend>
 
-      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+      <%= render :partial => "shared/common_edition_attributes", :locals => {:f => f} %>
 
       <%= form_group(f, :body) do %>
         <%= f.text_area :body, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control", data: {
-          module: "paste-html-to-govspeak"
+          module: "paste-html-to-govspeak",
         } %>
       <% end %>
     </fieldset>
   </div>
 </div>
 
-<%= render partial: 'shared/workflow_buttons', locals: { f: f } %>
+<%= render partial: "shared/workflow_buttons", locals: { f: f } %>

--- a/app/views/artefacts/new.html.erb
+++ b/app/views/artefacts/new.html.erb
@@ -1,11 +1,11 @@
 <%= content_for :page_title, "New artefact" %>
-<%= form_for(@artefact, html: { class: 'artefact', id: 'edit_artefact' }) do |f| %>
+<%= form_for(@artefact, html: { class: "artefact", id: "edit_artefact" }) do |f| %>
   <fieldset class="inputs">
     <legend class="page-header">
       <h1><%= yield :page_title %></h1>
     </legend>
 
-<%= render :partial => 'shared/legacy_error_summary', locals: { object: @artefact} %>
+<%= render :partial => "shared/legacy_error_summary", locals: { object: @artefact} %>
 
     <div class="row">
       <div class="col-md-12">
@@ -24,7 +24,7 @@
             <%= f.select :kind, formats.map { |s| [s.humanize, s]}, { include_blank: "Select a format" }, { class: "input-md-4 form-control" } %>
           <% end %>
 
-          <%= f.hidden_field :owning_app, value: 'publisher' %>
+          <%= f.hidden_field :owning_app, value: "publisher" %>
 
           <%= form_group(f, :language) do %>
             <%= f.select :language, { "English" => "en", "Welsh" => "cy" }, {}, { class: "input-md-4 form-control" } %>

--- a/app/views/campaigns/_fields.html.erb
+++ b/app/views/campaigns/_fields.html.erb
@@ -1,7 +1,7 @@
 <fieldset class="inputs">
   <div class="row">
     <div class="col-md-8">
-      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+      <%= render :partial => "shared/common_edition_attributes", :locals => {:f => f} %>
     </div>
   </div>
 
@@ -69,4 +69,4 @@
   </div>
 </fieldset>
 
-<%= render partial: 'shared/workflow_buttons', locals: { f: f } %>
+<%= render partial: "shared/workflow_buttons", locals: { f: f } %>

--- a/app/views/campaigns/_image_upload.html.erb
+++ b/app/views/campaigns/_image_upload.html.erb
@@ -14,7 +14,7 @@
           <% end %>
         </p>
       <% end %>
-      <p><%= label_tag do %>Remove image? <%= check_box_tag "edition[remove_#{format}_image]", "1", false, disabled: @resource.locked_for_edits?, class: 'js-no-ajax' %><% end %></p>
+      <p><%= label_tag do %>Remove image? <%= check_box_tag "edition[remove_#{format}_image]", "1", false, disabled: @resource.locked_for_edits?, class: "js-no-ajax" %><% end %></p>
     <% end %>
     <div class="form-group">
       <span class="form-label">

--- a/app/views/completed_transactions/_fields.html.erb
+++ b/app/views/completed_transactions/_fields.html.erb
@@ -5,7 +5,7 @@
         <h2 class="remove-top-margin add-bottom-margin h3">Edit Completed transaction</h2>
       </legend>
 
-      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+      <%= render :partial => "shared/common_edition_attributes", :locals => {:f => f} %>
 
       <%= form_group(f, :body, help: "The body text is overwritten by the service feedback survey") do %>
         <%= f.text_area :body, rows: 20, disabled: "disabled", class: "input-md-10 form-control" %>
@@ -27,25 +27,25 @@
       </p>
 
       <div class="form-group">
-        <%= f.radio_button :promotion_choice, 'none',
-          { checked: (f.object.promotion_choice == "none"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-none' } %>
-        <%= f.label :promotion_choice, "Don't promote anything on this page", value: 'none' %>
+        <%= f.radio_button :promotion_choice, "none",
+          { checked: (f.object.promotion_choice == "none"), disabled: @resource.locked_for_edits?, class: "promotion-choice-none" } %>
+        <%= f.label :promotion_choice, "Don't promote anything on this page", value: "none" %>
         <br />
-        <%= f.radio_button :promotion_choice, 'organ_donor',
-          { checked: (f.object.promotion_choice == "organ_donor"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-organ-donor' } %>
-        <%= f.label :promotion_choice, "Promote organ donation", value: 'organ_donor' %>
+        <%= f.radio_button :promotion_choice, "organ_donor",
+          { checked: (f.object.promotion_choice == "organ_donor"), disabled: @resource.locked_for_edits?, class: "promotion-choice-organ-donor" } %>
+        <%= f.label :promotion_choice, "Promote organ donation", value: "organ_donor" %>
         <br />
-        <%= f.radio_button :promotion_choice, 'bring_id_to_vote',
-          { checked: (f.object.promotion_choice == "bring_id_to_vote"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-bring-id-to-vote' } %>
-        <%= f.label :promotion_choice, "Promote bring photo ID to vote", value: 'bring_id_to_vote' %>
+        <%= f.radio_button :promotion_choice, "bring_id_to_vote",
+          { checked: (f.object.promotion_choice == "bring_id_to_vote"), disabled: @resource.locked_for_edits?, class: "promotion-choice-bring-id-to-vote" } %>
+        <%= f.label :promotion_choice, "Promote bring photo ID to vote", value: "bring_id_to_vote" %>
         <br />
-        <%= f.radio_button :promotion_choice, 'mot_reminder',
-          { checked: (f.object.promotion_choice == "mot_reminder"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-mot-reminder' } %>
-        <%= f.label :promotion_choice, "Promote MOT reminders", value: 'mot_reminder' %>
+        <%= f.radio_button :promotion_choice, "mot_reminder",
+          { checked: (f.object.promotion_choice == "mot_reminder"), disabled: @resource.locked_for_edits?, class: "promotion-choice-mot-reminder" } %>
+        <%= f.label :promotion_choice, "Promote MOT reminders", value: "mot_reminder" %>
         <br />
-        <%= f.radio_button :promotion_choice, 'electric_vehicle',
-          { checked: (f.object.promotion_choice == "electric_vehicle"), disabled: @resource.locked_for_edits?, class: 'promotion-choice-electric-vehicle' } %>
-        <%= f.label :promotion_choice, "Promote electric vehicles", value: 'electric_vehicle' %>
+        <%= f.radio_button :promotion_choice, "electric_vehicle",
+          { checked: (f.object.promotion_choice == "electric_vehicle"), disabled: @resource.locked_for_edits?, class: "promotion-choice-electric-vehicle" } %>
+        <%= f.label :promotion_choice, "Promote electric vehicles", value: "electric_vehicle" %>
 
         <%= form_group(f, :promotion_choice_url, attributes: { id: "promotion-choice-url" }) do %>
           <%= f.text_field :promotion_choice_url, disabled: @resource.locked_for_edits?, class: "input-md-8 form-control" %>
@@ -63,4 +63,4 @@
   </div>
 </div>
 
-<%= render partial: 'shared/workflow_buttons', locals: { f: f } %>
+<%= render partial: "shared/workflow_buttons", locals: { f: f } %>

--- a/app/views/downtimes/_datetime_fields.html.erb
+++ b/app/views/downtimes/_datetime_fields.html.erb
@@ -26,7 +26,7 @@
       <div class="govuk-grid-column-one-half">
         <%= render "govuk_publishing_components/components/fieldset", {
           legend_text: date_legend_text,
-          heading_size: "m"
+          heading_size: "m",
         } do %>
           <%= render "govuk_publishing_components/components/date_input", {
             hint: "For example, 01 08 2022",
@@ -38,7 +38,7 @@
       <div class="govuk-grid-column-one-half">
         <%= render "govuk_publishing_components/components/fieldset", {
           legend_text: time_legend_text,
-          heading_size: "m"
+          heading_size: "m",
         } do %>
           <%= render "time_input", {
             hint: "For example, 9:30 or 19:30",

--- a/app/views/downtimes/_form.html.erb
+++ b/app/views/downtimes/_form.html.erb
@@ -80,7 +80,7 @@
       margin_bottom: 8,
       label: {
         heading_size: "m",
-        text: "Message"
+        text: "Message",
       },
       hint: "Message is auto-generated once a schedule has been made.",
       id: "downtime_message",

--- a/app/views/downtimes/_time_input.html.erb
+++ b/app/views/downtimes/_time_input.html.erb
@@ -1,10 +1,9 @@
 <%
-
   id ||= "input-#{SecureRandom.hex(4)}"
   name ||= nil
   items ||= [
     { :name => "hour", :width => 2 },
-    { :name => "minute", :width => 2 }
+    { :name => "minute", :width => 2 },
   ]
 
   legend_text ||= nil
@@ -37,7 +36,7 @@
       <%= render "govuk_publishing_components/components/hint", {
         id: hint_id,
         text: hint,
-        margin_bottom: 2
+        margin_bottom: 2,
       } %>
     <% end %>
 
@@ -54,7 +53,7 @@
         <%= tag.div class: "govuk-date-input__item" do %>
           <%= render "govuk_publishing_components/components/input", {
             label: {
-              text: item[:label] || item[:name].capitalize
+              text: item[:label] || item[:name].capitalize,
             },
             grouped: true,
             has_error: has_error,
@@ -63,7 +62,7 @@
             width: item[:width],
             id: item[:id],
             type: "number",
-            data: item[:data]
+            data: item[:data],
           } %>
         <% end %>
       <% end %>
@@ -75,7 +74,7 @@
       describedby: aria_described_by,
       legend_text: legend_text,
       text: fieldset_content,
-      role: "group"
+      role: "group",
     } %>
   <% else %>
     <%= fieldset_content %>

--- a/app/views/downtimes/delete.html.erb
+++ b/app/views/downtimes/delete.html.erb
@@ -1,17 +1,17 @@
-<% content_for :page_title, 'Remove downtime message' %>
-<% content_for :title, 'Remove downtime message' %>
+<% content_for :page_title, "Remove downtime message" %>
+<% content_for :title, "Remove downtime message" %>
 
 <div class="govuk-grid-column-two-thirds">
   <%= render "govuk_publishing_components/components/lead_paragraph", {
     text: "Are you sure you want to remove the scheduled downtime message for \"#{@downtime.artefact.name}\"?",
-    margin_bottom: 8
+    margin_bottom: 8,
   } %>
 
-  <%= form_for @downtime, url: edition_downtime_path(@edition), html: { class: 'form well remove-top-margin', 'data-module': 'downtime-message' } do |f| %>
+  <%= form_for @downtime, url: edition_downtime_path(@edition), html: { class: "form well remove-top-margin", 'data-module': "downtime-message" } do |f| %>
     <div class="govuk-button-group">
       <%= render "govuk_publishing_components/components/button", {
         text: "Remove",
-        destructive: true
+        destructive: true,
       } %>
       <%= link_to "Cancel", downtimes_path, class: "govuk-link govuk-link--no-visited-state" %>
     </div>

--- a/app/views/downtimes/edit.html.erb
+++ b/app/views/downtimes/edit.html.erb
@@ -1,23 +1,23 @@
-<% content_for :page_title, 'Edit downtime message' %>
-<% content_for :title, 'Edit downtime message' %>
+<% content_for :page_title, "Edit downtime message" %>
+<% content_for :title, "Edit downtime message" %>
 <% content_for :title_context, @downtime.artefact.name %>
 <% unless @downtime.errors.empty? %>
-  <% content_for :error_summary, render("shared/error_summary", { object: @downtime })  %>
+  <% content_for :error_summary, render("shared/error_summary", { object: @downtime }) %>
 <% end %>
 
 <div class="govuk-grid-column-two-thirds">
   <%= render "govuk_publishing_components/components/lead_paragraph", {
     text: "Downtime message appear on the service's start page one day before the downtime is due to occur.",
-    margin_bottom: 6
+    margin_bottom: 6,
   } %>
 
-<%= form_for @downtime, url: edition_downtime_path(@edition), html: { class: 'form well remove-top-margin', 'data-module': 'downtime-message' } do |f| %>
-  <%= render 'form', f: f %>
+<%= form_for @downtime, url: edition_downtime_path(@edition), html: { class: "form well remove-top-margin", 'data-module': "downtime-message" } do |f| %>
+  <%= render "form", f: f %>
     <div class="govuk-button-group">
       <%= render "govuk_publishing_components/components/button", {
         text: "Save",
         value: "save",
-        name: "save"
+        name: "save",
       } %>
 
       <%= link_to "Cancel", downtimes_path, class: "govuk-link govuk-link--no-visited-state" %>

--- a/app/views/downtimes/index.html.erb
+++ b/app/views/downtimes/index.html.erb
@@ -1,11 +1,11 @@
-<% content_for :page_title, 'Downtime messages' %>
+<% content_for :page_title, "Downtime messages" %>
 <% content_for :title, "Downtime messages" %>
 
 <div class="govuk-grid-column-full">
 
   <%= render "govuk_publishing_components/components/lead_paragraph", {
     text: "Show a message on a published transaction start page for a specific time.",
-    margin_bottom: 6
+    margin_bottom: 6,
   } %>  
 
   <%= render "govuk_publishing_components/components/table", {
@@ -19,12 +19,12 @@
         text: "Service Status",
       },
       {
-        text: tag.span("Action", class: "govuk-visually-hidden")
+        text: tag.span("Action", class: "govuk-visually-hidden"),
       },
       {
-        text: tag.span("Link to view live on GOV.UK", class: "govuk-visually-hidden")
-      }
+        text: tag.span("Link to view live on GOV.UK", class: "govuk-visually-hidden"),
+      },
     ],
-    rows: transactions_table_entries(@transactions.to_a)
+    rows: transactions_table_entries(@transactions.to_a),
   } %>
 </div>

--- a/app/views/downtimes/new.html.erb
+++ b/app/views/downtimes/new.html.erb
@@ -1,24 +1,24 @@
-<% content_for :page_title, 'Schedule downtime' %>
-<% content_for :title, 'Add downtime message' %>
+<% content_for :page_title, "Schedule downtime" %>
+<% content_for :title, "Add downtime message" %>
 <% content_for :title_context, @downtime.artefact.name %>
 <% unless @downtime.errors.empty? %>
-  <% content_for :error_summary, render("shared/error_summary", { object: @downtime })  %>
+  <% content_for :error_summary, render("shared/error_summary", { object: @downtime }) %>
 <% end %>
 
 <div class="govuk-grid-column-two-thirds">
   <%= render "govuk_publishing_components/components/lead_paragraph", {
     text: "Downtime message appear on the service's start page one day before the downtime is due to occur.",
-    margin_bottom: 6
+    margin_bottom: 6,
   } %>
 
-  <%= form_for @downtime, url: edition_downtime_path(@edition), html: { class: 'form well remove-top-margin', 'data-module' => 'downtime-message' } do |f| %>
-    <%= render 'form', f: f %>
+  <%= form_for @downtime, url: edition_downtime_path(@edition), html: { class: "form well remove-top-margin", "data-module" => "downtime-message" } do |f| %>
+    <%= render "form", f: f %>
 
     <div class="govuk-button-group">
       <%= render "govuk_publishing_components/components/button", {
         text: "Save",
         value: "save",
-        name: "save"
+        name: "save",
       } %>
 
       <%= link_to "Cancel", downtimes_path, class: "govuk-link govuk-link--no-visited-state" %>

--- a/app/views/editions/_reviewer_field.html.erb
+++ b/app/views/editions/_reviewer_field.html.erb
@@ -1,3 +1,3 @@
 <%= form_group(f, :reviewer, label: "Reviewer") do %>
-  <%= f.select :reviewer, User.enabled.order_by([[:name, :asc]]).collect{ |p| [p.name, p.name] }, { :include_blank => true }, { :class => "form-control input-md-3", :disabled => @resource.locked_for_edits?, "data-module" => 'assignee-select'} %>
+  <%= f.select :reviewer, User.enabled.order_by([[:name, :asc]]).collect{ |p| [p.name, p.name] }, { :include_blank => true }, { :class => "form-control input-md-3", :disabled => @resource.locked_for_edits?, "data-module" => "assignee-select"} %>
 <% end %>

--- a/app/views/editions/diagram.html.erb
+++ b/app/views/editions/diagram.html.erb
@@ -1,4 +1,4 @@
-<%= render 'shared/edition_header' %>
+<%= render "shared/edition_header" %>
 
 <div class="smart-answer-flowchart" data-module="smart-answer-flowchart">
   <pre class="mermaid flowchart flowchart--hidden">

--- a/app/views/editions/diff.html.erb
+++ b/app/views/editions/diff.html.erb
@@ -1,4 +1,4 @@
-  <%= render 'shared/edition_header' %>
+  <%= render "shared/edition_header" %>
 
   <p>
     <%= link_to "Back to current edition", edition_path(@resource.history.first), :class => "btn btn-default" %>

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -1,5 +1,5 @@
 <% @edition = @resource %>
-  <%= render 'shared/edition_header' %>
+  <%= render "shared/edition_header" %>
 
   <% errors_hash = errors_to_display(@edition) %>
   <% if !errors_hash.empty? %>
@@ -25,15 +25,15 @@
     </ul>
 
     <div class="tab-content add-top-margin">
-        <div role="tabpanel" class="tab-pane <% if active_tab.name == 'edit'%>active<% end %>" id="edit">
+        <div role="tabpanel" class="tab-pane <% if active_tab.name == 'edit' %>active<% end %>" id="edit">
           <div class="link-check-report col-md-4">
             <% if @edition.class.to_s == "SimpleSmartAnswerEdition" %>
               <p>
-                View the <%= link_to "flow diagram (opens in a new tab)", diagram_edition_path(@edition), target: '_blank' %>
+                View the <%= link_to "flow diagram (opens in a new tab)", diagram_edition_path(@edition), target: "_blank", rel: "noopener" %>
               </p>
             <% end %>
 
-            <%= render 'link_check_reports/link_check_report', edition: @edition, report: @edition.latest_link_check_report %>
+            <%= render "link_check_reports/link_check_report", edition: @edition, report: @edition.latest_link_check_report %>
 
             <% if @edition.class.to_s.in?(Edition::HAS_GOVSPEAK_FIELDS) %>
               <h3 class="remove-top-margin add-bottom-margin">Govspeak help</h3>
@@ -56,7 +56,7 @@
         # because this action is triggered from a view where editing is not allowed.
         edition_activities_forms(@resource, Edition::CANCEL_SCHEDULED_PUBLISHING_ACTION) %>
 
-      <% tabs.reject {|t| t.name == 'edit'}.each do |tab| %>
+      <% tabs.reject {|t| t.name == "edit"}.each do |tab| %>
         <div role="tabpanel" class="tab-pane <% if tab == active_tab %>active<% end %>" id="<%= tab.name %>">
           <div class="well">
             <%= render :partial => "/shared/#{tab.name}", :locals => {:publication => @resource} %>

--- a/app/views/event_mailer/_approve_fact_check.text.erb
+++ b/app/views/event_mailer/_approve_fact_check.text.erb
@@ -1,4 +1,4 @@
-<%= @action.requester.name %> approved fact check "<%= @action.edition.title %>" (<%= @action.edition.format %>) at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
+<%= @action.requester.name %> approved fact check "<%= @action.edition.title %>" (<%= @action.edition.format %>) at <%= Time.zone.now.strftime("%R on %d/%m/%Y") %>
 
 Comment: <%= @action.comment %>
 

--- a/app/views/event_mailer/_approve_review.text.erb
+++ b/app/views/event_mailer/_approve_review.text.erb
@@ -1,4 +1,4 @@
-<%= @action.requester.name %> okayed "<%= @action.edition.title %>" (<%= @action.edition.format %>) at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
+<%= @action.requester.name %> okayed "<%= @action.edition.title %>" (<%= @action.edition.format %>) at <%= Time.zone.now.strftime("%R on %d/%m/%Y") %>
 
 Comment: <%= @action.comment %>
 

--- a/app/views/event_mailer/_assign.text.erb
+++ b/app/views/event_mailer/_assign.text.erb
@@ -1,6 +1,6 @@
 <% if @action.recipient -%>
-"<%= @action.edition.title %>" (<%= @action.edition.format %>) has been assigned to <%= @action.recipient.name %> at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
+"<%= @action.edition.title %>" (<%= @action.edition.format %>) has been assigned to <%= @action.recipient.name %> at <%= Time.zone.now.strftime("%R on %d/%m/%Y") %>
 <% else -%>
-"<%= @action.edition.title %>" (<%= @action.edition.format %>) has been unassigned at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
+"<%= @action.edition.title %>" (<%= @action.edition.format %>) has been unassigned at <%= Time.zone.now.strftime("%R on %d/%m/%Y") %>
 <% end -%>
 <%= "#{@preview_url}" %>

--- a/app/views/event_mailer/_cancel_scheduled_publishing.text.erb
+++ b/app/views/event_mailer/_cancel_scheduled_publishing.text.erb
@@ -1,3 +1,3 @@
-<%= @action.requester.name %> cancelled scheduled publishing of "<%= @action.edition.title %>" (<%= @action.edition.format %>) at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>.
+<%= @action.requester.name %> cancelled scheduled publishing of "<%= @action.edition.title %>" (<%= @action.edition.format %>) at <%= Time.zone.now.strftime("%R on %d/%m/%Y") %>.
 
 <%= "#{@preview_url}" %>

--- a/app/views/event_mailer/_create.text.erb
+++ b/app/views/event_mailer/_create.text.erb
@@ -1,3 +1,3 @@
-"<%= @action.edition.title %>" (<%= @action.edition.format %>) created by <%= @action.requester.name %> at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
+"<%= @action.edition.title %>" (<%= @action.edition.format %>) created by <%= @action.requester.name %> at <%= Time.zone.now.strftime("%R on %d/%m/%Y") %>
 
 <%= "#{@preview_url}" %>

--- a/app/views/event_mailer/_new_version.text.erb
+++ b/app/views/event_mailer/_new_version.text.erb
@@ -1,3 +1,3 @@
-New version of "<%= @action.edition.title %>" (<%= @action.edition.format %>) created by <%= @action.requester.name %> at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
+New version of "<%= @action.edition.title %>" (<%= @action.edition.format %>) created by <%= @action.requester.name %> at <%= Time.zone.now.strftime("%R on %d/%m/%Y") %>
 
 <%= "#{@preview_url}" %>

--- a/app/views/event_mailer/_publish.text.erb
+++ b/app/views/event_mailer/_publish.text.erb
@@ -1,3 +1,3 @@
-<%= @action.requester.name %> published "<%= @action.edition.title %>" (<%= @action.edition.format %>) at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
+<%= @action.requester.name %> published "<%= @action.edition.title %>" (<%= @action.edition.format %>) at <%= Time.zone.now.strftime("%R on %d/%m/%Y") %>
 
 <%= "#{@preview_url}" %>

--- a/app/views/event_mailer/_receive_fact_check.text.erb
+++ b/app/views/event_mailer/_receive_fact_check.text.erb
@@ -1,4 +1,4 @@
-Fact check response received for "<%= @action.edition.title %>" (<%= @action.edition.format %>) at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
+Fact check response received for "<%= @action.edition.title %>" (<%= @action.edition.format %>) at <%= Time.zone.now.strftime("%R on %d/%m/%Y") %>
 
 
 <%= "#{@preview_url}" %>

--- a/app/views/event_mailer/_request_amendments.text.erb
+++ b/app/views/event_mailer/_request_amendments.text.erb
@@ -1,4 +1,4 @@
-"<%= @action.edition.title %>" (<%= @action.edition.format %>) reviewed by <%= @action.requester.name %> at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
+"<%= @action.edition.title %>" (<%= @action.edition.format %>) reviewed by <%= @action.requester.name %> at <%= Time.zone.now.strftime("%R on %d/%m/%Y") %>
 
 Further amends required:
 <%= @action.comment %>

--- a/app/views/event_mailer/_request_review.text.erb
+++ b/app/views/event_mailer/_request_review.text.erb
@@ -2,7 +2,7 @@ Please review "<%= @action.edition.title %>" (<%= @action.edition.format %>)
 
 Comment: <%= @action.comment %>
 
-Requested by <%= @action.requester.name %> at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
+Requested by <%= @action.requester.name %> at <%= Time.zone.now.strftime("%R on %d/%m/%Y") %>
 
 View:
 <%= "#{@preview_url}" %>

--- a/app/views/event_mailer/_resend_fact_check.text.erb
+++ b/app/views/event_mailer/_resend_fact_check.text.erb
@@ -1,1 +1,1 @@
-Fact check email resent for "<%= @action.edition.title %>" (<%= @action.edition.format %>) by <%= @action.requester.name %> at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
+Fact check email resent for "<%= @action.edition.title %>" (<%= @action.edition.format %>) by <%= @action.requester.name %> at <%= Time.zone.now.strftime("%R on %d/%m/%Y") %>

--- a/app/views/event_mailer/_schedule_for_publishing.text.erb
+++ b/app/views/event_mailer/_schedule_for_publishing.text.erb
@@ -1,3 +1,3 @@
-<%= @action.requester.name %> scheduled "<%= @action.edition.title %>" (<%= @action.edition.format %>) to be published at <%= @action.edition.publish_at.strftime("%R on %d/%m/%Y") %>. This change was made at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>.
+<%= @action.requester.name %> scheduled "<%= @action.edition.title %>" (<%= @action.edition.format %>) to be published at <%= @action.edition.publish_at.strftime("%R on %d/%m/%Y") %>. This change was made at <%= Time.zone.now.strftime("%R on %d/%m/%Y") %>.
 
 <%= "#{@preview_url}" %>

--- a/app/views/event_mailer/_send_fact_check.text.erb
+++ b/app/views/event_mailer/_send_fact_check.text.erb
@@ -1,8 +1,8 @@
-Fact check requested for "<%= @action.edition.title %>" (<%= @action.edition.format %>) by <%= @action.requester.name %> at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
+Fact check requested for "<%= @action.edition.title %>" (<%= @action.edition.format %>) by <%= @action.requester.name %> at <%= Time.zone.now.strftime("%R on %d/%m/%Y") %>
 
 Sent to: <%= @action.email_addresses %>
 2nd eyes: <%= @action.requester.name %>
-Response expected by: <%= ((Date.today)+7).to_s %>
+Response expected by: <%= ((Time.zone.today)+7).to_s %>
 
 Comment: <%= @action.comment %>
 

--- a/app/views/event_mailer/_skip_fact_check.text.erb
+++ b/app/views/event_mailer/_skip_fact_check.text.erb
@@ -1,3 +1,3 @@
-<%= @action.requester.name %> skipped fact check for "<%= @action.edition.title %>" (<%= @action.edition.format %>) at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
+<%= @action.requester.name %> skipped fact check for "<%= @action.edition.title %>" (<%= @action.edition.format %>) at <%= Time.zone.now.strftime("%R on %d/%m/%Y") %>
 
 <%= "#{@preview_url}" %>

--- a/app/views/event_mailer/_skip_review.text.erb
+++ b/app/views/event_mailer/_skip_review.text.erb
@@ -1,4 +1,4 @@
-<%= @action.requester.name %> skipped reviewing "<%= @action.edition.title %>" (<%= @action.edition.format %>) at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
+<%= @action.requester.name %> skipped reviewing "<%= @action.edition.title %>" (<%= @action.edition.format %>) at <%= Time.zone.now.strftime("%R on %d/%m/%Y") %>
 
 Comment: <%= @action.comment %>
 

--- a/app/views/event_mailer/_start_work.text.erb
+++ b/app/views/event_mailer/_start_work.text.erb
@@ -1,3 +1,3 @@
-Work was started on "<%= @action.edition.title %>" (<%= @action.edition.format %>) by <%= @action.requester.name %> at <%=Time.zone.now.strftime("%R on %d/%m/%Y") %>
+Work was started on "<%= @action.edition.title %>" (<%= @action.edition.format %>) by <%= @action.requester.name %> at <%= Time.zone.now.strftime("%R on %d/%m/%Y") %>
 
 <%= "#{@preview_url}" %>

--- a/app/views/event_mailer/request_fact_check.text.erb
+++ b/app/views/event_mailer/request_fact_check.text.erb
@@ -3,7 +3,7 @@
 <%- else -%>
 Hi,
 
-We need you to check the factual accuracy of changes made to ‘<%= @edition.title%>’ before it’s published on GOV.UK.
+We need you to check the factual accuracy of changes made to ‘<%= @edition.title %>’ before it’s published on GOV.UK.
 
 The GOV.UK Content Team made the changes because
 

--- a/app/views/guides/_fields.html.erb
+++ b/app/views/guides/_fields.html.erb
@@ -6,7 +6,7 @@
         <h2 class="remove-top-margin add-bottom-margin h3">Edit Guide</h2>
       </legend>
 
-      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+      <%= render :partial => "shared/common_edition_attributes", :locals => {:f => f} %>
     </fieldset>
   </div>
 </div>
@@ -37,15 +37,15 @@
 
     <section class="panel-group" id="parts" data-module="parts">
       <%= f.fields_for :parts, @ordered_parts do |part| %>
-        <%= render partial: '/shared/common_part_attributes', locals: { f: part, editable: !@resource.locked_for_edits?, child_record_type: 'part' } %>
+        <%= render partial: "/shared/common_part_attributes", locals: { f: part, editable: !@resource.locked_for_edits?, child_record_type: "part" } %>
       <% end %>
     </section>
 
-    <%= f.link_to_add :parts, :data => { :target => "#parts" }, :class => 'btn btn-default' do %>
+    <%= f.link_to_add :parts, :data => { :target => "#parts" }, :class => "btn btn-default" do %>
       <i class="glyphicon glyphicon-plus add-right-margin"></i>Add new part
     <% end %>
 
   </div>
 </div>
 
-<%= render partial: 'shared/workflow_buttons', locals: { f: f } %>
+<%= render partial: "shared/workflow_buttons", locals: { f: f } %>

--- a/app/views/help_pages/_fields.html.erb
+++ b/app/views/help_pages/_fields.html.erb
@@ -5,15 +5,15 @@
         <h2 class="remove-top-margin add-bottom-margin h3">Edit Help page</h2>
       </legend>
 
-      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+      <%= render :partial => "shared/common_edition_attributes", :locals => {:f => f} %>
 
       <%= form_group(f, :body) do %>
         <%= f.text_area :body, rows: 20, disabled: @resource.locked_for_edits?, class: "form-control", data: {
-          module: "paste-html-to-govspeak"
+          module: "paste-html-to-govspeak",
         } %>
       <% end %>
     </fieldset>
   </div>
 </div>
 
-<%= render partial: 'shared/workflow_buttons', locals: { f: f } %>
+<%= render partial: "shared/workflow_buttons", locals: { f: f } %>

--- a/app/views/homepage/popular_links/_sidebar.html.erb
+++ b/app/views/homepage/popular_links/_sidebar.html.erb
@@ -17,8 +17,8 @@
         primary_link_button_for(edit_popular_links_path(@latest_popular_links), "Edit popular links") ,
         secondary_button_for(@latest_popular_links, publish_popular_links_path(@latest_popular_links), "Publish"),
         link_to("Preview (opens in new tab)", preview_homepage_path(@latest_popular_links), rel:"noreferrer noopener", target:"_blank", class: "govuk-link"),
-        link_to("Delete draft", confirm_destroy_popular_links_path(@latest_popular_links), class: "govuk-link gem-link--destructive")
-        ]
+        link_to("Delete draft", confirm_destroy_popular_links_path(@latest_popular_links), class: "govuk-link gem-link--destructive"),
+      ],
     } %>
   <% end %>
 </div>

--- a/app/views/homepage/popular_links/_sidebar.html.erb
+++ b/app/views/homepage/popular_links/_sidebar.html.erb
@@ -2,14 +2,14 @@
   <%= render "govuk_publishing_components/components/heading", {
     text: "Options",
     font_size: "s",
-    padding: true
+    padding: true,
   } %>
   <% if @latest_popular_links.state == "published" %>
     <%= render "govuk_publishing_components/components/list", {
       items: [
         primary_button_for(@latest_popular_links, create_popular_links_path, "Create new edition"),
-        link_to("View on GOV.UK (opens in new tab)", view_homepage_path, rel:"noreferrer noopener", target:"_blank", class: "govuk-link")
-      ]
+        link_to("View on GOV.UK (opens in new tab)", view_homepage_path, rel:"noreferrer noopener", target:"_blank", class: "govuk-link"),
+      ],
     } %>
   <% else %>
     <%= render "govuk_publishing_components/components/list", {

--- a/app/views/homepage/popular_links/_version_and_status.html.erb
+++ b/app/views/homepage/popular_links/_version_and_status.html.erb
@@ -5,11 +5,11 @@
   items: [
     {
       field: "Edition",
-      value: version
+      value: version,
     },
     {
       field: "Status",
-      value: status_tag
-    }
-  ]
+      value: status_tag,
+    },
+  ],
 } %>

--- a/app/views/homepage/popular_links/edit.html.erb
+++ b/app/views/homepage/popular_links/edit.html.erb
@@ -1,6 +1,6 @@
-<% content_for :page_title, 'Edit popular links' %>
-<% content_for :title, 'Edit popular links' %>
-<% content_for :title_context, 'Popular on GOV.UK' %>
+<% content_for :page_title, "Edit popular links" %>
+<% content_for :title, "Edit popular links" %>
+<% content_for :title_context, "Popular on GOV.UK" %>
 <% unless @latest_popular_links.errors.empty? %>
   <% content_for :error_summary do %>
     <%= render("govuk_publishing_components/components/error_summary", {
@@ -11,7 +11,7 @@
           text: error.message,
           href: "##{error.attribute.to_s}",
         }
-      end
+      end,
     }) %>
   <% end %>
 <% end %>

--- a/app/views/homepage/popular_links/show.html.erb
+++ b/app/views/homepage/popular_links/show.html.erb
@@ -1,6 +1,6 @@
-<% content_for :page_title, 'Popular on GOV.UK' %>
-<% content_for :title, 'Popular on GOV.UK' %>
-<% content_for :title_context, 'Homepage' %>
+<% content_for :page_title, "Popular on GOV.UK" %>
+<% content_for :title, "Popular on GOV.UK" %>
+<% content_for :title_context, "Homepage" %>
 <div class="govuk-grid-column-two-thirds">
   <%= render "homepage/popular_links/version_and_status", version: @latest_popular_links.version_number, status: @latest_popular_links.state %>
   <% @latest_popular_links.link_items.each_with_index do |item, index| %>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -8,7 +8,7 @@
   product_title: "Publisher",
   browser_title: yield(:page_title),
   environment: environment,
-  head: yield(:head)
+  head: yield(:head),
 } do %>
 
   <% render "layouts/google_tag_manager" %>
@@ -18,7 +18,7 @@
   <%= render "govuk_publishing_components/components/layout_header", {
     product_name: "Publisher",
     environment: environment,
-    navigation_items: navigation_items(is_editor: current_user.govuk_editor?, path: request.path, user_name: current_user.name)
+    navigation_items: navigation_items(is_editor: current_user.govuk_editor?, path: request.path, user_name: current_user.name),
   } %>
 
   <div class="govuk-width-container">

--- a/app/views/layouts/legacy_application.html.erb
+++ b/app/views/layouts/legacy_application.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, ' | GOV.UK Publisher' %>
+<% content_for :page_title, " | GOV.UK Publisher" %>
 <% content_for :favicon do %>
   <% environment_style = GovukAdminTemplate.environment_style %>
   <% favicon = environment_style ? "favicon-#{environment_style}.png" : "favicon.png" %>
@@ -16,15 +16,15 @@
 <% end %>
 
 <% content_for :navbar_items do %>
-  <%= nav_link 'Publications', root_path %>
+  <%= nav_link "Publications", root_path %>
 
   <% if current_user.govuk_editor? %>
-    <%= nav_link 'Add artefact', new_artefact_path %>
-    <%= nav_link 'Downtime', downtimes_path %>
+    <%= nav_link "Add artefact", new_artefact_path %>
+    <%= nav_link "Downtime", downtimes_path %>
   <% end %>
 
-  <%= nav_link 'Reports', reports_path %>
-  <%= nav_link 'Search by user', user_search_path %>
+  <%= nav_link "Reports", reports_path %>
+  <%= nav_link "Search by user", user_search_path %>
 <% end %>
 
 <% content_for :content do %>
@@ -59,4 +59,4 @@
 <% end %>
 
 <%# use the govuk_admin_template layout %>
-<%= render :template => 'layouts/govuk_admin_template' %>
+<%= render :template => "layouts/govuk_admin_template" %>

--- a/app/views/legacy_root/_amends_needed.html.erb
+++ b/app/views/legacy_root/_amends_needed.html.erb
@@ -8,6 +8,6 @@
     </tr>
   </thead>
   <tbody>
-    <%= render :collection => @presenter.amends_needed, :partial => 'publication', :locals => {:tab => :amends_needed} %>
+    <%= render :collection => @presenter.amends_needed, :partial => "publication", :locals => {:tab => :amends_needed} %>
   </tbody>
 </table>

--- a/app/views/legacy_root/_archived.html.erb
+++ b/app/views/legacy_root/_archived.html.erb
@@ -9,6 +9,6 @@
     </tr>
   </thead>
   <tbody>
-    <%= render :collection => @presenter.archived, :partial => 'publication', :locals => {:tab => :archived}  %>
+    <%= render :collection => @presenter.archived, :partial => "publication", :locals => {:tab => :archived} %>
   </tbody>
 </table>

--- a/app/views/legacy_root/_drafts.html.erb
+++ b/app/views/legacy_root/_drafts.html.erb
@@ -8,6 +8,6 @@
     </tr>
   </thead>
   <tbody>
-    <%= render :collection => @presenter.draft, :partial => 'publication', :locals => {:tab => :draft} %>
+    <%= render :collection => @presenter.draft, :partial => "publication", :locals => {:tab => :draft} %>
   </tbody>
 </table>

--- a/app/views/legacy_root/_fact_check_received.html.erb
+++ b/app/views/legacy_root/_fact_check_received.html.erb
@@ -8,6 +8,6 @@
     </tr>
   </thead>
   <tbody>
-    <%= render :collection => @presenter.fact_check_received, :partial => 'publication', :locals => {:tab => :fact_check_received}  %>
+    <%= render :collection => @presenter.fact_check_received, :partial => "publication", :locals => {:tab => :fact_check_received} %>
   </tbody>
 </table>

--- a/app/views/legacy_root/_in_review.html.erb
+++ b/app/views/legacy_root/_in_review.html.erb
@@ -10,6 +10,6 @@
     </tr>
   </thead>
   <tbody>
-    <%= render :collection => @presenter.in_review, :partial => 'publication', :locals => {:tab => :in_review} %>
+    <%= render :collection => @presenter.in_review, :partial => "publication", :locals => {:tab => :in_review} %>
   </tbody>
 </table>

--- a/app/views/legacy_root/_out_for_fact_check.html.erb
+++ b/app/views/legacy_root/_out_for_fact_check.html.erb
@@ -9,6 +9,6 @@
     </tr>
   </thead>
   <tbody>
-    <%= render :collection => @presenter.fact_check, :partial => 'publication', :locals => {:tab => :fact_check} %>
+    <%= render :collection => @presenter.fact_check, :partial => "publication", :locals => {:tab => :fact_check} %>
   </tbody>
 </table>

--- a/app/views/legacy_root/_publication.html.erb
+++ b/app/views/legacy_root/_publication.html.erb
@@ -11,14 +11,14 @@
     </h2>
 
     <% if publication.published? %>
-      <%= link_to "/#{publication.slug}", "#{Plek.website_root}/#{publication.slug}", class: 'link-muted' %>
+      <%= link_to "/#{publication.slug}", "#{Plek.website_root}/#{publication.slug}", class: "link-muted" %>
     <% elsif publication.safe_to_preview? %>
-      <%= link_to "/#{publication.slug}", preview_edition_path(publication), class: 'link-muted' %>
+      <%= link_to "/#{publication.slug}", preview_edition_path(publication), class: "link-muted" %>
     <% end %>
 
     <span class="text-muted"> &middot; <span title="Edition <%= publication.version_number %>">#<%= publication.version_number %></span></span>
     <% if tab && (tab == :published || tab == :archived) && publication.subsequent_siblings.first.present? %>
-      <span class="text-muted"> – <%= link_to "##{publication.subsequent_siblings.first.version_number} in #{publication.subsequent_siblings.first.state.humanize.downcase}", edition_path(publication.subsequent_siblings.first), class: 'link-inherit' %>
+      <span class="text-muted"> – <%= link_to "##{publication.subsequent_siblings.first.version_number} in #{publication.subsequent_siblings.first.state.humanize.downcase}", edition_path(publication.subsequent_siblings.first), class: "link-inherit" %>
       </span>
     <% end %>
 
@@ -56,7 +56,7 @@
       <%= time_ago_in_words(publication.review_requested_at) %>
     </td>
     <td>
-      <%= render partial: 'reviewer', locals: { publication: publication } %>
+      <%= render partial: "reviewer", locals: { publication: publication } %>
     </td>
   <% end %>
   <% if tab && tab == :published %>
@@ -68,9 +68,9 @@
     <td>
       <% if current_user.has_editor_permissions?(publication) %>
         <% if publication.can_create_new_edition? %>
-          <%= link_to 'Create new edition', duplicate_edition_path(publication), class: 'btn btn-default', method: :post %>
+          <%= link_to "Create new edition", duplicate_edition_path(publication), class: "btn btn-default", method: :post %>
         <% elsif publication.in_progress_sibling %>
-          <%= link_to 'Edit newer edition', edition_path(publication.in_progress_sibling), html_options = { "class" => "btn btn-info"} %>
+          <%= link_to "Edit newer edition", edition_path(publication.in_progress_sibling), html_options = { "class" => "btn btn-info"} %>
         <% end %>
       <% end %>
     </td>

--- a/app/views/legacy_root/_published.html.erb
+++ b/app/views/legacy_root/_published.html.erb
@@ -10,6 +10,6 @@
     </tr>
   </thead>
   <tbody>
-    <%= render :collection => @presenter.published, :partial => 'publication', :as => 'publication', :locals => {:tab => :published}  %>
+    <%= render :collection => @presenter.published, :partial => "publication", :as => "publication", :locals => {:tab => :published} %>
   </tbody>
 </table>

--- a/app/views/legacy_root/_ready.html.erb
+++ b/app/views/legacy_root/_ready.html.erb
@@ -8,6 +8,6 @@
     </tr>
   </thead>
   <tbody>
-    <%= render :collection => @presenter.ready, :partial => 'publication', :locals => {:tab => :ready} %>
+    <%= render :collection => @presenter.ready, :partial => "publication", :locals => {:tab => :ready} %>
   </tbody>
 </table>

--- a/app/views/legacy_root/_scheduled_for_publishing.html.erb
+++ b/app/views/legacy_root/_scheduled_for_publishing.html.erb
@@ -9,6 +9,6 @@
     </tr>
   </thead>
   <tbody>
-    <%= render :collection => @presenter.scheduled_for_publishing, :partial => 'publication', :locals => {:tab => :scheduled_for_publishing} %>
+    <%= render :collection => @presenter.scheduled_for_publishing, :partial => "publication", :locals => {:tab => :scheduled_for_publishing} %>
   </tbody>
 </table>

--- a/app/views/legacy_root/index.html.erb
+++ b/app/views/legacy_root/index.html.erb
@@ -31,18 +31,18 @@
             <label for="user_filter" class="nav-header">Assignee</label>
             <%=
               select_tag("user_filter", options_for_select(
-                [["All", "all"], ["Nobody", "nobody"]] +
+                [%w[All all], %w[Nobody nobody]] +
                 User.enabled.alphabetized.map{ |u| [u.name, u.uid] }, @user_filter
-              ), class: 'form-control js-user-filter', "data-module" => 'assignee-select')
+              ), class: "form-control js-user-filter", "data-module" => "assignee-select")
             %>
             <label for="string_filter" class="add-top-margin nav-header">Keyword</label>
-            <%= text_field_tag "string_filter", params[:string_filter], class: 'form-control', type: "search" %>
+            <%= text_field_tag "string_filter", params[:string_filter], class: "form-control", type: "search" %>
 
             <label for="format_filter" class="add-top-margin nav-header">Format</label>
             <%= select_tag("format_filter", options_for_select(
               legacy_format_filter_selection_options,
-              params[:format_filter]
-            ), class: 'form-control') %>
+              params[:format_filter],
+            ), class: "form-control") %>
             <input class="add-top-margin btn btn-default" type="submit" value="Filter publications">
           </form>
         </div>
@@ -58,7 +58,7 @@
 
       <div id="publication-list-container" class="col-md-10">
         <%= render @list %>
-        <%= paginate @presenter.send(@list), theme: 'twitter-bootstrap-3' %>
+        <%= paginate @presenter.send(@list), theme: "twitter-bootstrap-3" %>
       </div>
 
     </div><!--./row -->

--- a/app/views/licences/_fields.html.erb
+++ b/app/views/licences/_fields.html.erb
@@ -5,7 +5,7 @@
         <h2 class="remove-top-margin add-bottom-margin h3">Edit License</h2>
       </legend>
 
-      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+      <%= render :partial => "shared/common_edition_attributes", :locals => {:f => f} %>
 
       <%= form_group(f, :licence_identifier, label: "Licence identifier") do %>
         <%= f.text_field :licence_identifier, disabled: @resource.locked_for_edits?, class: "input-md-3 form-control" %>
@@ -25,11 +25,11 @@
 
       <%= form_group(f, :licence_overview) do %>
         <%= f.text_area :licence_overview, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control", data: {
-          module: "paste-html-to-govspeak"
+          module: "paste-html-to-govspeak",
         } %>
       <% end %>
     </fieldset>
   </div>
 </div>
 
-<%= render partial: 'shared/workflow_buttons', locals: { f: f } %>
+<%= render partial: "shared/workflow_buttons", locals: { f: f } %>

--- a/app/views/licences/new.html.erb
+++ b/app/views/licences/new.html.erb
@@ -8,9 +8,9 @@
   We need a bit more information to create your licence.
 </p>
 
-<%= render :partial => 'shared/legacy_error_summary', locals: { object: @publication } %>
+<%= render :partial => "shared/legacy_error_summary", locals: { object: @publication } %>
 
-<%= form_for(@publication, :url => editions_path, :as => :edition, :html => { :id => 'edition-form' } ) do |f| %>
+<%= form_for(@publication, :url => editions_path, :as => :edition, :html => { :id => "edition-form" } ) do |f| %>
   <%= form_group(f, :licence_identifier) do %>
     <%= f.text_field :licence_identifier, class: "form-control" %>
   <% end %>
@@ -21,5 +21,5 @@
     <%= f.hidden_field :title %>
     <%= f.hidden_field :slug %>
   </fieldset>
-  <%= f.submit "Create Licence edition", class: 'btn btn-success' %>
+  <%= f.submit "Create Licence edition", class: "btn btn-success" %>
 <% end %>

--- a/app/views/link_check_reports/_link_check_report.html.erb
+++ b/app/views/link_check_reports/_link_check_report.html.erb
@@ -5,14 +5,14 @@
       <noscript>
         <p>Please save ensure you have saved your changes before running a link check.</p>
       </noscript>
-      <%= render 'link_check_reports/form', edition: edition, button_text: 'Check for broken links' %>
+      <%= render "link_check_reports/form", edition: edition, button_text: "Check for broken links" %>
     </section>
   <% elsif report.in_progress? %>
     <section class="alert alert-info alert-link-info">
       Broken link report in progress.<br />Please wait.
       <%= link_to "Refresh",
                   link_check_report_path(report.id, edition_id: edition.id),
-                  class: 'js-broken-links-refresh js-hidden',
+                  class: "js-broken-links-refresh js-hidden",
                   remote: true %>
     </section>
   <% elsif report.broken_links.any? || report.caution_links.any? %>
@@ -24,7 +24,7 @@
         <ul class="issue-list">
           <% links.each do |link| %>
             <li>
-              <%= link_to link.uri.truncate(50), link.uri, title: link.uri, class: 'link-inherit' %>
+              <%= link_to link.uri.truncate(50), link.uri, title: link.uri, class: "link-inherit" %>
               <details>
                 <summary class="display-issue-details">See more details about this link</summary>
                 <p class="issue-summary"><%= link.problem_summary %></p>
@@ -36,12 +36,12 @@
           <% end %>
         </ul>
       <% end %>
-      <%= render 'link_check_reports/form', edition: edition, button_text: 'Check again' %>
+      <%= render "link_check_reports/form", edition: edition, button_text: "Check again" %>
     </section>
   <% else %>
     <section class='alert alert-success'>
       <p><span class="glyphicon glyphicon-ok add-right-margin"></span> This edition contains no broken links.</p>
-      <%= render 'link_check_reports/form', edition: edition, button_text: 'Check again' %>
+      <%= render "link_check_reports/form", edition: edition, button_text: "Check again" %>
     </section>
   <% end %>
 </div>

--- a/app/views/link_check_reports/create.js.erb
+++ b/app/views/link_check_reports/create.js.erb
@@ -1,1 +1,1 @@
-$('.broken-links-report').replaceWith('<%=escape_javascript render("link_check_reports/link_check_report", report: @report, edition: @edition ) %>');
+$('.broken-links-report').replaceWith('<%= escape_javascript render("link_check_reports/link_check_report", report: @report, edition: @edition ) %>');

--- a/app/views/link_check_reports/show.js.erb
+++ b/app/views/link_check_reports/show.js.erb
@@ -1,3 +1,3 @@
 <% if @report.completed? %>
-  $('.broken-links-report').replaceWith('<%=escape_javascript render("link_check_reports/link_check_report", report: @report, edition: @edition ) %>');
+  $('.broken-links-report').replaceWith('<%= escape_javascript render("link_check_reports/link_check_report", report: @report, edition: @edition ) %>');
 <% end %>

--- a/app/views/local_transactions/_devolved_administrations.html.erb
+++ b/app/views/local_transactions/_devolved_administrations.html.erb
@@ -1,7 +1,7 @@
 <% administrations = {
   "Scotland" => :scotland_availability,
   "Wales" => :wales_availability,
-  "Northern Ireland" => :northern_ireland_availability
+  "Northern Ireland" => :northern_ireland_availability,
 } %>
 <% administrations.each do |title, field_name| %>
   <%= f.fields_for field_name do |f| %>
@@ -10,7 +10,7 @@
     <div class="form-group">
       <div class="radio">
         <%= f.label :type_local_authority_service, class: "control-label" do %>
-          <%= f.radio_button :type, 'local_authority_service', disabled: @resource.locked_for_edits? %>
+          <%= f.radio_button :type, "local_authority_service", disabled: @resource.locked_for_edits? %>
           Service available from local council
         <% end %>
       </div>
@@ -19,7 +19,7 @@
     <div class="form-group">
       <div class="radio">
         <%= f.label :type_devolved_administration_service, class: "control-label" do %>
-          <%= f.radio_button :type, 'devolved_administration_service', disabled: @resource.locked_for_edits? %>
+          <%= f.radio_button :type, "devolved_administration_service", disabled: @resource.locked_for_edits? %>
           Service available from devolved administration (or a similar service is available)
         <% end %>
       </div>
@@ -32,7 +32,7 @@
     <div class="form-group">
       <div class="radio">
         <%= f.label :type_unavailable, class: "control-label" do %>
-          <%= f.radio_button :type, 'unavailable', disabled: @resource.locked_for_edits? %>
+          <%= f.radio_button :type, "unavailable", disabled: @resource.locked_for_edits? %>
           Service not available
         <% end %>
       </div>

--- a/app/views/local_transactions/_fields.html.erb
+++ b/app/views/local_transactions/_fields.html.erb
@@ -13,29 +13,29 @@
         <%= f.text_field :lgil_code, disabled: @resource.locked_for_edits?, class: "input-md-4 form-control" %>
       <% end %>
 
-      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+      <%= render :partial => "shared/common_edition_attributes", :locals => {:f => f} %>
 
       <%= form_group(f, :introduction, label: "Introductory paragraph", help: "Set the scene for the user. Explain that it's the responsibility of the local council and that we'll take you there.") do %>
         <%= f.text_area :introduction, rows: 8, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control", data: {
-          module: "paste-html-to-govspeak"
+          module: "paste-html-to-govspeak",
         } %>
       <% end %>
 
       <%= form_group(f, :more_information) do %>
         <%= f.text_area :more_information, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control", data: {
-          module: "paste-html-to-govspeak"
+          module: "paste-html-to-govspeak",
         } %>
       <% end %>
 
       <%= form_group(f, :need_to_know, label: "What you need to know") do %>
         <%= f.text_area :need_to_know, rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control", data: {
-          module: "paste-html-to-govspeak"
+          module: "paste-html-to-govspeak",
         } %>
       <% end %>
 
-      <%= render partial: 'local_transactions/devolved_administrations', locals: { f: f, resource: @resource } %>
+      <%= render partial: "local_transactions/devolved_administrations", locals: { f: f, resource: @resource } %>
     </fieldset>
   </div>
 </div>
 
-<%= render partial: 'shared/workflow_buttons', locals: { f: f } %>
+<%= render partial: "shared/workflow_buttons", locals: { f: f } %>

--- a/app/views/local_transactions/new.html.erb
+++ b/app/views/local_transactions/new.html.erb
@@ -7,9 +7,9 @@
   We need a bit more information to create your local transaction.
 </p>
 
-<%= render :partial => 'shared/legacy_error_summary', locals: { object: @publication} %>
+<%= render :partial => "shared/legacy_error_summary", locals: { object: @publication} %>
 
-<%= form_for(@publication, as: :edition, url: editions_path, html: { id: 'edition-form', novalidate: 'novalidate' } ) do |f| %>
+<%= form_for(@publication, as: :edition, url: editions_path, html: { id: "edition-form", novalidate: "novalidate" } ) do |f| %>
   <fieldset class="inputs">
     <%= form_group(f, :lgsl_code, label: "LGSL code") do %>
       <%= f.text_field :lgsl_code, class: "form-control" %>
@@ -24,5 +24,5 @@
       <%= f.text_field :lgil_code, class: "form-control" %>
     <% end %>
   </fieldset>
-  <%= f.submit "Create Local transaction edition", class: 'btn btn-success' %>
+  <%= f.submit "Create Local transaction edition", class: "btn btn-success" %>
 <% end %>

--- a/app/views/places/_fields.html.erb
+++ b/app/views/places/_fields.html.erb
@@ -5,7 +5,7 @@
         <h2 class="remove-top-margin add-bottom-margin h3">Edit Place</h2>
       </legend>
 
-      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+      <%= render :partial => "shared/common_edition_attributes", :locals => {:f => f} %>
 
       <%= form_group(f, :place_type, label: "This is the 'slug' assigned in the places manager app") do %>
         <%= f.text_field :place_type, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>
@@ -13,23 +13,23 @@
 
       <%= form_group(f, :introduction) do %>
         <%= f.text_area :introduction, rows: 5, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control", data: {
-          module: "paste-html-to-govspeak"
+          module: "paste-html-to-govspeak",
         } %>
       <% end %>
 
       <%= form_group(f, :more_information) do %>
         <%= f.text_area :more_information, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control", data: {
-          module: "paste-html-to-govspeak"
+          module: "paste-html-to-govspeak",
         } %>
       <% end %>
 
       <%= form_group(f, :need_to_know, label: "What you need to know", attributes: { class: %w[add-top-margin] }) do %>
         <%= f.text_area :need_to_know, rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control", data: {
-          module: "paste-html-to-govspeak"
+          module: "paste-html-to-govspeak",
         } %>
       <% end %>
     </fieldset>
   </div>
 </div>
 
-<%= render partial: 'shared/workflow_buttons', locals: { f: f } %>
+<%= render partial: "shared/workflow_buttons", locals: { f: f } %>

--- a/app/views/programmes/_fields.html.erb
+++ b/app/views/programmes/_fields.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-md-8">
     <fieldset class="inputs">
-      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+      <%= render :partial => "shared/common_edition_attributes", :locals => {:f => f} %>
     </fieldset>
   </div>
 </div>
@@ -22,11 +22,11 @@
 
     <section class="panel-group" id="parts" data-module="parts">
       <%= f.fields_for :parts, @ordered_parts do |part| %>
-        <%= render partial: '/shared/common_part_attributes', locals: { f: part, editable: false, child_record_type: 'part' } %>
+        <%= render partial: "/shared/common_part_attributes", locals: { f: part, editable: false, child_record_type: "part" } %>
       <% end %>
     </section>
 
   </div>
 </div>
 
-<%= render partial: 'shared/workflow_buttons', locals: { f: f } %>
+<%= render partial: "shared/workflow_buttons", locals: { f: f } %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-column-two-thirds">
   <%= render "govuk_publishing_components/components/lead_paragraph", {
     text: "These reports are updated every hour.",
-    margin_bottom: 6
+    margin_bottom: 6,
   } %>
 
   <%= render "govuk_publishing_components/components/document_list", {
@@ -13,74 +13,74 @@
       {
         link: {
           text: "All documents for departmental distribution",
-          path: organisation_content_report_path(format: :csv)
+          path: organisation_content_report_path(format: :csv),
         },
         metadata: {
           updated_at_time: report_generated_time_message("organisation_content"),
           public_updated_at: report_last_updated("organisation_content"),
-        }
+        },
       },
       {
         link: {
           text: "Churn in non-archived editions",
-          path: edition_churn_report_path(format: :csv)
+          path: edition_churn_report_path(format: :csv),
         },
         metadata: {
           updated_at_time: report_generated_time_message("edition_churn"),
           public_updated_at: report_last_updated("edition_churn"),
-        }
+        },
       },
       {
         link: {
           text: "Churn in all editions",
-          path: all_edition_churn_report_path(format: :csv)
+          path: all_edition_churn_report_path(format: :csv),
         },
         metadata: {
           updated_at_time: report_generated_time_message("all_edition_churn"),
           public_updated_at: report_last_updated("all_edition_churn"),
-        }
+        },
       },
       {
         link: {
           text: "Progress on all non-archived editions",
-          path: progress_report_path(format: :csv)
+          path: progress_report_path(format: :csv),
         },
         metadata: {
           updated_at_time: report_generated_time_message("editorial_progress"),
           public_updated_at: report_last_updated("editorial_progress"),
-        }
+        },
       },
       {
         link: {
           text: "Content summary and workflow history for all published editions",
-          path: content_workflow_report_path(format: :csv)
+          path: content_workflow_report_path(format: :csv),
         },
         metadata: {
           updated_at_time: report_generated_time_message("content_workflow"),
           public_updated_at: report_last_updated("content_workflow"),
-        }
+        },
       },
       {
         link: {
           text: "Content summary and workflow history for all editions",
-          path: all_content_workflow_report_path(format: :csv)
+          path: all_content_workflow_report_path(format: :csv),
         },
         metadata: {
           updated_at_time: report_generated_time_message("all_content_workflow"),
           public_updated_at: report_last_updated("all_content_workflow"),
-        }
+        },
       },
       {
         link: {
           text: "All URLs",
-          path: all_urls_report_path(format: :csv)
+          path: all_urls_report_path(format: :csv),
         },
         metadata: {
           updated_at_time: report_generated_time_message("all_urls"),
           public_updated_at: report_last_updated("all_urls"),
-        }
+        },
       },
-    ]
+    ],
   } %>
 
 </div>

--- a/app/views/shared/_clone_buttons.html.erb
+++ b/app/views/shared/_clone_buttons.html.erb
@@ -8,7 +8,7 @@
 
   <%= form_for @resource, url: duplicate_edition_path(@resource, from: edition_class.to_s), method: "post" do |f| %>
     <%= f.label :to, "Create as new", for: :to %>
-    <%= select_tag :to, options_for_select(format_conversion_select_options(@resource)), class: "form-control input-md-3 add-bottom-margin"%>
+    <%= select_tag :to, options_for_select(format_conversion_select_options(@resource)), class: "form-control input-md-3 add-bottom-margin" %>
     <%= f.submit "Change format", class: "btn btn-default" %>
   <% end %>
 <% end %>

--- a/app/views/shared/_common_edition_attributes.html.erb
+++ b/app/views/shared/_common_edition_attributes.html.erb
@@ -2,11 +2,11 @@
   <% if current_user.has_editor_permissions?(@resource) %>
     <div class="form-group">
       <label for="edition_assigned_to_id">Assigned to</label>
-      <%= f.select :assigned_to_id, enabled_users_select_options, {}, {:class => 'form-control input-md-3', :disabled => @resource.locked_for_edits?, "data-module" => 'assignee-select'} %>
+      <%= f.select :assigned_to_id, enabled_users_select_options, {}, {:class => "form-control input-md-3", :disabled => @resource.locked_for_edits?, "data-module" => "assignee-select"} %>
     </div>
   <% end %>
-<%= render partial: 'reviewer_field', locals: { f: f } if @resource.in_review? %>
-<%= render partial: 'major_change_fields', locals: { f: f } if @resource.published_edition %>
+<%= render partial: "reviewer_field", locals: { f: f } if @resource.in_review? %>
+<%= render partial: "major_change_fields", locals: { f: f } if @resource.published_edition %>
 
 <%= form_group(f, :title, label: "Title") do %>
   <%= f.text_field :title, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control" %>

--- a/app/views/shared/_common_part_attributes.html.erb
+++ b/app/views/shared/_common_part_attributes.html.erb
@@ -1,19 +1,19 @@
 <div class="panel panel-part part">
   <div class="panel-heading js-sort-handle">
     <h4 class="panel-title">
-      <a class="js-part-toggle" data-toggle="collapse" data-parent="#parts" href="#<%= f.object.slug || 'untitled-part' %>">
+      <a class="js-part-toggle" data-toggle="collapse" data-parent="#parts" href="#<%= f.object.slug || "untitled-part" %>">
         <i class="glyphicon glyphicon-chevron-down pull-left add-right-margin"></i>
-        <span class="js-part-title"><%= f.object.title.present? ? f.object.title : "Untitled #{child_record_type}" %></span>
+        <span class="js-part-title"><%= f.object.title.presence || "Untitled #{child_record_type}" %></span>
       </a>
     </h4>
   </div>
-  <div id="<%= f.object.slug || 'untitled-part' %>" class="js-part-toggle-target panel-collapse collapse in" aria-expanded="true">
+  <div id="<%= f.object.slug || "untitled-part" %>" class="js-part-toggle-target panel-collapse collapse in" aria-expanded="true">
     <div class="panel-body">
       <fieldset class="inputs">
         <%
-          slug_input_html = { class: 'slug form-control', disabled: !editable }
+          slug_input_html = { class: "slug form-control", disabled: !editable }
           if @resource.version_number == 1
-            slug_input_html['data-accepts-generated-value'] = true
+            slug_input_html["data-accepts-generated-value"] = true
           end
         %>
 
@@ -27,10 +27,10 @@
 
         <%= render partial: "/shared/#{child_record_type}", locals: {f: f, editable: ! @resource.locked_for_edits? } %>
 
-        <%= f.hidden_field :order, class: 'order', disabled: !editable %>
+        <%= f.hidden_field :order, class: "order", disabled: !editable %>
 
         <% unless @resource.locked_for_edits? %>
-          <%= f.link_to_remove class: 'btn btn-default btn-sm' do %>
+          <%= f.link_to_remove class: "btn btn-default btn-sm" do %>
             <i class="glyphicon glyphicon-remove glyphicon-smaller-than-text"></i> Remove this <%= child_record_type %>
           <% end %>
         <% end %>

--- a/app/views/shared/_edition_activity_fields.html.erb
+++ b/app/views/shared/_edition_activity_fields.html.erb
@@ -36,7 +36,7 @@
         <% end %>
         <textarea id="edition_activity_send_fact_check_attributes_customised_message"
                   name="edition[activity_send_fact_check_attributes][customised_message]"
-                  class="form-control" cols="60" rows="14"><%= render :template => 'event_mailer/request_fact_check', formats: [:text] %></textarea>
+                  class="form-control" cols="60" rows="14"><%= render :template => "event_mailer/request_fact_check", formats: [:text] %></textarea>
       <% elsif activity == :resend_fact_check %>
         <% latest_status_action = form_builder.object.latest_status_action %>
         <% if latest_status_action&.is_fact_check_request? %>
@@ -62,11 +62,14 @@
           Publish at <abbr title="required">*</abbr>
         <% end %>
         <div class="form-inline">
-        <%= activity_fields.time_select :publish_at, {}, { class: 'date form-control' } %>
-        &mdash;
-        <%= activity_fields.date_select :publish_at, { order: [:day, :month, :year],
-          default: Date.tomorrow, start_year: Date.today.year, end_year: Date.today.year.next },
-          { class: 'date form-control' } %>
+          <%= activity_fields.time_select :publish_at, {}, { class: "date form-control" } %>
+          &mdash;
+          <%= activity_fields.date_select :publish_at,
+                                          { order: [:day, :month, :year],
+                                            default: Date.tomorrow,
+                                            start_year: Time.zone.today.year,
+                                            end_year: Time.zone.today.year.next },
+                                          { class: "date form-control" } %>
         </div>
       <% end %>
       <p class="help-block add-top-margin remove-bottom-margin">

--- a/app/views/shared/_edition_header.html.erb
+++ b/app/views/shared/_edition_header.html.erb
@@ -9,7 +9,7 @@
   </span>
 </div>
 <% important_note = @resource.important_note %>
-<%= render partial: 'shared/important_note', locals: {important_note: @resource.important_note} %>
+<%= render partial: "shared/important_note", locals: {important_note: @resource.important_note} %>
 <% if @resource.artefact.state == "archived" %>
   <div class="callout callout-danger add-bottom-margin">
     <h2 class="callout-title">You can’t edit this publication</h2>
@@ -23,5 +23,5 @@
     </div>
   </div>
 <% else %>
-  <%= render 'shared/ready_or_review_or_fact_check' %>
+  <%= render "shared/ready_or_review_or_fact_check" %>
 <% end %>

--- a/app/views/shared/_error_summary.html.erb
+++ b/app/views/shared/_error_summary.html.erb
@@ -7,6 +7,6 @@
         text: error.full_message,
         href: "##{model.to_s.underscore + "_" + error.attribute.to_s}",
       }
-    end
+    end,
   } %>
 <% end %>

--- a/app/views/shared/_fact_check.html.erb
+++ b/app/views/shared/_fact_check.html.erb
@@ -8,6 +8,6 @@
     <p>Someone requested this edition be fact checked. We&rsquo;re awaiting a response.</p>
   <% end %>
   <% if current_user.has_editor_permissions?(@resource) %>
-    <%= render 'shared/request_amendments' %>
+    <%= render "shared/request_amendments" %>
   <% end %>
 </div>

--- a/app/views/shared/_fact_check_received.html.erb
+++ b/app/views/shared/_fact_check_received.html.erb
@@ -1,14 +1,14 @@
 <div class="alert alert-info">
   <p>We have received a fact check response for this edition.</p>
 
-   <% if current_user.has_editor_permissions?(@resource)%>
+   <% if current_user.has_editor_permissions?(@resource) %>
     <p>Please check the response in History &amp; Notes, and select an action below.</p>
 
     <div class="workflow-buttons">
-      <%= fact_check_buttons(@resource)%>
+      <%= fact_check_buttons(@resource) %>
     </div>
     <% if activity_forms_required? %>
-      <%= fact_check_forms(@resource)%>
+      <%= fact_check_forms(@resource) %>
     <% end %>
-  <% end%>
+  <% end %>
 </div>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,15 +1,15 @@
 <% [:success, :info, :warning, :danger, :notice, :alert].select { |k| flash[k].present? }.each do |k| %>
   <% if k == :warning || k == :danger || k == :alert %>
     <%= render "govuk_publishing_components/components/error_alert", {
-      message: sanitize(flash[k])
+      message: sanitize(flash[k]),
     } %>
   <% elsif k == :notice || k == :info %>
     <%= render "govuk_publishing_components/components/notice", {
-      description: sanitize(flash[k])
+      description: sanitize(flash[k]),
     } %>
   <% elsif k == :success %>
     <%= render "govuk_publishing_components/components/success_alert", {
-      message: sanitize(flash[k])
+      message: sanitize(flash[k]),
     } %>
   <% end %>
 <% end %>

--- a/app/views/shared/_history.html.erb
+++ b/app/views/shared/_history.html.erb
@@ -49,14 +49,14 @@
                 <%= f.label :comment, "Important note" %>
               </span>
               <span class="form-wrapper">
-                <%= f.text_area :comment, rows: 6, cols: 120, value: @resource.important_note ? @resource.important_note.comment : '', class: "form-control" %>
+                <%= f.text_area :comment, rows: 6, cols: 120, value: @resource.important_note ? @resource.important_note.comment : "", class: "form-control" %>
               </span>
               <p class="help-block">Add important notes that anyone who works on this edition needs to see, eg “(Doesn’t) need fact check, don’t publish.” Each edition can have only one important note at a time.</p>
             </div>
           </div>
           <footer class="modal-footer remove-top-margin">
             <a href="#" class="btn btn-default" data-dismiss="modal">Cancel</a>
-            <%= f.submit :class=>"btn btn-success", :value=>'Save important note' %>
+            <%= f.submit :class=>"btn btn-success", :value=>"Save important note" %>
           </footer>
         </fieldset>
       <% end %>
@@ -78,7 +78,7 @@
       <% if @resource.important_note %>
         <%= form_for(@resource.important_note, :url=> resolve_note_path, :html => { :class => "add-left-margin inline" }, :method => "put") do |f| %>
           <%= hidden_field_tag :edition_id, resource.id %>
-          <%= f.submit :class=>"btn btn-default", :value => 'Delete important note' %>
+          <%= f.submit :class=>"btn btn-default", :value => "Delete important note" %>
         <% end %>
       <% end %>
     </div>
@@ -96,6 +96,6 @@
   </p>
 
   <div class="panel-group">
-    <%= render collection: @resource.history, partial: '/shared/edition_history', as: 'edition' %>
+    <%= render collection: @resource.history, partial: "/shared/edition_history", as: "edition" %>
   </div>
 </div>

--- a/app/views/shared/_important_note.html.erb
+++ b/app/views/shared/_important_note.html.erb
@@ -5,8 +5,8 @@
     <%= action_note(@resource.important_note) %>
   </div>
   <div class="callout-important-note-detail">
-    Note <%= with_history ? 'updated' : 'created' %> <time datetime="<%= important_note.created_at %>"><%= important_note.created_at.to_date.to_fs(:govuk_date_short) %></time>
-    <% if important_note.requester.present? %> by <%= mail_to important_note.requester.email, important_note.requester.name, { class: 'link-inherit' }  %><% end %>
+    Note <%= with_history ? "updated" : "created" %> <time datetime="<%= important_note.created_at %>"><%= important_note.created_at.to_date.to_fs(:govuk_date_short) %></time>
+    <% if important_note.requester.present? %> by <%= mail_to important_note.requester.email, important_note.requester.name, { class: "link-inherit" } %><% end %>
     <% if with_history %>
      <span class="if-no-js-hide"> – <a href="#" class="js-toggle link-muted">See history</a></span>
     <% end %>

--- a/app/views/shared/_metadata.html.erb
+++ b/app/views/shared/_metadata.html.erb
@@ -1,7 +1,7 @@
 <h2 class="remove-top-margin add-bottom-margin h3">Metadata</h2>
 
 <% if Edition::PUBLISHING_API_DRAFT_STATES.include? publication.state %>
-  <%= form_for(@artefact, :html => { :class => 'artefact', :id => 'edit_artefact'}) do |f| %>
+  <%= form_for(@artefact, :html => { :class => "artefact", :id => "edit_artefact"}) do |f| %>
     <div class="row">
       <div class="col-md-12">
         <%= f.hidden_field :id, value: @artefact.id %>
@@ -15,14 +15,14 @@
         <% end %>
       </div>
     </div>
-    <%= f.submit 'Update metadata', class: "btn btn-success btn-large" %>
+    <%= f.submit "Update metadata", class: "btn btn-success btn-large" %>
   <% end %>
 <% else %>
   <div class="row">
     <div class="col-md-7">
-      <% @artefact.attributes.slice('slug', 'language').each do |key, value| %>
+      <% @artefact.attributes.slice("slug", "language").each do |key, value| %>
         <%= content_tag :label, key.humanize, for: key %>
-        <%= text_field_tag key, value, class: "form-control add-bottom-margin", disabled: 'disabled' %>
+        <%= text_field_tag key, value, class: "form-control add-bottom-margin", disabled: "disabled" %>
       <% end %>
     </div>
   </div>

--- a/app/views/shared/_part.html.erb
+++ b/app/views/shared/_part.html.erb
@@ -1,5 +1,5 @@
 <%= form_group(f, :body) do %>
   <%= f.text_area :body, rows: 25, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control body", data: {
-    module: "paste-html-to-govspeak"
+    module: "paste-html-to-govspeak",
   } %>
 <% end %>

--- a/app/views/shared/_ready.html.erb
+++ b/app/views/shared/_ready.html.erb
@@ -1,6 +1,6 @@
- <% if current_user.has_editor_permissions?(@resource)%>
+ <% if current_user.has_editor_permissions?(@resource) %>
   <div class="alert alert-info">
     <p>Request this edition to be amended further.</p>
-    <%= render 'shared/request_amendments' %>
+    <%= render "shared/request_amendments" %>
   </div>
 <% end %>

--- a/app/views/shared/_ready_or_review_or_fact_check.html.erb
+++ b/app/views/shared/_ready_or_review_or_fact_check.html.erb
@@ -1,14 +1,14 @@
 <% if @resource.in_review? %>
-  <%= render '/shared/review' %>
+  <%= render "/shared/review" %>
 <% elsif @resource.fact_check? %>
-  <%= render '/shared/fact_check' %>
+  <%= render "/shared/fact_check" %>
 <% elsif @resource.fact_check_received? %>
-  <%= render '/shared/fact_check_received' %>
+  <%= render "/shared/fact_check_received" %>
 <% elsif @resource.fact_check_skipped? %>
   <div class="alert alert-info">
     <p>Fact check was skipped for this edition.</p>
   </div>
-  <%= render '/shared/ready' %>
+  <%= render "/shared/ready" %>
 <% elsif @resource.ready? %>
-  <%= render '/shared/ready' %>
+  <%= render "/shared/ready" %>
 <% end %>

--- a/app/views/shared/_related_external_links.html.erb
+++ b/app/views/shared/_related_external_links.html.erb
@@ -12,11 +12,11 @@
         <div class="row relative">
           <div class="col-md-4">
             <%= link.label :title, "Title" %>
-            <%= link.text_field :title, class: 'form-control' %>
+            <%= link.text_field :title, class: "form-control" %>
           </div>
           <div class="col-md-5">
             <%= link.label :url, "URL" %>
-            <%= link.text_field :url, class: 'form-control' %>
+            <%= link.text_field :url, class: "form-control" %>
           </div>
           <% unless @resource.retired_format? %>
             <%= link.link_to_remove "Remove this URL", class: "remove-row remove-row-related" %>
@@ -34,6 +34,6 @@
     <% unless @resource.retired_format? %>
       <br/>
 
-      <%= f.submit 'Save links', class: "btn btn-success btn-large" %>
+      <%= f.submit "Save links", class: "btn btn-success btn-large" %>
     <% end %>
 <% end %>

--- a/app/views/shared/_review.html.erb
+++ b/app/views/shared/_review.html.erb
@@ -8,17 +8,17 @@
     <% else %>
       <p><%= @resource.latest_status_action(Action::REQUEST_REVIEW).requester.name %> has sent this edition to be reviewed.</p>
       <div class="workflow-buttons">
-        <%= review_buttons(@resource)%>
+        <%= review_buttons(@resource) %>
       </div>
       <% if activity_forms_required? %>
-        <%= review_forms(@resource)%>
+        <%= review_forms(@resource) %>
       <% end %>
     <% end %>
   <% else %>
     <p>We're having trouble accessing the action data. This edition has been sent to be reviewed.</p>
     <div class="workflow-buttons">
-      <%= review_buttons(@resource)%>
+      <%= review_buttons(@resource) %>
     </div>
-    <%= review_forms(@resource)%>
+    <%= review_forms(@resource) %>
   <% end %>
 </div>

--- a/app/views/shared/_tagging.html.erb
+++ b/app/views/shared/_tagging.html.erb
@@ -7,13 +7,13 @@
     <div class="row">
       <div class="col-md-7 edition-tags">
         <div class="form-group" id="edition_browse_pages_input">
-          <%= f.label :mainstream_browse_pages, "Mainstream browse pages", class: 'control-label' %>
+          <%= f.label :mainstream_browse_pages, "Mainstream browse pages", class: "control-label" %>
           <%= f.select :mainstream_browse_pages,
                        @linkables.mainstream_browse_pages,
                        {},
                        { multiple: true,
-                         class: 'select2',
-                         data: { module: "tagging", placeholder: 'Choose mainstream browse pages…' } } %>
+                         class: "select2",
+                         data: { module: "tagging", placeholder: "Choose mainstream browse pages\u2026" } } %>
 
           <p class='help-block'>
             Mainstream browse pages live under <a href="https://www.gov.uk/browse">/browse</a>.
@@ -23,13 +23,13 @@
         </div>
 
         <div class="form-group" id="edition_parent_input">
-          <%= f.label :parent, "Breadcrumb", class: 'control-label' %>
+          <%= f.label :parent, "Breadcrumb", class: "control-label" %>
           <%= f.select :parent,
                        @linkables.mainstream_browse_pages,
                        { include_blank: true },
                        { multiple: false,
-                         class: 'select2',
-                         data: { module: "tagging", placeholder: 'Choose a breadcrumb…' } } %>
+                         class: "select2",
+                         data: { module: "tagging", placeholder: "Choose a breadcrumb\u2026" } } %>
 
          <div class="alert mainstream alert-warning hidden">
            <br />
@@ -44,12 +44,12 @@
         </div>
 
         <div class="form-group" id="edition_organisations_input">
-          <%= f.label :organisations, "Organisations", class: 'control-label' %>
+          <%= f.label :organisations, "Organisations", class: "control-label" %>
           <%= f.select :organisations, @linkables.organisations,
                        {},
                        { multiple: true,
-                         class: 'select2',
-                         data: { placeholder: 'Choose Organisations…' } } %>
+                         class: "select2",
+                         data: { placeholder: "Choose Organisations\u2026" } } %>
 
            <p class="help-block">
            Tagging a page to an organisation will make it show up in search when filtered to the organisation(s).
@@ -58,13 +58,13 @@
         </div>
 
         <div class="form-group">
-          <%= f.label :meets_user_needs, 'User Needs', class: 'control-label' %>
+          <%= f.label :meets_user_needs, "User Needs", class: "control-label" %>
           <%= f.select :meets_user_needs,
                        @linkables.meets_user_needs,
                        {},
                        { multiple: true,
-                         class: 'select2',
-                         data: { module: "tagging", placeholder: 'Choose user needs…' } } %>
+                         class: "select2",
+                         data: { module: "tagging", placeholder: "Choose user needs\u2026" } } %>
 
            <p class='help-block'>
              Needs are managed through Maslow, and the list of user needs which a
@@ -83,16 +83,16 @@
             <ul class="list-unstyled js-list-sortable js-base-path-list">
             <% Array(@tagging_update.ordered_related_items).each do |related_item| %>
               <li>
-                <%= text_field_tag 'tagging_tagging_update_form[ordered_related_items][]',
-                      related_item['base_path'],
-                      class: 'form-control',
-                      data: { title: related_item['title'] } %>
+                <%= text_field_tag "tagging_tagging_update_form[ordered_related_items][]",
+                      related_item["base_path"],
+                      class: "form-control",
+                      data: { title: related_item["title"] } %>
               </li>
             <% end %>
             <% 5.times do %>
               <li>
-                <%= text_field_tag 'tagging_tagging_update_form[ordered_related_items][]', '',
-                      class: 'form-control' %>
+                <%= text_field_tag "tagging_tagging_update_form[ordered_related_items][]", "",
+                      class: "form-control" %>
               </li>
             <% end %>
             </ul>
@@ -112,6 +112,6 @@
     <% unless @resource.retired_format? %>
       <hr/>
 
-      <%= f.submit 'Update tags', class: "btn btn-success btn-large" %>
+      <%= f.submit "Update tags", class: "btn btn-success btn-large" %>
     <% end %>
 <% end %>

--- a/app/views/shared/_unpublish.html.erb
+++ b/app/views/shared/_unpublish.html.erb
@@ -15,10 +15,10 @@
       <span class="normal">
         For example: <code>https://www.gov.uk/redirect-to-replacement-page</code>
       </span>
-      <%= text_field_tag 'redirect_url', '', class: "form-control input-md-12" %>
+      <%= text_field_tag "redirect_url", "", class: "form-control input-md-12" %>
     </div>
-    <%= button_tag 'Unpublish',
-      "data-module" => 'confirm',
+    <%= button_tag "Unpublish",
+      "data-module" => "confirm",
       "data-message" => "This will remove ‘#{@artefact.name}’ from the website.\n\n Are you sure?",
       :class => "btn btn-danger" %>
   <% end %>

--- a/app/views/shared/_workflow_buttons.html.erb
+++ b/app/views/shared/_workflow_buttons.html.erb
@@ -7,16 +7,16 @@
           <%= preview_button(@resource) %>
            <% if current_user.has_editor_permissions?(@resource) %>
             <% if @resource.can_create_new_edition? %>
-              <%= link_to 'Create new edition', duplicate_edition_path(@resource), class: 'btn btn-primary btn-large', method: :post %>
+              <%= link_to "Create new edition", duplicate_edition_path(@resource), class: "btn btn-primary btn-large", method: :post %>
             <% end %>
             <% if @resource.in_progress_sibling.present? %>
-              <%= link_to 'Edit existing newer edition', edition_path(@resource.in_progress_sibling), html_options: { "class" => "btn btn-primary btn-large"} %>
+              <%= link_to "Edit existing newer edition", edition_path(@resource.in_progress_sibling), html_options: { "class" => "btn btn-primary btn-large"} %>
             <% end %>
           <% end %>
           <%= progress_buttons(@resource, skip_disabled_buttons: true) %>
         <% else %>
           <% if current_user.has_editor_permissions?(@resource) && !@resource.retired_format? %>
-            <%= f.submit 'Save', id: 'save-edition', class: 'btn btn-success btn-large js-save' %>
+            <%= f.submit "Save", id: "save-edition", class: "btn btn-success btn-large js-save" %>
           <% end %>
           <%= preview_button(@resource) %>
           <%= progress_buttons(@resource) %>

--- a/app/views/simple_smart_answers/_fields.html.erb
+++ b/app/views/simple_smart_answers/_fields.html.erb
@@ -5,12 +5,12 @@
         <h2 class="remove-top-margin add-bottom-margin h3">Edit Simple smart answer</h2>
       </legend>
 
-      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+      <%= render :partial => "shared/common_edition_attributes", :locals => {:f => f} %>
       <div class="row">
         <div class="col-md-10">
           <%= form_group(f, :body) do %>
             <%= f.text_area :body, rows: 20, disabled: @resource.locked_for_edits?, class: "form-control", data: {
-              module: "paste-html-to-govspeak"
+              module: "paste-html-to-govspeak",
             } %>
           <% end %>
         </div>
@@ -50,7 +50,7 @@
   </div>
 </div>
 
-<%= render partial: 'shared/workflow_buttons', locals: { f: f } %>
+<%= render partial: "shared/workflow_buttons", locals: { f: f } %>
 
 <% content_for :extra_javascript do %>
   <script>

--- a/app/views/simple_smart_answers/_node.html.erb
+++ b/app/views/simple_smart_answers/_node.html.erb
@@ -3,7 +3,7 @@
     <span class="node-label bold"><%= f.object.slug.to_s.titleize %></span>
     <%= f.link_to_remove "<i class=\"glyphicon glyphicon-remove glyphicon-smaller-than-text add-right-margin\"></i> <span class=\"remove-node-label\"> Remove #{f.object.kind} </span>".html_safe , :class => "btn btn-default pull-right remove-node" %>
   </legend>
-  <%= f.hidden_field :order, class: 'node-order' %>
+  <%= f.hidden_field :order, class: "node-order" %>
 
   <div class="form-group">
     <div class="form-wrapper">
@@ -17,7 +17,7 @@
     <span class="form-wrapper">
       <%= f.label :body, "Optional extra information" %>
       <%= f.text_area :body, rows: 10, class: "node-body form-control", data: {
-        module: "paste-html-to-govspeak"
+        module: "paste-html-to-govspeak",
       } %>
     </span>
   </div>
@@ -27,7 +27,7 @@
   <% unless f.object.kind == "outcome" %>
     <div class="options">
       <%= f.fields_for :options, :wrapper_class => "outcome-wrap option" do |o| %>
-        <div class="form-inline form-group<%= o.object.errors.empty? ? '' : ' error' %>">
+        <div class="form-inline form-group<%= o.object.errors.empty? ? "" : " error" %>">
           <div class="row">
             <div class="form-group col-md-3">
               <%= f.label :label, "Answer #{o.index.to_i + 1}",for: "edition_nodes_attributes_#{o.options[:parent_builder].index}_options_attributes_#{o.index}_label" %>

--- a/app/views/transactions/_fields.html.erb
+++ b/app/views/transactions/_fields.html.erb
@@ -5,11 +5,11 @@
         <h2 class="remove-top-margin add-bottom-margin h3">Edit Transaction</h2>
       </legend>
 
-      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+      <%= render :partial => "shared/common_edition_attributes", :locals => {:f => f} %>
 
       <%= form_group(f, :introduction, label: "Introductory paragraph", help: "Set the scene for the user. What is about to happen? (eg. \"you will need to fill in a form, print it out and take it to the post office\")") do %>
         <%= f.text_area :introduction, rows: 8, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control", data: {
-          module: "paste-html-to-govspeak"
+          module: "paste-html-to-govspeak",
         } %>
       <% end %>
 
@@ -33,19 +33,19 @@
 
       <%= form_group(f, :more_information) do %>
         <%= f.text_area :more_information, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control", data: {
-          module: "paste-html-to-govspeak"
+          module: "paste-html-to-govspeak",
         } %>
       <% end %>
 
       <%= form_group(f, :alternate_methods, label: "Other ways to apply", help: "Alternative ways of completing this transaction. Not displayed on front end if left blank.") do %>
         <%= f.text_area :alternate_methods, rows: 20, disabled: @resource.locked_for_edits?, class: "input-md-10 form-control", data: {
-          module: "paste-html-to-govspeak"
+          module: "paste-html-to-govspeak",
         } %>
       <% end %>
 
       <%= form_group(f, :need_to_know, label: "What you need to know", attributes: { class: %w[add-top-margin] } ) do %>
         <%= f.text_area :need_to_know, rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-7 form-control", data: {
-          module: "paste-html-to-govspeak"
+          module: "paste-html-to-govspeak",
         } %>
       <% end %>
     </fieldset>
@@ -66,11 +66,11 @@
 
     <section class="panel-group" id="parts" data-module="parts">
       <%= f.fields_for :variants, @ordered_variants do |variant| %>
-        <%= render partial: '/shared/common_part_attributes', locals: {f: variant, editable: ! @resource.locked_for_edits?, child_record_type: 'variant' } %>
+        <%= render partial: "/shared/common_part_attributes", locals: {f: variant, editable: ! @resource.locked_for_edits?, child_record_type: "variant" } %>
       <% end %>
     </section>
 
-    <%= f.link_to_add :variants, :data => { :target => "#parts" }, :class => 'btn btn-default' do %>
+    <%= f.link_to_add :variants, :data => { :target => "#parts" }, :class => "btn btn-default" do %>
       <i class="glyphicon glyphicon-plus add-right-margin"></i>Add new variant
     <% end %>
 
@@ -78,4 +78,4 @@
 
 </div>
 
-<%= render partial: 'shared/workflow_buttons', locals: { f: f } %>
+<%= render partial: "shared/workflow_buttons", locals: { f: f } %>

--- a/app/views/user_search/index.html.erb
+++ b/app/views/user_search/index.html.erb
@@ -18,8 +18,8 @@
           <label for="format_filter" class="add-top-margin nav-header">Format</label>
           <%= select_tag("format_filter", options_for_select(
             legacy_format_filter_selection_options,
-            params[:format_filter]
-          ), class: 'form-control') %>
+            params[:format_filter],
+          ), class: "form-control") %>
           <input class="add-top-margin btn btn-default" type="submit" value="Filter publications">
         </form>
         </div>
@@ -77,7 +77,7 @@
             <% end %>
           </tbody>
         </table>
-        <%= paginate @page_info, theme: 'twitter-bootstrap-3' %>
+        <%= paginate @page_info, theme: "twitter-bootstrap-3" %>
       </div><!--./col-md-10 -->
 
     </div><!--./row -->

--- a/app/views/videos/_fields.html.erb
+++ b/app/views/videos/_fields.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-md-8">
     <fieldset class="inputs">
-      <%= render :partial => 'shared/common_edition_attributes', :locals => {:f => f} %>
+      <%= render :partial => "shared/common_edition_attributes", :locals => {:f => f} %>
 
       <div class="form-group">
         <span class="form-label">
@@ -27,7 +27,7 @@
           <div class="uploaded-caption-file">
             <h4>Current caption file</h4>
             <p><%= link_to @edition.caption_file.name, @edition.caption_file.file_url %></p>
-            <p><%= label_tag do %>Remove caption file? <%= check_box_tag "edition[remove_caption_file]", "1", false, disabled: @resource.locked_for_edits?, class: 'js-no-ajax' %><% end %></p>
+            <p><%= label_tag do %>Remove caption file? <%= check_box_tag "edition[remove_caption_file]", "1", false, disabled: @resource.locked_for_edits?, class: "js-no-ajax" %><% end %></p>
           </div>
 
           <h4>Replace caption file</h4>
@@ -60,4 +60,4 @@
   </div>
 </div>
 
-<%= render partial: 'shared/workflow_buttons', locals: { f: f } %>
+<%= render partial: "shared/workflow_buttons", locals: { f: f } %>

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,5 +1,10 @@
 desc "Run all linters"
 task lint: :environment do
+  if Rails.env.development?
+    sh "bundle exec erblint --lint-all --autocorrect"
+  else
+    sh "bundle exec erblint --lint-all"
+  end
   sh "bundle exec rubocop"
   sh "yarn run lint"
 end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,10 +1,6 @@
 desc "Run all linters"
 task lint: :environment do
-  if Rails.env.development?
-    sh "bundle exec erblint --lint-all --autocorrect"
-  else
-    sh "bundle exec erblint --lint-all"
-  end
+  sh "bundle exec erblint --lint-all"
   sh "bundle exec rubocop"
   sh "yarn run lint"
 end


### PR DESCRIPTION
Currently in most(may be all) of our app there is no linting mechanism for erb files. We want some way of linting erb files and hence we have introduced [erb_lint](https://rubygems.org/gems/erb_lint/versions/0.5.0?locale=en) gem for the same.

The changes in this PR allows us to have a workflow to run erb lint.
All the files that have been linted after running erblint.

When we run the command 'erblint --lint-all' it uses the default '.erb_lint.yml' file inside the project to apply any custom rules.

[Trello](https://trello.com/c/Uu2PjlVp)
----
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
