### PR TITLE
Revert "Merge pull request #2495 from alphagov/enable-permission-rest…

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -18,7 +18,7 @@ Flipflop.configure do
           description: "Update the publications edit page to use the GOV.UK Design System"
 
   feature :restrict_access_by_org,
-          default: true,
+          default: false,
           description: "Restrict access to editions based on the user's org and which org(s) own the edition"
 
   feature :show_link_to_content_block_manager,

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -4,7 +4,7 @@ class EditionsControllerTest < ActionController::TestCase
   setup do
     login_as_stub_user
     test_strategy = Flipflop::FeatureSet.current.test!
-    test_strategy.switch!(:restrict_access_by_org, true)
+    test_strategy.switch!(:restrict_access_by_org, false)
     @edition = FactoryBot.create(:edition, :fact_check)
     @welsh_edition = FactoryBot.create(:edition, :fact_check, :welsh)
   end
@@ -46,16 +46,6 @@ class EditionsControllerTest < ActionController::TestCase
   end
 
   context "when 'restrict_access_by_org' feature toggle is disabled" do
-    setup do
-      test_strategy = Flipflop::FeatureSet.current.test!
-      test_strategy.switch!(:restrict_access_by_org, false)
-    end
-
-    teardown do
-      test_strategy = Flipflop::FeatureSet.current.test!
-      test_strategy.switch!(:restrict_access_by_org, true)
-    end
-
     %i[show metadata history admin related_external_links unpublish].each do |action|
       context "##{action}" do
         setup do
@@ -74,6 +64,16 @@ class EditionsControllerTest < ActionController::TestCase
   end
 
   context "when 'restrict_access_by_org' feature toggle is enabled" do
+    setup do
+      test_strategy = Flipflop::FeatureSet.current.test!
+      test_strategy.switch!(:restrict_access_by_org, true)
+    end
+
+    teardown do
+      test_strategy = Flipflop::FeatureSet.current.test!
+      test_strategy.switch!(:restrict_access_by_org, false)
+    end
+
     %i[show metadata history admin related_external_links unpublish].each do |action|
       context "##{action}" do
         setup do

--- a/test/functional/legacy_editions_controller_test.rb
+++ b/test/functional/legacy_editions_controller_test.rb
@@ -7,7 +7,7 @@ class LegacyEditionsControllerTest < ActionController::TestCase
     stub_holidays_used_by_fact_check
 
     test_strategy = Flipflop::FeatureSet.current.test!
-    test_strategy.switch!(:restrict_access_by_org, true)
+    test_strategy.switch!(:restrict_access_by_org, false)
   end
 
   context "#create" do
@@ -1309,16 +1309,6 @@ class LegacyEditionsControllerTest < ActionController::TestCase
   end
 
   context "when 'restrict_access_by_org' feature toggle is disabled" do
-    setup do
-      test_strategy = Flipflop::FeatureSet.current.test!
-      test_strategy.switch!(:restrict_access_by_org, false)
-    end
-
-    teardown do
-      test_strategy = Flipflop::FeatureSet.current.test!
-      test_strategy.switch!(:restrict_access_by_org, true)
-    end
-
     %i[metadata history].each do |action|
       context "##{action}" do
         setup do
@@ -1337,6 +1327,16 @@ class LegacyEditionsControllerTest < ActionController::TestCase
   end
 
   context "when 'restrict_access_by_org' feature toggle is enabled" do
+    setup do
+      test_strategy = Flipflop::FeatureSet.current.test!
+      test_strategy.switch!(:restrict_access_by_org, true)
+    end
+
+    teardown do
+      test_strategy = Flipflop::FeatureSet.current.test!
+      test_strategy.switch!(:restrict_access_by_org, false)
+    end
+
     %i[show metadata history admin unpublish duplicate update linking update_tagging update_related_external_links review destroy progress diff process_unpublish diagram].each do |action|
       context "##{action}" do
         setup do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -52,7 +52,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "#gds_editor? is false if user's organisation is not GDS" do
-    user = FactoryBot.create(:user, organisation_slug: "some-other-org", organisation_content_id: "some-other-org-id")
+    user = FactoryBot.create(:user, organisation_slug: "some-other-org")
 
     assert_not user.gds_editor?
   end

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -8,7 +8,6 @@ FactoryBot.define do
     sequence(:uid) { |n| "uid-#{n}" }
     sequence(:name) { |n| "Joe Bloggs #{n}" }
     sequence(:email) { |n| "joe#{n}@bloggs.com" }
-    organisation_content_id { PublishService::GDS_ORGANISATION_ID }
 
     if defined?(GDS::SSO::Config)
       # Grant permission to signin to the app using the gem


### PR DESCRIPTION
…rictions"

This reverts commit 7753720d9668279fb275f1d15064b85fd6f37af1, reversing changes made to 00b2fe850a3522b93e85622632c35e2aef290f35.

Reverting this change as it is impacting other non-GDS users of Mainstream Publisher that we were unaware of

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
