### PR TITLE
Memoize FilteredEditionsPresenter.editions

### DIFF
--- a/app/presenters/filtered_editions_presenter.rb
+++ b/app/presenters/filtered_editions_presenter.rb
@@ -59,6 +59,12 @@ class FilteredEditionsPresenter
   end
 
   def editions
+    @editions ||= query_editions
+  end
+
+private
+
+  def query_editions
     result = editions_by_content_type
     result = apply_states_filter(result)
     result = apply_assigned_to_filter(result)
@@ -67,8 +73,6 @@ class FilteredEditionsPresenter
     result = result.where.not(_type: "PopularLinksEdition")
     result.order_by(%w[updated_at desc]).page(@page).per(ITEMS_PER_PAGE)
   end
-
-private
 
   def available_users
     User.enabled.alphabetized

--- a/test/unit/presenters/filtered_editions_presenter_test.rb
+++ b/test/unit/presenters/filtered_editions_presenter_test.rb
@@ -199,6 +199,14 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       assert_equal(middle, filtered_editions[1])
       assert_equal(oldest, filtered_editions[2])
     end
+
+    should "only query the database once, regardless of how many times it is called" do
+      presenter = FilteredEditionsPresenter.new(a_gds_user)
+      presenter.expects(:query_editions).once.returns([])
+
+      presenter.editions
+      presenter.editions
+    end
   end
 
   context "#assignees" do


### PR DESCRIPTION
The view calls `#editions` three times, which means it is querying the database three times; memoize the result so that it is only querying the database once.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
