### PR TITLE
(703) Add Content Block guidance to Whitehall in non-production environments

### DIFF
--- a/app/views/legacy_editions/_content_block_guidance.html.erb
+++ b/app/views/legacy_editions/_content_block_guidance.html.erb
@@ -1,0 +1,8 @@
+<h3 class="remove-top-margin add-bottom-margin">Content block</h3>
+
+<div class="well">
+  <p>
+    To create, edit and use standardised content, go to the
+    <%= link_to "Content Block Manager (opens in new tab)", "#{Plek.external_url_for('whitehall-admin')}/content-block-manager", target: "_blank", rel: "noopener" %>.
+  </p>
+</div>

--- a/app/views/legacy_editions/show.html.erb
+++ b/app/views/legacy_editions/show.html.erb
@@ -41,6 +41,10 @@
               <div class="well">
                 <%= render "shared/govspeak_help" %>
               </div>
+
+              <% if Flipflop.show_link_to_content_block_manager? %>
+                <%= render "content_block_guidance" %>
+              <% end %>
             <% end %>
           </div>
 

--- a/config/features.rb
+++ b/config/features.rb
@@ -20,4 +20,8 @@ Flipflop.configure do
   feature :restrict_access_by_org,
           default: false,
           description: "Restrict access to editions based on the user's org and which org(s) own the edition"
+
+  feature :show_link_to_content_block_manager,
+          default: %w[integration staging].include?(ENV["GOVUK_ENVIRONMENT"]),
+          description: "Shows link to Content Block Manager from Mainstream editor"
 end

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -529,6 +529,32 @@ class EditionEditTest < IntegrationTest
         end
       end
     end
+
+    context "content block guidance" do
+      context "when show_link_to_content_block_manager? is false" do
+        setup do
+          test_strategy = Flipflop::FeatureSet.current.test!
+          test_strategy.switch!(:show_link_to_content_block_manager, false)
+          visit_draft_edition
+        end
+
+        should "not show the content block guidance" do
+          assert_not page.has_text?("Content block")
+        end
+      end
+
+      context "when show_link_to_content_block_manager? is true" do
+        setup do
+          test_strategy = Flipflop::FeatureSet.current.test!
+          test_strategy.switch!(:show_link_to_content_block_manager, true)
+          visit_draft_edition
+        end
+
+        should "show the content block guidance" do
+          assert page.has_text?("Content block")
+        end
+      end
+    end
   end
 
 private


### PR DESCRIPTION
https://trello.com/c/UZJt5Je1/703-update-mainstream-publisher-to-allow-insert-journey

To allow user testing of the "insert" journey for Content Modelling, we need to add a link to the Content Block Manager in the sidebar when editing content. This is enabled by a feature flag, which is set to true by default in Staging/Integration.

## Screenshot

![image](https://github.com/user-attachments/assets/3bb480fa-f20c-408d-868e-1baf7c3bf7af)
