### PR TITLE
Edit assignee updates following desk check

### DIFF
--- a/app/helpers/editions_helper.rb
+++ b/app/helpers/editions_helper.rb
@@ -53,4 +53,22 @@ module EditionsHelper
         [displayed_format_name, format_name]
       end
   end
+
+  def document_summary_items(edition)
+    [
+      {
+        field: "Assigned to",
+        value: edition.assigned_to || "None",
+        edit: assignee_edit_link(edition),
+      },
+      {
+        field: "Content type",
+        value: edition.format.underscore.humanize,
+      },
+      {
+        field: "Edition",
+        value: sanitize("#{edition.version_number} <span class='govuk-tag govuk-tag--#{edition.state}'>#{edition.status_text}</span>"),
+      },
+    ]
+  end
 end

--- a/app/helpers/tabbed_nav_helper.rb
+++ b/app/helpers/tabbed_nav_helper.rb
@@ -81,7 +81,7 @@ private
       items << :or
     end
     User.enabled.order_by([%i[name asc]]).each do |user|
-      items << { value: user.id, text: user.name } unless user.name == edition.assignee
+      items << { value: user.id, text: user.name } unless user.name == edition.assignee || !user.has_editor_permissions?(edition)
     end
     items
   end

--- a/app/helpers/tabbed_nav_helper.rb
+++ b/app/helpers/tabbed_nav_helper.rb
@@ -73,15 +73,15 @@ private
     ]
   end
 
-  def available_assignee_items(resource)
+  def available_assignee_items(edition)
     items = []
-    unless resource.assignee.nil?
-      items << { value: resource.assigned_to_id, text: resource.assignee, checked: true }
+    unless edition.assignee.nil?
+      items << { value: edition.assigned_to_id, text: edition.assignee, checked: true }
       items << { value: "none", text: "None" }
       items << :or
     end
     User.enabled.order_by([%i[name asc]]).each do |user|
-      items << { value: user.id, text: user.name } unless user.name == resource.assignee
+      items << { value: user.id, text: user.name } unless user.name == edition.assignee
     end
     items
   end

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -21,21 +21,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds editions__edit__summary">
     <%= render "govuk_publishing_components/components/summary_list", {
-      items: [
-        {
-          field: "Assigned to",
-          value: @resource.assigned_to,
-          edit: assignee_edit_link(@resource),
-        },
-        {
-          field: "Content type",
-          value: @resource.format.underscore.humanize,
-        },
-        {
-          field: "Edition",
-          value: sanitize("#{@resource.version_number} <span class='govuk-tag govuk-tag--#{@resource.state}'>#{@resource.status_text}</span>"),
-        },
-      ],
+      items: document_summary_items(@resource),
     } %>
   </div>
 </div>

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -36,6 +36,22 @@ class EditionEditTest < IntegrationTest
       assert row[2].has_text?("1")
       assert row[2].has_text?("Published")
     end
+
+    should "indicate when an edition does not have an assignee" do
+      within all(".govuk-summary-list__row")[0] do
+        assert_selector(".govuk-summary-list__key", text: "Assigned to")
+        assert_selector(".govuk-summary-list__value", text: "None")
+      end
+    end
+
+    should "show the person assigned to an edition" do
+      visit_draft_edition
+
+      within all(".govuk-summary-list__row")[0] do
+        assert_selector(".govuk-summary-list__key", text: "Assigned to")
+        assert_selector(".govuk-summary-list__value", text: @draft_edition.assignee)
+      end
+    end
   end
 
   context "metadata tab" do

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -10,7 +10,7 @@ class EditionEditTest < IntegrationTest
     stub_linkables
   end
 
-  context "all tabs" do
+  context "edit page" do
     setup do
       visit_published_edition
     end
@@ -51,6 +51,18 @@ class EditionEditTest < IntegrationTest
         assert_selector(".govuk-summary-list__key", text: "Assigned to")
         assert_selector(".govuk-summary-list__value", text: @draft_edition.assignee)
       end
+    end
+  end
+
+  context "edit assignee page" do
+    should "only show editors as available for assignment" do
+      edition = FactoryBot.create(:answer_edition, state: "draft")
+      non_editor_user = FactoryBot.create(:user, name: "Non Editor User")
+
+      visit edit_assignee_edition_path(edition)
+
+      assert_selector "label", text: @govuk_editor.name
+      assert_no_selector "label", text: non_editor_user.name
     end
   end
 


### PR DESCRIPTION
## What
This PR addresses two comments from desk-checking the edit assigned to story:
* It displays the text "None" in the document summary when nobody is assigned to an edition.
* It doesn't show users that would not be able to edit an edition in the list of available users to assign to.

## Screenshots

![image](https://github.com/user-attachments/assets/149c14f9-eefb-47b0-a5c1-23b798555bac)

## Trello

[Trello card](https://trello.com/c/NMCUGhvR/408-edit-assigned-to-for-answer-and-help-content-types-edit-page)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
