### PR TITLE
Add delete to admin tab

### DIFF
--- a/app/assets/stylesheets/editions.scss
+++ b/app/assets/stylesheets/editions.scss
@@ -8,3 +8,9 @@
   @include govuk-responsive-padding(4, "top");
   border-top: 1px solid $govuk-border-colour;
 }
+
+.editions__admin__tab {
+  .govuk-link {
+    margin-top: govuk-spacing(3)
+  }
+}

--- a/app/views/editions/secondary_nav_tabs/_admin.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_admin.html.erb
@@ -1,14 +1,12 @@
 <% @edition = @resource %>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds editions__admin__tab">
     <%= header_for("Admin") %>
-
-    <% if @edition.fact_check? %>
-      <%= form_for @edition, url: skip_fact_check_edition_path(@edition), method: "post" do %>
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Skip fact check",
-        } %>
-        <% end %>
-    <% end %>
+    <%= render "govuk_publishing_components/components/list", {
+      items: [
+        ( primary_button_for(@edition, skip_fact_check_edition_path(@edition), "Skip fact check") if @edition.fact_check? ),
+        ( link_to("Delete edition #{@edition.version_number}", confirm_destroy_edition_path(@resource), class: "govuk-link gem-link--destructive") if @edition.can_destroy? ),
+      ],
+    } %>
   </div>
 </div>

--- a/app/views/editions/secondary_nav_tabs/confirm_destroy.html.erb
+++ b/app/views/editions/secondary_nav_tabs/confirm_destroy.html.erb
@@ -1,7 +1,7 @@
 <% @edition = @resource %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "Unpublish" %>
-<% content_for :title, "Unpublish" %>
+<% content_for :page_title, "Delete edition" %>
+<% content_for :title, "Delete edition" %>
 <div class="govuk-grid-row">
   <% unless @edition.errors.empty? %>
     <% content_for :error_summary do %>
@@ -20,18 +20,17 @@
 
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/inset_text", {
-      text: "If you unpublish a page from GOV.UK it cannot be undone.",
+      text: "If you delete this edition it cannot be undone.",
     } %>
 
-    <%= form_for @edition, url: process_unpublish_edition_path(@edition), method: :post do %>
-      <%= hidden_field_tag :redirect_url, params[:redirect_url] %>
-      <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to unpublish this document?</p>
+    <%= form_for @edition, url: admin_delete_edition_path(@edition), method: :delete do %>
+      <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete this edition?</p>
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {
-          text: "Unpublish document",
+          text: "Delete edition",
           destructive: true,
         } %>
-        <%= link_to("Cancel", unpublish_edition_path, class: "govuk-link govuk-link--no-visited-state") %>
+        <%= link_to("Cancel", admin_edition_path, class: "govuk-link govuk-link--no-visited-state") %>
       </div>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
         get "unpublish"
         get "unpublish/confirm-unpublish", to: "editions#confirm_unpublish", as: "confirm_unpublish"
         post "process_unpublish"
+        get "admin/confirm-destroy", to: "editions#confirm_destroy", as: "confirm_destroy"
+        delete "admin/delete-edition", to: "editions#destroy", as: "admin_delete"
         post "progress"
         post "skip_fact_check",
              to: "editions#progress",


### PR DESCRIPTION
[Trello](https://trello.com/c/SJf1WFqO/456-admin-delete-edition-button-confirmation-page-edit-admin)

Add delete addition functionality to admin page.

Draft edition
<img width="890" alt="delete_draft_edition" src="https://github.com/user-attachments/assets/aed01297-3342-4b7c-a726-a80075615668">


fact check edition
<img width="960" alt="delete_fact_check_edition" src="https://github.com/user-attachments/assets/79e967bc-6b70-4cfe-b221-28a573a69adb">


confirm delete page
<img width="613" alt="confirm_delete" src="https://github.com/user-attachments/assets/0ea42a19-0fe9-4645-a93b-aec8a13d9962">

delete success message
<img width="1535" alt="delete_success" src="https://github.com/user-attachments/assets/10e77142-bb20-437d-88a9-314179b37edc">



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
