### PR TITLE
472 admin tab update content type

### DIFF
--- a/app/helpers/editions_helper.rb
+++ b/app/helpers/editions_helper.rb
@@ -19,9 +19,30 @@ module EditionsHelper
     nested_form_for resource, as: :edition, url: edition_path(resource), html: html_options, &form_definition
   end
 
-  def format_conversion_select_options(edition)
+  def legacy_format_conversion_select_options(edition)
     possible_target_formats = Edition.convertible_formats - [edition.artefact.kind]
     possible_target_formats.map { |format_name| [format_name.humanize, format_name] }
+  end
+
+  def conversion_items(edition)
+    radio_options_hints = {
+      "answer" => "One page guidance",
+      "completed_transaction" => "Done page for end of a service",
+      "guide" => "Multi-page guidance",
+      "help_page" => "Info about GOV.UK website, for example Privacy",
+      "place" => "Postcode look-up for places/services near you",
+      "simple_smart_answer" => "Simple questions and answers that route users to relevant outcomes",
+      "transaction" => "Start page for a service",
+    }
+
+    possible_target_formats = Edition.convertible_formats - [edition.artefact.kind]
+    possible_target_formats.map do |format_name|
+      {
+        text: format_name.humanize,
+        value: format_name,
+        hint_text: radio_options_hints[format_name],
+      }
+    end
   end
 
   def legacy_format_filter_selection_options

--- a/app/views/editions/secondary_nav_tabs/_admin.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_admin.html.erb
@@ -1,12 +1,36 @@
 <% @edition = @resource %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds editions__admin__tab">
     <%= header_for("Admin") %>
-    <%= render "govuk_publishing_components/components/list", {
-      items: [
-        ( primary_button_for(@edition, skip_fact_check_edition_path(@edition), "Skip fact check") if @edition.fact_check? ),
-        ( link_to("Delete edition #{@edition.version_number}", confirm_destroy_edition_path(@resource), class: "govuk-link gem-link--destructive") if @edition.can_destroy? ),
-      ],
-    } %>
+
+    <% if @edition.can_create_new_edition? && @edition.published? %>
+      <p class="govuk-body">No content will be lost, but content in some fields might not make it into the new edition. If it can't be copied to a new content type it will still be available in the previous edition. Content in multiple fields might be combined into a single field.</p>
+
+      <% if @edition.respond_to?(:parts) %>
+        <p class="govuk-body">All parts of Guide Editions will be copied across. If the format you are converting to doesn't have parts, the content of all the parts will be copied into the body, with the part title displayed as a top-level sub-heading.</p>
+      <% end %>
+
+      <%= form_for @resource, url: duplicate_edition_path(@resource), method: "post" do %>
+        <%= render "govuk_publishing_components/components/radio", {
+          heading: "Update content type",
+          heading_level: 0,
+          heading_size: "s",
+          name: "to",
+          items: conversion_items(@resource),
+        } %>
+
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Update",
+        } %>
+      <% end %>
+    <% else %>
+      <%= render "govuk_publishing_components/components/list", {
+        items: [
+          ( primary_button_for(@edition, skip_fact_check_edition_path(@edition), "Skip fact check") if @edition.fact_check? ),
+          ( link_to("Delete edition #{@edition.version_number}", confirm_destroy_edition_path(@resource), class: "govuk-link gem-link--destructive") if @edition.can_destroy? ),
+        ],
+      } %>
+    <% end %>
   </div>
 </div>

--- a/app/views/shared/_clone_buttons.html.erb
+++ b/app/views/shared/_clone_buttons.html.erb
@@ -8,7 +8,7 @@
 
   <%= form_for @resource, url: duplicate_edition_path(@resource, from: edition_class.to_s), method: "post" do |f| %>
     <%= f.label :to, "Create as new", for: :to %>
-    <%= select_tag :to, options_for_select(format_conversion_select_options(@resource)), class: "form-control input-md-3 add-bottom-margin" %>
+    <%= select_tag :to, options_for_select(legacy_format_conversion_select_options(@resource)), class: "form-control input-md-3 add-bottom-margin" %>
     <%= f.submit "Change format", class: "btn btn-default" %>
   <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
         get "metadata"
         get "history"
         get "admin"
+        post "duplicate"
         get "related_external_links", to: "editions#linking"
         get "tagging", to: "editions#linking"
         get "unpublish"


### PR DESCRIPTION
[Trello](https://trello.com/c/qLZmHXIu/472-admin-update-content-type-edit-admin?filter=label:Design%20System%20MVP)

Adds the functionality for the user to update the content type of a document on the Admin tab. The work involves
- adding a new partial for the Admin tab
- adding the `duplicate` method to the editions controller
- updating the editions controller test 
- updating the edit editions test
- a bit of renaming of methods in the editions helper and where these are used in the legacy code

|View|Screenshot|
|-|-|
|Admin tab|![Screenshot 2024-11-22 at 12 43 36](https://github.com/user-attachments/assets/0ba2b00e-6b45-4d11-86d3-7ae8ded55971)|
|Redirect to edit page on success|![Screenshot 2024-11-22 at 12 47 38](https://github.com/user-attachments/assets/0f7ddf16-f167-4908-a104-b1945b68c23a)|
|Redirect to edit with error when another user has already created a new version|![Screenshot 2024-11-22 at 12 58 20](https://github.com/user-attachments/assets/49d04f56-4bb0-44c8-b8f6-d08f6f1c3152)|