### PR TITLE
Fix removal methods and add tests

### DIFF
--- a/lib/tasks/access_and_permissions.rake
+++ b/lib/tasks/access_and_permissions.rake
@@ -52,45 +52,47 @@ namespace :permissions do
     end
   end
 
-  desc "Remove an organisation from an document's access permissions list"
+  desc "Remove an organisation from a document's access permissions list"
   task :remove_organisation_access, %i[document_content_id org_content_id] => :environment do |_, args|
-    document = Artefact.find_by(id: args[:document_content_id])
+    document_content_id = args[:document_content_id]
+    org_content_id = args[:org_content_id]
+
+    document = Artefact.find_by(id: document_content_id)
 
     if document.nil?
-      message = "Document not found, no permissions changed."
-    elsif !document.latest_edition.owning_org_content_ids.include?(args[:org_content_id])
-      message = "Organisation with ID #{args[:organisation_id]} did not have access to document with ID - #{document.id} no change made"
+      puts "Document ID #{document_content_id} not found, no permissions removed for organisation with ID: #{org_content_id}"
     else
-      Edition.where(panopticon_id: document.id).each do |edition|
-        edition.owning_org_content_ids.delete(args[:org_content_id])
-        edition.save!(validate: false)
+      editions = Edition.where(panopticon_id: document.id).select { |edition| edition.owning_org_content_ids.include?(org_content_id) }
+      if editions.empty?
+        puts "Organisation with ID #{org_content_id} did not have access to document with ID: #{document.id}. No permissions changed"
+      else
+        editions.each do |edition|
+          owning_org_content_ids = edition.owning_org_content_ids - [org_content_id]
+          edition.update_columns(owning_org_content_ids: owning_org_content_ids)
+        end
+        document.save_as_task!("PermissionsRemoval")
+        puts "Access permission successfully removed for the organisation with ID #{org_content_id} from document with ID: #{document.id}"
       end
-      document.save_as_task!("PermissionsRemoval")
-      message = "Access permission for successfully removed for the organisation with ID #{args[:organisation_id]} from document with ID - #{document.id}"
     end
-    puts message
-  rescue Mongoid::Errors::DocumentNotFound => e
-    error_message = "An error occurred while processing document with ID #{args[:document_content_id]}: #{e.message}"
-    puts error_message
+  rescue ActiveRecord::RecordNotFound => e
+    puts "An error occurred while processing document with ID #{document_content_id}: #{e.message}"
   end
 
-  desc "Remove all access permissions from an document"
+  desc "Remove all access permissions from a document"
   task :remove_all_access_flags, %i[document_content_id] => :environment do |_, args|
-    document = Artefact.find_by(id: args[:document_content_id])
+    document_content_id = args[:document_content_id]
+    document = Artefact.find_by(id: document_content_id)
 
     if document.nil?
-      message = "Document not found, no permissions changed."
+      puts "Document ID #{document_content_id} not found, no permissions changed"
     else
-      Edition.where(panopticon_id: document.id).each do |edition|
-        edition.owning_org_content_ids.clear
-        edition.save!(validate: false)
+      Edition.where(panopticon_id: document.id).find_each do |edition|
+        edition.update_columns(owning_org_content_ids: [])
       end
       document.save_as_task!("PermissionsClear")
-      message = "All access permissions for all organisations successfully removed from document with ID - #{document.id}"
+      puts "All access permissions for all organisations successfully removed from document with ID - #{document.id}"
     end
-    puts message
-  rescue Mongoid::Errors::DocumentNotFound => e
-    error_message = "An error occurred while processing document with ID #{args[:document_content_id]}: #{e.message}"
-    puts error_message
+  rescue ActiveRecord::RecordNotFound => e
+    puts "An error occurred while processing document with ID #{document_content_id}: #{e.message}"
   end
 end

--- a/test/unit/tasks/access_and_permissions_test.rb
+++ b/test/unit/tasks/access_and_permissions_test.rb
@@ -8,13 +8,20 @@ class AccessAndPermissionsTaskTest < ActiveSupport::TestCase
     @add_organisation_access_task = Rake::Task["permissions:add_organisation_access"]
     @bulk_process_task = Rake::Task["permissions:bulk_process_access_flags"]
 
+    @remove_organisation_access_task = Rake::Task["permissions:remove_organisation_access"]
+    @remove_all_access_flags_task = Rake::Task["permissions:remove_all_access_flags"]
+
     @add_organisation_access_task.reenable
     @bulk_process_task.reenable
+    @remove_organisation_access_task.reenable
+    @remove_all_access_flags_task.reenable
 
     @artefact1 = FactoryBot.create(:artefact, slug: "example-slug-1")
     @artefact2 = FactoryBot.create(:artefact, slug: "example-slug-2")
+
     @edition1 = FactoryBot.create(:edition, panopticon_id: @artefact1.id, owning_org_content_ids: [])
     @edition2 = FactoryBot.create(:edition, panopticon_id: @artefact2.id, owning_org_content_ids: [])
+
     @csv_file_path = Rails.root.join("tmp/test_bulk_access.csv")
     CSV.open(@csv_file_path, "w") do |csv|
       csv << %w[Header1 URL]
@@ -70,5 +77,52 @@ class AccessAndPermissionsTaskTest < ActiveSupport::TestCase
 
     assert_includes @edition1.owning_org_content_ids, organisation_id
     assert_includes @edition2.owning_org_content_ids, organisation_id
+  end
+
+  test "remove_organisation_access removes permissions correctly" do
+    organisation_id = "org-id-to-remove"
+
+    @add_organisation_access_task.invoke(@artefact1.id, organisation_id)
+    @edition1.reload
+    assert_includes @edition1.owning_org_content_ids, organisation_id
+
+    @remove_organisation_access_task.invoke(@artefact1.id, organisation_id)
+    @edition1.reload
+
+    assert_not_includes @edition1.owning_org_content_ids, organisation_id
+  end
+
+  test "remove_organisation_access does not affect other organisation permissions" do
+    org_id_to_keep = "saved-org-id"
+    org_id_to_remove = "removable-org-id"
+    artefact3 = FactoryBot.create(:artefact, slug: "example-slug-3")
+    edition3 = FactoryBot.create(:edition, panopticon_id: artefact3.id, owning_org_content_ids: [org_id_to_keep, org_id_to_remove])
+    assert_includes edition3.owning_org_content_ids, org_id_to_keep
+    assert_includes edition3.owning_org_content_ids, org_id_to_remove
+
+    @remove_organisation_access_task.invoke(artefact3.id, org_id_to_remove)
+    edition3.reload
+
+    assert_not_includes edition3.owning_org_content_ids, org_id_to_remove
+    assert_includes edition3.owning_org_content_ids, org_id_to_keep
+  end
+
+  test "remove_all_access_flags removes all permissions" do
+    organisation_id1 = "org-id-one"
+    organisation_id2 = "org-id-two"
+
+    @add_organisation_access_task.invoke(@artefact1.id, organisation_id1)
+    @add_organisation_access_task.reenable
+    @add_organisation_access_task.invoke(@artefact1.id, organisation_id2)
+    @edition1.reload
+
+    assert_includes @edition1.owning_org_content_ids, organisation_id1
+    assert_includes @edition1.owning_org_content_ids, organisation_id2
+
+    @remove_all_access_flags_task.invoke(@artefact1.id, organisation_id2)
+    @edition1.reload
+
+    assert_not_includes @edition1.owning_org_content_ids, organisation_id1
+    assert_not_includes @edition1.owning_org_content_ids, organisation_id2
   end
 end

--- a/test/unit/tasks/access_and_permissions_test.rb
+++ b/test/unit/tasks/access_and_permissions_test.rb
@@ -79,50 +79,62 @@ class AccessAndPermissionsTaskTest < ActiveSupport::TestCase
     assert_includes @edition2.owning_org_content_ids, organisation_id
   end
 
-  test "remove_organisation_access removes permissions correctly" do
+  test "remove_organisation_access removes permissions from every edition on an artefact" do
     organisation_id = "org-id-to-remove"
+    artefact = FactoryBot.create(:artefact)
+    edition1 = FactoryBot.create(:edition, panopticon_id: artefact.id, owning_org_content_ids: [organisation_id])
+    edition2 = FactoryBot.create(:edition, panopticon_id: artefact.id, owning_org_content_ids: [organisation_id])
 
-    @add_organisation_access_task.invoke(@artefact1.id, organisation_id)
-    @edition1.reload
-    assert_includes @edition1.owning_org_content_ids, organisation_id
+    @remove_organisation_access_task.invoke(artefact.id, organisation_id)
+    edition1.reload
+    edition2.reload
 
-    @remove_organisation_access_task.invoke(@artefact1.id, organisation_id)
-    @edition1.reload
-
-    assert_not_includes @edition1.owning_org_content_ids, organisation_id
+    assert_not_includes edition1.owning_org_content_ids, organisation_id
+    assert_not_includes edition2.owning_org_content_ids, organisation_id
   end
 
   test "remove_organisation_access does not affect other organisation permissions" do
     org_id_to_keep = "saved-org-id"
     org_id_to_remove = "removable-org-id"
-    artefact3 = FactoryBot.create(:artefact, slug: "example-slug-3")
-    edition3 = FactoryBot.create(:edition, panopticon_id: artefact3.id, owning_org_content_ids: [org_id_to_keep, org_id_to_remove])
-    assert_includes edition3.owning_org_content_ids, org_id_to_keep
-    assert_includes edition3.owning_org_content_ids, org_id_to_remove
+    artefact = FactoryBot.create(:artefact)
+    edition = FactoryBot.create(:edition, panopticon_id: artefact.id, owning_org_content_ids: [org_id_to_keep, org_id_to_remove])
 
-    @remove_organisation_access_task.invoke(artefact3.id, org_id_to_remove)
-    edition3.reload
+    @remove_organisation_access_task.invoke(artefact.id, org_id_to_remove)
+    edition.reload
 
-    assert_not_includes edition3.owning_org_content_ids, org_id_to_remove
-    assert_includes edition3.owning_org_content_ids, org_id_to_keep
+    assert_not_includes edition.owning_org_content_ids, org_id_to_remove
+    assert_includes edition.owning_org_content_ids, org_id_to_keep
   end
 
-  test "remove_all_access_flags removes all permissions" do
+  test "remove_all_access_flags removes all permissions from every edition on an artefact" do
     organisation_id1 = "org-id-one"
     organisation_id2 = "org-id-two"
+    artefact = FactoryBot.create(:artefact)
+    edition1 = FactoryBot.create(:edition, panopticon_id: artefact.id, owning_org_content_ids: [organisation_id1, organisation_id2])
+    edition2 = FactoryBot.create(:edition, panopticon_id: artefact.id, owning_org_content_ids: [organisation_id1, organisation_id2])
 
-    @add_organisation_access_task.invoke(@artefact1.id, organisation_id1)
-    @add_organisation_access_task.reenable
-    @add_organisation_access_task.invoke(@artefact1.id, organisation_id2)
-    @edition1.reload
+    @remove_all_access_flags_task.invoke(artefact.id)
+    edition1.reload
+    edition2.reload
 
-    assert_includes @edition1.owning_org_content_ids, organisation_id1
-    assert_includes @edition1.owning_org_content_ids, organisation_id2
+    assert_empty edition1.owning_org_content_ids
+    assert_empty edition2.owning_org_content_ids
+  end
 
-    @remove_all_access_flags_task.invoke(@artefact1.id, organisation_id2)
-    @edition1.reload
+  test "remove_all_access_flags does not affect other artefact's editions" do
+    organisation_id1 = "org-id-one"
+    organisation_id2 = "org-id-two"
+    artefact1 = FactoryBot.create(:artefact)
+    edition1 = FactoryBot.create(:edition, panopticon_id: artefact1.id, owning_org_content_ids: [organisation_id1, organisation_id2])
 
-    assert_not_includes @edition1.owning_org_content_ids, organisation_id1
-    assert_not_includes @edition1.owning_org_content_ids, organisation_id2
+    artefact2 = FactoryBot.create(:artefact)
+    edition2 = FactoryBot.create(:edition, panopticon_id: artefact2.id, owning_org_content_ids: [organisation_id1])
+
+    @remove_all_access_flags_task.invoke(artefact1.id)
+    edition1.reload
+    edition2.reload
+
+    assert_empty edition1.owning_org_content_ids
+    assert_includes edition2.owning_org_content_ids, organisation_id1
   end
 end


### PR DESCRIPTION
To be reviewed during next Maintenance sprint - as we still use the add owning org task, it would be useful to update and test this to get it merged in case we need to revert any owning org flags. 

[Trello Card](https://trello.com/c/zCKYKEjC) 
Implements rake task methods which allow the removal of “owning org” flags from an artefact by two methods:

- Remove a particular owning organisation id from an artefact, thereby removing access permission for that particular organisation
- Remove ALL owning organisation ids from an artefact, essentially resetting it to open permission.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
