### PR TITLE
Add owning_org_content_ids to base_field_keys

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -530,6 +530,7 @@ private
       panopticon_id
       overview
       slug
+      owning_org_content_ids
     ]
   end
 

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -176,11 +176,13 @@ class EditionTest < ActiveSupport::TestCase
       version_number: 1,
       overview: "I am a test overview",
       in_beta: true,
+      owning_org_content_ids: %w[org-1],
     )
     clone_edition = edition.build_clone
     assert_equal "I am a test overview", clone_edition.overview
     assert_equal true, clone_edition.in_beta
     assert_equal 2, clone_edition.version_number
+    assert_equal %w[org-1], clone_edition.owning_org_content_ids
   end
 
   test "cloning can only occur from a published edition" do


### PR DESCRIPTION
This is to ensure new editions have wning_org_content_ids copied from existing ones so department users can create new content

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
