### PR TITLE
Restore correct ordering for imported stylesheets

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,12 +3,8 @@ $govuk-page-width: 1140px;
 // GOVUK Design System
 @import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/component_support';
-@import 'govuk_publishing_components/components/button';
-// The import for the "add-another" stylesheet is listed out of (alphabetical) order to prevent its styles being over-written by the "button" component stylesheet
-// An issue has been opened for this here: https://github.com/alphagov/govuk_publishing_components/issues/4548
-// When this is resolved the components can be reordered to the preferred alphabetical lsiting. 
-// There is a card for this work here: https://trello.com/c/doZRh9Gi/587-list-imported-add-another-component-stylesheet-correctly
 @import 'govuk_publishing_components/components/add-another';
+@import 'govuk_publishing_components/components/button';
 @import 'govuk_publishing_components/components/checkboxes';
 @import 'govuk_publishing_components/components/date-input';
 @import 'govuk_publishing_components/components/details';


### PR DESCRIPTION
[Trello](https://trello.com/c/doZRh9Gi/587-list-imported-add-another-component-stylesheet-correctly)

When the "Add another" component is rendered in Publisher (e.g. on the "Related external links" tab) there was a problem if the standard (alphabetical) ordering of imported stylesheets was used whereby some styles specific to the component were over-written by more generic styles imported from the "Button" component. This affected the "Delete" button as shown in the screenshots below. 

To get around this the stylesheets were imported in a different order so that styles for the "Add another" component were imported after the "Button" component. This has now been fixed in the Publishing Components gem so the stylesheets can be imported in alphabetical order.

The change in this PR restores the import order to an alphabetical listing now that the change in the component has been released. 

|Using the previous version of the Publishing Components gem|Using the current version of the Publishing Components gem|
|-|-|
|![Image](https://github.com/user-attachments/assets/f8da1745-57de-405c-9a94-527fc20e699f)|![Image](https://github.com/user-attachments/assets/3cb8e871-314d-4e2a-99dd-658d7e16b2ca)|