### PR TITLE
Remove ga code

### DIFF
--- a/app/assets/javascripts/legacy_modules/ajax_save.js
+++ b/app/assets/javascripts/legacy_modules/ajax_save.js
@@ -85,7 +85,6 @@
 
         // Save successful, form is no longer dirty
         GOVUKAdmin.Data.editionFormDirty = false
-        window.GOVUKAdmin.trackEvent('ajax-save', 'success')
 
         element.trigger('success.ajaxsave.admin', response)
       }
@@ -98,13 +97,10 @@
           showErrors(responseJSON)
           destroyErrorSummaryComponent()
           displayErrorSummaryComponent(responseJSON)
-          trackErrors(JSON.stringify(responseJSON))
 
           if (typeof responseJSON.base === 'object') {
             messageAddendum = '<strong>' + responseJSON.base[0] + '</strong>.'
           }
-        } else {
-          window.GOVUKAdmin.trackEvent('ajax-save', 'error', { value: textStatus + ': ' + errorThrown })
         }
 
         message.addClass('workflow-message-error').removeClass('workflow-message-saving')
@@ -177,12 +173,6 @@
         if (errorSummaryComponent != null) {
           errorSummaryComponent.remove()
         }
-      }
-
-      function trackErrors (label) {
-        // Normalise parts errors, eg "54c0db08e5274000cc:10": to "part":
-        label = label.replace(/"[0-9a-fA-F]+:\d{1,2}":/g, '"part":')
-        window.GOVUKAdmin.trackEvent('ajax-save-error', label)
       }
 
       function hideErrors () {

--- a/app/assets/javascripts/legacy_modules/tab_switcher.js
+++ b/app/assets/javascripts/legacy_modules/tab_switcher.js
@@ -7,9 +7,6 @@
 
         if (window.history && window.history.replaceState) {
           window.history.replaceState(null, null, tabHref)
-
-          // Track tab switch as pageview
-          window.GOVUKAdmin.trackPageview(tabHref)
         }
 
         // Shim Boostrap tabs, which are only capabable of removing

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -298,7 +298,6 @@ protected
         :more_information,
         :alternate_methods,
         :need_to_know,
-        :department_analytics_profile,
         { variants_attributes: %i[title slug introduction link more_information alternate_methods order id _destroy] },
       ]
     when :completed_transaction_edition

--- a/app/models/transaction_edition.rb
+++ b/app/models/transaction_edition.rb
@@ -11,13 +11,11 @@ class TransactionEdition < Edition
   field :link, type: String
   field :more_information, type: String
   field :need_to_know, type: String
-  field :department_analytics_profile, type: String
   field :alternate_methods, type: String
   field :start_button_text, type: String, default: "Start now"
 
   GOVSPEAK_FIELDS = %i[introduction more_information alternate_methods need_to_know].freeze
 
-  validates :department_analytics_profile, format: { with: /UA-\d+-\d+/i, allow_blank: true, message: "Invalid format for service analytics profile: must be in format UA-xxxxx-x where xs are digits" }
   validates :start_button_text, presence: true
   validates_with SafeHtml
 

--- a/app/presenters/formats/service_sign_in_presenter.rb
+++ b/app/presenters/formats/service_sign_in_presenter.rb
@@ -91,13 +91,6 @@ module Formats
         choose_sign_in[:description] = govspeak_content(description)
       end
 
-      tracking_code = content[:choose_sign_in][:tracking_code]
-      tracking_domain = content[:choose_sign_in][:tracking_domain]
-      tracking_name = content[:choose_sign_in][:tracking_name]
-      choose_sign_in[:tracking_code] = tracking_code if tracking_code.present?
-      choose_sign_in[:tracking_domain] = tracking_domain if tracking_domain.present?
-      choose_sign_in[:tracking_name] = tracking_name if tracking_name.present?
-
       choose_sign_in
     end
 

--- a/app/presenters/formats/transaction_presenter.rb
+++ b/app/presenters/formats/transaction_presenter.rb
@@ -21,7 +21,6 @@ module Formats
         other_ways_to_apply: govspeak(edition.alternate_methods),
         what_you_need_to_know: govspeak(edition.need_to_know),
         external_related_links:,
-        department_analytics_profile: edition.department_analytics_profile,
         downtime_message:,
       }.delete_if { |_, value| value.nil? }
     end

--- a/app/views/transactions/_fields.html.erb
+++ b/app/views/transactions/_fields.html.erb
@@ -48,10 +48,6 @@
           module: "paste-html-to-govspeak"
         } %>
       <% end %>
-
-      <%= form_group(f, :department_analytics_profile, label: "Service analytics profile", help: "Let service teams track user journeys between GOV.UK and their service using Google Analytics.", attributes: { class: %w[add-top-margin] }) do %>
-        <%= f.text_area :department_analytics_profile, placeholder: 'UA-XXXXXX-X', rows: 4, disabled: @resource.locked_for_edits?, class: "input-md-2 form-control" %>
-      <% end %>
     </fieldset>
   </div>
 </div>

--- a/lib/service_sign_in/example.en.yaml
+++ b/lib/service_sign_in/example.en.yaml
@@ -4,9 +4,6 @@ choose_sign_in:
   title: Prove your identity to continue
   slug: choose-sign-in
   description: Your State Pension forecast is provided for your information only and the service does not offer financial advice. When planning for your retirement, you should seek professional advice.
-  tracking_code: UA-xxxxxx
-  tracking_domain: tax.service.gov.uk
-  tracking_name: somethingClicky
   options:
     - text: Use Government Gateway
       url: https://www.tax.service.gov.uk/gg/sign-in?continue=/account/&origin=SA-frontend

--- a/spec/javascripts/spec/ajax_save.spec.js
+++ b/spec/javascripts/spec/ajax_save.spec.js
@@ -164,18 +164,6 @@ describe('An ajax save module', function () {
     })
   })
 
-  describe('when an ajax save errors without validation messages', function () {
-    it('tracks the error status and HTTP text', function () {
-      spyOn($, 'ajax').and.callFake(function (options) {
-        options.error({}, 'abort', 'Not Found')
-      })
-      spyOn(window.GOVUKAdmin, 'trackEvent')
-      element.find('.js-save').trigger('click')
-
-      expect(window.GOVUKAdmin.trackEvent).toHaveBeenCalledWith('ajax-save', 'error', { value: 'abort: Not Found' })
-    })
-  })
-
   describe('when an ajax save errors with validation messages', function () {
     var timeoutTime, ajaxError, ajaxSuccess
 
@@ -291,22 +279,6 @@ describe('An ajax save module', function () {
       })
       ajaxError({ not_a_field: ['nonsense'] })
       expect(errorResponse).toEqual({ responseJSON: { not_a_field: ['nonsense'] } })
-    })
-
-    it('tracks the error (and normalises part IDs)', function () {
-      spyOn(window.GOVUKAdmin, 'trackEvent')
-      ajaxError({
-        parts:
-        [
-          {
-            '5f00000001:1': { slug: ["can't be blank", 'is invalid'] },
-            '5f00000002:2': { title: ["can't be blank"] },
-            '101:3': { title: ['must not walk on the grass'] }
-          }
-        ]
-      })
-
-      expect(window.GOVUKAdmin.trackEvent).toHaveBeenCalledWith('ajax-save-error', '{"parts":[{"part":{"slug":["can\'t be blank","is invalid"]},"part":{"title":["can\'t be blank"]},"part":{"title":["must not walk on the grass"]}}]}')
     })
 
     describe('when the form is saved again', function () {

--- a/test/integration/transaction_create_edit_test.rb
+++ b/test/integration/transaction_create_edit_test.rb
@@ -64,28 +64,6 @@ class TransactionCreateEditTest < LegacyJavascriptIntegrationTest
       assert_equal "Get your licence to fly to Mars", t.introduction
       assert_equal "UK Terrestrial Mars Office", t.will_continue_on
     end
-
-    should "allow only a valid Service analytics profile" do
-      transaction = FactoryBot.create(
-        :transaction_edition,
-        panopticon_id: @artefact.id,
-        title: "Register for space flight",
-      )
-
-      visit_edition transaction
-
-      fill_in "Service analytics profile", with: "UA-INVALID-SPACE-FLIGHT"
-      save_edition_and_assert_error(
-        "Invalid format for service analytics profile: must be in format UA-xxxxx-x where xs are digits",
-        "#edition_department_analytics_profile",
-      )
-
-      fill_in "Service analytics profile", with: "UA-00100000-1"
-      save_edition_and_assert_success
-
-      t = TransactionEdition.find(transaction.id)
-      assert_equal "UA-00100000-1", t.department_analytics_profile
-    end
   end
 
   should "disable fields for a published edition" do

--- a/test/models/transaction_edition_test.rb
+++ b/test/models/transaction_edition_test.rb
@@ -5,22 +5,6 @@ class TransactionEditionTest < ActiveSupport::TestCase
     @artefact = FactoryBot.create(:artefact)
   end
 
-  context "Department analytics profiles" do
-    should "only allow valid Google Analytics profiles" do
-      transaction = FactoryBot.create(:transaction_edition, panopticon_id: @artefact.id)
-
-      %w[invalid ua-12345 UA-1234A-1].each do |id|
-        transaction.department_analytics_profile = id
-        assert_not transaction.valid?
-      end
-
-      %w[ua-123456-1 UA-00-10].each do |id|
-        transaction.department_analytics_profile = id
-        assert transaction.valid?
-      end
-    end
-  end
-
   context "indexable_content" do
     should "include the introduction without markup" do
       transaction = FactoryBot.create(:transaction_edition, introduction: "## introduction", more_information: "", panopticon_id: @artefact.id)

--- a/test/unit/presenters/formats/service_sign_in_presenter_test.rb
+++ b/test/unit/presenters/formats/service_sign_in_presenter_test.rb
@@ -158,23 +158,6 @@ class ServiceSignInTest < ActiveSupport::TestCase
         end
       end
 
-      context "[:tracking_code] [:tracking_domain] and [:tracking_name]" do
-        should "be present in the payload when it is present in the YAML file" do
-          assert_equal "UA-xxxxxx", result[:details][:choose_sign_in][:tracking_code]
-          assert_equal "tax.service.gov.uk", result[:details][:choose_sign_in][:tracking_domain]
-          assert_equal "somethingClicky", result[:details][:choose_sign_in][:tracking_name]
-        end
-
-        should "not be present in the payload when it is not present in the YAML file" do
-          @content[:choose_sign_in].delete(:tracking_code)
-          @content[:choose_sign_in].delete(:tracking_domain)
-          @content[:choose_sign_in].delete(:tracking_name)
-          assert_not result[:details][:choose_sign_in].key?(:tracking_code)
-          assert_not result[:details][:choose_sign_in].key?(:tracking_domain)
-          assert_not result[:details][:choose_sign_in].key?(:tracking_name)
-        end
-      end
-
       context "[:options]" do
         should "include standard options with an external url" do
           option_one = @content[:choose_sign_in][:options][0]

--- a/test/unit/presenters/formats/transaction_presenter_test.rb
+++ b/test/unit/presenters/formats/transaction_presenter_test.rb
@@ -158,11 +158,6 @@ class TransactionPresenterTest < ActiveSupport::TestCase
       assert_equal "foo", result[:details][:transaction_start_link]
     end
 
-    should "[:department_analytics_profile]" do
-      edition.update!(department_analytics_profile: "UA-000000-2")
-      assert_equal "UA-000000-2", result[:details][:department_analytics_profile]
-    end
-
     should "[:start_button_text]" do
       edition.update!(start_button_text: "Sign in")
       assert_equal "Sign in", result[:details][:start_button_text]


### PR DESCRIPTION
The old Google Analytics, Universal Analytics (UA), has stopped working after 1st July 2024.
This PR removes any reference or use the old Analytics code.

This means we wont be sending department_analytics_profile for cross domain tracking for transaction edition and service sign wont be tracking domains anymore.


[Trello](https://trello.com/c/W01PhDtL/342-remove-remaining-ua-code-from-mainstream-publisher)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
