### PR TITLE
require prometheus client libs in mail_fetcher

### DIFF
--- a/script/mail_fetcher
+++ b/script/mail_fetcher
@@ -11,6 +11,10 @@ Publisher::Application.mail_fetcher_config.configure
 
 require "fact_check_email_handler"
 
+require "prometheus/client"
+require "prometheus/client/push"
+require "prometheus/client/registry"
+
 require "redis"
 require "redis-lock"
 


### PR DESCRIPTION
This is job is currently erroring in all environments, albeit after it's already done all the important work.

    {"@timestamp":"2024-09-16T13:05:05.605Z","message":"Finished running MailFetcher in production mode - 2024-09-16 13:05:05 UTC","level":"INFO","tags":["rails"]}
		script/mail_fetcher:58:in `<main>': uninitialized constant Prometheus::Client::Push (NameError)
		Prometheus::Client::Push.new(

Note the "Finished running MailFetcher in production mode" log before the error
- the script has still done everything it needs to, it just hasn't sent the metrics, which fortunately is on the very last line of the script.

This looks like the same mistake I made when doing metrics for publishing-api:

    https://github.com/alphagov/publishing-api/commit/30374578660e126bd49e3654ebe0ebf3ce2a3dff

We need to explicitly require the push library to use it. I'm not 100% sure if we really need the other two imports (client and registry), but publishing-api has them, so we may as well be consistent. Can't hurt, surely.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
