### PR TITLE
Add constraint to allow only Answer Edition and Help Page Edition

### DIFF
--- a/app/constraints/allowed_content_types_constraint.rb
+++ b/app/constraints/allowed_content_types_constraint.rb
@@ -1,0 +1,12 @@
+class AllowedContentTypesConstraint
+  def initialize(allowed_content_types)
+    @allowed_content_types = allowed_content_types
+  end
+
+  def matches?(request)
+    request_path_parameters = "action_dispatch.request.path_parameters"
+    if request.env[request_path_parameters] && request.env[request_path_parameters][:id]
+      @allowed_content_types.include?(Edition.find(request.env[request_path_parameters][:id]).class)
+    end
+  end
+end

--- a/app/constraints/new_design_system_constraint.rb
+++ b/app/constraints/new_design_system_constraint.rb
@@ -1,0 +1,5 @@
+class NewDesignSystemConstraint
+  def matches?(request)
+    AllowedContentTypesConstraint.new([AnswerEdition, HelpPageEdition]).matches?(request) && FeatureConstraint.new("design_system_edit").matches?(request)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
 
   resources :artefacts, only: %i[new create update]
 
-  constraints FeatureConstraint.new("design_system_edit") do
+  constraints NewDesignSystemConstraint.new do
     resources :editions do
       member do
         get "metadata"


### PR DESCRIPTION
For incremental release of new design system pages, we want to restrict them with content types and only Answer Edition and Help Page Edition are to be released first.

[Trello](https://trello.com/c/omH0r8co/499-restrict-edit-page-changes-to-help-page-answer-content-types)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
