### PR TITLE
Send `last_edited_by_editor_id` to Publishing API

### DIFF
--- a/app/presenters/formats/edition_format_presenter.rb
+++ b/app/presenters/formats/edition_format_presenter.rb
@@ -28,6 +28,7 @@ module Formats
         schema_name:,
         document_type:,
         public_updated_at: public_updated_at.rfc3339(3),
+        last_edited_by_editor_id:,
         publishing_app: "publisher",
         rendering_app:,
         routes:,
@@ -36,7 +37,7 @@ module Formats
         change_note: edition.latest_change_note,
         details:,
         locale: artefact.language,
-      }
+      }.compact
     end
 
     def schema_name
@@ -96,6 +97,13 @@ module Formats
 
     def public_updated_at
       edition.public_updated_at || edition.updated_at
+    end
+
+    # We can't reliably get the exact user who last edited the edition,
+    # so we rely on who created the edition, which is a fair enough
+    # approximation
+    def last_edited_by_editor_id
+      edition.created_by&.uid
     end
   end
 end

--- a/test/support/presenter_test_helpers.rb
+++ b/test/support/presenter_test_helpers.rb
@@ -1,0 +1,21 @@
+module PresenterTestHelpers
+  def it_includes_last_edited_by_editor_id
+    test "[:last_edited_by_editor_id] should return the creator of the edition" do
+      editor = FactoryBot.create(:user)
+      edition.actions.create!(request_type: Action::CREATE, requester: editor)
+
+      assert_equal editor.uid, result[:last_edited_by_editor_id]
+    end
+
+    test "[:last_edited_by_editor_id] should return the creator of a new version" do
+      editor = FactoryBot.create(:user)
+      edition.actions.create!(request_type: Action::NEW_VERSION, requester: editor)
+
+      assert_equal editor.uid, result[:last_edited_by_editor_id]
+    end
+
+    test "[:last_edited_by_editor_id] should return nil when there are no new version or create actions" do
+      assert_nil result[:last_edited_by_editor_id]
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,7 @@ require "support/holidays_test_helpers"
 require "support/action_processor_helpers"
 require "support/factories"
 require "support/local_services"
+require "support/presenter_test_helpers"
 require "govuk_schemas/assert_matchers"
 require "govuk_sidekiq/testing"
 
@@ -99,4 +100,5 @@ class ActiveSupport::TestCase
   include TabTestHelpers
   include HolidaysTestHelpers
   include ActionProcessorHelpers
+  extend PresenterTestHelpers
 end

--- a/test/unit/presenters/formats/answer_presenter_test.rb
+++ b/test/unit/presenters/formats/answer_presenter_test.rb
@@ -17,6 +17,8 @@ class AnswerPresenterTest < ActiveSupport::TestCase
     subject.render_for_publishing_api
   end
 
+  it_includes_last_edited_by_editor_id
+
   should "be valid against schema" do
     assert_valid_against_publisher_schema(result, "answer")
   end

--- a/test/unit/presenters/formats/completed_transaction_presenter_test.rb
+++ b/test/unit/presenters/formats/completed_transaction_presenter_test.rb
@@ -23,6 +23,8 @@ class CompletedTransactionPresenterTest < ActiveSupport::TestCase
     subject.render_for_publishing_api
   end
 
+  it_includes_last_edited_by_editor_id
+
   should "be valid against schema" do
     assert_valid_against_publisher_schema(result, "completed_transaction")
   end

--- a/test/unit/presenters/formats/edition_format_presenter_test.rb
+++ b/test/unit/presenters/formats/edition_format_presenter_test.rb
@@ -29,6 +29,7 @@ class EditionFormatPresenterTest < ActiveSupport::TestCase
       edition.stubs :latest_change_note
       edition.stubs :auth_bypass_id
       edition.stubs :exact_route?
+      edition.stubs created_by: FactoryBot.build(:user)
 
       artefact.stubs :language
     end
@@ -159,6 +160,13 @@ class EditionFormatPresenterTest < ActiveSupport::TestCase
       edition.expects(:auth_bypass_id).returns("foo")
       expected = { auth_bypass_ids: %w[foo] }
       assert_equal expected, result[:access_limited]
+    end
+
+    should "[:last_edited_by_editor_id]" do
+      uid = SecureRandom.uuid
+      user = FactoryBot.build(:user, uid:)
+      edition.expects(:created_by).returns(user)
+      assert_equal uid, result[:last_edited_by_editor_id]
     end
   end
 end

--- a/test/unit/presenters/formats/guide_presenter_test.rb
+++ b/test/unit/presenters/formats/guide_presenter_test.rb
@@ -27,6 +27,8 @@ class GuidePresenterTest < ActiveSupport::TestCase
     subject.render_for_publishing_api
   end
 
+  it_includes_last_edited_by_editor_id
+
   should "be valid against schema" do
     assert_valid_against_publisher_schema(result, "guide")
   end

--- a/test/unit/presenters/formats/help_page_presenter_test.rb
+++ b/test/unit/presenters/formats/help_page_presenter_test.rb
@@ -21,6 +21,8 @@ class HelpPagePresenterTest < ActiveSupport::TestCase
     assert_valid_against_publisher_schema(result, "help_page")
   end
 
+  it_includes_last_edited_by_editor_id
+
   should "[:schema_name]" do
     assert_equal "help_page", result[:schema_name]
   end

--- a/test/unit/presenters/formats/licence_presenter_test.rb
+++ b/test/unit/presenters/formats/licence_presenter_test.rb
@@ -32,6 +32,8 @@ class LicencePresenterTest < ActiveSupport::TestCase
     assert_valid_against_publisher_schema(result, "licence")
   end
 
+  it_includes_last_edited_by_editor_id
+
   should "[:schema_name]" do
     assert_equal "licence", result[:schema_name]
   end

--- a/test/unit/presenters/formats/local_transaction_presenter_test.rb
+++ b/test/unit/presenters/formats/local_transaction_presenter_test.rb
@@ -36,6 +36,8 @@ class LocalTransactionPresenterTest < ActiveSupport::TestCase
     assert_valid_against_publisher_schema(result, "local_transaction")
   end
 
+  it_includes_last_edited_by_editor_id
+
   should "[:schema_name]" do
     assert_equal "local_transaction", result[:schema_name]
   end

--- a/test/unit/presenters/formats/place_presenter_test.rb
+++ b/test/unit/presenters/formats/place_presenter_test.rb
@@ -21,6 +21,8 @@ class PlacePresenterTest < ActiveSupport::TestCase
     assert_valid_against_publisher_schema(result, "place")
   end
 
+  it_includes_last_edited_by_editor_id
+
   should "[:schema_name]" do
     assert_equal "place", result[:schema_name]
   end

--- a/test/unit/presenters/formats/simple_smart_answer_presenter_test.rb
+++ b/test/unit/presenters/formats/simple_smart_answer_presenter_test.rb
@@ -60,6 +60,8 @@ class SimpleSmartAnswerPresenterTest < ActiveSupport::TestCase
     subject.render_for_publishing_api
   end
 
+  it_includes_last_edited_by_editor_id
+
   should "be valid against schema" do
     assert_valid_against_publisher_schema(result, "simple_smart_answer")
   end

--- a/test/unit/presenters/formats/transaction_presenter_test.rb
+++ b/test/unit/presenters/formats/transaction_presenter_test.rb
@@ -37,6 +37,8 @@ class TransactionPresenterTest < ActiveSupport::TestCase
     subject.render_for_publishing_api
   end
 
+  it_includes_last_edited_by_editor_id
+
   should "be valid against schema" do
     assert_valid_against_publisher_schema(result, "transaction")
   end


### PR DESCRIPTION
This is a new field that will allow us to identify the last person who has edited an Edition within the Publishing API.