### PR TITLE
Restrict access to publications based on the user's organisation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -63,4 +63,8 @@ class ApplicationController < ActionController::Base
     flash[:danger] = "You do not have correct editor permissions for this action."
     redirect_to edition_path(resource)
   end
+
+  def require_user_accessibility_to_edition(edition)
+    render plain: "404 Not Found", status: :not_found unless edition.is_accessible_to?(current_user)
+  end
 end

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -4,6 +4,9 @@ class EditionsController < InheritedResources::Base
 
   defaults resource_class: Edition, collection_name: "editions", instance_name: "resource"
   before_action :setup_view_paths, except: %i[index]
+  before_action except: %i[index] do
+    require_user_accessibility_to_edition(@resource)
+  end
 
   helper_method :locale_to_language
 

--- a/app/controllers/legacy_editions_controller.rb
+++ b/app/controllers/legacy_editions_controller.rb
@@ -5,6 +5,9 @@ class LegacyEditionsController < InheritedResources::Base
   actions :create, :update, :destroy
   defaults resource_class: Edition, collection_name: "editions", instance_name: "resource"
   before_action :setup_view_paths, except: %i[index new create]
+  before_action except: %i[index create] do
+    require_user_accessibility_to_edition(@resource)
+  end
   before_action only: %i[update duplicate progress review destroy admin] do
     require_editor_permissions
   end

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -29,6 +29,7 @@ class RootController < ApplicationController
     content_type_filter = filter_params_hash[:content_type_filter]
     title_filter = filter_params_hash[:title_filter]
     @presenter = FilteredEditionsPresenter.new(
+      current_user,
       states_filter: sanitised_states_filter_params,
       assigned_to_filter: assignee_filter,
       content_type_filter:,

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -35,9 +35,19 @@ class Edition
 
   field :auth_bypass_id,       type: String, default: -> { SecureRandom.uuid }
 
+  field :owning_org_slugs, type: Array, default: []
+
   belongs_to :assigned_to, class_name: "User", optional: true
 
   embeds_many :link_check_reports
+
+  scope :accessible_to,
+        lambda { |user|
+          return all unless Flipflop.enabled?(:restrict_access_by_org)
+          return all if user.gds_editor?
+
+          where(owning_org_slugs: user.organisation_slug)
+        }
 
   # state_machine comes from Workflow
   state_machine.states.map(&:name).each do |state|
@@ -501,6 +511,13 @@ class Edition
     end
 
     paths
+  end
+
+  def is_accessible_to?(user)
+    return true unless Flipflop.enabled?(:restrict_access_by_org)
+    return true if user.gds_editor?
+
+    owning_org_slugs.include?(user.organisation_slug)
   end
 
 private

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -35,7 +35,7 @@ class Edition
 
   field :auth_bypass_id,       type: String, default: -> { SecureRandom.uuid }
 
-  field :owning_org_slugs, type: Array, default: []
+  field :owning_org_content_ids, type: Array, default: []
 
   belongs_to :assigned_to, class_name: "User", optional: true
 
@@ -46,7 +46,7 @@ class Edition
           return all unless Flipflop.enabled?(:restrict_access_by_org)
           return all if user.gds_editor?
 
-          where(owning_org_slugs: user.organisation_slug)
+          where(owning_org_content_ids: user.organisation_content_id)
         }
 
   # state_machine comes from Workflow
@@ -517,7 +517,7 @@ class Edition
     return true unless Flipflop.enabled?(:restrict_access_by_org)
     return true if user.gds_editor?
 
-    owning_org_slugs.include?(user.organisation_slug)
+    owning_org_content_ids.include?(user.organisation_content_id)
   end
 
 private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -87,4 +87,8 @@ class User
   def has_editor_permissions?(resource)
     govuk_editor? || (welsh_editor? && resource.artefact.welsh?)
   end
+
+  def gds_editor?
+    organisation_slug == "government-digital-service"
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,6 +89,6 @@ class User
   end
 
   def gds_editor?
-    organisation_slug == "government-digital-service"
+    organisation_content_id == PublishService::GDS_ORGANISATION_ID
   end
 end

--- a/app/presenters/filtered_editions_presenter.rb
+++ b/app/presenters/filtered_editions_presenter.rb
@@ -3,7 +3,8 @@
 class FilteredEditionsPresenter
   ITEMS_PER_PAGE = 20
 
-  def initialize(states_filter: [], assigned_to_filter: nil, content_type_filter: nil, title_filter: nil, page: nil)
+  def initialize(user, states_filter: [], assigned_to_filter: nil, content_type_filter: nil, title_filter: nil, page: nil)
+    @user = user
     @states_filter = states_filter || []
     @assigned_to_filter = assigned_to_filter
     @content_type_filter = content_type_filter
@@ -62,6 +63,7 @@ class FilteredEditionsPresenter
     result = apply_states_filter(result)
     result = apply_assigned_to_filter(result)
     result = apply_title_filter(result)
+    result = result.accessible_to(user)
     result = result.where.not(_type: "PopularLinksEdition")
     result.order_by(%w[updated_at desc]).page(@page).per(ITEMS_PER_PAGE)
   end
@@ -129,5 +131,5 @@ private
     editions.title_contains(title_filter)
   end
 
-  attr_reader :states_filter, :assigned_to_filter, :content_type_filter, :title_filter, :page
+  attr_reader :user, :states_filter, :assigned_to_filter, :content_type_filter, :title_filter, :page
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -16,4 +16,8 @@ Flipflop.configure do
   feature :design_system_edit,
           default: false,
           description: "Update the publications edit page to use the GOV.UK Design System"
+
+  feature :restrict_access_by_org,
+          default: false,
+          description: "Restrict access to editions based on the user's org and which org(s) own the edition"
 end

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -5,6 +5,9 @@ class EditionsControllerTest < ActionController::TestCase
     login_as_stub_user
     stub_linkables
     stub_holidays_used_by_fact_check
+
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:restrict_access_by_org, false)
   end
 
   context "#template_folder_for" do
@@ -62,6 +65,52 @@ class EditionsControllerTest < ActionController::TestCase
 
     should "alias to show method" do
       assert_equal EditionsController.new.method(:metadata).super_method.name, :show
+    end
+  end
+
+  context "when 'restrict_access_by_org' feature toggle is disabled" do
+    %i[show metadata history admin linking unpublish].each do |action|
+      context "##{action}" do
+        setup do
+          @edition = FactoryBot.create(:edition, owning_org_slugs: %w[org-two])
+        end
+
+        should "return a 200 when requesting an edition owned by a different organisation" do
+          login_as(FactoryBot.create(:user, organisation_slug: "org-one"))
+
+          get action, params: { id: @edition.id }
+
+          assert_response :ok
+        end
+      end
+    end
+  end
+
+  context "when 'restrict_access_by_org' feature toggle is enabled" do
+    setup do
+      test_strategy = Flipflop::FeatureSet.current.test!
+      test_strategy.switch!(:restrict_access_by_org, true)
+    end
+
+    teardown do
+      test_strategy = Flipflop::FeatureSet.current.test!
+      test_strategy.switch!(:restrict_access_by_org, false)
+    end
+
+    %i[show metadata history admin linking unpublish].each do |action|
+      context "##{action}" do
+        setup do
+          @edition = FactoryBot.create(:edition, owning_org_slugs: %w[org-two])
+        end
+
+        should "return a 404 when requesting an edition owned by a different organisation" do
+          login_as(FactoryBot.create(:user, organisation_slug: "org-one"))
+
+          get action, params: { id: @edition.id }
+
+          assert_response :not_found
+        end
+      end
     end
   end
 end

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -20,7 +20,7 @@ class EditionsControllerTest < ActionController::TestCase
   end
 
   context "#index" do
-    should "editions index redirects to root" do
+    should "redirect to root" do
       get :index
       assert_response :redirect
       assert_redirected_to root_path
@@ -39,12 +39,12 @@ class EditionsControllerTest < ActionController::TestCase
       @guide = GuideEdition.create!(title: "test", slug: "test2", panopticon_id: artefact.id)
     end
 
-    should "requesting a publication that doesn't exist returns a 404" do
+    should "return a 404 when requesting a publication that doesn't exist" do
       get :show, params: { id: "4e663834e2ba80480a0000e6" }
       assert_response :not_found
     end
 
-    should "we can view a guide" do
+    should "return a view for the requested guide" do
       get :show, params: { id: @guide.id }
       assert_response :success
       assert_not_nil assigns(:resource)

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -72,11 +72,11 @@ class EditionsControllerTest < ActionController::TestCase
     %i[show metadata history admin linking unpublish].each do |action|
       context "##{action}" do
         setup do
-          @edition = FactoryBot.create(:edition, owning_org_slugs: %w[org-two])
+          @edition = FactoryBot.create(:edition, owning_org_content_ids: %w[org-two])
         end
 
         should "return a 200 when requesting an edition owned by a different organisation" do
-          login_as(FactoryBot.create(:user, organisation_slug: "org-one"))
+          login_as(FactoryBot.create(:user, organisation_content_id: "org-one"))
 
           get action, params: { id: @edition.id }
 
@@ -100,11 +100,11 @@ class EditionsControllerTest < ActionController::TestCase
     %i[show metadata history admin linking unpublish].each do |action|
       context "##{action}" do
         setup do
-          @edition = FactoryBot.create(:edition, owning_org_slugs: %w[org-two])
+          @edition = FactoryBot.create(:edition, owning_org_content_ids: %w[org-two])
         end
 
         should "return a 404 when requesting an edition owned by a different organisation" do
-          login_as(FactoryBot.create(:user, organisation_slug: "org-one"))
+          login_as(FactoryBot.create(:user, organisation_content_id: "org-one"))
 
           get action, params: { id: @edition.id }
 

--- a/test/functional/legacy_editions_controller_test.rb
+++ b/test/functional/legacy_editions_controller_test.rb
@@ -5,6 +5,9 @@ class LegacyEditionsControllerTest < ActionController::TestCase
     login_as_stub_user
     stub_linkables
     stub_holidays_used_by_fact_check
+
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:restrict_access_by_org, false)
   end
 
   context "#create" do
@@ -1301,6 +1304,52 @@ class LegacyEditionsControllerTest < ActionController::TestCase
       should "return a 404" do
         get :diagram, params: { id: @welsh_guide.id }
         assert_response :not_found
+      end
+    end
+  end
+
+  context "when 'restrict_access_by_org' feature toggle is disabled" do
+    %i[metadata history].each do |action|
+      context "##{action}" do
+        setup do
+          @edition = FactoryBot.create(:edition, owning_org_slugs: %w[org-two])
+        end
+
+        should "return a 200 when requesting an edition owned by a different organisation" do
+          login_as(FactoryBot.create(:user, organisation_slug: "org-one"))
+
+          get action, params: { id: @edition.id }
+
+          assert_response :ok
+        end
+      end
+    end
+  end
+
+  context "when 'restrict_access_by_org' feature toggle is enabled" do
+    setup do
+      test_strategy = Flipflop::FeatureSet.current.test!
+      test_strategy.switch!(:restrict_access_by_org, true)
+    end
+
+    teardown do
+      test_strategy = Flipflop::FeatureSet.current.test!
+      test_strategy.switch!(:restrict_access_by_org, false)
+    end
+
+    %i[show metadata history admin unpublish duplicate update linking update_tagging update_related_external_links review destroy progress diff process_unpublish diagram].each do |action|
+      context "##{action}" do
+        setup do
+          @edition = FactoryBot.create(:edition, owning_org_slugs: %w[org-two])
+        end
+
+        should "return a 404 when requesting an edition owned by a different organisation" do
+          login_as(FactoryBot.create(:user, :govuk_editor, organisation_slug: "org-one"))
+
+          get action, params: { id: @edition.id }
+
+          assert_response :not_found
+        end
       end
     end
   end

--- a/test/functional/legacy_editions_controller_test.rb
+++ b/test/functional/legacy_editions_controller_test.rb
@@ -1312,11 +1312,11 @@ class LegacyEditionsControllerTest < ActionController::TestCase
     %i[metadata history].each do |action|
       context "##{action}" do
         setup do
-          @edition = FactoryBot.create(:edition, owning_org_slugs: %w[org-two])
+          @edition = FactoryBot.create(:edition, owning_org_content_ids: %w[org-two])
         end
 
         should "return a 200 when requesting an edition owned by a different organisation" do
-          login_as(FactoryBot.create(:user, organisation_slug: "org-one"))
+          login_as(FactoryBot.create(:user, organisation_content_id: "org-one"))
 
           get action, params: { id: @edition.id }
 
@@ -1340,11 +1340,11 @@ class LegacyEditionsControllerTest < ActionController::TestCase
     %i[show metadata history admin unpublish duplicate update linking update_tagging update_related_external_links review destroy progress diff process_unpublish diagram].each do |action|
       context "##{action}" do
         setup do
-          @edition = FactoryBot.create(:edition, owning_org_slugs: %w[org-two])
+          @edition = FactoryBot.create(:edition, owning_org_content_ids: %w[org-two])
         end
 
         should "return a 404 when requesting an edition owned by a different organisation" do
-          login_as(FactoryBot.create(:user, :govuk_editor, organisation_slug: "org-one"))
+          login_as(FactoryBot.create(:user, :govuk_editor, organisation_content_id: "org-one"))
 
           get action, params: { id: @edition.id }
 

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -152,7 +152,7 @@ class RootControllerTest < ActionController::TestCase
     should "ignore unrecognised filter states" do
       FilteredEditionsPresenter
         .expects(:new)
-        .with(has_entry(:states_filter, %w[draft]))
+        .with(anything, has_entry(:states_filter, %w[draft]))
         .returns(stub(
                    editions: Kaminari.paginate_array([]).page(1),
                    available_users: [],

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -1256,4 +1256,191 @@ class EditionTest < ActiveSupport::TestCase
       assert_equal edition.paths, ["/test-path", "/test-path/test-part"]
     end
   end
+
+  context "when 'restrict_access_by_org' feature toggle is enabled" do
+    setup do
+      test_strategy = Flipflop::FeatureSet.current.test!
+      test_strategy.switch!(:restrict_access_by_org, true)
+    end
+
+    teardown do
+      test_strategy = Flipflop::FeatureSet.current.test!
+      test_strategy.switch!(:restrict_access_by_org, false)
+    end
+
+    context "accessible_to scope" do
+      should "omit editions that are owned by an organisation that is different to the user's" do
+        FactoryBot.create(:edition, owning_org_slugs: %w[one])
+        user = FactoryBot.create(:user, organisation_slug: "two")
+
+        query_result = Edition.accessible_to(user)
+
+        assert_empty query_result
+      end
+
+      should "omit editions not owned by any organisation" do
+        FactoryBot.create(:edition, owning_org_slugs: [])
+        user = FactoryBot.create(:user, organisation_slug: "two")
+
+        query_result = Edition.accessible_to(user)
+
+        assert_empty query_result
+      end
+
+      should "include editions that are owned by the user's organisation" do
+        FactoryBot.create(:edition, owning_org_slugs: %w[one])
+        user = FactoryBot.create(:user, organisation_slug: "one")
+
+        query_result = Edition.accessible_to(user)
+
+        assert_equal 1, query_result.count
+      end
+
+      should "include editions that are not owned by any organisation, when the user's organisation is GDS" do
+        FactoryBot.create(:edition, owning_org_slugs: [])
+        user = FactoryBot.create(:user, organisation_slug: "government-digital-service")
+
+        query_result = Edition.accessible_to(user)
+
+        assert_equal 1, query_result.count
+      end
+
+      should "include editions that are owned by an organisation that is different to the user's, when the user's organisation is GDS" do
+        FactoryBot.create(:edition, owning_org_slugs: %w[one])
+        user = FactoryBot.create(:user, organisation_slug: "government-digital-service")
+
+        query_result = Edition.accessible_to(user)
+
+        assert_equal 1, query_result.count
+      end
+    end
+
+    context "#is_accessible_to?" do
+      should "return false for editions that are owned by an organisation that is different to the user's" do
+        edition = FactoryBot.create(:edition, owning_org_slugs: %w[one])
+        user = FactoryBot.create(:user, organisation_slug: "two")
+
+        assert_not edition.is_accessible_to?(user)
+      end
+
+      should "return false for editions not owned by any organisation" do
+        edition = FactoryBot.create(:edition, owning_org_slugs: [])
+        user = FactoryBot.create(:user, organisation_slug: "two")
+
+        assert_not edition.is_accessible_to?(user)
+      end
+
+      should "return true for editions that are owned by the user's organisation" do
+        edition = FactoryBot.create(:edition, owning_org_slugs: %w[one])
+        user = FactoryBot.create(:user, organisation_slug: "one")
+
+        assert edition.is_accessible_to?(user)
+      end
+
+      should "return true for editions that are not owned by any organisation, when the user's organisation is GDS" do
+        edition = FactoryBot.create(:edition, owning_org_slugs: [])
+        user = FactoryBot.create(:user, organisation_slug: "government-digital-service")
+
+        assert edition.is_accessible_to?(user)
+      end
+
+      should "return true for editions that are owned by an organisation that is different to the user's, when the user's organisation is GDS" do
+        edition = FactoryBot.create(:edition, owning_org_slugs: %w[one])
+        user = FactoryBot.create(:user, organisation_slug: "government-digital-service")
+
+        assert edition.is_accessible_to?(user)
+      end
+    end
+  end
+
+  context "when 'restrict_access_by_org' feature toggle is disabled" do
+    setup do
+      test_strategy = Flipflop::FeatureSet.current.test!
+      test_strategy.switch!(:restrict_access_by_org, false)
+    end
+
+    context "accessible_to scope" do
+      should "include editions that are owned by an organisation that is different to the user's" do
+        FactoryBot.create(:edition, owning_org_slugs: %w[one])
+        user = FactoryBot.create(:user, organisation_slug: "two")
+
+        query_result = Edition.accessible_to(user)
+
+        assert_equal 1, query_result.count
+      end
+
+      should "include editions not owned by any organisation" do
+        FactoryBot.create(:edition, owning_org_slugs: [])
+        user = FactoryBot.create(:user, organisation_slug: "two")
+
+        query_result = Edition.accessible_to(user)
+
+        assert_equal 1, query_result.count
+      end
+
+      should "include editions that are owned by the user's organisation" do
+        FactoryBot.create(:edition, owning_org_slugs: %w[one])
+        user = FactoryBot.create(:user, organisation_slug: "one")
+
+        query_result = Edition.accessible_to(user)
+
+        assert_equal 1, query_result.count
+      end
+
+      should "include editions that are not owned by any organisation, when the user's organisation is GDS" do
+        FactoryBot.create(:edition, owning_org_slugs: [])
+        user = FactoryBot.create(:user, organisation_slug: "government-digital-service")
+
+        query_result = Edition.accessible_to(user)
+
+        assert_equal 1, query_result.count
+      end
+
+      should "include editions that are owned by an organisation that is different to the user's, when the user's organisation is GDS" do
+        FactoryBot.create(:edition, owning_org_slugs: %w[one])
+        user = FactoryBot.create(:user, organisation_slug: "government-digital-service")
+
+        query_result = Edition.accessible_to(user)
+
+        assert_equal 1, query_result.count
+      end
+    end
+
+    context "#is_accessible_to?" do
+      should "return true for editions that are owned by an organisation that is different to the user's" do
+        edition = FactoryBot.create(:edition, owning_org_slugs: %w[one])
+        user = FactoryBot.create(:user, organisation_slug: "two")
+
+        assert edition.is_accessible_to?(user)
+      end
+
+      should "return true for editions not owned by any organisation" do
+        edition = FactoryBot.create(:edition, owning_org_slugs: [])
+        user = FactoryBot.create(:user, organisation_slug: "two")
+
+        assert edition.is_accessible_to?(user)
+      end
+
+      should "return true for editions that are owned by the user's organisation" do
+        edition = FactoryBot.create(:edition, owning_org_slugs: %w[one])
+        user = FactoryBot.create(:user, organisation_slug: "one")
+
+        assert edition.is_accessible_to?(user)
+      end
+
+      should "return true for editions that are not owned by any organisation, when the user's organisation is GDS" do
+        edition = FactoryBot.create(:edition, owning_org_slugs: [])
+        user = FactoryBot.create(:user, organisation_slug: "government-digital-service")
+
+        assert edition.is_accessible_to?(user)
+      end
+
+      should "return true for editions that are owned by an organisation that is different to the user's, when the user's organisation is GDS" do
+        edition = FactoryBot.create(:edition, owning_org_slugs: %w[one])
+        user = FactoryBot.create(:user, organisation_slug: "government-digital-service")
+
+        assert edition.is_accessible_to?(user)
+      end
+    end
+  end
 end

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -1270,8 +1270,17 @@ class EditionTest < ActiveSupport::TestCase
 
     context "accessible_to scope" do
       should "omit editions that are owned by an organisation that is different to the user's" do
-        FactoryBot.create(:edition, owning_org_slugs: %w[one])
-        user = FactoryBot.create(:user, organisation_slug: "two")
+        FactoryBot.create(:edition, owning_org_content_ids: %w[one])
+        user = FactoryBot.create(:user, organisation_content_id: "two")
+
+        query_result = Edition.accessible_to(user)
+
+        assert_empty query_result
+      end
+
+      should "omit editions that are owned by an organisation when the user has no organisation" do
+        FactoryBot.create(:edition, owning_org_content_ids: %w[one])
+        user = FactoryBot.create(:user, organisation_content_id: nil)
 
         query_result = Edition.accessible_to(user)
 
@@ -1279,8 +1288,17 @@ class EditionTest < ActiveSupport::TestCase
       end
 
       should "omit editions not owned by any organisation" do
-        FactoryBot.create(:edition, owning_org_slugs: [])
-        user = FactoryBot.create(:user, organisation_slug: "two")
+        FactoryBot.create(:edition, owning_org_content_ids: [])
+        user = FactoryBot.create(:user, organisation_content_id: "two")
+
+        query_result = Edition.accessible_to(user)
+
+        assert_empty query_result
+      end
+
+      should "omit editions not owned by any organisation when the user has no organisation" do
+        FactoryBot.create(:edition, owning_org_content_ids: [])
+        user = FactoryBot.create(:user, organisation_content_id: nil)
 
         query_result = Edition.accessible_to(user)
 
@@ -1288,8 +1306,8 @@ class EditionTest < ActiveSupport::TestCase
       end
 
       should "include editions that are owned by the user's organisation" do
-        FactoryBot.create(:edition, owning_org_slugs: %w[one])
-        user = FactoryBot.create(:user, organisation_slug: "one")
+        FactoryBot.create(:edition, owning_org_content_ids: %w[one])
+        user = FactoryBot.create(:user, organisation_content_id: "one")
 
         query_result = Edition.accessible_to(user)
 
@@ -1297,8 +1315,8 @@ class EditionTest < ActiveSupport::TestCase
       end
 
       should "include editions that are not owned by any organisation, when the user's organisation is GDS" do
-        FactoryBot.create(:edition, owning_org_slugs: [])
-        user = FactoryBot.create(:user, organisation_slug: "government-digital-service")
+        FactoryBot.create(:edition, owning_org_content_ids: [])
+        user = FactoryBot.create(:user, organisation_content_id: PublishService::GDS_ORGANISATION_ID)
 
         query_result = Edition.accessible_to(user)
 
@@ -1306,8 +1324,8 @@ class EditionTest < ActiveSupport::TestCase
       end
 
       should "include editions that are owned by an organisation that is different to the user's, when the user's organisation is GDS" do
-        FactoryBot.create(:edition, owning_org_slugs: %w[one])
-        user = FactoryBot.create(:user, organisation_slug: "government-digital-service")
+        FactoryBot.create(:edition, owning_org_content_ids: %w[one])
+        user = FactoryBot.create(:user, organisation_content_id: PublishService::GDS_ORGANISATION_ID)
 
         query_result = Edition.accessible_to(user)
 
@@ -1317,36 +1335,50 @@ class EditionTest < ActiveSupport::TestCase
 
     context "#is_accessible_to?" do
       should "return false for editions that are owned by an organisation that is different to the user's" do
-        edition = FactoryBot.create(:edition, owning_org_slugs: %w[one])
-        user = FactoryBot.create(:user, organisation_slug: "two")
+        edition = FactoryBot.create(:edition, owning_org_content_ids: %w[one])
+        user = FactoryBot.create(:user, organisation_content_id: "two")
+
+        assert_not edition.is_accessible_to?(user)
+      end
+
+      should "return false for editions that are owned by an organisation when the user has no organisation" do
+        edition = FactoryBot.create(:edition, owning_org_content_ids: %w[one])
+        user = FactoryBot.create(:user, organisation_content_id: nil)
 
         assert_not edition.is_accessible_to?(user)
       end
 
       should "return false for editions not owned by any organisation" do
-        edition = FactoryBot.create(:edition, owning_org_slugs: [])
-        user = FactoryBot.create(:user, organisation_slug: "two")
+        edition = FactoryBot.create(:edition, owning_org_content_ids: [])
+        user = FactoryBot.create(:user, organisation_content_id: "two")
+
+        assert_not edition.is_accessible_to?(user)
+      end
+
+      should "return false for editions not owned by any organisation when the user has no organisation" do
+        edition = FactoryBot.create(:edition, owning_org_content_ids: [])
+        user = FactoryBot.create(:user, organisation_content_id: nil)
 
         assert_not edition.is_accessible_to?(user)
       end
 
       should "return true for editions that are owned by the user's organisation" do
-        edition = FactoryBot.create(:edition, owning_org_slugs: %w[one])
-        user = FactoryBot.create(:user, organisation_slug: "one")
+        edition = FactoryBot.create(:edition, owning_org_content_ids: %w[one])
+        user = FactoryBot.create(:user, organisation_content_id: "one")
 
         assert edition.is_accessible_to?(user)
       end
 
       should "return true for editions that are not owned by any organisation, when the user's organisation is GDS" do
-        edition = FactoryBot.create(:edition, owning_org_slugs: [])
-        user = FactoryBot.create(:user, organisation_slug: "government-digital-service")
+        edition = FactoryBot.create(:edition, owning_org_content_ids: [])
+        user = FactoryBot.create(:user, organisation_content_id: PublishService::GDS_ORGANISATION_ID)
 
         assert edition.is_accessible_to?(user)
       end
 
       should "return true for editions that are owned by an organisation that is different to the user's, when the user's organisation is GDS" do
-        edition = FactoryBot.create(:edition, owning_org_slugs: %w[one])
-        user = FactoryBot.create(:user, organisation_slug: "government-digital-service")
+        edition = FactoryBot.create(:edition, owning_org_content_ids: %w[one])
+        user = FactoryBot.create(:user, organisation_content_id: PublishService::GDS_ORGANISATION_ID)
 
         assert edition.is_accessible_to?(user)
       end
@@ -1361,8 +1393,17 @@ class EditionTest < ActiveSupport::TestCase
 
     context "accessible_to scope" do
       should "include editions that are owned by an organisation that is different to the user's" do
-        FactoryBot.create(:edition, owning_org_slugs: %w[one])
-        user = FactoryBot.create(:user, organisation_slug: "two")
+        FactoryBot.create(:edition, owning_org_content_ids: %w[one])
+        user = FactoryBot.create(:user, organisation_content_id: "two")
+
+        query_result = Edition.accessible_to(user)
+
+        assert_equal 1, query_result.count
+      end
+
+      should "include editions that are owned by an organisation when the user has no organisation" do
+        FactoryBot.create(:edition, owning_org_content_ids: %w[one])
+        user = FactoryBot.create(:user, organisation_content_id: nil)
 
         query_result = Edition.accessible_to(user)
 
@@ -1370,8 +1411,17 @@ class EditionTest < ActiveSupport::TestCase
       end
 
       should "include editions not owned by any organisation" do
-        FactoryBot.create(:edition, owning_org_slugs: [])
-        user = FactoryBot.create(:user, organisation_slug: "two")
+        FactoryBot.create(:edition, owning_org_content_ids: [])
+        user = FactoryBot.create(:user, organisation_content_id: "two")
+
+        query_result = Edition.accessible_to(user)
+
+        assert_equal 1, query_result.count
+      end
+
+      should "include editions not owned by any organisation when the user has no organisation" do
+        FactoryBot.create(:edition, owning_org_content_ids: [])
+        user = FactoryBot.create(:user, organisation_content_id: nil)
 
         query_result = Edition.accessible_to(user)
 
@@ -1379,8 +1429,8 @@ class EditionTest < ActiveSupport::TestCase
       end
 
       should "include editions that are owned by the user's organisation" do
-        FactoryBot.create(:edition, owning_org_slugs: %w[one])
-        user = FactoryBot.create(:user, organisation_slug: "one")
+        FactoryBot.create(:edition, owning_org_content_ids: %w[one])
+        user = FactoryBot.create(:user, organisation_content_id: "one")
 
         query_result = Edition.accessible_to(user)
 
@@ -1388,8 +1438,8 @@ class EditionTest < ActiveSupport::TestCase
       end
 
       should "include editions that are not owned by any organisation, when the user's organisation is GDS" do
-        FactoryBot.create(:edition, owning_org_slugs: [])
-        user = FactoryBot.create(:user, organisation_slug: "government-digital-service")
+        FactoryBot.create(:edition, owning_org_content_ids: [])
+        user = FactoryBot.create(:user, organisation_content_id: PublishService::GDS_ORGANISATION_ID)
 
         query_result = Edition.accessible_to(user)
 
@@ -1397,8 +1447,8 @@ class EditionTest < ActiveSupport::TestCase
       end
 
       should "include editions that are owned by an organisation that is different to the user's, when the user's organisation is GDS" do
-        FactoryBot.create(:edition, owning_org_slugs: %w[one])
-        user = FactoryBot.create(:user, organisation_slug: "government-digital-service")
+        FactoryBot.create(:edition, owning_org_content_ids: %w[one])
+        user = FactoryBot.create(:user, organisation_content_id: PublishService::GDS_ORGANISATION_ID)
 
         query_result = Edition.accessible_to(user)
 
@@ -1408,36 +1458,50 @@ class EditionTest < ActiveSupport::TestCase
 
     context "#is_accessible_to?" do
       should "return true for editions that are owned by an organisation that is different to the user's" do
-        edition = FactoryBot.create(:edition, owning_org_slugs: %w[one])
-        user = FactoryBot.create(:user, organisation_slug: "two")
+        edition = FactoryBot.create(:edition, owning_org_content_ids: %w[one])
+        user = FactoryBot.create(:user, organisation_content_id: "two")
+
+        assert edition.is_accessible_to?(user)
+      end
+
+      should "return true for editions that are owned by an organisation when the user has no organisation" do
+        edition = FactoryBot.create(:edition, owning_org_content_ids: %w[one])
+        user = FactoryBot.create(:user, organisation_content_id: nil)
 
         assert edition.is_accessible_to?(user)
       end
 
       should "return true for editions not owned by any organisation" do
-        edition = FactoryBot.create(:edition, owning_org_slugs: [])
-        user = FactoryBot.create(:user, organisation_slug: "two")
+        edition = FactoryBot.create(:edition, owning_org_content_ids: [])
+        user = FactoryBot.create(:user, organisation_content_id: "two")
+
+        assert edition.is_accessible_to?(user)
+      end
+
+      should "return true for editions not owned by any organisation when the user has no organisation" do
+        edition = FactoryBot.create(:edition, owning_org_content_ids: [])
+        user = FactoryBot.create(:user, organisation_content_id: nil)
 
         assert edition.is_accessible_to?(user)
       end
 
       should "return true for editions that are owned by the user's organisation" do
-        edition = FactoryBot.create(:edition, owning_org_slugs: %w[one])
-        user = FactoryBot.create(:user, organisation_slug: "one")
+        edition = FactoryBot.create(:edition, owning_org_content_ids: %w[one])
+        user = FactoryBot.create(:user, organisation_content_id: "one")
 
         assert edition.is_accessible_to?(user)
       end
 
       should "return true for editions that are not owned by any organisation, when the user's organisation is GDS" do
-        edition = FactoryBot.create(:edition, owning_org_slugs: [])
-        user = FactoryBot.create(:user, organisation_slug: "government-digital-service")
+        edition = FactoryBot.create(:edition, owning_org_content_ids: [])
+        user = FactoryBot.create(:user, organisation_content_id: PublishService::GDS_ORGANISATION_ID)
 
         assert edition.is_accessible_to?(user)
       end
 
       should "return true for editions that are owned by an organisation that is different to the user's, when the user's organisation is GDS" do
-        edition = FactoryBot.create(:edition, owning_org_slugs: %w[one])
-        user = FactoryBot.create(:user, organisation_slug: "government-digital-service")
+        edition = FactoryBot.create(:edition, owning_org_content_ids: %w[one])
+        user = FactoryBot.create(:user, organisation_content_id: PublishService::GDS_ORGANISATION_ID)
 
         assert edition.is_accessible_to?(user)
       end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -46,7 +46,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "#gds_editor? is true if user's organisation is GDS" do
-    user = FactoryBot.create(:user, organisation_slug: "government-digital-service")
+    user = FactoryBot.create(:user, organisation_content_id: PublishService::GDS_ORGANISATION_ID)
 
     assert user.gds_editor?
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -45,6 +45,18 @@ class UserTest < ActiveSupport::TestCase
     assert user.welsh_editor?
   end
 
+  test "#gds_editor? is true if user's organisation is GDS" do
+    user = FactoryBot.create(:user, organisation_slug: "government-digital-service")
+
+    assert user.gds_editor?
+  end
+
+  test "#gds_editor? is false if user's organisation is not GDS" do
+    user = FactoryBot.create(:user, organisation_slug: "some-other-org")
+
+    assert_not user.gds_editor?
+  end
+
   test "should convert to string using name by preference" do
     user = User.new(name: "Bob", email: "user@example.com")
     assert_equal "Bob", user.to_s

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -78,7 +78,7 @@ class ActiveSupport::TestCase
   end
 
   def login_as_govuk_editor
-    @user = FactoryBot.create(:user, :govuk_editor, name: "Stub User")
+    @user = FactoryBot.create(:user, :govuk_editor, name: "Stub User", organisation_slug: "government-digital-service")
     login_as(@user)
   end
 

--- a/test/unit/presenters/filtered_editions_presenter_test.rb
+++ b/test/unit/presenters/filtered_editions_presenter_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class FilteredEditionsPresenterTest < ActiveSupport::TestCase
   def a_gds_user
-    FactoryBot.create(:user, organisation_slug: "government-digital-service")
+    FactoryBot.create(:user, organisation_content_id: PublishService::GDS_ORGANISATION_ID)
   end
 
   context "#content_types" do
@@ -152,8 +152,8 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       end
 
       should "filter out editions not accessible to the user" do
-        user = FactoryBot.create(:user, organisation_slug: "an-org")
-        FactoryBot.create(:guide_edition, owning_org_slugs: %w[another-org])
+        user = FactoryBot.create(:user, organisation_content_id: "an-org")
+        FactoryBot.create(:guide_edition, owning_org_content_ids: %w[another-org])
 
         filtered_editions = FilteredEditionsPresenter.new(user).editions
 

--- a/test/unit/presenters/filtered_editions_presenter_test.rb
+++ b/test/unit/presenters/filtered_editions_presenter_test.rb
@@ -3,9 +3,13 @@
 require "test_helper"
 
 class FilteredEditionsPresenterTest < ActiveSupport::TestCase
+  def a_gds_user
+    FactoryBot.create(:user, organisation_slug: "government-digital-service")
+  end
+
   context "#content_types" do
     should "return content types with none selected when no content type filter has been specified" do
-      content_types = FilteredEditionsPresenter.new.content_types
+      content_types = FilteredEditionsPresenter.new(a_gds_user).content_types
 
       assert_equal(13, content_types.count)
       assert_includes(content_types, { text: "All", value: "all" })
@@ -24,7 +28,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
     end
 
     should "mark the relevant content type as selected when a content type filter has been specified" do
-      content_types = FilteredEditionsPresenter.new(content_type_filter: "answer").content_types
+      content_types = FilteredEditionsPresenter.new(a_gds_user, content_type_filter: "answer").content_types
 
       assert_includes(content_types, { text: "Answer", value: "answer", selected: "true" })
       assert_includes(content_types, { text: "Place", value: "place" }) # Not selected
@@ -33,7 +37,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
 
   context "#edition_states" do
     should "return states with none checked when no state filter has been specified" do
-      states = FilteredEditionsPresenter.new.edition_states
+      states = FilteredEditionsPresenter.new(a_gds_user).edition_states
 
       assert_equal(9, states.count)
       assert_includes(states, { label: "Drafts", value: :draft })
@@ -48,7 +52,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
     end
 
     should "mark the relevant states as checked when a state filter has been specified" do
-      states = FilteredEditionsPresenter.new(states_filter: %w[in_review ready]).edition_states
+      states = FilteredEditionsPresenter.new(a_gds_user, states_filter: %w[in_review ready]).edition_states
 
       assert_includes(states, { label: "In review", value: :in_review, checked: "true" })
       assert_includes(states, { label: "Ready", value: :ready, checked: "true" })
@@ -61,7 +65,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       draft_guide = FactoryBot.create(:guide_edition, state: "draft")
       published_guide = FactoryBot.create(:guide_edition, state: "published")
 
-      filtered_editions = FilteredEditionsPresenter.new.editions
+      filtered_editions = FilteredEditionsPresenter.new(a_gds_user).editions
 
       assert_equal(2, filtered_editions.count)
       assert_includes(filtered_editions, draft_guide)
@@ -72,7 +76,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       draft_guide = FactoryBot.create(:guide_edition, state: "draft")
       FactoryBot.create(:guide_edition, state: "published")
 
-      filtered_editions = FilteredEditionsPresenter.new(states_filter: %w[draft]).editions
+      filtered_editions = FilteredEditionsPresenter.new(a_gds_user, states_filter: %w[draft]).editions
 
       assert_equal(1, filtered_editions.count)
       assert_equal(draft_guide, filtered_editions[0])
@@ -83,7 +87,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       assigned_to_anna = FactoryBot.create(:guide_edition, assigned_to: anna.id)
       FactoryBot.create(:guide_edition)
 
-      filtered_editions = FilteredEditionsPresenter.new(assigned_to_filter: anna.id).editions
+      filtered_editions = FilteredEditionsPresenter.new(a_gds_user, assigned_to_filter: anna.id).editions
 
       assert_equal([assigned_to_anna], filtered_editions.to_a)
     end
@@ -93,7 +97,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       FactoryBot.create(:guide_edition, assigned_to: anna.id)
       not_assigned = FactoryBot.create(:guide_edition)
 
-      filtered_editions = FilteredEditionsPresenter.new(assigned_to_filter: "nobody").editions
+      filtered_editions = FilteredEditionsPresenter.new(a_gds_user, assigned_to_filter: "nobody").editions
 
       assert_equal([not_assigned], filtered_editions.to_a)
     end
@@ -104,7 +108,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       FactoryBot.create(:guide_edition)
 
       filtered_editions =
-        FilteredEditionsPresenter.new(assigned_to_filter: "not a valid user id").editions
+        FilteredEditionsPresenter.new(a_gds_user, assigned_to_filter: "not a valid user id").editions
 
       assert_equal(2, filtered_editions.count)
     end
@@ -113,7 +117,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       guide = FactoryBot.create(:guide_edition)
       FactoryBot.create(:completed_transaction_edition)
 
-      filtered_editions = FilteredEditionsPresenter.new(content_type_filter: "guide").editions
+      filtered_editions = FilteredEditionsPresenter.new(a_gds_user, content_type_filter: "guide").editions
 
       assert_equal([guide], filtered_editions.to_a)
     end
@@ -122,7 +126,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       FactoryBot.create(:guide_edition)
       FactoryBot.create(:completed_transaction_edition)
 
-      filtered_editions = FilteredEditionsPresenter.new(content_type_filter: "all").editions
+      filtered_editions = FilteredEditionsPresenter.new(a_gds_user, content_type_filter: "all").editions
 
       assert_equal(2, filtered_editions.count)
     end
@@ -131,16 +135,37 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       guide_fawkes = FactoryBot.create(:guide_edition, title: "Guide Fawkes")
       FactoryBot.create(:guide_edition, title: "Hitchhiker's Guide")
 
-      filtered_editions = FilteredEditionsPresenter.new(title_filter: "Fawkes").editions
+      filtered_editions = FilteredEditionsPresenter.new(a_gds_user, title_filter: "Fawkes").editions
 
       assert_equal([guide_fawkes], filtered_editions.to_a)
+    end
+
+    context "when 'restrict_access_by_org' feature toggle is enabled" do
+      setup do
+        test_strategy = Flipflop::FeatureSet.current.test!
+        test_strategy.switch!(:restrict_access_by_org, true)
+      end
+
+      teardown do
+        test_strategy = Flipflop::FeatureSet.current.test!
+        test_strategy.switch!(:restrict_access_by_org, false)
+      end
+
+      should "filter out editions not accessible to the user" do
+        user = FactoryBot.create(:user, organisation_slug: "an-org")
+        FactoryBot.create(:guide_edition, owning_org_slugs: %w[another-org])
+
+        filtered_editions = FilteredEditionsPresenter.new(user).editions
+
+        assert_equal(0, filtered_editions.count)
+      end
     end
 
     should "not return popular links" do
       guide_fawkes = FactoryBot.create(:guide_edition)
       FactoryBot.create(:popular_links)
 
-      filtered_editions = FilteredEditionsPresenter.new.editions
+      filtered_editions = FilteredEditionsPresenter.new(a_gds_user).editions
 
       assert_equal([guide_fawkes], filtered_editions.to_a)
     end
@@ -148,7 +173,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
     should "return a single 'page' of results when no page number is specified" do
       FactoryBot.create_list(:guide_edition, FilteredEditionsPresenter::ITEMS_PER_PAGE + 1)
 
-      filtered_editions = FilteredEditionsPresenter.new.editions
+      filtered_editions = FilteredEditionsPresenter.new(a_gds_user).editions
 
       assert_equal(FilteredEditionsPresenter::ITEMS_PER_PAGE + 1, filtered_editions.count)
       assert_equal(FilteredEditionsPresenter::ITEMS_PER_PAGE, filtered_editions.to_a.count)
@@ -157,7 +182,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
     should "return the specified 'page' of results" do
       FactoryBot.create_list(:guide_edition, FilteredEditionsPresenter::ITEMS_PER_PAGE + 1)
 
-      filtered_editions = FilteredEditionsPresenter.new(page: 2).editions
+      filtered_editions = FilteredEditionsPresenter.new(a_gds_user, page: 2).editions
 
       assert_equal(1, filtered_editions.to_a.count)
     end
@@ -167,7 +192,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       newest = FactoryBot.create(:guide_edition, updated_at: Time.utc(2024, 1))
       middle = FactoryBot.create(:guide_edition, updated_at: Time.utc(2023, 1))
 
-      filtered_editions = FilteredEditionsPresenter.new.editions
+      filtered_editions = FilteredEditionsPresenter.new(a_gds_user).editions
 
       assert_equal(3, filtered_editions.count)
       assert_equal(newest, filtered_editions[0])
@@ -178,21 +203,21 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
 
   context "#assignees" do
     should "return an 'all assignees' item" do
-      assignees = FilteredEditionsPresenter.new.assignees
+      assignees = FilteredEditionsPresenter.new(a_gds_user).assignees
 
-      assert_equal([{ text: "All assignees", value: "" }], assignees)
+      assert_includes(assignees, { text: "All assignees", value: "" })
     end
 
     should "return users who are not the assignee as unselected" do
       anna = FactoryBot.create(:user, name: "Anna")
-      assignees = FilteredEditionsPresenter.new.assignees
+      assignees = FilteredEditionsPresenter.new(a_gds_user).assignees
 
       assert_includes(assignees, { text: anna.name, value: anna.id })
     end
 
     should "return the assignee as selected" do
       anna = FactoryBot.create(:user, name: "Anna")
-      assignees = FilteredEditionsPresenter.new(assigned_to_filter: anna.id.to_s).assignees
+      assignees = FilteredEditionsPresenter.new(a_gds_user, assigned_to_filter: anna.id.to_s).assignees
 
       assert_includes(assignees, { text: anna.name, value: anna.id, selected: "true" })
     end
@@ -202,7 +227,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       charlie = FactoryBot.create(:user, name: "Charlie")
       anna = FactoryBot.create(:user, name: "Anna")
 
-      assignees = FilteredEditionsPresenter.new.assignees
+      assignees = FilteredEditionsPresenter.new(a_gds_user).assignees
 
       assert_equal(anna.name, assignees[1][:text])
       assert_equal(bob.name, assignees[2][:text])
@@ -210,14 +235,14 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
     end
 
     should "not include disabled users" do
-      enabled_user = FactoryBot.create(:user, name: "enabled user")
       disabled_user = FactoryBot.create(:user, name: "disabled user", disabled: true)
+      a_user = a_gds_user
 
-      users = FilteredEditionsPresenter.new.assignees
+      users = FilteredEditionsPresenter.new(a_user).assignees
 
       assert_equal(2, users.count)
       assert_equal("All assignees", users[0][:text])
-      assert_equal(enabled_user.name, users[1][:text])
+      assert_equal(a_user.name, users[1][:text])
       assert_not_includes users.map { |user| user[:text] }, disabled_user.name
     end
   end


### PR DESCRIPTION
## What
Prevent non-GDS users from accessing editions that are "owned" by other organisations. GDS users will still see all editions.

Introduces the concept of editions having an array of owning organisations, as represented by an array of those organisations' slugs.

The organisation slug is used as it is the only information we have to tie a user to an organisation (via the user's `organisation_slug`).

This is part of our work to open up Mainstream Publisher to users outside of GDS.

This PR does not include assigning any content items to organisations—that will follow as a separate piece of work. This means that, for now, turning on the feature toggle will result in non-GDS users simply seeing no content in Mainstream Publisher.

## Feature toggle
The changes are behind a new feature toggle `restrict_access_by_org`, which defaults to off.

## Trello
[Trello card](https://trello.com/c/rAqyyCyt/345-restrict-access-to-publications-based-on-the-users-organisation-publisher)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
