### PR TITLE
Update button text from "Update" to "Save"

### DIFF
--- a/app/views/editions/secondary_nav_tabs/_admin.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_admin.html.erb
@@ -21,7 +21,7 @@
         } %>
 
         <%= render "govuk_publishing_components/components/button", {
-          text: "Update",
+          text: "Save",
         } %>
       <% end %>
     <% else %>


### PR DESCRIPTION
[Trello](https://trello.com/c/qLZmHXIu/472-admin-update-content-type-edit-admin)

This makes a small update post desk-check to change the button text on the admin tab from "Update" to "Save". 

|Current|Update|
|-|-|
|![Screenshot 2024-12-02 at 15 31 54](https://github.com/user-attachments/assets/30418835-e596-48a8-9193-861370f6f2e8)|![Screenshot 2024-12-02 at 15 31 32](https://github.com/user-attachments/assets/b4069afc-5f59-41c3-9d11-58e4df026a76)|
