### PR TITLE
Remove incorrect updated_at call from public_updated_at

### DIFF
--- a/app/presenters/formats/edition_format_presenter.rb
+++ b/app/presenters/formats/edition_format_presenter.rb
@@ -16,8 +16,9 @@ module Formats
     def optional_fields
       access_limited = { auth_bypass_ids: [edition.auth_bypass_id] }
       phase = edition.in_beta ? "beta" : nil
+      public_updated_at = edition.public_updated_at ? edition.public_updated_at.rfc3339(3) : nil
 
-      { access_limited:, phase: }.compact
+      { access_limited:, phase:, public_updated_at: }.compact
     end
 
     def required_fields(republish)
@@ -27,7 +28,6 @@ module Formats
         description: edition.overview || "",
         schema_name:,
         document_type:,
-        public_updated_at: public_updated_at.rfc3339(3),
         last_edited_by_editor_id:,
         publishing_app: "publisher",
         rendering_app:,
@@ -93,10 +93,6 @@ module Formats
 
     def major_change?
       edition.major_change || edition.version_number == 1
-    end
-
-    def public_updated_at
-      edition.public_updated_at || edition.updated_at
     end
 
     # We can't reliably get the exact user who last edited the edition,

--- a/test/unit/presenters/formats/edition_format_presenter_test.rb
+++ b/test/unit/presenters/formats/edition_format_presenter_test.rb
@@ -80,15 +80,13 @@ class EditionFormatPresenterTest < ActiveSupport::TestCase
     context "[:public_updated_at]" do
       should "return edition.public_updated_at if not nil" do
         now = Time.zone.now
+        edition.stubs(:public_updated_at).returns(now)
         edition.expects(:public_updated_at).returns(now)
         assert_equal now.rfc3339(3), result[:public_updated_at]
       end
 
-      should "return edition.updated_at otherwise" do
-        edition.stubs(:public_updated_at).returns(nil)
-        now = Time.zone.now
-        edition.expects(:updated_at).returns(now)
-        assert_equal now.rfc3339(3), result[:public_updated_at]
+      should "return nil otherwise" do
+        assert_equal nil, result[:public_updated_at]
       end
     end
 

--- a/test/unit/presenters/formats/generic_edition_presenter_test.rb
+++ b/test/unit/presenters/formats/generic_edition_presenter_test.rb
@@ -97,11 +97,6 @@ class GenericEditionPresenterTest < ActiveSupport::TestCase
       assert_valid_against_publisher_schema(@output, "generic_with_external_related_links")
     end
 
-    should "use updated_at value if public_updated_at is nil" do
-      assert_nil @edition.public_updated_at
-      assert_equal @edition.updated_at, @output[:public_updated_at]
-    end
-
     should "choose locale based on the artefact language" do
       assert_equal "cy", @output[:locale]
     end


### PR DESCRIPTION
Our previous behaviour was reporting the public_updated_at as the
last time the documented was updated overall. This was causing
the document to be misreported as having major updates every change.

By default the publishing_api handles this by updating the field only if the
change is a major one, so this is an unnecessary override. As the field can
now be nil, it has been made optional.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
