### PR TITLE
Update popular links views for updated grid

### DIFF
--- a/app/views/homepage/popular_links/confirm_destroy.html.erb
+++ b/app/views/homepage/popular_links/confirm_destroy.html.erb
@@ -2,15 +2,17 @@
 <% content_for :page_title, "Delete draft" %>
 <% content_for :title, "Delete draft" %>
 
-<div class="govuk-grid-column-two-thirds">
-  <%= form_tag delete_popular_links_path(@latest_popular_links), method: :delete do %>
-    <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete this draft?</p>
-    <div class="govuk-button-group govuk-!-margin-bottom-6">
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Delete",
-        destructive: true,
-      } %>
-      <%= link_to("Cancel", show_popular_links_path, class: "govuk-link govuk-link--no-visited-state") %>
-    </div>
-  <% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_tag delete_popular_links_path(@latest_popular_links), method: :delete do %>
+      <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete this draft?</p>
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+        } %>
+        <%= link_to("Cancel", show_popular_links_path, class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/homepage/popular_links/edit.html.erb
+++ b/app/views/homepage/popular_links/edit.html.erb
@@ -16,17 +16,19 @@
   <% end %>
 <% end %>
 
-<div class="govuk-grid-column-two-thirds">
-  <%= form_for @latest_popular_links, url: update_popular_links_path(@latest_popular_links), method: "patch" do |form| %>
-    <% @latest_popular_links.link_items.each_with_index do |item, index| %>
-      <%= render "homepage/popular_links/form", item:, index:, form: %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @latest_popular_links, url: update_popular_links_path(@latest_popular_links), method: "patch" do |form| %>
+      <% @latest_popular_links.link_items.each_with_index do |item, index| %>
+        <%= render "homepage/popular_links/form", item:, index:, form: %>
+      <% end %>
+      <div class="govuk-button-group">
+        <%= render("govuk_publishing_components/components/button", {
+          text: "Save",
+          type: "submit",
+        }) %>
+        <%= link_to("Cancel", show_popular_links_path, class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
     <% end %>
-    <div class="govuk-button-group">
-      <%= render("govuk_publishing_components/components/button", {
-        text: "Save",
-        type: "submit",
-      }) %>
-      <%= link_to("Cancel", show_popular_links_path, class: "govuk-link govuk-link--no-visited-state") %>
-    </div>
-  <% end %>
+  </div>
 </div>

--- a/app/views/homepage/popular_links/show.html.erb
+++ b/app/views/homepage/popular_links/show.html.erb
@@ -2,18 +2,20 @@
 <% content_for :title, "Popular on GOV.UK" %>
 <% content_for :title_context, "Homepage" %>
 
-<div class="govuk-grid-column-two-thirds">
-  <section>
-    <%= render "homepage/popular_links/version_and_status", version: @latest_popular_links.version_number, status: @latest_popular_links.state %>
-  </section>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <section>
+      <%= render "homepage/popular_links/version_and_status", version: @latest_popular_links.version_number, status: @latest_popular_links.state %>
+    </section>
 
-  <section>
-    <% @latest_popular_links.link_items.each_with_index do |item, index| %>
-      <%= render "homepage/popular_links/link", item:, index: %>
-    <% end %>
-  </section>
-</div>
+    <section>
+      <% @latest_popular_links.link_items.each_with_index do |item, index| %>
+        <%= render "homepage/popular_links/link", item:, index: %>
+      <% end %>
+    </section>
+  </div>
 
-<div class = "govuk-grid-column-one-third popular-links__sidebar" >
-  <%= render "homepage/popular_links/sidebar" %>
+  <div class = "govuk-grid-column-one-third popular-links__sidebar" >
+    <%= render "homepage/popular_links/sidebar" %>
+  </div>
 </div>


### PR DESCRIPTION
[Trello](https://trello.com/c/Q7Gx5wiI/486-amend-design-system-layout-to-make-correct-use-of-the-grid-system)

This is a further set of changes related to [PR2377](https://github.com/alphagov/publisher/pull/2377) to update the markup structure for the grid system. These changes are to the Popular Links pages. 
