### PR TITLE
Supress warnings

### DIFF
--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,0 +1,1 @@
+ENV["RUBYOPT"] = "-W0"


### PR DESCRIPTION
Rake task for test has been generating alot of noise "Non US-ASCII detected and no charset defined.
Defaulting to UTF-8, set your own if this is incorrect.". Have tried to fix the warning itself to no avail and hence just suppressing it.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
