### PR TITLE
Move secrets to credentials to stop secrets deprecation warning

### DIFF
--- a/app/controllers/link_checker_api_controller.rb
+++ b/app/controllers/link_checker_api_controller.rb
@@ -46,6 +46,6 @@ private
   end
 
   def webhook_secret_token
-    Rails.application.secrets.link_checker_api_secret_token
+    Rails.application.credentials.link_checker_api_secret_token
   end
 end

--- a/app/services/link_check_report_creator.rb
+++ b/app/services/link_check_report_creator.rb
@@ -48,7 +48,7 @@ private
     GdsApi.link_checker_api.create_batch(
       uris,
       webhook_uri: callback_url,
-      webhook_secret_token: Rails.application.secrets.link_checker_api_secret_token,
+      webhook_secret_token: Rails.application.credentials.link_checker_api_secret_token,
     )
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -63,7 +63,7 @@ module Publisher
     config.asset_host = ENV.fetch("ASSET_HOST", nil)
 
     config.action_mailer.notify_settings = {
-      api_key: Rails.application.secrets.notify_api_key || "fake-test-api-key",
+      api_key: Rails.application.credentials.notify_api_key || "fake-test-api-key",
     }
 
     config.generators do |g|

--- a/config/initializers/secrets_to_credentials.rb
+++ b/config/initializers/secrets_to_credentials.rb
@@ -1,0 +1,7 @@
+# Rails 7 has begun to deprecate Rails.application.secrets in favour
+# of Rails.application.credentials, but that adds the burden of master key
+# administration without giving us any benefit (because our production
+# secrets are handled as env vars, not committed to our repo. Here we
+# load the config/secrets.YML values into Rails.application.credentials,
+# retaining the existing behaviour while dropping deprecated references.
+Rails.application.credentials.merge!(Rails.application.config_for(:secrets))

--- a/test/functional/link_check_reports_controller_test.rb
+++ b/test/functional/link_check_reports_controller_test.rb
@@ -16,7 +16,7 @@ class LinkCheckReportsControllerTest < ActionController::TestCase
         uris: ["https://www.gov.uk"],
         id: 1234,
         webhook_uri: link_checker_api_callback_url(host: Plek.find("publisher")),
-        webhook_secret_token: Rails.application.secrets.link_checker_api_secret_token,
+        webhook_secret_token: Rails.application.credentials.link_checker_api_secret_token,
       )
     end
 

--- a/test/functional/link_checker_api_controller_test.rb
+++ b/test/functional/link_checker_api_controller_test.rb
@@ -48,7 +48,7 @@ class LinkCheckerApiControllerTest < ActionController::TestCase
   def set_headers(post_body)
     headers = {
       "Content-Type": "application/json",
-      "X-LinkCheckerApi-Signature": generate_signature(post_body.to_json, Rails.application.secrets.link_checker_api_secret_token),
+      "X-LinkCheckerApi-Signature": generate_signature(post_body.to_json, Rails.application.credentials.link_checker_api_secret_token),
     }
 
     request.headers.merge! headers

--- a/test/integration/edition_link_check_test.rb
+++ b/test/integration/edition_link_check_test.rb
@@ -13,7 +13,7 @@ class EditionLinkCheckTest < LegacyJavascriptIntegrationTest
       uris: ["https://www.gov.uk"],
       id: 1234,
       webhook_uri: link_checker_api_callback_url(host: Plek.find("publisher")),
-      webhook_secret_token: Rails.application.secrets.link_checker_api_secret_token,
+      webhook_secret_token: Rails.application.credentials.link_checker_api_secret_token,
     )
 
     @place = FactoryBot.create(:place_edition, introduction: "This is [link](https://www.gov.uk) text.")

--- a/test/unit/services/link_check_report_creator_test.rb
+++ b/test/unit/services/link_check_report_creator_test.rb
@@ -14,7 +14,7 @@ class LinkCheckReportCreatorTest < ActiveSupport::TestCase
       uris: ["https://www.gov.uk"],
       id: 1234,
       webhook_uri: link_checker_api_callback_url(host: Plek.find("publisher")),
-      webhook_secret_token: Rails.application.secrets.link_checker_api_secret_token,
+      webhook_secret_token: Rails.application.credentials.link_checker_api_secret_token,
     )
   end
 


### PR DESCRIPTION
Rails 7 has begun to deprecate Rails.application.secrets in favour of Rails.application.credentials, this would ideally need to be fixed by getting secrets from environment variables probably through app config though its a bigger change that we intend to do and for now we have taken this approach of merging secrets with credentials and then just using credentials to stop the noise around deprecation warnings.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
