### PR TITLE
Add Actionlint Github checks to Publisher Repo

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,12 @@
+name: Lint GitHub Actions
+on:
+  push:
+    paths: ['.github/**']
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+      - uses: alphagov/govuk-infrastructure/.github/actions/actionlint@main


### PR DESCRIPTION
## What?
This adds Github Action Linting Checks to Publisher. This makes it harder to merge broken Workflows. :-)