### PR TITLE
Add Sub Navigation component to Edit page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,10 +239,10 @@ GEM
       sentry-rails (~> 5.3)
       sentry-ruby (~> 5.3)
       statsd-ruby (~> 1.5)
-    govuk_personalisation (0.16.0)
+    govuk_personalisation (1.0.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (41.1.1)
+    govuk_publishing_components (43.3.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -688,7 +688,7 @@ GEM
     rexml (3.3.6)
       strscan
     rinku (2.0.6)
-    rouge (4.3.0)
+    rouge (4.4.0)
     rubocop (1.64.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 $govuk-page-width: 1140px;
 
 // GOVUK Design System
+@import "govuk/base";
 @import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/component_support';
 @import 'govuk_publishing_components/components/button';
@@ -23,6 +24,7 @@ $govuk-page-width: 1140px;
 @import 'govuk_publishing_components/components/notice';
 @import 'govuk_publishing_components/components/previous-and-next-navigation';
 @import 'govuk_publishing_components/components/search';
+@import 'govuk_publishing_components/components/secondary-navigation';
 @import 'govuk_publishing_components/components/select';
 @import 'govuk_publishing_components/components/skip-link';
 @import 'govuk_publishing_components/components/success-alert';

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -16,6 +16,26 @@ class EditionsController < InheritedResources::Base
     render action: "show"
   end
 
+  def metadata
+    render action: "show"
+  end
+
+  def history
+    render action: "show"
+  end
+
+  def admin
+    render action: "show"
+  end
+
+  def linking
+    render action: "show"
+  end
+
+  def unpublish
+    render action: "show"
+  end
+
 protected
 
   def setup_view_paths

--- a/app/helpers/tabbed_nav_helper.rb
+++ b/app/helpers/tabbed_nav_helper.rb
@@ -1,0 +1,32 @@
+module TabbedNavHelper
+  def edition_nav_items(edition)
+    nav_items = []
+    items = %w[edit tagging metadata history admin related_external_links unpublish]
+
+    items.each do |item|
+      nav_items << standard_nav_items(item, edition)
+    end
+
+    nav_items.flatten
+  end
+
+  def standard_nav_items(item, edition)
+    url = item.eql?("edit") ? url_for([:edition, { id: edition.id }]) : url_for([:edition, { action: item, id: edition.id }])
+
+    label = Edition::Tab[item].title
+    href = url
+    current = request.path == url
+
+    edit_nav_item(label, href, current)
+  end
+
+  def edit_nav_item(label, href, current)
+    [
+      {
+        label:,
+        href:,
+        current:,
+      },
+    ]
+  end
+end

--- a/app/views/editions/_secondary_navigation.html.erb
+++ b/app/views/editions/_secondary_navigation.html.erb
@@ -1,0 +1,4 @@
+<%= render "govuk_publishing_components/components/secondary_navigation", {
+  aria_label: "Document navigation",
+  items: edition_nav_items(@edition),
+} %>

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -22,4 +22,8 @@
       ],
     } %>
   </div>
+
+  <div class="govuk-grid-column-full">
+    <%= render partial: "secondary_navigation" %>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,16 @@ Rails.application.routes.draw do
   resources :artefacts, only: %i[new create update]
 
   constraints FeatureConstraint.new("design_system_edit") do
-    resources :editions, only: %i[show index]
+    resources :editions do
+      member do
+        get "metadata"
+        get "history"
+        get "admin"
+        get "related_external_links", to: "editions#linking"
+        get "tagging", to: "editions#linking"
+        get "unpublish"
+      end
+    end
   end
 
   get "editions/:id" => "legacy_editions#show"

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -22,4 +22,17 @@ class EditionEditTest < IntegrationTest
     assert row[2].has_text?("1")
     assert row[2].has_text?("Draft")
   end
+
+  should "show all the tabs for the edit" do
+    edition = FactoryBot.create(:guide_edition, title: "Edit page title", state: "draft")
+    visit edition_path(edition)
+
+    assert page.has_text?("Edit")
+    assert page.has_text?("Tagging")
+    assert page.has_text?("Metadata")
+    assert page.has_text?("History and notes")
+    assert page.has_text?("Admin")
+    assert page.has_text?("Related external links")
+    assert page.has_text?("Unpublish")
+  end
 end

--- a/test/unit/helpers/admin/tabbed_nav_helper_test.rb
+++ b/test/unit/helpers/admin/tabbed_nav_helper_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class TabbedNavHelperTest < ActionView::TestCase
+  test "#secondary_navigation_tabs_items for edit edition page" do
+    resource = FactoryBot.create(:guide_edition, title: "Edit page title", state: "draft")
+
+    expected_output = [
+      {
+        label: "Edit",
+        href: "/editions/#{resource.id}",
+        current: false,
+      },
+      {
+        label: "Tagging",
+        href: "/editions/#{resource.id}/tagging",
+        current: false,
+      },
+      {
+        label: "Metadata",
+        href: "/editions/#{resource.id}/metadata",
+        current: false,
+      },
+      {
+        label: "History and notes",
+        href: "/editions/#{resource.id}/history",
+        current: false,
+      },
+      {
+        label: "Admin",
+        href: "/editions/#{resource.id}/admin",
+        current: false,
+      },
+      {
+        label: "Related external links",
+        href: "/editions/#{resource.id}/related_external_links",
+        current: false,
+      },
+      {
+        label: "Unpublish",
+        href: "/editions/#{resource.id}/unpublish",
+        current: false,
+      },
+    ]
+
+    assert_equal expected_output, edition_nav_items(resource)
+  end
+end


### PR DESCRIPTION
Add sub nav items and default render show edit path for each of the sub nav items.

_Note_: Changes also include Gemfile.lock change although no gem file change, this is to update to latest publishing component gem.

<img width="1240" alt="sub nav items" src="https://github.com/user-attachments/assets/38f456ea-4d61-4cff-842a-ccc18746fe6e">
