### PR TITLE
Default the state filters on the publications page

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -15,10 +15,16 @@ class RootController < ApplicationController
     archived
   ].freeze
 
+  DEFAULT_FILTER_STATES = %w[draft amends_needed in_review fact_check fact_check_received ready].freeze
+
   def index
     filter_params_hash = filter_params.to_h
     states_filter_params = filter_params_hash[:states_filter]
-    sanitised_states_filter_params = states_filter_params&.select { |fp| PERMITTED_FILTER_STATES.include?(fp) }
+    sanitised_states_filter_params = if user_has_submitted_filters?
+                                       states_filter_params&.select { |fp| PERMITTED_FILTER_STATES.include?(fp) }
+                                     else
+                                       DEFAULT_FILTER_STATES
+                                     end
     assignee_filter = filter_params_hash[:assignee_filter]
     content_type_filter = filter_params_hash[:content_type_filter]
     title_filter = filter_params_hash[:title_filter]
@@ -32,6 +38,10 @@ class RootController < ApplicationController
   end
 
 private
+
+  def user_has_submitted_filters?
+    filter_params.to_h[:title_filter]
+  end
 
   def filter_params
     params.permit(:page, :assignee_filter, :content_type_filter, :title_filter, states_filter: [])


### PR DESCRIPTION
When visiting the root page, with no filters set, default the state filters so that only editions in the "pre-published" states are shown, as these are the editions that users of Mainstream Publisher mostly care about.

Uses the presence of the title filter as a proxy for whether any filters have been set, since that filter is always present when the 'update filter' button is clicked (even if no title text has been supplied, in which case it will have an empty value).

[Trello card](https://trello.com/c/GqI64TRd)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️