### PR TITLE
(Content modelling/785) Show content block updates in Mainstream

### DIFF
--- a/app/controllers/legacy_editions_controller.rb
+++ b/app/controllers/legacy_editions_controller.rb
@@ -33,6 +33,7 @@ class LegacyEditionsController < InheritedResources::Base
 
     @tagging_update = tagging_update_form
     @artefact = @resource.artefact
+    @update_events = HostContentUpdateEvent.all_for_artefact(@artefact)
     render action: "show"
   end
 
@@ -115,6 +116,7 @@ class LegacyEditionsController < InheritedResources::Base
         @tagging_update = tagging_update_form
         @linkables = Tagging::Linkables.new
         @artefact = @resource.artefact
+        @update_events = HostContentUpdateEvent.all_for_artefact(@artefact)
         render action: "show"
       end
       success.json do
@@ -134,6 +136,7 @@ class LegacyEditionsController < InheritedResources::Base
     @linkables = Tagging::Linkables.new
     @tagging_update = tagging_update_form
     @artefact = @resource.artefact
+    @update_events = HostContentUpdateEvent.all_for_artefact(@artefact)
     render action: "show"
   end
 

--- a/app/helpers/action_helper.rb
+++ b/app/helpers/action_helper.rb
@@ -1,8 +1,11 @@
 module ActionHelper
-  def edition_actions(edition)
-    edition.actions.reverse.delete_if do |a|
+  def edition_actions(edition, update_events)
+    actions = edition.actions.reject do |a|
       [Action::IMPORTANT_NOTE, Action::IMPORTANT_NOTE_RESOLVED].include?(a.request_type)
     end
+    update_actions = update_events.select { |e| e.is_for_edition?(edition) }.map(&:to_action)
+    actions.append(*update_actions)
+    actions.sort_by(&:created_at).reverse
   end
 
   def action_note?(action)

--- a/app/helpers/action_helper.rb
+++ b/app/helpers/action_helper.rb
@@ -13,9 +13,12 @@ module ActionHelper
     notes = []
 
     if action.comment.present?
-      if action.request_type == Action::RECEIVE_FACT_CHECK
+      case action.request_type
+      when Action::RECEIVE_FACT_CHECK
         formatted_email_parts = format_email_text(action.comment)
         notes.concat(formatted_email_parts)
+      when HostContentUpdateEvent::Action::CONTENT_BLOCK_UPDATE
+        notes << content_block_update_comment(action)
       else
         notes << format_and_auto_link_plain_text(action.comment)
       end
@@ -30,6 +33,10 @@ module ActionHelper
     end
 
     notes.join.html_safe
+  end
+
+  def content_block_update_comment(action)
+    "#{action.comment} (#{link_to 'View in Content Block Manager', action.block_url, target: '_blank', rel: 'noopener'})"
   end
 
   def action_class(action)

--- a/app/lib/services.rb
+++ b/app/lib/services.rb
@@ -4,7 +4,14 @@ module Services
   def self.publishing_api
     @publishing_api ||= GdsApi::PublishingApi.new(
       Plek.find("publishing-api"),
-      bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example",
+      bearer_token: ENV.fetch("PUBLISHING_API_BEARER_TOKEN", "example"),
+    )
+  end
+
+  def self.signon_api
+    @signon_api ||= GdsApi::SignonApi.new(
+      Plek.find("signon", external: true),
+      bearer_token: ENV.fetch("SIGNON_API_BEARER_TOKEN", "example"),
     )
   end
 end

--- a/app/models/host_content_update_event.rb
+++ b/app/models/host_content_update_event.rb
@@ -34,4 +34,8 @@ class HostContentUpdateEvent < Data.define(:author, :created_at, :content_id, :c
       false
     end
   end
+
+  def to_action
+    Action.new(self)
+  end
 end

--- a/app/models/host_content_update_event.rb
+++ b/app/models/host_content_update_event.rb
@@ -1,0 +1,27 @@
+class HostContentUpdateEvent < Data.define(:author, :created_at, :content_id, :content_title, :document_type)
+  Author = Data.define(:name, :email)
+  def self.all_for_artefact(artefact)
+    events = Services.publishing_api.get_events_for_content_id(artefact.content_id, {
+      action: "HostContentUpdateJob",
+    })
+
+    user_uuids = events.map { |event| event["payload"]["source_block"]["updated_by_user_uid"] }
+    users = users_with_uuids(user_uuids)
+
+    events.map do |event|
+      HostContentUpdateEvent.new(
+        author: users[event["payload"]["source_block"]["updated_by_user_uid"]],
+        created_at: Time.zone.parse(event["created_at"]),
+        content_id: event["payload"]["source_block"]["content_id"],
+        content_title: event["payload"]["source_block"]["title"],
+        document_type: event["payload"]["source_block"]["document_type"],
+      )
+    end
+  end
+
+  def self.users_with_uuids(uuids)
+    Services.signon_api.get_users(uuids:).map { |user|
+      [user["uid"], Author.new(user["name"], user["email"])]
+    }.to_h
+  end
+end

--- a/app/models/host_content_update_event/action.rb
+++ b/app/models/host_content_update_event/action.rb
@@ -1,0 +1,57 @@
+class HostContentUpdateEvent
+  class Action
+    CONTENT_BLOCK_UPDATE = "content_block_update".freeze
+
+    attr_reader :host_content_update_event
+
+    def initialize(host_content_update_event)
+      @host_content_update_event = host_content_update_event
+    end
+
+    def request_type
+      CONTENT_BLOCK_UPDATE
+    end
+
+    delegate :created_at, to: :host_content_update_event
+
+    def requester
+      host_content_update_event.author
+    end
+
+    def to_s
+      "Content block updated"
+    end
+
+    def comment
+      "#{humanized_document_type} updated"
+    end
+
+    def block_url
+      [
+        Plek.external_url_for("whitehall-admin"),
+        "content-block-manager",
+        "content-block",
+        "content-id",
+        host_content_update_event.content_id,
+      ].join("/")
+    end
+
+    def comment_sanitized
+      false
+    end
+
+    def is_fact_check_request?
+      false
+    end
+
+    def recipient_id
+      nil
+    end
+
+  private
+
+    def humanized_document_type
+      host_content_update_event.document_type.delete_prefix("content_block_").humanize
+    end
+  end
+end

--- a/app/traits/recordable_actions.rb
+++ b/app/traits/recordable_actions.rb
@@ -40,13 +40,21 @@ module RecordableActions
     end
 
     def published_by
-      publication = actions.where(request_type: Action::PUBLISH).first
-      publication.requester if publication
+      latest_action_of_type(Action::PUBLISH)&.requester
     end
 
-    def archived_by
-      publication = actions.where(request_type: Action::ARCHIVE).first
-      publication.requester if publication
+    def published_at
+      latest_action_of_type(Action::PUBLISH)&.created_at
+    end
+
+    def superseded_at
+      subsequent_siblings.first&.published_at
+    end
+
+  private
+
+    def latest_action_of_type(request_type)
+      actions.where(request_type:).first
     end
   end
 end

--- a/app/views/shared/_edition_history.html.erb
+++ b/app/views/shared/_edition_history.html.erb
@@ -12,7 +12,7 @@
 
     <div class="panel-collapse collapse<% if edition_counter == 0 %> in<% end %>" id="body<%= edition.version_number %>">
       <ul class="panel-body list-unstyled remove-bottom-margin">
-        <% edition_actions(edition).each do |action| %>
+        <% edition_actions(edition, update_events).each do |action| %>
           <li class="action-<%= action_class(action) %> add-bottom-margin add-left-margin">
             <h3 class="h4">
               <div class="add-label-margin normal">

--- a/app/views/shared/_history.html.erb
+++ b/app/views/shared/_history.html.erb
@@ -96,6 +96,6 @@
   </p>
 
   <div class="panel-group">
-    <%= render collection: @resource.history, partial: "/shared/edition_history", as: "edition" %>
+    <%= render collection: @resource.history, partial: "/shared/edition_history", as: "edition", locals: { update_events: @update_events } %>
   </div>
 </div>

--- a/test/functional/legacy_editions_controller_test.rb
+++ b/test/functional/legacy_editions_controller_test.rb
@@ -5,6 +5,8 @@ class LegacyEditionsControllerTest < ActionController::TestCase
     login_as_stub_user
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
 
     test_strategy = Flipflop::FeatureSet.current.test!
     test_strategy.switch!(:restrict_access_by_org, false)

--- a/test/integration/add_artefact_test.rb
+++ b/test/integration/add_artefact_test.rb
@@ -5,6 +5,8 @@ class AddArtefactTest < LegacyIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
   end
 
   should "create a new artefact" do

--- a/test/integration/adding_parts_to_guides_test.rb
+++ b/test/integration/adding_parts_to_guides_test.rb
@@ -5,6 +5,8 @@ class AddingPartsToGuidesTest < LegacyJavascriptIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
 
     test_strategy = Flipflop::FeatureSet.current.test!
     test_strategy.switch!(:design_system_publications_filter, false)

--- a/test/integration/adding_variants_to_transactions_test.rb
+++ b/test/integration/adding_variants_to_transactions_test.rb
@@ -5,6 +5,8 @@ class AddingVariantsToTransactionsTest < LegacyJavascriptIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
 
     test_strategy = Flipflop::FeatureSet.current.test!
     test_strategy.switch!(:design_system_publications_filter, false)

--- a/test/integration/change_edition_type_test.rb
+++ b/test/integration/change_edition_type_test.rb
@@ -5,6 +5,8 @@ class ChangeEditionTypeTest < LegacyJavascriptIntegrationTest
     stub_linkables
     FactoryBot.create(:user, :govuk_editor)
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
   end
 
   teardown do

--- a/test/integration/completed_transactions_create_edit_test.rb
+++ b/test/integration/completed_transactions_create_edit_test.rb
@@ -13,6 +13,8 @@ class CompletedTransactionCreateEditTest < LegacyJavascriptIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
   end
 
   should "create a new CompletedTransactionEdition" do

--- a/test/integration/delete_edition_test.rb
+++ b/test/integration/delete_edition_test.rb
@@ -5,6 +5,8 @@ class DeleteEditionTest < LegacyIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
 
     test_strategy = Flipflop::FeatureSet.current.test!
     test_strategy.switch!(:design_system_publications_filter, false)

--- a/test/integration/edit_artefact_test.rb
+++ b/test/integration/edit_artefact_test.rb
@@ -5,6 +5,8 @@ class EditArtefactTest < LegacyIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
     test_strategy = Flipflop::FeatureSet.current.test!
     test_strategy.switch!(:design_system_edit, false)
   end

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -8,6 +8,8 @@ class EditionEditTest < IntegrationTest
     test_strategy.switch!(:design_system_edit, true)
     stub_holidays_used_by_fact_check
     stub_linkables
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
   end
 
   context "edit page" do

--- a/test/integration/edition_history_test.rb
+++ b/test/integration/edition_history_test.rb
@@ -5,6 +5,8 @@ class EditionHistoryTest < LegacyJavascriptIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
   end
 
   context "viewing the history and notes tab" do

--- a/test/integration/edition_link_check_test.rb
+++ b/test/integration/edition_link_check_test.rb
@@ -8,6 +8,8 @@ class EditionLinkCheckTest < LegacyJavascriptIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
 
     @stubbed_api_request = stub_link_checker_api_create_batch(
       uris: ["https://www.gov.uk"],

--- a/test/integration/edition_major_change_test.rb
+++ b/test/integration/edition_major_change_test.rb
@@ -5,6 +5,8 @@ class EditionMajorChangeTest < LegacyJavascriptIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
   end
 
   teardown do

--- a/test/integration/edition_scheduled_publishing_test.rb
+++ b/test/integration/edition_scheduled_publishing_test.rb
@@ -5,6 +5,8 @@ class EditionScheduledPublishingTest < LegacyJavascriptIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
     # queue up the edition, don't perform inline
     Sidekiq::Testing.fake!
 

--- a/test/integration/edition_tab_test.rb
+++ b/test/integration/edition_tab_test.rb
@@ -5,6 +5,8 @@ class EditionTabTest < LegacyJavascriptIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
 
     @guide = FactoryBot.create(:guide_edition, state: "draft")
   end

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -8,6 +8,8 @@ class EditionWorkflowTest < LegacyJavascriptIntegrationTest
   setup do
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
 
     @alice = FactoryBot.create(:user, :govuk_editor, name: "Alice")
     @bob = FactoryBot.create(:user, :govuk_editor, name: "Bob")

--- a/test/integration/guide_create_edit_test.rb
+++ b/test/integration/guide_create_edit_test.rb
@@ -5,6 +5,8 @@ class GuideCreateEditTest < LegacyJavascriptIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
 
     @artefact = FactoryBot.create(
       :artefact,

--- a/test/integration/help_page_create_edit_test.rb
+++ b/test/integration/help_page_create_edit_test.rb
@@ -13,6 +13,8 @@ class HelpPageCreateEditTest < LegacyJavascriptIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
   end
 
   should "create a new HelpPageEdition" do

--- a/test/integration/host_content_update_history_test.rb
+++ b/test/integration/host_content_update_history_test.rb
@@ -1,0 +1,141 @@
+require "legacy_integration_test_helper"
+
+class HostContentUpdateHistoryTest < LegacyJavascriptIntegrationTest
+  setup do
+    setup_users
+    stub_linkables
+    stub_holidays_used_by_fact_check
+  end
+
+  context "Viewing content update history" do
+    setup do
+      user1 = {
+        "uid" => SecureRandom.uuid,
+        "name" => "User 1",
+        "email" => "user1@example.com",
+      }
+
+      user2 = {
+        "uid" => SecureRandom.uuid,
+        "name" => "User 2",
+        "email" => "user2@example.com",
+      }
+
+      @host_content_update_events = []
+
+      @out_of_scope_content_update_event = create_content_update_event(
+        updated_by_user_uid: user1["uid"],
+      )
+
+      some_time_passes
+      edition1 = FactoryBot.create(:answer_edition, slug: "test-slug")
+
+      some_time_passes
+      edition1.new_action(@author, Action::SEND_FACT_CHECK)
+
+      some_time_passes
+      edition1.new_action(@author, Action::RECEIVE_FACT_CHECK)
+
+      some_time_passes
+      edition1.new_action(@author, Action::PUBLISH)
+      edition1.state = "published"
+      edition1.save!
+
+      some_time_passes
+      @edition1_content_update_event = create_content_update_event(
+        updated_by_user_uid: user1["uid"],
+      )
+
+      some_time_passes
+      edition2 = edition1.build_clone
+      edition2.save!
+
+      some_time_passes
+      edition2.new_action(@author, Action::SEND_FACT_CHECK)
+
+      some_time_passes
+      edition2.new_action(@author, Action::RECEIVE_FACT_CHECK)
+
+      some_time_passes
+      edition2.new_action(@author, Action::PUBLISH)
+      edition1.state = "archived"
+      edition1.save!
+      edition2.state = "published"
+      edition2.save!
+
+      some_time_passes
+      @edition2_content_update_event_1 = create_content_update_event(
+        updated_by_user_uid: user2["uid"],
+      )
+
+      some_time_passes
+      @edition2_content_update_event_2 = create_content_update_event(
+        updated_by_user_uid: user1["uid"],
+      )
+
+      some_time_passes
+      @edition3 = edition2.build_clone(GuideEdition)
+      @edition3.save!
+
+      all_events = [
+        @out_of_scope_content_update_event,
+        @edition1_content_update_event,
+        @edition2_content_update_event_1,
+        @edition2_content_update_event_2,
+      ]
+
+      stub_events_for_all_content_ids(events: all_events)
+      stub_users_from_signon_api([user1["uid"], user2["uid"]], [user1, user2])
+    end
+
+    should "show host content update actions" do
+      visit_edition @edition3
+      click_on "History and notes"
+
+      assert page.has_no_content?("Content block updated")
+      assert page.has_no_content?("Email address updated")
+
+      click_on "Edition 2"
+      within "#version2" do
+        within page.all(".action-content-block-update")[0] do
+          assert page.has_content?(Time.zone.parse(@edition2_content_update_event_2["created_at"]).to_fs(:govuk_date))
+          assert page.has_content?("Content block updated by User 1")
+          assert page.has_content?("Email address updated")
+        end
+
+        within page.all(".action-content-block-update")[1] do
+          assert page.has_content?(Time.zone.parse(@edition2_content_update_event_1["created_at"]).to_fs(:govuk_date))
+          assert page.has_content?("Content block updated by User 2")
+          assert page.has_content?("Email address updated")
+        end
+      end
+
+      click_on "Edition 1"
+      within "#version1" do
+        within ".action-content-block-update" do
+          assert page.has_content?(Time.zone.parse(@edition1_content_update_event["created_at"]).to_fs(:govuk_date))
+          assert page.has_content?("Content block updated by User 1")
+          assert page.has_content?("Email address updated")
+        end
+      end
+    end
+  end
+
+  def some_time_passes
+    travel_to rand(1.hour..1.week).from_now
+  end
+
+  def create_content_update_event(updated_by_user_uid:)
+    {
+      "created_at" => Time.zone.now.to_s,
+      "payload" => {
+        "source_block" => {
+          "updated_by_user_uid" => updated_by_user_uid,
+          "content_id" => SecureRandom.uuid,
+          "title" => "Some content",
+          "document_type" => "content_block_email_address",
+        },
+      },
+    }
+  end
+end

--- a/test/integration/legacy_root_overview_test.rb
+++ b/test/integration/legacy_root_overview_test.rb
@@ -3,6 +3,8 @@ require_relative "../legacy_integration_test_helper"
 class LegacyRootOverviewTest < LegacyIntegrationTest
   setup do
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
 
     test_strategy = Flipflop::FeatureSet.current.test!
     test_strategy.switch!(:design_system_publications_filter, false)

--- a/test/integration/local_transaction_create_edit_test.rb
+++ b/test/integration/local_transaction_create_edit_test.rb
@@ -15,6 +15,8 @@ class LocalTransactionCreateEditTest < LegacyJavascriptIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
   end
 
   test "creating a local transaction sends the right emails" do

--- a/test/integration/mark_edition_in_beta_test.rb
+++ b/test/integration/mark_edition_in_beta_test.rb
@@ -5,6 +5,8 @@ class MarkEditionInBetaTest < LegacyJavascriptIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
 
     test_strategy = Flipflop::FeatureSet.current.test!
     test_strategy.switch!(:design_system_publications_filter, false)

--- a/test/integration/previous_edition_differences_test.rb
+++ b/test/integration/previous_edition_differences_test.rb
@@ -6,6 +6,8 @@ class PreviousEditionDifferencesTest < LegacyJavascriptIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
 
     @first_edition = FactoryBot.create(
       :answer_edition,

--- a/test/integration/root_overview_test.rb
+++ b/test/integration/root_overview_test.rb
@@ -4,6 +4,9 @@ require_relative "../integration_test_helper"
 
 class RootOverviewTest < IntegrationTest
   setup do
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
+
     test_strategy = Flipflop::FeatureSet.current.test!
     test_strategy.switch!(:design_system_publications_filter, true)
   end

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -14,6 +14,8 @@ class SimpleSmartAnswersTest < LegacyJavascriptIntegrationTest
     GDS::SSO.test_user = @author
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
 
     test_strategy = Flipflop::FeatureSet.current.test!
     test_strategy.switch!(:design_system_publications_filter, false)

--- a/test/integration/skip_review_test.rb
+++ b/test/integration/skip_review_test.rb
@@ -11,6 +11,8 @@ class SkipReviewTest < LegacyJavascriptIntegrationTest
 
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
 
     @artefact = FactoryBot.create(
       :artefact,

--- a/test/integration/tagging_test.rb
+++ b/test/integration/tagging_test.rb
@@ -6,6 +6,8 @@ class TaggingTest < LegacyJavascriptIntegrationTest
     stub_linkables
     stub_holidays_used_by_fact_check
     stub_publishing_api_has_lookups({})
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
 
     @edition = FactoryBot.create(:guide_edition)
     @artefact = @edition.artefact

--- a/test/integration/transaction_create_edit_test.rb
+++ b/test/integration/transaction_create_edit_test.rb
@@ -13,6 +13,8 @@ class TransactionCreateEditTest < LegacyJavascriptIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
 
     login_as @author
   end

--- a/test/integration/unpublish_test.rb
+++ b/test/integration/unpublish_test.rb
@@ -18,6 +18,8 @@ class UnpublishTest < LegacyIntegrationTest
     setup_users
     stub_linkables
     stub_holidays_used_by_fact_check
+    stub_events_for_all_content_ids
+    stub_users_from_signon_api
 
     test_strategy = Flipflop::FeatureSet.current.test!
     test_strategy.switch!(:design_system_publications_filter, false)

--- a/test/models/host_content_update_event/action_test.rb
+++ b/test/models/host_content_update_event/action_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class HostContentUpdateEvent::ActionTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:content_id) { SecureRandom.uuid }
+
+  let(:host_content_update_event) { FactoryBot.build(:host_content_update_event, document_type: "content_block_email_address", content_id:) }
+  let(:action) { HostContentUpdateEvent::Action.new(host_content_update_event) }
+
+  it "returns a duck-typed representation of an Action" do
+    assert_equal action.request_type, HostContentUpdateEvent::Action::CONTENT_BLOCK_UPDATE
+    assert_equal action.created_at, host_content_update_event.created_at
+    assert_equal action.requester, host_content_update_event.author
+    assert_equal action.to_s, "Content block updated"
+    assert_equal action.comment, "Email address updated"
+    assert_equal action.block_url, "#{Plek.external_url_for('whitehall-admin')}/content-block-manager/content-block/content-id/#{content_id}"
+    assert_equal action.comment_sanitized, false
+    assert_equal action.is_fact_check_request?, false
+    assert_equal action.recipient_id, nil
+  end
+end

--- a/test/models/host_content_update_event_test.rb
+++ b/test/models/host_content_update_event_test.rb
@@ -147,4 +147,14 @@ class HostContentUpdateEventTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe "#to_action" do
+    it "returns the object as an action" do
+      event = FactoryBot.build(:host_content_update_event)
+      action = mock("HostContentUpdateEvent::Action")
+      HostContentUpdateEvent::Action.expects(:new).with(event).returns(action)
+
+      assert_equal event.to_action, action
+    end
+  end
 end

--- a/test/models/host_content_update_event_test.rb
+++ b/test/models/host_content_update_event_test.rb
@@ -1,0 +1,95 @@
+require "test_helper"
+
+class HostContentUpdateEventTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:artefact) { FactoryBot.create(:artefact) }
+
+  describe ".all_for_artefact" do
+    it "returns all HostContentUpdateJobs" do
+      user1_uuid = SecureRandom.uuid
+      user2_uuid = SecureRandom.uuid
+
+      users = [
+        {
+          "uid" => user1_uuid,
+          "name" => "User 1",
+          "email" => "user1@example.com",
+        },
+        {
+          "uid" => user2_uuid,
+          "name" => "User 2",
+          "email" => "user2@example.com",
+        },
+      ]
+
+      Services.signon_api.expects(:get_users)
+              .with(uuids: [user1_uuid, user2_uuid])
+              .returns(users)
+
+      Services.publishing_api.expects(:get_events_for_content_id).with(
+        artefact.content_id, { action: "HostContentUpdateJob" }
+      ).returns(
+        [
+          {
+            "id" => 1593,
+            "action" => "HostContentUpdateJob",
+            "created_at" => "2024-01-01T00:00:00.000Z",
+            "updated_at" => "2024-01-01T00:00:00.000Z",
+            "request_id" => SecureRandom.uuid,
+            "content_id" => artefact.content_id,
+            "payload" => {
+              "title" => "Host content updated by content block update",
+              "locale" => "en",
+              "content_id" => artefact.content_id,
+              "source_block" => {
+                "title" => "An exciting piece of content",
+                "content_id" => "ef224ae6-7a81-4c59-830b-e9884fe57ec8",
+                "updated_by_user_uid" => user1_uuid,
+                "document_type" => "content_block_email_address",
+              },
+            },
+          },
+          {
+            "id" => 1593,
+            "action" => "HostContentUpdateJob",
+            "user_uid" => SecureRandom.uuid,
+            "created_at" => "2023-12-01T00:00:00.000Z",
+            "updated_at" => "2023-12-01T00:00:00.000Z",
+            "request_id" => SecureRandom.uuid,
+            "content_id" => artefact.content_id,
+            "payload" => {
+              "title" => "Host content updated by content block update",
+              "locale" => "en",
+              "content_id" => artefact.content_id,
+              "source_block" => {
+                "title" => "Another exciting piece of content",
+                "content_id" => "5c5520ce-6677-4a76-bd6e-4515f46a804e",
+                "updated_by_user_uid" => user2_uuid,
+                "document_type" => "content_block_something_else",
+              },
+            },
+          },
+        ],
+        )
+
+      result = HostContentUpdateEvent.all_for_artefact(artefact)
+
+      assert_equal result.count, 2
+
+      assert_equal result.first.author.name, "User 1"
+      assert_equal result.first.author.email, "user1@example.com"
+      assert_equal result.first.created_at, Time.zone.parse("2024-01-01T00:00:00.000Z")
+      assert_equal result.first.content_id, "ef224ae6-7a81-4c59-830b-e9884fe57ec8"
+      assert_equal result.first.content_title, "An exciting piece of content"
+      assert_equal result.first.document_type, "content_block_email_address"
+
+      assert_equal result.second.author.name, "User 2"
+      assert_equal result.second.author.email, "user2@example.com"
+      assert_equal result.second.created_at, Time.zone.parse("2023-12-01T00:00:00.000Z")
+      assert_equal result.second.content_id, "5c5520ce-6677-4a76-bd6e-4515f46a804e"
+      assert_equal result.second.content_title, "Another exciting piece of content"
+      assert_equal result.second.document_type, "content_block_something_else"
+    end
+  end
+end

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -334,7 +334,7 @@ FactoryBot.define do
   end
 
   factory :host_content_update_event, class: "HostContentUpdateEvent" do
-    author { HostContentUpdateEvent::Author.new(name: "someone", email: "foo@example.com") }
+    author { build(:host_content_update_event_author) }
     created_at { Time.zone.now }
     content_id { SecureRandom.uuid }
     content_title { "Something" }
@@ -347,6 +347,18 @@ FactoryBot.define do
         content_id:,
         content_title:,
         document_type:,
+      )
+    end
+  end
+
+  factory :host_content_update_event_author, class: "HostContentUpdateEvent::Author" do
+    name { "Someone" }
+    email { "foo@example.com" }
+
+    initialize_with do
+      new(
+        name:,
+        email:,
       )
     end
   end

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -333,6 +333,24 @@ FactoryBot.define do
     suggested_fix { "example fix" }
   end
 
+  factory :host_content_update_event, class: "HostContentUpdateEvent" do
+    author { HostContentUpdateEvent::Author.new(name: "someone", email: "foo@example.com") }
+    created_at { Time.zone.now }
+    content_id { SecureRandom.uuid }
+    content_title { "Something" }
+    document_type { "document_type" }
+
+    initialize_with do
+      new(
+        author:,
+        created_at:,
+        content_id:,
+        content_title:,
+        document_type:,
+      )
+    end
+  end
+
   factory :link_check_report do
     batch_id { 1 }
     status { "in_progress" }

--- a/test/support/host_content_update_test_helpers.rb
+++ b/test/support/host_content_update_test_helpers.rb
@@ -1,0 +1,10 @@
+module HostContentUpdateHelpers
+  def stub_events_for_all_content_ids(action: "HostContentUpdateJob", events: [])
+    Services.publishing_api.stubs(:get_events_for_content_id).with(
+      regexp_matches(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/),
+      {
+        action:,
+      },
+    ).returns(events)
+  end
+end

--- a/test/support/signon_api_helpers.rb
+++ b/test/support/signon_api_helpers.rb
@@ -1,0 +1,5 @@
+module SignonApiHelpers
+  def stub_users_from_signon_api(uuids = [], users = [])
+    Services.signon_api.stubs(:get_users).with(uuids:).returns(users)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,8 +17,11 @@ require "support/tab_test_helpers"
 require "support/holidays_test_helpers"
 require "support/action_processor_helpers"
 require "support/factories"
+require "support/host_content_update_test_helpers"
 require "support/local_services"
 require "support/presenter_test_helpers"
+require "support/signon_api_helpers"
+
 require "govuk_schemas/assert_matchers"
 require "govuk_sidekiq/testing"
 
@@ -101,4 +104,6 @@ class ActiveSupport::TestCase
   include HolidaysTestHelpers
   include ActionProcessorHelpers
   extend PresenterTestHelpers
+  include SignonApiHelpers
+  include HostContentUpdateHelpers
 end

--- a/test/traits/recordable_actions_test.rb
+++ b/test/traits/recordable_actions_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+
+class ModelWithRecordableActions
+  include Mongoid::Document
+  include RecordableActions
+
+  attr_accessor :subsequent_siblings
+end
+
+class RecordableActionsTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:object_under_test) { ModelWithRecordableActions.create }
+  let(:user) { FactoryBot.create(:user) }
+
+  describe "#published_by" do
+    it "returns who published the object" do
+      object_under_test.actions.create!(
+        request_type: Action::PUBLISH,
+        requester: user,
+      )
+
+      assert_equal user, object_under_test.published_by
+    end
+
+    it "returns nil when there are no published actions" do
+      assert_equal nil, object_under_test.published_by
+    end
+  end
+
+  describe "#published_at" do
+    it "returns when the object was created" do
+      created_at = Time.zone.now - 4.days
+      object_under_test.actions.create!(
+        request_type: Action::PUBLISH,
+        requester: user,
+        created_at:,
+      )
+
+      assert_equal created_at, object_under_test.published_at
+    end
+
+    it "returns nil when there are no published actions" do
+      assert_equal nil, object_under_test.published_at
+    end
+  end
+
+  describe "#superseded_at" do
+    it "returns when the object was superseded by another edition" do
+      expected_superseded_at = Time.zone.now - 3.days
+
+      subsequent_editions = 4.times.map { stub("Edition") }
+      subsequent_editions.first.stubs(:published_at).returns(expected_superseded_at)
+
+      object_under_test.subsequent_siblings = subsequent_editions
+
+      assert_equal expected_superseded_at, object_under_test.superseded_at
+    end
+
+    it "returns nil when there are no subsequent editions" do
+      object_under_test.subsequent_siblings = []
+
+      assert_equal nil, object_under_test.superseded_at
+    end
+
+    it "returns nil when the first subsequent edition is not published" do
+      unpublished_edition = stub("Edition", published_at: nil)
+      object_under_test.subsequent_siblings = [unpublished_edition]
+
+      assert_equal nil, object_under_test.superseded_at
+    end
+  end
+end

--- a/test/unit/helpers/admin/action_helper_test.rb
+++ b/test/unit/helpers/admin/action_helper_test.rb
@@ -58,4 +58,15 @@ class ActionHelperTest < ActionView::TestCase
       assert_match(/older/, unformatted_email.last)
     end
   end
+
+  test "#action_note supports host content update events" do
+    host_content_update_event = FactoryBot.build(:host_content_update_event, document_type: "Something")
+    action = host_content_update_event.to_action
+
+    note = action_note(action)
+
+    assert_match(/Something updated/, note)
+    assert_match(/View in Content Block Manager/, note)
+    assert_match(/#{action.block_url}/, note)
+  end
 end

--- a/test/unit/helpers/admin/action_helper_test.rb
+++ b/test/unit/helpers/admin/action_helper_test.rb
@@ -69,4 +69,44 @@ class ActionHelperTest < ActionView::TestCase
     assert_match(/View in Content Block Manager/, note)
     assert_match(/#{action.block_url}/, note)
   end
+
+  test "#edition_actions includes update_events" do
+    edition = FactoryBot.create(:edition)
+
+    edition_actions = [
+      stub(:create_action, request_type: Action::CREATE, created_at: Time.zone.now - 1.week),
+      stub(:note_action, request_type: Action::NOTE, created_at: Time.zone.now - 2.days),
+      stub(:sent_fact_check_action, request_type: Action::SEND_FACT_CHECK, created_at: Time.zone.now - 3.days),
+      stub(:receive_fact_check_action, request_type: Action::RECEIVE_FACT_CHECK, created_at: Time.zone.now - 1.day),
+      stub(:important_note_action, request_type: Action::IMPORTANT_NOTE, created_at: Time.zone.now - 1.week),
+      stub(:important_note_resolved_action, request_type: Action::IMPORTANT_NOTE_RESOLVED, created_at: Time.zone.now - 1.week),
+      stub(:publish_action, request_type: Action::PUBLISH, created_at: Time.zone.now - 12.hours),
+    ]
+
+    edition.stubs(:actions).returns(edition_actions)
+
+    update_events = [
+      stub("HostContentUpdateEvent", to_action: stub(:host_content_update_event_action, created_at: Time.zone.now - 2.hours)),
+      stub("HostContentUpdateEvent", to_action: stub(:host_content_update_event_action, created_at: Time.zone.now - 3.hours)),
+      stub("HostContentUpdateEvent", to_action: stub(:host_content_update_event_action, created_at: Time.zone.now)),
+    ]
+
+    update_events[0].stubs(:is_for_edition?).with(edition).returns(true)
+    update_events[1].stubs(:is_for_edition?).with(edition).returns(true)
+    update_events[2].stubs(:is_for_edition?).with(edition).returns(false)
+
+    expected_actions = [
+      update_events[0].to_action,
+      update_events[1].to_action,
+      edition_actions[6],
+      edition_actions[3],
+      edition_actions[1],
+      edition_actions[2],
+      edition_actions[0],
+    ]
+
+    result = edition_actions(edition, update_events)
+
+    assert_equal expected_actions, result
+  end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/4UrVJbKH/785-show-content-block-updates-in-mainstream

This updates the history component to list when content blocks being used by a particular artefact have been updated.

This works by calling the Publishing API to find all events of a `HostContentUpdateJob` type for the artefact's content ID. We then use the new Signon API to fetch user details for each author and marshal this into a list of `HostContentUpdateEvent` objects

We call this method each time we load an edition, when showing history entries for each previous / subsequent edition, we check if an event took place during the lifecycle of this edition by checking if it occurred after an edition was published and (optionally) before the next edition was published.

We have a similar approach in Whitehall (see https://github.com/alphagov/whitehall/pull/9754) which is now live and in production.

We may need to iterate some elements of the content design, but this puts all the various pieces into play for us to iterate on.

## Screenshot

![image](https://github.com/user-attachments/assets/ea0850b2-1980-4b18-b952-a1f36fbf5d1c)
