### PR TITLE
Add slug text for editions listed on publications table

### DIFF
--- a/app/views/root/_table.html.erb
+++ b/app/views/root/_table.html.erb
@@ -20,7 +20,8 @@
       [
         {
           text:
-            sanitize("<p class='title govuk-body'><a href='editions/#{publication._id}' class='govuk-link govuk-!-font-weight-bold'>#{publication.title}</a></p>") +
+            sanitize("<p class='title govuk-body govuk-!-margin-bottom-0'><a href='editions/#{publication._id}' class='govuk-link govuk-!-font-weight-bold'>#{publication.title}</a></p>") +
+              sanitize("<p class='govuk-body'>/#{publication.slug}</p>") +
               (render "govuk_publishing_components/components/details", {
                 title: "More details",
               } do

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -146,7 +146,7 @@ class RootControllerTest < ActionController::TestCase
 
       assert_response :ok
       assert_select "p.publications-table__heading", "1 document(s)"
-      assert_select "p.title", "What to do in the event of a zombie apocalypse"
+      assert_select "p.title", /What to do in the event of a zombie apocalypse/
     end
 
     should "ignore unrecognised filter states" do

--- a/test/integration/root_overview_test.rb
+++ b/test/integration/root_overview_test.rb
@@ -303,4 +303,14 @@ class RootOverviewTest < IntegrationTest
     assert page.has_content?("Draft guide")
     assert page.has_no_content?("Popular links edition")
   end
+
+  should "show slug for editions on publications table" do
+    alice = FactoryBot.create(:user, :govuk_editor, name: "Alice", uid: "alice")
+    edition = FactoryBot.create(:edition, title: "Guides and Gals", assigned_to: alice)
+
+    visit "/"
+    row = find_all(".govuk-table__row")
+
+    assert row[1].text.include?("/#{edition.slug}")
+  end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/jVusqS9k/538-display-the-slug-in-the-table-on-the-publications-page-publications-page)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
