### PR TITLE
Amend Design System layout to make correct use of the grid system

### DIFF
--- a/app/assets/stylesheets/editions.scss
+++ b/app/assets/stylesheets/editions.scss
@@ -1,4 +1,4 @@
-.editions__edit {
+.editions__edit__summary {
   .govuk-tag {
     display: inline;
   }

--- a/app/views/downtimes/delete.html.erb
+++ b/app/views/downtimes/delete.html.erb
@@ -1,19 +1,21 @@
 <% content_for :page_title, "Remove downtime message" %>
 <% content_for :title, "Remove downtime message" %>
 
-<div class="govuk-grid-column-two-thirds">
-  <%= render "govuk_publishing_components/components/lead_paragraph", {
-    text: "Are you sure you want to remove the scheduled downtime message for \"#{@downtime.artefact.name}\"?",
-    margin_bottom: 8,
-  } %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/lead_paragraph", {
+      text: "Are you sure you want to remove the scheduled downtime message for \"#{@downtime.artefact.name}\"?",
+      margin_bottom: 8,
+    } %>
 
-  <%= form_for @downtime, url: edition_downtime_path(@edition), html: { class: "form well remove-top-margin", 'data-module': "downtime-message" } do |f| %>
-    <div class="govuk-button-group">
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Remove",
-        destructive: true,
-      } %>
-      <%= link_to "Cancel", downtimes_path, class: "govuk-link govuk-link--no-visited-state" %>
-    </div>
-  <% end %>
+    <%= form_for @downtime, url: edition_downtime_path(@edition), html: { class: "form well remove-top-margin", 'data-module': "downtime-message" } do |f| %>
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Remove",
+          destructive: true,
+        } %>
+        <%= link_to "Cancel", downtimes_path, class: "govuk-link govuk-link--no-visited-state" %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/downtimes/edit.html.erb
+++ b/app/views/downtimes/edit.html.erb
@@ -5,23 +5,25 @@
   <% content_for :error_summary, render("shared/error_summary", { object: @downtime }) %>
 <% end %>
 
-<div class="govuk-grid-column-two-thirds">
-  <%= render "govuk_publishing_components/components/lead_paragraph", {
-    text: "Downtime message appear on the service's start page one day before the downtime is due to occur.",
-    margin_bottom: 6,
-  } %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/lead_paragraph", {
+      text: "Downtime message appear on the service's start page one day before the downtime is due to occur.",
+      margin_bottom: 6,
+    } %>
 
-<%= form_for @downtime, url: edition_downtime_path(@edition), html: { class: "form well remove-top-margin", 'data-module': "downtime-message" } do |f| %>
-  <%= render "form", f: f %>
-    <div class="govuk-button-group">
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Save",
-        value: "save",
-        name: "save",
-      } %>
+  <%= form_for @downtime, url: edition_downtime_path(@edition), html: { class: "form well remove-top-margin", 'data-module': "downtime-message" } do |f| %>
+    <%= render "form", f: f %>
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
+          value: "save",
+          name: "save",
+        } %>
 
-      <%= link_to "Cancel", downtimes_path, class: "govuk-link govuk-link--no-visited-state" %>
-      <%= link_to "Remove", edition_destroy_downtime_path, class: "govuk-link remove-link" %>
-    </div>
-<% end %>
+        <%= link_to "Cancel", downtimes_path, class: "govuk-link govuk-link--no-visited-state" %>
+        <%= link_to "Remove", edition_destroy_downtime_path, class: "govuk-link remove-link" %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/downtimes/index.html.erb
+++ b/app/views/downtimes/index.html.erb
@@ -1,30 +1,31 @@
 <% content_for :page_title, "Downtime messages" %>
 <% content_for :title, "Downtime messages" %>
 
-<div class="govuk-grid-column-full">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/lead_paragraph", {
+      text: "Show a message on a published transaction start page for a specific time.",
+      margin_bottom: 6,
+    } %>
 
-  <%= render "govuk_publishing_components/components/lead_paragraph", {
-    text: "Show a message on a published transaction start page for a specific time.",
-    margin_bottom: 6,
-  } %>  
-
-  <%= render "govuk_publishing_components/components/table", {
-    filterable: true,
-    label: "Filter by service or service status",
-    head: [
-      {
-        text: "Service",
-      },
-      {
-        text: "Service Status",
-      },
-      {
-        text: tag.span("Action", class: "govuk-visually-hidden"),
-      },
-      {
-        text: tag.span("Link to view live on GOV.UK", class: "govuk-visually-hidden"),
-      },
-    ],
-    rows: transactions_table_entries(@transactions.to_a),
-  } %>
+    <%= render "govuk_publishing_components/components/table", {
+      filterable: true,
+      label: "Filter by service or service status",
+      head: [
+        {
+          text: "Service",
+        },
+        {
+          text: "Service Status",
+        },
+        {
+          text: tag.span("Action", class: "govuk-visually-hidden"),
+        },
+        {
+          text: tag.span("Link to view live on GOV.UK", class: "govuk-visually-hidden"),
+        },
+      ],
+      rows: transactions_table_entries(@transactions.to_a),
+    } %>
+  </div>
 </div>

--- a/app/views/downtimes/new.html.erb
+++ b/app/views/downtimes/new.html.erb
@@ -5,23 +5,25 @@
   <% content_for :error_summary, render("shared/error_summary", { object: @downtime }) %>
 <% end %>
 
-<div class="govuk-grid-column-two-thirds">
-  <%= render "govuk_publishing_components/components/lead_paragraph", {
-    text: "Downtime message appear on the service's start page one day before the downtime is due to occur.",
-    margin_bottom: 6,
-  } %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/lead_paragraph", {
+      text: "Downtime message appear on the service's start page one day before the downtime is due to occur.",
+      margin_bottom: 6,
+    } %>
 
-  <%= form_for @downtime, url: edition_downtime_path(@edition), html: { class: "form well remove-top-margin", "data-module" => "downtime-message" } do |f| %>
-    <%= render "form", f: f %>
+    <%= form_for @downtime, url: edition_downtime_path(@edition), html: { class: "form well remove-top-margin", "data-module" => "downtime-message" } do |f| %>
+      <%= render "form", f: f %>
 
-    <div class="govuk-button-group">
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Save",
-        value: "save",
-        name: "save",
-      } %>
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
+          value: "save",
+          name: "save",
+        } %>
 
-      <%= link_to "Cancel", downtimes_path, class: "govuk-link govuk-link--no-visited-state" %>
-    </div>
-  <% end %>
+        <%= link_to "Cancel", downtimes_path, class: "govuk-link govuk-link--no-visited-state" %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/editions/secondary_nav_tabs/_metadata.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_metadata.html.erb
@@ -1,59 +1,61 @@
-<div class="govuk-grid-column-two-thirds">
-  <%= render "govuk_publishing_components/components/heading", {
-    text: "Metadata",
-    heading_level: 2,
-    margin_bottom: 5,
-  } %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Metadata",
+      heading_level: 2,
+      margin_bottom: 5,
+    } %>
 
-  <% if Edition::PUBLISHING_API_DRAFT_STATES.include? publication.state %>
-    <%= form_for(@artefact, :html => { :class => "artefact", :id => "edit_artefact" }) do |f| %>
-      <%= f.hidden_field :id, value: @artefact.id %>
+    <% if Edition::PUBLISHING_API_DRAFT_STATES.include? publication.state %>
+      <%= form_for(@artefact, :html => { :class => "artefact", :id => "edit_artefact" }) do |f| %>
+        <%= f.hidden_field :id, value: @artefact.id %>
 
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Slug",
-        },
-        hint: "If you change the slug of a published page, the old slug will automatically redirect to the new one.",
-        name: "artefact[slug]",
-        value: publication.slug,
-        heading_level: 3,
-        heading_size: "m",
-      } %>
-
-      <%= render "govuk_publishing_components/components/radio", {
-        heading: "Language",
-        name: "artefact[language]",
-        heading_level: 3,
-        heading_size: "m",
-        inline: true,
-        items: [
-          {
-            value: "en",
-            text: "English",
-            checked: publication.artefact.language == "en" ? true : false,
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: "Slug",
           },
-          {
-            value: "cy",
-            text: "Welsh",
-            checked: publication.artefact.language == "cy" ? true : false,
-          },
-        ],
-      } %>
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Update",
-      } %>
+          hint: "If you change the slug of a published page, the old slug will automatically redirect to the new one.",
+          name: "artefact[slug]",
+          value: publication.slug,
+          heading_level: 3,
+          heading_size: "m",
+        } %>
+
+        <%= render "govuk_publishing_components/components/radio", {
+          heading: "Language",
+          name: "artefact[language]",
+          heading_level: 3,
+          heading_size: "m",
+          inline: true,
+          items: [
+            {
+              value: "en",
+              text: "English",
+              checked: publication.artefact.language == "en" ? true : false,
+            },
+            {
+              value: "cy",
+              text: "Welsh",
+              checked: publication.artefact.language == "cy" ? true : false,
+            },
+          ],
+        } %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Update",
+        } %>
+      <% end %>
+    <% else %>
+      <% @artefact.attributes.slice("slug", "language").each do |key, value| %>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: key.humanize,
+          heading_level: 3,
+          font_size: "m",
+          margin_bottom: 3,
+        } %>
+        <p class="govuk-body">
+          <%= key.eql?("slug") ? value : locale_to_language(value) %>
+        </p>
+      <% end %>
     <% end %>
-  <% else %>
-    <% @artefact.attributes.slice("slug", "language").each do |key, value| %>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: key.humanize,
-        heading_level: 3,
-        font_size: "m",
-        margin_bottom: 3,
-      } %>
-      <p class="govuk-body">
-        <%= key.eql?("slug") ? value : locale_to_language(value) %>
-      </p>
-    <% end %>
-  <% end %>
+  </div>
 </div>

--- a/app/views/editions/secondary_nav_tabs/_temp_nav_text.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_temp_nav_text.html.erb
@@ -1,3 +1,5 @@
-<div class="govuk-grid-column-two-thirds">
-  <h3>Work in progress</h3>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h3>Work in progress</h3>
+  </div>
 </div>

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -3,8 +3,8 @@
 <% content_for :page_title, @resource.title %>
 <% content_for :title, @resource.title %>
 
-<div class="govuk-grid-column-full-width editions__edit">
-  <div class="govuk-grid-column-two-thirds">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds editions__edit__summary">
     <%= render "govuk_publishing_components/components/summary_list", {
       items: [
         {
@@ -22,11 +22,12 @@
       ],
     } %>
   </div>
+</div>
 
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render partial: "secondary_navigation" %>
   </div>
-
-  <%= render partial: "secondary_nav_tabs/#{current_tab_name}", :locals => { :publication => @resource } %>
-
 </div>
+
+<%= render partial: "secondary_nav_tabs/#{current_tab_name}", :locals => { :publication => @resource } %>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -47,9 +47,7 @@
         </div>
       <% end %>
 
-      <div class="govuk-grid-row">
-        <%= yield %>
-      </div>
+      <%= yield %>
     </main>
   </div>
 

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,86 +1,87 @@
 <% content_for :page_title, "Reports" %>
 <% content_for :title, "CSV Reports" %>
 
-<div class="govuk-grid-column-two-thirds">
-  <%= render "govuk_publishing_components/components/lead_paragraph", {
-    text: "These reports are updated every hour.",
-    margin_bottom: 6,
-  } %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/lead_paragraph", {
+      text: "These reports are updated every hour.",
+      margin_bottom: 6,
+    } %>
 
-  <%= render "govuk_publishing_components/components/document_list", {
-    margin_bottom: 6,
-    items: [
-      {
-        link: {
-          text: "All documents for departmental distribution",
-          path: organisation_content_report_path(format: :csv),
+    <%= render "govuk_publishing_components/components/document_list", {
+      margin_bottom: 6,
+      items: [
+        {
+          link: {
+            text: "All documents for departmental distribution",
+            path: organisation_content_report_path(format: :csv),
+          },
+          metadata: {
+            updated_at_time: report_generated_time_message("organisation_content"),
+            public_updated_at: report_last_updated("organisation_content"),
+          },
         },
-        metadata: {
-          updated_at_time: report_generated_time_message("organisation_content"),
-          public_updated_at: report_last_updated("organisation_content"),
+        {
+          link: {
+            text: "Churn in non-archived editions",
+            path: edition_churn_report_path(format: :csv),
+          },
+          metadata: {
+            updated_at_time: report_generated_time_message("edition_churn"),
+            public_updated_at: report_last_updated("edition_churn"),
+          },
         },
-      },
-      {
-        link: {
-          text: "Churn in non-archived editions",
-          path: edition_churn_report_path(format: :csv),
+        {
+          link: {
+            text: "Churn in all editions",
+            path: all_edition_churn_report_path(format: :csv),
+          },
+          metadata: {
+            updated_at_time: report_generated_time_message("all_edition_churn"),
+            public_updated_at: report_last_updated("all_edition_churn"),
+          },
         },
-        metadata: {
-          updated_at_time: report_generated_time_message("edition_churn"),
-          public_updated_at: report_last_updated("edition_churn"),
+        {
+          link: {
+            text: "Progress on all non-archived editions",
+            path: progress_report_path(format: :csv),
+          },
+          metadata: {
+            updated_at_time: report_generated_time_message("editorial_progress"),
+            public_updated_at: report_last_updated("editorial_progress"),
+          },
         },
-      },
-      {
-        link: {
-          text: "Churn in all editions",
-          path: all_edition_churn_report_path(format: :csv),
+        {
+          link: {
+            text: "Content summary and workflow history for all published editions",
+            path: content_workflow_report_path(format: :csv),
+          },
+          metadata: {
+            updated_at_time: report_generated_time_message("content_workflow"),
+            public_updated_at: report_last_updated("content_workflow"),
+          },
         },
-        metadata: {
-          updated_at_time: report_generated_time_message("all_edition_churn"),
-          public_updated_at: report_last_updated("all_edition_churn"),
+        {
+          link: {
+            text: "Content summary and workflow history for all editions",
+            path: all_content_workflow_report_path(format: :csv),
+          },
+          metadata: {
+            updated_at_time: report_generated_time_message("all_content_workflow"),
+            public_updated_at: report_last_updated("all_content_workflow"),
+          },
         },
-      },
-      {
-        link: {
-          text: "Progress on all non-archived editions",
-          path: progress_report_path(format: :csv),
+        {
+          link: {
+            text: "All URLs",
+            path: all_urls_report_path(format: :csv),
+          },
+          metadata: {
+            updated_at_time: report_generated_time_message("all_urls"),
+            public_updated_at: report_last_updated("all_urls"),
+          },
         },
-        metadata: {
-          updated_at_time: report_generated_time_message("editorial_progress"),
-          public_updated_at: report_last_updated("editorial_progress"),
-        },
-      },
-      {
-        link: {
-          text: "Content summary and workflow history for all published editions",
-          path: content_workflow_report_path(format: :csv),
-        },
-        metadata: {
-          updated_at_time: report_generated_time_message("content_workflow"),
-          public_updated_at: report_last_updated("content_workflow"),
-        },
-      },
-      {
-        link: {
-          text: "Content summary and workflow history for all editions",
-          path: all_content_workflow_report_path(format: :csv),
-        },
-        metadata: {
-          updated_at_time: report_generated_time_message("all_content_workflow"),
-          public_updated_at: report_last_updated("all_content_workflow"),
-        },
-      },
-      {
-        link: {
-          text: "All URLs",
-          path: all_urls_report_path(format: :csv),
-        },
-        metadata: {
-          updated_at_time: report_generated_time_message("all_urls"),
-          public_updated_at: report_last_updated("all_urls"),
-        },
-      },
-    ],
-  } %>
-
+      ],
+    } %>
+  </div>
 </div>

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -1,11 +1,13 @@
 <% content_for :page_title, "Publications" %>
 <% content_for :title, "Publications" %>
 
-<div class="govuk-grid-column-one-third">
-  <%= render :partial => "filter" %>
-</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    <%= render :partial => "filter" %>
+  </div>
 
-<div class="govuk-grid-column-two-thirds">
-  <%= render :partial => "table" %>
-  <%= paginate @presenter.editions %>
+  <div class="govuk-grid-column-two-thirds">
+    <%= render :partial => "table" %>
+    <%= paginate @presenter.editions %>
+  </div>
 </div>


### PR DESCRIPTION
[Trello](https://trello.com/c/Q7Gx5wiI/486-amend-design-system-layout-to-make-correct-use-of-the-grid-system)

These changes updates the Design System template to apply the `govuk-grid-row` wrapper on each view rather than globally. This is necessary to ensure that the Design System Grid is fully utilised throughout the app, by allowing the `govuk-grid-row` wrapper to be able to be used multiple times in each view where required.

In summary:
- Delete `govuk-grid-row` wrapper from Design System template
- Add `govuk-grid-row` wrapper to
  - Publications view
  - Downtimes views
  - Reports view
  - Edit views

