### PR TITLE
Rename method to avoid misleading readers

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -15,7 +15,7 @@ class EditionsController < InheritedResources::Base
     require_editor_permissions
   end
   before_action only: %i[confirm_destroy destroy] do
-    destroyable_edition?
+    require_destroyable
   end
 
   before_action only: %i[edit_assignee update_assignee] do
@@ -217,7 +217,7 @@ private
     params.require(:edition).permit(%i[title overview in_beta body major_change change_note])
   end
 
-  def destroyable_edition?
+  def require_destroyable
     return if @resource.can_destroy?
 
     flash[:danger] = "Cannot delete a #{description(@resource).downcase} that has ever been published."


### PR DESCRIPTION
The `destroyable_edition?` method had a misleading name, as it isn't a
 querying method that returns a boolean value—it checks whether an
 edition is destroyable and, if it isn't, shows a flash message and
 redirects to the edition's show page.

There's already a similar method, `require_assignee_editable`, for
 checking whether an edition can have its assignee updated, so rename
 the method to be consistent with that one.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
