### PR TITLE
Design changes

### DIFF
--- a/app/assets/stylesheets/editions.scss
+++ b/app/assets/stylesheets/editions.scss
@@ -3,3 +3,8 @@
     display: inline;
   }
 }
+
+.edit_edition__change_note {
+  @include govuk-responsive-padding(4, "top");
+  border-top: 1px solid $govuk-border-colour;
+}

--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -58,45 +58,48 @@
         },
         name: "edition[body]",
         value: @resource.body,
+        rows: 14,
         hint: ("Refer to #{link_to("Refer to the Govspeak guidance (opens in new tab)", "https://govspeak-preview.publishing.service.gov.uk/guide", target: "_blank", rel: "noopener", class: "govuk-link")}").html_safe,
       } %>
 
       <% if @resource.published_edition %>
-        <%= render "govuk_publishing_components/components/details", {
-          title: "Add a public change note",
-        } do %>
-          <%= render "govuk_publishing_components/components/radio", {
-            heading: "Add a public change note",
-            heading_level: 3,
-            heading_size: "m",
-            name: "edition[major_change]",
-            hint: "Telling users when published information has changed is important for transparency.",
-            items: [
-              {
-                hint_text: "A change note will be published on the page and emailed to users subscribed to email alerts. The ‘last updated’ date will change.",
-                text: "Yes - information has been added, updated or removed.",
-                checked: @resource.major_change,
-                bold: true,
-                value: true,
-                conditional: render("govuk_publishing_components/components/textarea", {
-                  label: {
-                    text: "Describe the change for users",
-                    bold: true,
-                  },
-                  name: "edition[change_note]",
-                  value: @resource.change_note,
-                  hint: ("<p class=\"govuk-!-margin-0\">Tell users what has changed, where and why. Write in full sentences, leading with the most important words. For example, \"College A has been removed from the registered sponsors list because its licence has been suspended.\"</p><a href=\"https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes\" target=\"_blank\">Guidance on change notes (opens in a new tab)</a>").html_safe,
-                }),
-              },
-              {
-                value: false,
-                text: "No",
-                bold: true,
-                checked: !@resource.major_change,
-              },
-            ],
-          } %>
-        <% end %>
+        <div class="edit_edition__change_note">
+          <%= render "govuk_publishing_components/components/details", {
+            title: "Add a public change note",
+          } do %>
+            <%= render "govuk_publishing_components/components/radio", {
+              heading: "Add a public change note",
+              heading_level: 3,
+              heading_size: "m",
+              name: "edition[major_change]",
+              hint: "Telling users when published information has changed is important for transparency.",
+              items: [
+                {
+                  hint_text: "A change note will be published on the page and emailed to users subscribed to email alerts. The ‘last updated’ date will change.",
+                  text: "Yes - information has been added, updated or removed.",
+                  checked: @resource.major_change,
+                  bold: true,
+                  value: true,
+                  conditional: render("govuk_publishing_components/components/textarea", {
+                    label: {
+                      text: "Describe the change for users",
+                      bold: true,
+                    },
+                    name: "edition[change_note]",
+                    value: @resource.change_note,
+                    hint: ("<p class=\"govuk-!-margin-0\">Tell users what has changed, where and why. Write in full sentences, leading with the most important words. For example, \"College A has been removed from the registered sponsors list because its licence has been suspended.\"</p><a href=\"https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes\" target=\"_blank\">Guidance on change notes (opens in a new tab)</a>").html_safe,
+                  }),
+                },
+                {
+                  value: false,
+                  text: "No",
+                  bold: true,
+                  checked: !@resource.major_change,
+                },
+              ],
+            } %>
+          <% end %>
+        </div>
       <% end %>
     </div>
 

--- a/app/views/editions/secondary_nav_tabs/_metadata.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_metadata.html.erb
@@ -13,14 +13,13 @@
           hint: "If you change the slug of a published page, the old slug will automatically redirect to the new one.",
           name: "artefact[slug]",
           value: publication.slug,
-          heading_level: 3,
           heading_size: "m",
         } %>
 
         <%= render "govuk_publishing_components/components/radio", {
           heading: "Language",
           name: "artefact[language]",
-          heading_level: 3,
+          heading_level: 0,
           heading_size: "m",
           inline: true,
           items: [


### PR DESCRIPTION
[Trello](https://trello.com/c/CHePz7xP/407-edit-answer-help-content-types-edit-page)

The changes in this PR make a couple of small changes on the Edit and Metadata tabs (screenshots below). The reason for the changes to the label/legend elements on the Metadata tag is to be consistent across Publisher and render these elements just as a `<label>` or `<legend>` without wrapping them in a header tag which is better for accessibility. 
- Edit:
  - Increases the depth of the body field
  - Adds a rule above change note section (does not display when the change note is not rendered)
- Metatags:
  - remove headings from label/legend (no visual changes - removes the `<h3>` tags from the label and legend)

|Current|Updated|
|-|-|
|Admin tab|Admin tab|
|![Screenshot 2024-11-12 at 13 16 59](https://github.com/user-attachments/assets/3afeeff9-64df-49c5-bfc4-6436dc7d25bf)|![Screenshot 2024-11-12 at 13 16 44](https://github.com/user-attachments/assets/6dd4b7d6-7eb7-4148-9194-a264b922f6bd)|
|Metadata tab|Metadata tab|
|![Screenshot 2024-11-12 at 13 06 19](https://github.com/user-attachments/assets/a127ad37-01f0-45f7-824b-244ea7c5df25)|No visual change|
