### PR TITLE
454 customise select2 styles

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.scss
+++ b/app/assets/stylesheets/bootstrap_and_overrides.scss
@@ -1,4 +1,5 @@
-// stylelint-disable selector-no-qualifying-type
+// stylelint-disable scss/comment-no-loud, selector-no-qualifying-type
+
 .alert .modal {
   color: $text-color;
 }
@@ -108,3 +109,88 @@ legend p {
     width: 100%;
   }
 }
+
+// Adds an over-ride style for the crown logo after the upgrade to Dart Sass which requires `background: url` in place of `background: image-url`
+.navbar-brand {
+  background: url("govuk_admin_template/header-crown.png") 0 .67em no-repeat;
+}
+
+// Adds over-ride styles for the select2 component after the upgrade to Dart Sass which requires `background: url` in place of `background: image-url`
+.select2-choice {
+  abbr {
+    background: url("select2.png") right top no-repeat;
+  }
+
+  .select2-arrow {
+    b {
+      background: url("select2.png") no-repeat 0 1px
+    }
+  }
+}
+
+/* stylelint-disable function-linear-gradient-no-nonstandard-direction */
+.select2-search {
+  input {
+    background: #ffffff url("select2.png") no-repeat 100% -22px;
+    background: url("select2.png") no-repeat 100% -22px,-webkit-gradient(linear, left bottom, left top, color-stop(0.85, #ffffff), color-stop(0.99, #eeeeee));
+    background: url("select2.png") no-repeat 100% -22px,-webkit-linear-gradient(center bottom, #ffffff 85%, #eeeeee 99%);
+    background: url("select2.png") no-repeat 100% -22px,-moz-linear-gradient(center bottom, #ffffff 85%, #eeeeee 99%);
+    background: url("select2.png") no-repeat 100% -22px,linear-gradient(to bottom, #ffffff 85%, #eeeeee 99%) 0 0
+  }
+
+  input.select2-active {
+    background: #ffffff url("select2-spinner.gif") no-repeat 100%;
+    background: url("select2-spinner.gif") no-repeat 100%,-webkit-gradient(linear, left bottom, left top, color-stop(0.85, #ffffff), color-stop(0.99, #eeeeee));
+    background: url("select2-spinner.gif") no-repeat 100%,-webkit-linear-gradient(center bottom, #ffffff 85%, #eeeeee 99%);
+    background: url("select2-spinner.gif") no-repeat 100%,-moz-linear-gradient(center bottom, #ffffff 85%, #eeeeee 99%);
+    background: url("select2-spinner.gif") no-repeat 100%,linear-gradient(to bottom, #ffffff 85%, #eeeeee 99%) 0 0
+  }
+}
+
+html[dir="rtl"] {
+  .select2-search {
+    input {
+      background: #ffffff url("select2.png") no-repeat -37px -22px;
+      background: url("select2.png") no-repeat -37px -22px,-webkit-gradient(linear, left bottom, left top, color-stop(0.85, #ffffff), color-stop(0.99, #eeeeee));
+      background: url("select2.png") no-repeat -37px -22px,-webkit-linear-gradient(center bottom, #ffffff 85%, #eeeeee 99%);
+      background: url("select2.png") no-repeat -37px -22px,-moz-linear-gradient(center bottom, #ffffff 85%, #eeeeee 99%);
+      background: url("select2.png") no-repeat -37px -22px,linear-gradient(to bottom, #ffffff 85%, #eeeeee 99%) 0 0
+    }
+  }
+}
+/* stylelint-enable function-linear-gradient-no-nonstandard-direction */
+
+.select2-more-results {
+  &.select2-active {
+    background: #f4f4f4 url("select2-spinner.gif") no-repeat 100%;
+  }
+}
+
+.select2-search-choice-close {
+  background: url("select2.png") right top no-repeat
+}
+
+/* stylelint-disable declaration-no-important */
+.select2-container-multi {
+  .select2-choices {
+    .select2-search-field input.select2-active {
+      background: #ffffff url("select2-spinner.gif") no-repeat 100% !important;
+    }
+  }
+}
+
+@media only screen and (-webkit-min-device-pixel-ratio: 1.5), only screen and (min-resolution: 2dppx) {
+  .select2-search input,
+  .select2-search-choice-close,
+  .select2-container .select2-choice abbr,
+  .select2-container .select2-choice .select2-arrow b {
+    background-image: url("select2x2.png") !important;
+    background-repeat: no-repeat !important;
+    background-size: 60px 40px !important
+  }
+
+  .select2-search input {
+    background-position: 100% -21px !important
+  }
+}
+/* stylelint-enable declaration-no-important */


### PR DESCRIPTION
[Trello](https://trello.com/c/j3xsgpqe)

These changes add a number of over-ride styles to existing bootstrap styles that became necessary after the upgrade to Dart Sass. 

The need for these became evident in the request receive to fix a problem that became evident after that upgrade (detailed in the Trello card), concerning the user's ability to remove a selection from a dropdown selector. Upon closer inspection it became apparent that a number of other over-ride styles were required to restore some instances of broken UI as follows (see screenshots below): 
- The crown is missing in the header
- The dropdown is missing the remove and arrow icons
- The Select2 search bar is missing the search icon and some shading around the box
- The Select2 search bar in active state is missing the spinner icon

There are some styles added specifically for the display of right-to-left languages.

In addition some over-rides have been added for the Select2 element that are not used in this app but are present for completeness and potential future use. 

|Over-ride added|Current|Update|
|-|-|-|
|Crown in navbar|![Screenshot 2024-09-30 at 17 34 22](https://github.com/user-attachments/assets/3e3b3b64-6ced-41f9-b8d6-f9385529d4c5)|![Screenshot 2024-09-30 at 17 34 07](https://github.com/user-attachments/assets/d2fa7379-5972-4ceb-bbb4-6b21f3bb575b)|
|Select2 dropdown|![Screenshot 2024-09-30 at 17 37 10](https://github.com/user-attachments/assets/f9390933-afea-47fa-8ef1-90adf484ac62)|![Screenshot 2024-09-30 at 17 36 55](https://github.com/user-attachments/assets/ed9eaeb4-9e5a-416a-9a50-7487d04eae3c)|
|Select2 search bar|![Screenshot 2024-09-30 at 17 41 24](https://github.com/user-attachments/assets/aa5f1c7e-9689-412e-85a0-6eca8f298301)|![Screenshot 2024-09-30 at 17 41 43](https://github.com/user-attachments/assets/2f18fcc1-9d96-42a2-af08-b265ee9233cc)|
|Select2 search bar (active state)|![Screenshot 2024-09-30 at 17 44 23](https://github.com/user-attachments/assets/87e41304-6d85-4f4a-9212-df836b79269e)|![Screenshot 2024-09-30 at 17 43 52](https://github.com/user-attachments/assets/207ffad8-f0f7-45d6-b118-7b26a1d21465)|
