### PR TITLE
Update mongo dependency to 2.20.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,7 +352,7 @@ GEM
       ruby2_keywords (>= 0.0.5)
     momentjs-rails (2.29.4.1)
       railties (>= 3.1)
-    mongo (2.20.0)
+    mongo (2.20.1)
       bson (>= 4.14.1, < 6.0.0)
     mongoid (8.1.2)
       activemodel (>= 5.1, < 7.1, != 7.0.0)


### PR DESCRIPTION
Does not update the bson dependency to v5, as that has compatibility
 issues.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
