### PR TITLE
Fix 'More Details' summary contents width

### DIFF
--- a/app/assets/stylesheets/publications-table.scss
+++ b/app/assets/stylesheets/publications-table.scss
@@ -1,5 +1,17 @@
+$width: 40;
+
 .publications-table {
-  position: relative;
+  th:first-child {
+    width: calc($width * 1%);
+  }
+
+  details {
+    width: calc(100 / $width * 100%);
+  }
+
+  table {
+    table-layout: fixed;
+  }
 
   &--expand-link {
     float: right;
@@ -46,14 +58,6 @@
 
   .govuk-table {
     border-top: 2px solid $govuk-text-colour;
-
-    .govuk-table__header {
-      white-space: nowrap;
-    }
-
-    .govuk-table__cell__updated {
-      white-space: nowrap;
-    }
   }
 
   .govuk-details {


### PR DESCRIPTION
Updated sass allows the contents of the 'More Details' summary section to spread out across all table columns. 
Previously, this content was squashed into the first column which made it difficult to read. 
More work may be done on this in future but this functionality is needed for user testing. 
See Trello Card - [Increase width of 'more details' section of the table [Publication Page]](https://trello.com/c/6jf5jino)
