### PR TITLE
Add user to top assignee list

### DIFF
--- a/app/presenters/filtered_editions_presenter.rb
+++ b/app/presenters/filtered_editions_presenter.rb
@@ -44,15 +44,13 @@ class FilteredEditionsPresenter
 
   def assignees
     users = [{ text: "All assignees", value: "" }]
+    users << create_assignee_list_item(@user)
 
     available_users.map do |user|
-      users << if user.id.to_s == @assigned_to_filter
-                 { text: user.name, value: user.id, selected: "true" }
-               else
-                 { text: user.name, value: user.id }
-               end
-    end
+      next if user == @user
 
+      users << create_assignee_list_item(user)
+    end
     users
   end
 
@@ -61,6 +59,19 @@ class FilteredEditionsPresenter
   end
 
 private
+
+  def create_assignee_list_item(user)
+    user_name = if user == @user
+                  "#{user.name} (You)"
+                else
+                  user.name
+                end
+    if user.id.to_s == @assigned_to_filter
+      { text: user_name, value: user.id, selected: "true" }
+    else
+      { text: user_name, value: user.id }
+    end
+  end
 
   def query_editions
     result = editions_by_content_type


### PR DESCRIPTION
Update the list of users in the “Assigned to” dropdown to move the current user to the top of the list, under “All assignees” and append (You).

Trello: https://trello.com/c/xBKmLTnk/539-move-logged-in-user-to-top-of-assigned-to-list-in-publications-filter-publications-page

![TopUser](https://github.com/user-attachments/assets/83da062e-cf78-4b96-bcde-2f61ed2a302b)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
