### PR TITLE
Crating a rake task to publish any missed scheduled editions

### DIFF
--- a/lib/tasks/publish_missed_scheduled_editions.rake
+++ b/lib/tasks/publish_missed_scheduled_editions.rake
@@ -1,0 +1,11 @@
+namespace :editions do
+  desc "Publish editions missed in scheduled publishing"
+  task publish_missed_scheduled_editions: :environment do
+    scheduled_editions = Edition.scheduled_for_publishing.where(:publish_at.lt => Time.zone.now)
+
+    scheduled_editions.each do |edition|
+      ScheduledPublisher.new.perform(edition.id.to_s)
+      Rails.logger.warn "Published missed scheduled edition with ID: #{edition.id} "
+    end
+  end
+end

--- a/test/unit/tasks/publish_missed_scheduled_editions_test.rb
+++ b/test/unit/tasks/publish_missed_scheduled_editions_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+require "rake"
+
+class PublishMissedScheduledEditionsTaskTest < ActiveSupport::TestCase
+  def setup
+    Rake::Task["editions:publish_missed_scheduled_editions"].reenable
+  end
+
+  test "publishes editions that have missed their scheduled publish time" do
+    missed_edition = FactoryBot.create(:edition, state: "scheduled_for_publishing", publish_at: 1.hour.from_now)
+    missed_edition.update_attribute(:publish_at, 1.hour.ago) # rubocop:disable Rails/SkipsModelValidations
+
+    Rake::Task["editions:publish_missed_scheduled_editions"].invoke
+    missed_edition.reload
+
+    assert_equal "published", missed_edition.state
+  end
+
+  test "does not publish editions with publishing scheduled in the future" do
+    edition_scheduled_in_future = FactoryBot.create(:edition, state: "scheduled_for_publishing", publish_at: 1.hour.from_now)
+
+    Rake::Task["editions:publish_missed_scheduled_editions"].invoke
+    edition_scheduled_in_future.reload
+
+    assert_equal "scheduled_for_publishing", edition_scheduled_in_future.state
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/FDV98XMH/489-ensure-scheduled-editions-are-published-mainstream)

Daily cronjob is set up to run this rake task in govuk-helm-charts [PR](https://github.com/alphagov/govuk-helm-charts/pull/2716)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
