### PR TITLE
Update error message copy

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -28,7 +28,7 @@ class HomepageController < ApplicationController
     render "homepage/popular_links/edit"
   rescue StandardError => e
     Rails.logger.error "Error #{e.class} #{e.message}"
-    flash[:danger] = "Due to an application error, the edition couldn't be saved."
+    flash[:danger] = "Due to an application error, the edition couldn't be saved. #{try_again_message} #{raise_support_error_message}"
     render "homepage/popular_links/edit"
   end
 
@@ -40,7 +40,7 @@ class HomepageController < ApplicationController
     flash[:danger] = rescue_already_published_error(e)
   rescue StandardError => e
     Rails.logger.error "Error #{e.class} #{e.message}"
-    flash[:danger] = "Due to an application error, the edition couldn't be published."
+    flash[:danger] = "Due to an application error, the edition couldn't be published. #{try_again_message} #{raise_support_error_message}"
   ensure
     redirect_to show_popular_links_path
   end
@@ -74,7 +74,7 @@ private
   end
 
   def application_error_message
-    "Due to an application error, the draft couldn't be deleted.".html_safe
+    "Due to an application error, the draft couldn't be deleted. #{try_again_message} #{raise_support_error_message}".html_safe
   end
 
   def rescue_already_published_error(error)
@@ -108,5 +108,13 @@ private
       link_items << link
     end
     link_items
+  end
+
+  def raise_support_error_message
+    "If the problem persists #{support_link}"
+  end
+
+  def support_link
+    "<a href=\"#{Plek.external_url_for('support')}/technical_fault_report/new\">please raise a support ticket</a>"
   end
 end

--- a/test/functional/homepage_controller_test.rb
+++ b/test/functional/homepage_controller_test.rb
@@ -130,7 +130,7 @@ class HomepageControllerTest < ActionController::TestCase
                                      "5" => { "title" => "title5", "url" => "/url5" },
                                      "6" => { "title" => "title6", "url" => "/url6" } } }
 
-        assert_equal "Due to an application error, the edition couldn't be saved.", flash[:danger]
+        assert_equal "Due to an application error, the edition couldn't be saved. Please wait for a few minutes and try again. If the problem persists <a href=\"#{Plek.external_url_for('support')}/technical_fault_report/new\">please raise a support ticket</a>", flash[:danger]
       end
 
       should "render edit template" do
@@ -223,7 +223,7 @@ class HomepageControllerTest < ActionController::TestCase
       should "alert 'application error'" do
         post :publish, params: { id: @popular_links.id }
 
-        assert_equal "Due to an application error, the edition couldn't be published.", flash[:danger]
+        assert_equal "Due to an application error, the edition couldn't be published. Please wait for a few minutes and try again. If the problem persists <a href=\"#{Plek.external_url_for('support')}/technical_fault_report/new\">please raise a support ticket</a>", flash[:danger]
       end
     end
 
@@ -300,7 +300,7 @@ class HomepageControllerTest < ActionController::TestCase
 
         delete :destroy, params: { id: @popular_links.id }
 
-        assert_equal "Due to an application error, the draft couldn't be deleted.", flash[:danger]
+        assert_equal "Due to an application error, the draft couldn't be deleted. Please wait for a few minutes and try again. If the problem persists <a href=\"#{Plek.external_url_for('support')}/technical_fault_report/new\">please raise a support ticket</a>", flash[:danger]
         assert_redirected_to show_popular_links_path
       end
     end
@@ -328,7 +328,7 @@ class HomepageControllerTest < ActionController::TestCase
 
         delete :destroy, params: { id: @popular_links.id }
 
-        assert_equal "Due to an application error, the draft couldn't be deleted.", flash[:danger]
+        assert_equal "Due to an application error, the draft couldn't be deleted. Please wait for a few minutes and try again. If the problem persists <a href=\"#{Plek.external_url_for('support')}/technical_fault_report/new\">please raise a support ticket</a>", flash[:danger]
         assert_redirected_to show_popular_links_path
       end
     end


### PR DESCRIPTION
In order to provide user consistent and useful messaging around database errors, we have updated the messaging to give user information on what they can do.
Discussions and feedbacks around this is captured in the [documentation ](https://docs.google.com/document/d/1r_z2JLF-5RHpuHLainh0u4-pYHhaayrKvaC-yxNE_pQ/edit)

This might change in future based on the feedback.

[Trello](https://trello.com/c/NBTlQZEj/372-take-homepage-popular-links-to-production)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
