### PR TITLE
Get content by content id

### DIFF
--- a/app/controllers/content_item_controller.rb
+++ b/app/controllers/content_item_controller.rb
@@ -4,7 +4,12 @@ class ContentItemController < ApplicationController
       Artefact.find_by(content_id: params[:content_id])
 
     if artefact
-      redirect_to edition_path(artefact.latest_edition)
+      redirect_url = if Flipflop.enabled?("design_system_publications_filter".to_sym)
+                       "/?title_filter=#{artefact.latest_edition.title}&assignee_filter=&content_type_filter=all&states_filter%5B%5D=draft&states_filter%5B%5D=in_review&states_filter%5B%5D=amends_needed&states_filter%5B%5D=fact_check&states_filter%5B%5D=fact_check_received&states_filter%5B%5D=ready&states_filter%5B%5D=scheduled_for_publishing&states_filter%5B%5D=published"
+                     else
+                       "/?list=published&string_filter=#{artefact.latest_edition.slug}&user_filter=all"
+                     end
+      redirect_to redirect_url
     else
       redirect_to_root_path_with_error
     end

--- a/test/functional/content_item_controller_test.rb
+++ b/test/functional/content_item_controller_test.rb
@@ -4,19 +4,45 @@ class ContentItemControllerTest < ActionController::TestCase
   def setup
     login_as_stub_user
     @edition = FactoryBot.create(:edition)
+    @test_strategy = Flipflop::FeatureSet.current.test!
   end
 
-  should "redirect to content by content_id" do
-    get :by_content_id, params: { content_id: @edition.content_id }
+  context "design_system_publications_filter switch is enabled" do
+    setup do
+      @test_strategy.switch!(:design_system_publications_filter, true)
+    end
 
-    assert_redirected_to edition_path(@edition.artefact.latest_edition)
+    should "redirect to new design system publications page" do
+      get :by_content_id, params: { content_id: @edition.content_id }
+
+      assert_routing("/", controller: "root", action: "index")
+    end
+
+    should "redirect to root with error message if content_id is not found" do
+      get :by_content_id, params: { content_id: "#{@edition.artefact.content_id}wrong-id" }
+
+      assert_redirected_to root_path
+      assert_equal "The requested content was not found", flash[:danger]
+    end
   end
 
-  should "redirect to root with error message if content_id is not found" do
-    get :by_content_id, params: { content_id: "#{@edition.artefact.content_id}wrong-id" }
+  context "design_system_publications_filter switch is disabled" do
+    setup do
+      @test_strategy.switch!(:design_system_publications_filter, false)
+    end
 
-    assert_redirected_to root_path
-    assert_equal "The requested content was not found", flash[:danger]
+    should "redirect to old bootstrap ui publications page" do
+      get :by_content_id, params: { content_id: @edition.content_id }
+
+      assert_routing("/", controller: "legacy_root", action: "index")
+    end
+
+    should "redirect to root with error message if content_id is not found" do
+      get :by_content_id, params: { content_id: "#{@edition.artefact.content_id}wrong-id" }
+
+      assert_redirected_to root_path
+      assert_equal "The requested content was not found", flash[:danger]
+    end
   end
 
   should "redirect to root with error message if any error" do

--- a/test/integration/get_content_by_content_id_test.rb
+++ b/test/integration/get_content_by_content_id_test.rb
@@ -1,0 +1,116 @@
+require "integration_test_helper"
+
+class GetContentByContentIdTest < IntegrationTest
+  def setup
+    login_as_stub_user
+    @artefact = FactoryBot.create(:artefact, name: "browser extension test")
+    @test_strategy = Flipflop::FeatureSet.current.test!
+  end
+
+  context "design_system_publications_filter switch is enabled" do
+    setup do
+      @test_strategy.switch!(:design_system_publications_filter, true)
+    end
+
+    should "show only one edition when content item has only one draft edition" do
+      create_draft_edition
+      visit "by-content-id/#{@draft_edition.content_id}"
+
+      assert_content("1 document(s)")
+      assert page.has_content?("some title")
+    end
+
+    should "show only one edition when content item has only one published edition" do
+      create_published_edition
+      visit "by-content-id/#{@published_edition.content_id}"
+
+      assert_content("1 document(s)")
+      assert page.has_content?("some title")
+    end
+
+    should "show two editions when content item has one published and one draft edition" do
+      create_published_edition
+      create_draft_edition
+      visit "by-content-id/#{@published_edition.content_id}"
+
+      assert_content("2 document(s)")
+      assert page.has_content?("some title")
+    end
+  end
+
+  context "design_system_publications_filter switch is disabled" do
+    setup do
+      @test_strategy.switch!(:design_system_publications_filter, false)
+    end
+
+    context "Content items that have only one edition, in the draft state" do
+      should "show main list as empty and 'filter by status' counts all as zero except for 'Drafts'" do
+        filter_by_status = ["Filter by Status", "Drafts 1", "In review 0", "Amends needed 0", "Out for fact check 0", "Fact check received 0", "Ready 0", "Scheduled 0", "Published 0", "Archived 0"]
+        create_draft_edition
+        visit "by-content-id/#{@draft_edition.content_id}"
+
+        sidebar_filter_by_status = find_all(".nav-list")[0]
+        within sidebar_filter_by_status do
+          statuses = find_all("li")
+          statuses.each do |status|
+            assert filter_by_status.include?(status.text)
+          end
+        end
+
+        assert page.has_no_css?("#publication-list-container table tbody tr")
+        assert page.has_no_content?("some title")
+      end
+    end
+
+    context "Content items that have only one edition, in the published state " do
+      should "show main list with a single edition and a 'Create new edition' button and 'filter by status' counts all as zero except for 'Published'" do
+        filter_by_status = ["Filter by Status", "Drafts 0", "In review 0", "Amends needed 0", "Out for fact check 0", "Fact check received 0", "Ready 0", "Scheduled 0", "Published 1", "Archived 0"]
+        create_published_edition
+        visit "by-content-id/#{@published_edition.content_id}"
+
+        sidebar_filter_by_status = find_all(".nav-list")[0]
+        within sidebar_filter_by_status do
+          statuses = find_all("li")
+          statuses.each do |status|
+            assert filter_by_status.include?(status.text)
+          end
+        end
+
+        assert page.has_css?("#publication-list-container table tbody tr")
+        assert page.has_content?("some title")
+        assert page.has_link?("Create new edition")
+      end
+    end
+
+    context "Content items that have one edition in the published state and one item in draft state " do
+      should "show main list with a single edition and a 'Edit newer edition' button and 'filter by status' counts all as zero except for 'Published' and 'Draft'" do
+        filter_by_status = ["Filter by Status", "Drafts 1", "In review 0", "Amends needed 0", "Out for fact check 0", "Fact check received 0", "Ready 0", "Scheduled 0", "Published 1", "Archived 0"]
+        create_published_edition
+        create_draft_edition
+        visit "by-content-id/#{@published_edition.content_id}"
+
+        sidebar_filter_by_status = find_all(".nav-list")[0]
+        within sidebar_filter_by_status do
+          statuses = find_all("li")
+          statuses.each do |status|
+            assert filter_by_status.include?(status.text)
+          end
+        end
+
+        assert page.has_css?("#publication-list-container table tbody tr")
+        assert page.has_content?("some title")
+        assert page.has_link?("Edit newer edition")
+      end
+    end
+  end
+
+private
+
+  def create_draft_edition
+    @draft_edition = FactoryBot.create(:edition, state: :draft, title: "some title", panopticon_id: @artefact.id, slug: "browser-extension-test")
+  end
+
+  def create_published_edition
+    @published_edition = FactoryBot.create(:edition, state: :published, title: "some title", panopticon_id: @artefact.id, slug: "browser-extension-test")
+  end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/ALBWddMn/519-implement-a-new-endpoint-for-searching-by-content-id-mainstream)

Implement an endpoint in Mainstream Publisher that takes a content ID as a parameter, and returns a redirect to the publications (search) page with the appropriate query parameters set.

Note that a route has already been created at /by-content-id/:content_id, which routes to the ContentItemController—this can be used as a starting point (this endpoint was created as part of the first attempt to fix the browser extension issue, and so is not currently in use and can safely be adapted)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
