### PR TITLE
Update access and permissions rake task

### DIFF
--- a/lib/tasks/access_and_permissions.rake
+++ b/lib/tasks/access_and_permissions.rake
@@ -11,8 +11,9 @@ namespace :permissions do
       message = "Organisation with ID: #{args[:org_content_id]} already has permission to access the document with ID: #{document.id}"
     else
       Edition.where(panopticon_id: document.id).each do |edition|
-        edition.owning_org_content_ids << args[:org_content_id]
-        edition.save!(validate: false)
+        owning_org_content_ids = edition.owning_org_content_ids
+        owning_org_content_ids << args[:org_content_id]
+        edition.set(owning_org_content_ids:)
       end
       document.save_as_task!("PermissionsAddition")
       message = "Access permission for organisation ID: #{args[:org_content_id]}, successfully assigned to document with ID: #{document.id}"

--- a/test/unit/tasks/access_and_permissions_test.rb
+++ b/test/unit/tasks/access_and_permissions_test.rb
@@ -41,6 +41,23 @@ class AccessAndPermissionsTaskTest < ActiveSupport::TestCase
     assert_equal(1, @edition1.owning_org_content_ids.count { |id| id == organisation_id })
   end
 
+  test "add_organisation_access does not update 'updated_at' values" do
+    organisation_id = "test-org-id"
+    # For some reason, the "updated_at" value when reloaded is different from the one in the object returned by the
+    # factory, so we need to do a reload before storing a copy of the original value.
+    @edition1.reload
+    @artefact1.reload
+    original_edition_updated_at = @edition1.updated_at
+    original_artefact_updated_at = @artefact1.updated_at
+
+    @add_organisation_access_task.invoke(@artefact1.id, organisation_id)
+    @edition1.reload
+    @artefact1.reload
+
+    assert_equal(original_edition_updated_at, @edition1.updated_at)
+    assert_equal(original_artefact_updated_at, @artefact1.updated_at)
+  end
+
   test "bulk_process_access_flags processes all rows in CSV" do
     organisation_id = "test-org-id"
 


### PR DESCRIPTION
Update the rake task for adding owning organisations to publications so that the "updated_at" field is not updated, which given published and archived editions are being modified will avoid potential confusion of them looking like they were updated after publishing/archival.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️