### PR TITLE
Fix deprecation warnings

### DIFF
--- a/app/helpers/tabbed_nav_helper.rb
+++ b/app/helpers/tabbed_nav_helper.rb
@@ -28,6 +28,17 @@ module TabbedNavHelper
     end
   end
 
+  def assignee_edit_link(edition)
+    if current_user.has_editor_permissions?(edition) && can_update_assignee?(edition)
+      {
+        href: edit_assignee_edition_path,
+        link_text: "Edit",
+      }
+    else
+      {}
+    end
+  end
+
 private
 
   def all_tab_names
@@ -60,5 +71,22 @@ private
         current:,
       },
     ]
+  end
+
+  def available_assignee_items(resource)
+    items = []
+    unless resource.assignee.nil?
+      items << { value: resource.assigned_to_id, text: resource.assignee, checked: true }
+      items << { value: "none", text: "None" }
+      items << :or
+    end
+    User.enabled.order_by([%i[name asc]]).each do |user|
+      items << { value: user.id, text: user.name } unless user.name == resource.assignee
+    end
+    items
+  end
+
+  def can_update_assignee?(resource)
+    %w[published archived scheduled_for_publishing].exclude?(resource.state)
   end
 end

--- a/app/views/editions/secondary_nav_tabs/_edit_assignee.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit_assignee.html.erb
@@ -1,0 +1,37 @@
+<% content_for :title_context, @resource.title %>
+<% content_for :page_title, "Assign person" %>
+<% content_for :title, "Assign person" %>
+
+<%= form_for @resource, url: update_assignee_edition_path(@resource) do %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <%= render "govuk_publishing_components/components/radio", {
+          name: "assignee_id",
+          heading: "Choose a person to assign",
+          visually_hidden_heading: true,
+          items: available_assignee_items(@resource),
+        } %>
+    </div>
+
+    <div class="govuk-grid-column-one-third options-sidebar">
+      <div class="sidebar-components">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Options",
+          heading_level: 3,
+          font_size: "s",
+          padding: true,
+        } %>
+
+        <%= render "govuk_publishing_components/components/list", {
+          items: [
+            (render "govuk_publishing_components/components/button", {
+              text: "Save",
+              margin_bottom: 3,
+            }),
+            link_to("Cancel", edition_path(@resource), class: "govuk-link govuk-link--no-visited-state"),
+          ],
+        } %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -25,6 +25,7 @@
         {
           field: "Assigned to",
           value: @resource.assigned_to,
+          edit: assignee_edit_link(@resource),
         },
         {
           field: "Content type",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,8 @@ Rails.application.routes.draw do
         get "admin/confirm-destroy", to: "editions#confirm_destroy", as: "confirm_destroy"
         delete "admin/delete-edition", to: "editions#destroy", as: "admin_delete"
         post "progress"
+        get "edit_assignee"
+        patch "update_assignee"
         post "skip_fact_check",
              to: "editions#progress",
              edition: {


### PR DESCRIPTION
Merge application secret with application credentials as application secret is going to be deprecated in rails 7.2.
This is kind of a hack to get away with deprecation warnings. All the currently used secrets are present as env variables and can be fetched directly from envs though that would require a relatively bigger changes, hence for now we are merging secrets with credentials.




⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
