### PR TITLE
Add route for browser extension to get routed to publisher

### DIFF
--- a/app/controllers/content_item_controller.rb
+++ b/app/controllers/content_item_controller.rb
@@ -1,0 +1,21 @@
+class ContentItemController < ApplicationController
+  def by_content_id
+    artefact =
+      Artefact.find_by(content_id: params[:content_id])
+
+    if artefact
+      redirect_to edition_path(artefact.latest_edition)
+    else
+      redirect_to_root_path_with_error
+    end
+  rescue StandardError
+    redirect_to_root_path_with_error
+  end
+
+private
+
+  def redirect_to_root_path_with_error
+    flash[:danger] = "The requested content was not found"
+    redirect_to root_path
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,8 @@ Rails.application.routes.draw do
   delete "/homepage/popular-links/:id" => "homepage#destroy", as: "delete_popular_links"
   get "homepage/popular-links/:id/confirm-destroy" => "homepage#confirm_destroy", as: "confirm_destroy_popular_links"
 
+  get "by-content-id/:content_id" => "content_item#by_content_id"
+
   mount GovukAdminTemplate::Engine, at: "/style-guide"
   mount Flipflop::Engine => "/flipflop"
   mount GovukPublishingComponents::Engine, at: "/component-guide"

--- a/test/functional/content_item_controller_test.rb
+++ b/test/functional/content_item_controller_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class ContentItemControllerTest < ActionController::TestCase
+  def setup
+    login_as_stub_user
+    @edition = FactoryBot.create(:edition)
+  end
+
+  should "redirect to content by content_id" do
+    get :by_content_id, params: { content_id: @edition.content_id }
+
+    assert_redirected_to edition_path(@edition.artefact.latest_edition)
+  end
+
+  should "redirect to root with error message if content_id is not found" do
+    get :by_content_id, params: { content_id: "#{@edition.artefact.content_id}wrong-id" }
+
+    assert_redirected_to root_path
+    assert_equal "The requested content was not found", flash[:danger]
+  end
+
+  should "redirect to root with error message if any error" do
+    Artefact.any_instance.stubs(:find_by).raises(StandardError)
+
+    get :by_content_id, params: { content_id: "#{@edition.artefact.content_id}wrong-id" }
+
+    assert_equal "The requested content was not found", flash[:danger]
+    assert_redirected_to root_path
+  end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/8XrdpwX2/484-browser-extension-doesnt-work-on-transitioned-publication-page-publications-page?filter=label:Design%20System%20MVP)

As Mainstream publisher moves to new design sytem, we would need to make changes to the current external link that navigates to filter publication page, we did discuss [different options](https://docs.google.com/document/d/1DPl6MuUPDMLqRHjvbt3ByJyGVQT_F8on0Ek_-udcgjE/edit?tab=t.0) we had to make this work.

This PR is coupled with the [changes in browser extension ](https://github.com/alphagov/govuk-browser-extension/pull/212)
