### PR TITLE
Remove require for polyfills closest as its no longer available

### DIFF
--- a/app/assets/javascripts/modules/downtime_message.js
+++ b/app/assets/javascripts/modules/downtime_message.js
@@ -1,5 +1,3 @@
-//= require govuk_publishing_components/vendor/polyfills/closest
-
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {};
 


### PR DESCRIPTION
Polyfills closest are no longer available in publishing components and hence we are removing its require.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
