### PR TITLE
Refactor save before publish

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -81,11 +81,11 @@ private
   end
 
   def rescue_already_published_error(error)
-    already_published_error?(JSON.parse(error.http_body)) ? "Popular links publish was unsuccessful, cannot publish an already published content item.".html_safe : publishing_api_publish_error_message
+    already_published_error?(JSON.parse(error.http_body)) ? "Popular links publish was unsuccessful, cannot publish an already published edition.".html_safe : publishing_api_publish_error_message
   end
 
   def already_published_error?(error_body)
-    error_body["error"] && error_body["error"]["message"] && error_body["error"]["message"].include?("already published content item")
+    error_body["error"] && error_body["error"]["message"] && error_body["error"]["message"].include?("Cannot publish an already published")
   end
 
   def fetch_latest_popular_link

--- a/app/models/popular_links_edition.rb
+++ b/app/models/popular_links_edition.rb
@@ -35,7 +35,7 @@ class PopularLinksEdition < Edition
   end
 
   def publish_latest
-    save_draft
+    save_draft if is_draft?
     Services.publishing_api.publish(content_id, update_type, locale:)
     # This publish_popular_links is a new workflow that was introduced for popular links.
     publish_popular_links
@@ -61,6 +61,12 @@ class PopularLinksEdition < Edition
   end
 
   def can_delete?
+    is_draft?
+  end
+
+private
+
+  def is_draft?
     state == "draft"
   end
 end


### PR DESCRIPTION
This PR includes change to:

Call to save in publishing api only if state is draft before publish is called.
Improve error wordings to reflect publishing api error response

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
