### PR TITLE
Add homepage editor permission for all controller actions

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -1,6 +1,9 @@
 class HomepageController < ApplicationController
   layout "design_system"
   before_action :fetch_latest_popular_link
+  before_action :require_homepage_editor_permissions
+
+  include GDS::SSO::ControllerMethods
 
   def show
     render "homepage/popular_links/show"
@@ -116,5 +119,9 @@ private
 
   def support_link
     "<a href=\"#{Plek.external_url_for('support')}/technical_fault_report/new\">please raise a support ticket</a>"
+  end
+
+  def require_homepage_editor_permissions
+    authorise_user!("homepage_editor")
   end
 end

--- a/test/functional/homepage_controller_test.rb
+++ b/test/functional/homepage_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class HomepageControllerTest < ActionController::TestCase
   setup do
-    login_as_stub_user
+    login_as_homepage_editor
   end
 
   context "#show" do

--- a/test/integration/homepage_popular_links_test.rb
+++ b/test/integration/homepage_popular_links_test.rb
@@ -1,211 +1,235 @@
 require "integration_test_helper"
 
 class HomepagePopularLinksTest < JavascriptIntegrationTest
-  setup do
-    setup_users
-    @popular_links = FactoryBot.create(:popular_links, state: "published")
-    visit_popular_links
+  context "no homepage editor access" do
+    setup do
+      login_as(FactoryBot.create(:user, name: "Stub User"))
+      @popular_links = FactoryBot.create(:popular_links, state: "published")
+      visit_popular_links
+    end
+
+    should "show permissions error" do
+      assert_text "Sorry, you don't seem to have the homepage_editor permission for this app."
+    end
   end
 
-  context "#show" do
-    should "render page title" do
-      assert_title "Popular on GOV.UK"
+  context "homepage editor access" do
+    setup do
+      login_as_homepage_editor
+      @popular_links = FactoryBot.create(:popular_links, state: "published")
+      visit_popular_links
     end
 
-    should "render 'Homepage' as a page title context" do
-      assert page.has_content?("Homepage")
-    end
+    context "#show" do
+      should "render page title" do
+        assert_title "Popular on GOV.UK"
+      end
 
-    should "have 6 links with title and url" do
-      assert page.has_css?(".govuk-summary-card__title", count: 6)
-      assert page.has_text?("Title", count: 6)
-      assert page.has_text?("URL", count: 6)
-    end
+      should "render 'Homepage' as a page title context" do
+        assert page.has_content?("Homepage")
+      end
 
-    should "have popular links version and status" do
-      assert page.has_text?("Edition")
-      assert page.has_text?(@popular_links.version_number)
-      assert page.has_text?("Status")
-      assert page.has_text?("Published")
-      assert page.has_css?(".govuk-tag--green")
-    end
+      should "have 6 links with title and url" do
+        assert page.has_css?(".govuk-summary-card__title", count: 6)
+        assert page.has_text?("Title", count: 6)
+        assert page.has_text?("URL", count: 6)
+      end
 
-    should "have link to view 'GOV.UK'" do
-      assert page.has_link?("View on GOV.UK (opens in new tab)", href: Plek.website_root)
-    end
+      should "have popular links version and status" do
+        assert page.has_text?("Edition")
+        assert page.has_text?(@popular_links.version_number)
+        assert page.has_text?("Status")
+        assert page.has_text?("Published")
+        assert page.has_css?(".govuk-tag--green")
+      end
 
-    should "have 'Create new edition' button" do
-      assert page.has_text?("Create new edition")
-    end
+      should "have link to view 'GOV.UK'" do
+        assert page.has_link?("View on GOV.UK (opens in new tab)", href: Plek.website_root)
+      end
 
-    should "navigate to create path on click of 'Create new edition'" do
-      click_button("Create new edition")
-      assert_current_path create_popular_links_path
-    end
+      should "have 'Create new edition' button" do
+        assert page.has_text?("Create new edition")
+      end
 
-    should "render new draft popular links with edit option when 'Create new edition' button is clicked" do
-      click_button("Create new edition")
-      within(:css, ".govuk-tag--yellow") do
-        assert page.has_content?("Draft")
+      should "navigate to create path on click of 'Create new edition'" do
+        click_button("Create new edition")
+        assert_current_path create_popular_links_path
+      end
+
+      should "render new draft popular links with edit option when 'Create new edition' button is clicked" do
+        click_button("Create new edition")
+        within(:css, ".govuk-tag--yellow") do
+          assert page.has_content?("Draft")
+        end
       end
     end
-  end
 
-  context "#create" do
-    should "create and show new edition with draft status and with an option to edit popular links" do
-      click_button("Create new edition")
+    context "#create" do
+      should "create and show new edition with draft status and with an option to edit popular links" do
+        click_button("Create new edition")
 
-      assert page.has_text?("Edition")
-      assert page.has_text?(@popular_links.version_number)
-      assert page.has_text?("Status")
-      assert page.has_text?("Draft")
-      assert page.has_css?(".govuk-tag--yellow")
-      assert page.has_text?("Edit popular links")
+        assert page.has_text?("Edition")
+        assert page.has_text?(@popular_links.version_number)
+        assert page.has_text?("Status")
+        assert page.has_text?("Draft")
+        assert page.has_css?(".govuk-tag--yellow")
+        assert page.has_text?("Edit popular links")
+      end
+
+      should "have link to preview on draft-origin" do
+        click_button("Create new edition")
+
+        assert page.has_link?("Preview (opens in new tab)", href: /#{Plek.external_url_for('draft-origin')}/)
+      end
+
+      should "have 'delete draft' link navigating to 'confirm destroy' page" do
+        click_button("Create new edition")
+
+        assert page.has_link?("Delete draft", href: /confirm-destroy/)
+      end
+
+      should "create a new record with next version and 'draft' status" do
+        row = find_all(".govuk-summary-list__row")
+        assert row[0].has_text?("Edition")
+        assert row[0].has_text?("1")
+        assert row[1].has_text?("Status")
+        assert row[1].has_text?("Published")
+
+        click_button("Create new edition")
+
+        row = find_all(".govuk-summary-list__row")
+        assert row[0].has_text?("Edition")
+        assert row[0].has_text?("2")
+        assert row[1].has_text?("Status")
+        assert row[1].has_text?("Draft")
+      end
     end
 
-    should "have link to preview on draft-origin" do
-      click_button("Create new edition")
+    context "#edit" do
+      setup do
+        click_button("Create new edition")
+        click_link("Edit popular links")
+      end
 
-      assert page.has_link?("Preview (opens in new tab)", href: /#{Plek.external_url_for('draft-origin')}/)
+      should "render page title" do
+        assert_title "Edit popular links"
+      end
+
+      should "render 'Popular on GOV.UK' as a page title context" do
+        assert page.has_content?("Popular on GOV.UK")
+      end
+
+      should "have 6 links with title and url" do
+        assert page.has_css?(".govuk-input", count: 12)
+        assert page.has_text?("Title", count: 6)
+        assert page.has_text?("URL", count: 6)
+      end
+
+      should "update record when 'Save' is clicked" do
+        fill_in "popular_links[1][title]", with: "new title 1"
+        click_button("Save")
+
+        assert page.has_text?("Popular links draft saved.")
+        assert page.has_text?("new title 1")
+      end
+
+      should "show validation errors for missing link and url" do
+        fill_in "popular_links[1][title]", with: ""
+        fill_in "popular_links[1][url]", with: ""
+        click_button("Save")
+
+        assert page.has_text?("Title is required for Link 1")
+        assert page.has_text?("URL is required for Link 1")
+      end
+
+      should "trim spaces from start and end of urls" do
+        fill_in "popular_links[1][url]", with: " /abc "
+        click_button("Save")
+
+        assert page.has_text?("/abc")
+        assert_not page.has_text?(" /abc ")
+      end
+
+      should "render create page when 'Cancel' is clicked" do
+        click_link("Cancel")
+
+        assert_current_path show_popular_links_path
+      end
+
+      should "not save any changes when 'Cancel' is clicked" do
+        fill_in "popular_links[1][url]", with: "/abc"
+        click_link("Cancel")
+
+        assert_not page.has_text?("/abc")
+      end
     end
 
-    should "have 'delete draft' link navigating to 'confirm destroy' page" do
-      click_button("Create new edition")
+    context "#publish" do
+      setup do
+        click_button("Create new edition")
+      end
 
-      assert page.has_link?("Delete draft", href: /confirm-destroy/)
+      should "publish latest edition when 'Publish' is clicked" do
+        click_button("Publish")
+
+        assert page.has_text?("Published")
+        assert page.has_text?("Popular links successfully published.")
+      end
     end
 
-    should "create a new record with next version and 'draft' status" do
-      row = find_all(".govuk-summary-list__row")
-      assert row[0].has_text?("Edition")
-      assert row[0].has_text?("1")
-      assert row[1].has_text?("Status")
-      assert row[1].has_text?("Published")
+    context "#confirm_destroy" do
+      setup do
+        click_button("Create new edition")
+      end
 
-      click_button("Create new edition")
+      should "show the 'Delete draft' confirmation page" do
+        click_link("Delete draft")
 
-      row = find_all(".govuk-summary-list__row")
-      assert row[0].has_text?("Edition")
-      assert row[0].has_text?("2")
-      assert row[1].has_text?("Status")
-      assert row[1].has_text?("Draft")
-    end
-  end
+        assert page.has_text?("Delete draft")
+        assert page.has_text?("Are you sure you want to delete this draft?")
+      end
 
-  context "#edit" do
-    setup do
-      click_button("Create new edition")
-      click_link("Edit popular links")
+      should "navigate to show page when 'Cancel' button is clicked" do
+        click_link("Delete draft")
+        click_link("Cancel")
+
+        assert_title "Popular on GOV.UK"
+      end
     end
 
-    should "render page title" do
-      assert_title "Edit popular links"
-    end
+    context "#destroy" do
+      setup do
+        click_button("Create new edition")
+      end
 
-    should "render 'Popular on GOV.UK' as a page title context" do
-      assert page.has_content?("Popular on GOV.UK")
-    end
+      should "show the previously published edition when a draft is deleted" do
+        row = find_all(".govuk-summary-list__row")
+        assert row[0].has_text?("Edition")
+        assert row[0].has_text?("2")
+        assert row[1].has_text?("Draft")
 
-    should "have 6 links with title and url" do
-      assert page.has_css?(".govuk-input", count: 12)
-      assert page.has_text?("Title", count: 6)
-      assert page.has_text?("URL", count: 6)
-    end
+        click_link("Delete draft")
+        click_button("Delete")
 
-    should "update record when 'Save' is clicked" do
-      fill_in "popular_links[1][title]", with: "new title 1"
-      click_button("Save")
-
-      assert page.has_text?("Popular links draft saved.")
-      assert page.has_text?("new title 1")
-    end
-
-    should "show validation errors for missing link and url" do
-      fill_in "popular_links[1][title]", with: ""
-      fill_in "popular_links[1][url]", with: ""
-      click_button("Save")
-
-      assert page.has_text?("Title is required for Link 1")
-      assert page.has_text?("URL is required for Link 1")
-    end
-
-    should "trim spaces from start and end of urls" do
-      fill_in "popular_links[1][url]", with: " /abc "
-      click_button("Save")
-
-      assert page.has_text?("/abc")
-      assert_not page.has_text?(" /abc ")
-    end
-
-    should "render create page when 'Cancel' is clicked" do
-      click_link("Cancel")
-
-      assert_current_path show_popular_links_path
-    end
-
-    should "not save any changes when 'Cancel' is clicked" do
-      fill_in "popular_links[1][url]", with: "/abc"
-      click_link("Cancel")
-
-      assert_not page.has_text?("/abc")
-    end
-  end
-
-  context "#publish" do
-    setup do
-      click_button("Create new edition")
-    end
-
-    should "publish latest edition when 'Publish' is clicked" do
-      click_button("Publish")
-
-      assert page.has_text?("Published")
-      assert page.has_text?("Popular links successfully published.")
-    end
-  end
-
-  context "#confirm_destroy" do
-    setup do
-      click_button("Create new edition")
-    end
-
-    should "show the 'Delete draft' confirmation page" do
-      click_link("Delete draft")
-
-      assert page.has_text?("Delete draft")
-      assert page.has_text?("Are you sure you want to delete this draft?")
-    end
-
-    should "navigate to show page when 'Cancel' button is clicked" do
-      click_link("Delete draft")
-      click_link("Cancel")
-
-      assert_title "Popular on GOV.UK"
-    end
-  end
-
-  context "#destroy" do
-    setup do
-      click_button("Create new edition")
-    end
-
-    should "show the previously published edition when a draft is deleted" do
-      row = find_all(".govuk-summary-list__row")
-      assert row[0].has_text?("Edition")
-      assert row[0].has_text?("2")
-      assert row[1].has_text?("Draft")
-
-      click_link("Delete draft")
-      click_button("Delete")
-
-      row = find_all(".govuk-summary-list__row")
-      assert row[0].has_text?("Edition")
-      assert row[0].has_text?("1")
-      assert row[1].has_text?("Published")
+        row = find_all(".govuk-summary-list__row")
+        assert row[0].has_text?("Edition")
+        assert row[0].has_text?("1")
+        assert row[1].has_text?("Published")
+      end
     end
   end
 
   def visit_popular_links
     visit "/homepage/popular-links"
+  end
+
+  def login_as_homepage_editor
+    user = FactoryBot.create(:user, :homepage_editor, name: "Stub User")
+    login_as(user)
+  end
+
+  def login_as(user)
+    GDS::SSO.test_user = user
+    super(user)
   end
 end

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -23,6 +23,10 @@ FactoryBot.define do
     end
   end
 
+  trait :homepage_editor do
+    permissions { %w[homepage_editor signin] }
+  end
+
   factory :disabled_user, parent: :user do
     disabled { true }
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -87,6 +87,11 @@ class ActiveSupport::TestCase
     login_as(@user)
   end
 
+  def login_as_homepage_editor
+    @user = FactoryBot.create(:user, :homepage_editor, name: "Stub User")
+    login_as(@user)
+  end
+
   alias_method :login_as_stub_user, :login_as_govuk_editor
 
   include GdsApi::TestHelpers::PublishingApi


### PR DESCRIPTION
In order to restrict access to homepage popular links, we have added homepage editor permission. 

**Why inside Mainstream?**
- Homepage popular links is going to be managed inside Mainstream and hence its related permission.

**Considerations and side-effects:**
Homepage appears as a separate app on sign-on though technically its just a separate controller accessed via Mainstream, this has a side-effect to understand that homepage permissions are to be access via Mainstream. This is something we understand as a team and have gone ahead with.
We are trying to mitigate the degree of effects through our messaging on signon and via access error message. We shall be iterating on this based on any feedback.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
