### PR TITLE
Enable editing the person assigned to an edition

### DIFF
--- a/app/helpers/tabbed_nav_helper.rb
+++ b/app/helpers/tabbed_nav_helper.rb
@@ -28,6 +28,17 @@ module TabbedNavHelper
     end
   end
 
+  def assignee_edit_link(edition)
+    if current_user.has_editor_permissions?(edition) && can_update_assignee?(edition)
+      {
+        href: edit_assignee_edition_path,
+        link_text: "Edit",
+      }
+    else
+      {}
+    end
+  end
+
 private
 
   def all_tab_names
@@ -60,5 +71,22 @@ private
         current:,
       },
     ]
+  end
+
+  def available_assignee_items(resource)
+    items = []
+    unless resource.assignee.nil?
+      items << { value: resource.assigned_to_id, text: resource.assignee, checked: true }
+      items << { value: "none", text: "None" }
+      items << :or
+    end
+    User.enabled.order_by([%i[name asc]]).each do |user|
+      items << { value: user.id, text: user.name } unless user.name == resource.assignee
+    end
+    items
+  end
+
+  def can_update_assignee?(resource)
+    %w[published archived scheduled_for_publishing].exclude?(resource.state)
   end
 end

--- a/app/views/editions/secondary_nav_tabs/_edit_assignee.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit_assignee.html.erb
@@ -1,0 +1,37 @@
+<% content_for :title_context, @resource.title %>
+<% content_for :page_title, "Assign person" %>
+<% content_for :title, "Assign person" %>
+
+<%= form_for @resource, url: update_assignee_edition_path(@resource) do %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <%= render "govuk_publishing_components/components/radio", {
+          name: "assignee_id",
+          heading: "Choose a person to assign",
+          visually_hidden_heading: true,
+          items: available_assignee_items(@resource),
+        } %>
+    </div>
+
+    <div class="govuk-grid-column-one-third options-sidebar">
+      <div class="sidebar-components">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Options",
+          heading_level: 3,
+          font_size: "s",
+          padding: true,
+        } %>
+
+        <%= render "govuk_publishing_components/components/list", {
+          items: [
+            (render "govuk_publishing_components/components/button", {
+              text: "Save",
+              margin_bottom: 3,
+            }),
+            link_to("Cancel", edition_path(@resource), class: "govuk-link govuk-link--no-visited-state"),
+          ],
+        } %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -25,6 +25,7 @@
         {
           field: "Assigned to",
           value: @resource.assigned_to,
+          edit: assignee_edit_link(@resource),
         },
         {
           field: "Content type",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,8 @@ Rails.application.routes.draw do
         get "admin/confirm-destroy", to: "editions#confirm_destroy", as: "confirm_destroy"
         delete "admin/delete-edition", to: "editions#destroy", as: "admin_delete"
         post "progress"
+        get "edit_assignee"
+        patch "update_assignee"
         post "skip_fact_check",
              to: "editions#progress",
              edition: {


### PR DESCRIPTION
Add an edit link to the document summary (at the top of the page) when viewing an edition with the GOV.UK Design System template.

On the Bootstrap UI this was managed as just another dropdown field on the "Edit" tab. With the new Design System views, the edit link takes the user to a separate page for selecting the user to be assigned.

## Screenshots

### Document summary when viewing an edition that may be edited

![image](https://github.com/user-attachments/assets/2b20fc50-0218-4055-ab86-655702ae0147)

### Document summary when viewing an edition that may not be edited

![image](https://github.com/user-attachments/assets/860ca7fa-0bee-4228-9d0a-5ce95aca115e)

### Edit assigned person page when nobody is currently assigned

![image](https://github.com/user-attachments/assets/b754e43c-4e43-4ad5-9aa1-cb66769fa755)

### Edit assigned person page when a user is already assigned

![image](https://github.com/user-attachments/assets/ed0a389a-7c83-4d10-8314-a185c1265689)

### Old Bootstrap UI for editing the assigned person

![image](https://github.com/user-attachments/assets/720299c7-430c-4073-939f-1f978191d85f)

## Trello

[Trello card](https://trello.com/c/NMCUGhvR)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
