### PR TITLE
425 metadata tab edit page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,6 +23,7 @@ $govuk-page-width: 1140px;
 @import 'govuk_publishing_components/components/lead-paragraph';
 @import 'govuk_publishing_components/components/notice';
 @import 'govuk_publishing_components/components/previous-and-next-navigation';
+@import 'govuk_publishing_components/components/radio';
 @import 'govuk_publishing_components/components/search';
 @import 'govuk_publishing_components/components/secondary-navigation';
 @import 'govuk_publishing_components/components/select';

--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -31,7 +31,7 @@ class ArtefactsController < ApplicationController
 private
 
   def show_success_message
-    if FeatureConstraint.new("design_system_edit")
+    if Flipflop.enabled?("design_system_edit".to_sym)
       flash[:success] = "Metadata has successfully updated".html_safe
     else
       flash[:notice] = "Metadata updated"

--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -18,16 +18,25 @@ class ArtefactsController < ApplicationController
     artefact = Artefact.find(updatable_params[:id])
     if artefact.update_as(current_user, updatable_params)
       UpdateWorker.perform_async(artefact.latest_edition_id)
-      flash[:notice] = "Metadata updated"
+      show_success_message
     else
       flash[:danger] = artefact.errors.full_messages.join("\n")
     end
+
     redirect_to metadata_artefact_path(artefact)
   end
 
   helper_method :formats
 
 private
+
+  def show_success_message
+    if FeatureConstraint.new("design_system_edit")
+      flash[:success] = "Metadata has successfully updated".html_safe
+    else
+      flash[:notice] = "Metadata updated"
+    end
+  end
 
   def formats
     Artefact::FORMATS_BY_DEFAULT_OWNING_APP["publisher"] - Artefact::RETIRED_FORMATS

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -1,7 +1,5 @@
-require "edition_duplicator"
-require "edition_progressor"
-
 class EditionsController < InheritedResources::Base
+  include TabbedNavHelper
   layout "design_system"
 
   defaults resource_class: Edition, collection_name: "editions", instance_name: "resource"
@@ -13,12 +11,11 @@ class EditionsController < InheritedResources::Base
 
   def show
     @artefact = @resource.artefact
+
     render action: "show"
   end
 
-  def metadata
-    render action: "show"
-  end
+  alias_method :metadata, :show
 
   def history
     render action: "show"

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -5,6 +5,8 @@ class EditionsController < InheritedResources::Base
   defaults resource_class: Edition, collection_name: "editions", instance_name: "resource"
   before_action :setup_view_paths, except: %i[index]
 
+  helper_method :locale_to_language
+
   def index
     redirect_to root_path
   end
@@ -44,5 +46,16 @@ private
   def setup_view_paths_for(publication)
     prepend_view_path "app/views/editions"
     prepend_view_path template_folder_for(publication)
+  end
+
+  def locale_to_language(locale)
+    case locale
+    when "en"
+      "English"
+    when "cy"
+      "Welsh"
+    else
+      ""
+    end
   end
 end

--- a/app/helpers/tabbed_nav_helper.rb
+++ b/app/helpers/tabbed_nav_helper.rb
@@ -1,9 +1,8 @@
 module TabbedNavHelper
   def edition_nav_items(edition)
     nav_items = []
-    items = %w[edit tagging metadata history admin related_external_links unpublish]
 
-    items.each do |item|
+    all_tab_names.each do |item|
       nav_items << standard_nav_items(item, edition)
     end
 
@@ -28,5 +27,16 @@ module TabbedNavHelper
         current:,
       },
     ]
+  end
+
+  def current_tab_name
+    current_tab = (request.path.split("/") & all_tab_names).first
+    current_tab == "metadata" ? "metadata" : "temp_nav_text"
+  end
+
+private
+
+  def all_tab_names
+    %w[edit tagging metadata history admin related_external_links unpublish]
   end
 end

--- a/app/views/editions/secondary_nav_tabs/_metadata.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_metadata.html.erb
@@ -1,0 +1,44 @@
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Metadata",
+  heading_level: 2,
+  margin_bottom: 5,
+} %>
+
+<% if Edition::PUBLISHING_API_DRAFT_STATES.include? publication.state %>
+  <%= form_for(@artefact, :html => { :class => "artefact", :id => "edit_artefact" }) do |f| %>
+    <%= f.hidden_field :id, value: @artefact.id %>
+
+    <%= render "govuk_publishing_components/components/input", {
+      label: {
+        text: "Slug",
+      },
+      hint: "If you change the slug of a published page, the old slug will automatically redirect to the new one.",
+      name: "artefact[slug]",
+      value: publication.slug,
+      heading_level: 2,
+      heading_size: "m",
+    } %>
+
+    <%= render "govuk_publishing_components/components/radio", {
+      heading: "Language",
+      name: "artefact[language]",
+      inline: true,
+      items: [
+        {
+          value: "en",
+          text: "English",
+          checked: publication.artefact.language == "en" ? true : false,
+        },
+        {
+          value: "cy",
+          text: "Welsh",
+          checked: publication.artefact.language == "cy" ? true : false,
+        },
+      ],
+    } %>
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Update",
+    } %>
+  <% end %>
+<% else %>
+<% end %>

--- a/app/views/editions/secondary_nav_tabs/_metadata.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_metadata.html.erb
@@ -15,13 +15,15 @@
       hint: "If you change the slug of a published page, the old slug will automatically redirect to the new one.",
       name: "artefact[slug]",
       value: publication.slug,
-      heading_level: 2,
+      heading_level: 3,
       heading_size: "m",
     } %>
 
     <%= render "govuk_publishing_components/components/radio", {
       heading: "Language",
       name: "artefact[language]",
+      heading_level: 3,
+      heading_size: "m",
       inline: true,
       items: [
         {
@@ -41,4 +43,15 @@
     } %>
   <% end %>
 <% else %>
+  <% @artefact.attributes.slice("slug", "language").each do |key, value| %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: key.humanize,
+      heading_level: 3,
+      font_size: "m",
+      margin_bottom: 3,
+    } %>
+    <p class="govuk-body">
+      <%= key.eql?("slug") ? value : locale_to_language(value) %>
+    </p>
+  <% end %>
 <% end %>

--- a/app/views/editions/secondary_nav_tabs/_temp_nav_text.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_temp_nav_text.html.erb
@@ -1,0 +1,1 @@
+<h3>Work in progress</h3>

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -26,4 +26,8 @@
   <div class="govuk-grid-column-full">
     <%= render partial: "secondary_navigation" %>
   </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render partial: "secondary_nav_tabs/#{current_tab_name}", :locals => { :publication => @resource } %>
+  </div>
 </div>

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -26,14 +26,14 @@ class EditionsControllerTest < ActionController::TestCase
 
   context "#show" do
     setup do
-      artefact2 = FactoryBot.create(
+      artefact = FactoryBot.create(
         :artefact,
         slug: "test2",
         kind: "guide",
         name: "test",
         owning_app: "publisher",
       )
-      @guide = GuideEdition.create!(title: "test", slug: "test2", panopticon_id: artefact2.id)
+      @guide = GuideEdition.create!(title: "test", slug: "test2", panopticon_id: artefact.id)
     end
 
     should "requesting a publication that doesn't exist returns a 404" do
@@ -45,6 +45,23 @@ class EditionsControllerTest < ActionController::TestCase
       get :show, params: { id: @guide.id }
       assert_response :success
       assert_not_nil assigns(:resource)
+    end
+  end
+
+  context "#metadata" do
+    setup do
+      artefact = FactoryBot.create(
+        :artefact,
+        slug: "test2",
+        kind: "guide",
+        name: "test",
+        owning_app: "publisher",
+      )
+      @guide = GuideEdition.create!(title: "test", slug: "test2", panopticon_id: artefact.id)
+    end
+
+    should "alias to show method" do
+      assert EditionsController.new.method(:metadata).super_method.name.eql?(:show)
     end
   end
 end

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -61,7 +61,7 @@ class EditionsControllerTest < ActionController::TestCase
     end
 
     should "alias to show method" do
-      assert EditionsController.new.method(:metadata).super_method.name.eql?(:show)
+      assert_equal EditionsController.new.method(:metadata).super_method.name, :show
     end
   end
 end

--- a/test/integration/edit_artefact_test.rb
+++ b/test/integration/edit_artefact_test.rb
@@ -5,6 +5,8 @@ class EditArtefactTest < LegacyIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:design_system_edit, false)
   end
 
   should "edit a draft artefact" do

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -6,58 +6,92 @@ class EditionEditTest < IntegrationTest
     test_strategy = Flipflop::FeatureSet.current.test!
     test_strategy.switch!(:design_system_edit, true)
     stub_linkables
-    edition = FactoryBot.create(:guide_edition, title: "Edit page title", state: "draft")
-    visit edition_path(edition)
   end
 
-  should "show document summary and title" do
-    assert page.has_title?("Edit page title")
-
-    row = find_all(".govuk-summary-list__row")
-    assert row[0].has_content?("Assigned to")
-    assert row[1].has_text?("Content type")
-    assert row[1].has_text?("Guide")
-    assert row[2].has_text?("Edition")
-    assert row[2].has_text?("1")
-    assert row[2].has_text?("Draft")
-  end
-
-  should "show all the tabs for the edit" do
-    assert page.has_text?("Edit")
-    assert page.has_text?("Tagging")
-    assert page.has_text?("Metadata")
-    assert page.has_text?("History and notes")
-    assert page.has_text?("Admin")
-    assert page.has_text?("Related external links")
-    assert page.has_text?("Unpublish")
-  end
-
-  context "#metadata" do
+  context "when edition is draft" do
     setup do
-      click_link("Metadata")
+      edition = FactoryBot.create(:guide_edition, title: "Edit page title", state: "draft")
+      visit edition_path(edition)
     end
 
-    should "'Metadata' header and an update button" do
-      within :css, ".gem-c-heading" do
-        assert page.has_text?("Metadata")
+    should "show document summary and title" do
+      assert page.has_title?("Edit page title")
+
+      row = find_all(".govuk-summary-list__row")
+      assert row[0].has_content?("Assigned to")
+      assert row[1].has_text?("Content type")
+      assert row[1].has_text?("Guide")
+      assert row[2].has_text?("Edition")
+      assert row[2].has_text?("1")
+      assert row[2].has_text?("Draft")
+    end
+
+    should "show all the tabs for the edit" do
+      assert page.has_text?("Edit")
+      assert page.has_text?("Tagging")
+      assert page.has_text?("Metadata")
+      assert page.has_text?("History and notes")
+      assert page.has_text?("Admin")
+      assert page.has_text?("Related external links")
+      assert page.has_text?("Unpublish")
+    end
+
+    context "metadata tab" do
+      setup do
+        click_link("Metadata")
       end
-      assert page.has_button?("Update")
+
+      should "show 'Metadata' header and an update button" do
+        within :css, ".gem-c-heading" do
+          assert page.has_text?("Metadata")
+        end
+        assert page.has_button?("Update")
+      end
+
+      should "show slug input box prefilled" do
+        assert page.has_text?("Slug")
+        assert page.has_text?("If you change the slug of a published page, the old slug will automatically redirect to the new one.")
+        assert page.has_field?("artefact[slug]", with: /slug/)
+      end
+
+      should "update and show success message" do
+        fill_in "artefact[slug]", with: "changed-slug"
+        choose("Welsh")
+        click_button("Update")
+
+        assert find(".gem-c-radio input[value='cy']").checked?
+        assert page.has_text?("Metadata has successfully updated")
+        assert page.has_field?("artefact[slug]", with: "changed-slug")
+      end
     end
+  end
 
-    should "show slug input box prefilled" do
-      assert page.has_text?("Slug")
-      assert page.has_text?("If you change the slug of a published page, the old slug will automatically redirect to the new one.")
-      assert page.has_field?("artefact[slug]", with: /slug/)
-    end
+  context "when edition is published" do
+    context "metadata tab" do
+      setup do
+        edition = FactoryBot.create(
+          :completed_transaction_edition,
+          panopticon_id: FactoryBot.create(
+            :artefact,
+            slug: "can-i-get-a-driving-licence",
+          ).id,
+          state: "published",
+          slug: "can-i-get-a-driving-licence",
+        )
 
-    should "update and show success message" do
-      fill_in "artefact[slug]", with: "changed-slug"
-      choose("Welsh")
-      click_button("Update")
+        visit edition_path(edition)
+        click_link("Metadata")
+      end
 
-      assert find(".gem-c-radio input[value='cy']").checked?
-      assert page.has_text?("Metadata has successfully updated")
-      assert page.has_field?("artefact[slug]", with: "changed-slug")
+      should "show un-editable current value for slug and language" do
+        assert page.has_no_field?("artefact[slug]")
+        assert page.has_no_field?("artefact[language]")
+
+        assert page.has_text?("Slug")
+        assert page.has_text?(/can-i-get-a-driving-licence/)
+        assert page.has_text?("Language")
+        assert page.has_text?(/English/)
+      end
     end
   end
 end

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -6,12 +6,11 @@ class EditionEditTest < IntegrationTest
     test_strategy = Flipflop::FeatureSet.current.test!
     test_strategy.switch!(:design_system_edit, true)
     stub_linkables
+    edition = FactoryBot.create(:guide_edition, title: "Edit page title", state: "draft")
+    visit edition_path(edition)
   end
 
   should "show document summary and title" do
-    edition = FactoryBot.create(:guide_edition, title: "Edit page title", state: "draft")
-    visit edition_path(edition)
-
     assert page.has_title?("Edit page title")
 
     row = find_all(".govuk-summary-list__row")
@@ -24,9 +23,6 @@ class EditionEditTest < IntegrationTest
   end
 
   should "show all the tabs for the edit" do
-    edition = FactoryBot.create(:guide_edition, title: "Edit page title", state: "draft")
-    visit edition_path(edition)
-
     assert page.has_text?("Edit")
     assert page.has_text?("Tagging")
     assert page.has_text?("Metadata")
@@ -34,5 +30,34 @@ class EditionEditTest < IntegrationTest
     assert page.has_text?("Admin")
     assert page.has_text?("Related external links")
     assert page.has_text?("Unpublish")
+  end
+
+  context "#metadata" do
+    setup do
+      click_link("Metadata")
+    end
+
+    should "'Metadata' header and an update button" do
+      within :css, ".gem-c-heading" do
+        assert page.has_text?("Metadata")
+      end
+      assert page.has_button?("Update")
+    end
+
+    should "show slug input box prefilled" do
+      assert page.has_text?("Slug")
+      assert page.has_text?("If you change the slug of a published page, the old slug will automatically redirect to the new one.")
+      assert page.has_field?("artefact[slug]", with: /slug/)
+    end
+
+    should "update and show success message" do
+      fill_in "artefact[slug]", with: "changed-slug"
+      choose("Welsh")
+      click_button("Update")
+
+      assert find(".gem-c-radio input[value='cy']").checked?
+      assert page.has_text?("Metadata has successfully updated")
+      assert page.has_field?("artefact[slug]", with: "changed-slug")
+    end
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/N4sWF2NI/425-metadata-tab-edit-page)

Move Metadata tab to new design system

<img width="943" alt="Screenshot_metadata_tab" src="https://github.com/user-attachments/assets/abd3acac-487c-4384-a383-dbbd8a34e797">

