### PR TITLE
Default the assignee filter on the publications page

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -25,7 +25,7 @@ class RootController < ApplicationController
                                      else
                                        DEFAULT_FILTER_STATES
                                      end
-    assignee_filter = filter_params_hash[:assignee_filter]
+    session[:assignee_filter] = assignee_filter
     content_type_filter = filter_params_hash[:content_type_filter]
     title_filter = filter_params_hash[:title_filter]
     @presenter = FilteredEditionsPresenter.new(

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -43,6 +43,17 @@ private
     filter_params.to_h[:title_filter]
   end
 
+  def assignee_filter
+    filter_params_hash = filter_params.to_h
+    if filter_params_hash[:assignee_filter]
+      filter_params_hash[:assignee_filter]
+    elsif session[:assignee_filter]
+      session[:assignee_filter]
+    else
+      current_user.id.to_s
+    end
+  end
+
   def filter_params
     params.permit(:page, :assignee_filter, :content_type_filter, :title_filter, states_filter: [])
   end

--- a/app/presenters/filtered_editions_presenter.rb
+++ b/app/presenters/filtered_editions_presenter.rb
@@ -43,10 +43,6 @@ class FilteredEditionsPresenter
     states
   end
 
-  def available_users
-    User.enabled.alphabetized
-  end
-
   def assignees
     users = [{ text: "All assignees", value: "" }]
 
@@ -71,6 +67,10 @@ class FilteredEditionsPresenter
   end
 
 private
+
+  def available_users
+    User.enabled.alphabetized
+  end
 
   def state_names
     {

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -64,6 +64,7 @@ class RootControllerTest < ActionController::TestCase
 
       assert_response :ok
       assert_select "p.publications-table__heading", "1 document(s)"
+      assert_select "td.govuk-table__cell", "Draft"
     end
 
     should "default the assignee to the current user" do
@@ -82,6 +83,7 @@ class RootControllerTest < ActionController::TestCase
 
       assert_response :ok
       assert_select "p.publications-table__heading", "1 document(s)"
+      assert_select "td.govuk-table__cell", "Stub User"
     end
 
     should "filter publications by assignee in the session" do
@@ -103,6 +105,7 @@ class RootControllerTest < ActionController::TestCase
 
       assert_response :ok
       assert_select "p.publications-table__heading", "1 document(s)"
+      assert_select "td.govuk-table__cell", "Anna"
     end
 
     should "store the assignee parameter value in the session" do
@@ -132,6 +135,7 @@ class RootControllerTest < ActionController::TestCase
 
       assert_response :ok
       assert_select "p.publications-table__heading", "1 document(s)"
+      assert_select "dd.govuk-summary-list__value", "Guide"
     end
 
     should "filter publications by title text" do
@@ -142,6 +146,7 @@ class RootControllerTest < ActionController::TestCase
 
       assert_response :ok
       assert_select "p.publications-table__heading", "1 document(s)"
+      assert_select "p.title", "What to do in the event of a zombie apocalypse"
     end
 
     should "ignore unrecognised filter states" do

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -66,7 +66,17 @@ class RootControllerTest < ActionController::TestCase
       assert_select "p.publications-table__heading", "1 document(s)"
     end
 
-    should "filter publications by assignee" do
+    should "filter publications by assignee in the session" do
+      anna = FactoryBot.create(:user, name: "Anna")
+      @request.session[:assignee_filter] = anna.id.to_s
+
+      get :index
+
+      assert_response :ok
+      assert_select "#assignee_filter > option[value='#{anna.id}'][selected]"
+    end
+
+    should "filter publications by assignee parameter" do
       anna = FactoryBot.create(:user, name: "Anna")
       FactoryBot.create(:guide_edition, assigned_to: anna)
       FactoryBot.create(:guide_edition)
@@ -75,6 +85,25 @@ class RootControllerTest < ActionController::TestCase
 
       assert_response :ok
       assert_select "p.publications-table__heading", "1 document(s)"
+    end
+
+    should "store the assignee parameter value in the session" do
+      anna = FactoryBot.create(:user, name: "Anna")
+
+      get :index, params: { assignee_filter: anna.id }
+
+      assert_equal anna.id.to_s, @request.session[:assignee_filter]
+    end
+
+    should "filter publications by assignee parameter in preference to the one in the session" do
+      anna = FactoryBot.create(:user, name: "Anna")
+      bob = FactoryBot.create(:user, name: "Bob")
+      @request.session[:assignee_filter] = bob.id
+
+      get :index, params: { assignee_filter: anna.id }
+
+      assert_response :ok
+      assert_select "#assignee_filter > option[value='#{anna.id}'][selected]"
     end
 
     should "filter publications by content type" do

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -68,9 +68,10 @@ class RootControllerTest < ActionController::TestCase
 
     should "filter publications by assignee" do
       anna = FactoryBot.create(:user, name: "Anna")
+      FactoryBot.create(:guide_edition, assigned_to: anna)
       FactoryBot.create(:guide_edition)
 
-      get :index, params: { assignee_filter: [anna.id] }
+      get :index, params: { assignee_filter: anna.id }
 
       assert_response :ok
       assert_select "p.publications-table__heading", "1 document(s)"

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -34,16 +34,16 @@ class RootControllerTest < ActionController::TestCase
     end
 
     should "default the applied state filters when no filters are specified" do
-      FactoryBot.create(:edition, state: "draft")
-      FactoryBot.create(:edition, state: "amends_needed")
-      FactoryBot.create(:edition, state: "in_review", review_requested_at: 1.hour.ago)
-      fact_check_edition = FactoryBot.create(:edition, state: "fact_check", title: "Check yo fax")
+      FactoryBot.create(:edition, state: "draft", assigned_to: @user)
+      FactoryBot.create(:edition, state: "amends_needed", assigned_to: @user)
+      FactoryBot.create(:edition, state: "in_review", review_requested_at: 1.hour.ago, assigned_to: @user)
+      fact_check_edition = FactoryBot.create(:edition, state: "fact_check", title: "Check yo fax", assigned_to: @user)
       fact_check_edition.new_action(FactoryBot.create(:user), "send_fact_check")
-      FactoryBot.create(:edition, state: "fact_check_received")
-      FactoryBot.create(:edition, state: "ready")
+      FactoryBot.create(:edition, state: "fact_check_received", assigned_to: @user)
+      FactoryBot.create(:edition, state: "ready", assigned_to: @user)
       FactoryBot.create(:edition, state: "scheduled_for_publishing", publish_at: Time.zone.now + 1.hour)
-      FactoryBot.create(:edition, state: "published")
-      FactoryBot.create(:edition, state: "archived")
+      FactoryBot.create(:edition, state: "published", assigned_to: @user)
+      FactoryBot.create(:edition, state: "archived", assigned_to: @user)
 
       get :index
 

--- a/test/integration/adding_parts_to_guides_test.rb
+++ b/test/integration/adding_parts_to_guides_test.rb
@@ -5,6 +5,9 @@ class AddingPartsToGuidesTest < LegacyJavascriptIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
+
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:design_system_publications_filter, false)
   end
 
   context "creating a guide with parts" do

--- a/test/integration/adding_variants_to_transactions_test.rb
+++ b/test/integration/adding_variants_to_transactions_test.rb
@@ -5,6 +5,9 @@ class AddingVariantsToTransactionsTest < LegacyJavascriptIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
+
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:design_system_publications_filter, false)
   end
 
   context "creating a transaction with variants" do

--- a/test/integration/root_overview_test.rb
+++ b/test/integration/root_overview_test.rb
@@ -9,9 +9,9 @@ class RootOverviewTest < IntegrationTest
   end
 
   should "be able to view different pages of results" do
-    FactoryBot.create(:user, :govuk_editor, name: "Alice", uid: "alice")
-    FactoryBot.create(:guide_edition, title: "Guides and Gals")
-    FactoryBot.create_list(:guide_edition, FilteredEditionsPresenter::ITEMS_PER_PAGE)
+    alice = FactoryBot.create(:user, :govuk_editor, name: "Alice", uid: "alice")
+    FactoryBot.create(:guide_edition, title: "Guides and Gals", assigned_to: alice)
+    FactoryBot.create_list(:guide_edition, FilteredEditionsPresenter::ITEMS_PER_PAGE, assigned_to: alice)
 
     visit "/"
     assert_content("21 document(s)")

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -14,6 +14,9 @@ class SimpleSmartAnswersTest < LegacyJavascriptIntegrationTest
     GDS::SSO.test_user = @author
     stub_linkables
     stub_holidays_used_by_fact_check
+
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:design_system_publications_filter, false)
   end
 
   # fill_in does not trigger 'change' events until the element loses focus


### PR DESCRIPTION
Default the assignee filter on the publications page

When visiting the root page, with no filters set, default the assignee
 filter so that only editions assigned to the current user are shown.

Order of precedence is:
1. assignee parameter
2. assignee in session
3. current user

[Trello card](https://trello.com/c/TVkDk1Oe)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
