### PR TITLE
Replace repo name with image name

### DIFF
--- a/.github/workflows/deploy_mongo_to_pg.yml
+++ b/.github/workflows/deploy_mongo_to_pg.yml
@@ -26,7 +26,7 @@ jobs:
     uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.event.release.tag_name }}
-      ecrRepositoryName: publisher-on-postgres-branch
+      imageName: publisher-on-postgres-branch
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Replace repo name with image name as repo name does not exists in the actual workflow

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
