### PR TITLE
Update rake task to have relative urls

### DIFF
--- a/lib/tasks/create_popular_links_and_link_to_homepage.rake
+++ b/lib/tasks/create_popular_links_and_link_to_homepage.rake
@@ -2,12 +2,12 @@ desc "Create popular links and links to homepage"
 task create_popular_links_and_link_to_homepage: [:environment] do
   homepage_content_id = "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a".freeze
   popular_links = PopularLinksEdition.new(title: "Homepage popular links",
-                                          link_items: [{ url: "url1.com", title: "title1" },
-                                                       { url: "url2.com", title: "title2" },
-                                                       { url: "url3.com", title: "title3" },
-                                                       { url: "url4.com", title: "title4" },
-                                                       { url: "url5.com", title: "title5" },
-                                                       { url: "url6.com", title: "title6" }])
+                                          link_items: [{ url: "/url1", title: "title1" },
+                                                       { url: "/url2", title: "title2" },
+                                                       { url: "/url3", title: "title3" },
+                                                       { url: "/url4", title: "title4" },
+                                                       { url: "/url5", title: "title5" },
+                                                       { url: "/url6", title: "title6" }])
 
   popular_links.save!
 


### PR DESCRIPTION
Homepage popular links are now relative instead of absolute, hence we have updated rake task to update urls as relative urls

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
