### PR TITLE
help_page's use frontend for rendering app

### DIFF
--- a/app/presenters/formats/help_page_presenter.rb
+++ b/app/presenters/formats/help_page_presenter.rb
@@ -11,7 +11,7 @@ module Formats
     end
 
     def rendering_app
-      "government-frontend"
+      "frontend"
     end
 
     def details

--- a/test/unit/presenters/formats/help_page_presenter_test.rb
+++ b/test/unit/presenters/formats/help_page_presenter_test.rb
@@ -61,6 +61,6 @@ class HelpPagePresenterTest < ActiveSupport::TestCase
   end
 
   should "[:rendering_app]" do
-    assert_equal "government-frontend", result[:rendering_app]
+    assert_equal "frontend", result[:rendering_app]
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Ticket: https://trello.com/c/GP0bkcD4/350-move-document-type-helppage-from-government-frontend-to-frontend
