### PR TITLE
Remove duplicate import in `application.scss`

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,7 +1,6 @@
 $govuk-page-width: 1140px;
 
 // GOVUK Design System
-@import "govuk/base";
 @import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/component_support';
 @import 'govuk_publishing_components/components/button';


### PR DESCRIPTION
[Trello](https://trello.com/c/kbJAW2Ds/528-scss-not-compiling-publisher)

This deals with a problem in how the Sass is compiled that was causing an error when trying to update to a later version of the Publishing Components gem.

There is a reference in the `application.scss` file that duplicates an import in the gem and isn’t required here as that file is already imported in the gem itself. This is causing the SCSS to fail to compile in this app.

Removing the reference to that allows the SCSS to compile successfully and displays the styles on the app as expected. 

This will then allow the updated Publishing Components gem to be included in Publisher.