### PR TITLE
Replace title component with heading

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -35,7 +35,6 @@ $govuk-page-width: 1140px;
 @import 'govuk_publishing_components/components/summary-list';
 @import 'govuk_publishing_components/components/table';
 @import 'govuk_publishing_components/components/textarea';
-@import 'govuk_publishing_components/components/title';
 @import "tags";
 @import "downtimes";
 @import "options_sidebar";

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -37,11 +37,12 @@
       <% if yield(:title).present? %>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
-            <%= render "govuk_publishing_components/components/title", {
-              title: yield(:title),
+            <%= render "govuk_publishing_components/components/heading", {
+              text: yield(:title),
               context: yield(:title_context),
-              margin_top: 0,
               margin_bottom: 6,
+              font_size: "xl",
+              heading_level: 1,
             } %>
           </div>
         </div>

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -74,7 +74,7 @@ class EditionEditTest < IntegrationTest
       end
 
       should "show 'Metadata' header and an update button" do
-        within :css, ".gem-c-heading" do
+        within :css, ".gem-c-heading h2" do
           assert page.has_text?("Metadata")
         end
         assert page.has_button?("Update")
@@ -139,7 +139,7 @@ class EditionEditTest < IntegrationTest
         end
 
         should "show 'Unpublish' header and 'Continue' button" do
-          within :css, ".gem-c-heading" do
+          within :css, ".gem-c-heading h2" do
             assert page.has_text?("Unpublish")
           end
           assert page.has_button?("Continue")
@@ -215,7 +215,7 @@ class EditionEditTest < IntegrationTest
           end
 
           should "show 'Admin' header and not show 'Skip fact check' button" do
-            within :css, ".gem-c-heading" do
+            within :css, ".gem-c-heading h2" do
               assert page.has_text?("Admin")
             end
             assert page.has_no_button?("Skip fact check")
@@ -235,7 +235,7 @@ class EditionEditTest < IntegrationTest
           end
 
           should "show 'Admin' header and not show 'Skip fact check' button" do
-            within :css, ".gem-c-heading" do
+            within :css, ".gem-c-heading h2" do
               assert page.has_text?("Admin")
             end
             assert page.has_no_button?("Skip fact check")
@@ -262,7 +262,7 @@ class EditionEditTest < IntegrationTest
         end
 
         should "show 'Admin' header and an 'Skip fact check' button" do
-          within :css, ".gem-c-heading" do
+          within :css, ".gem-c-heading h2" do
             assert page.has_text?("Admin")
           end
           assert page.has_button?("Skip fact check")


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Replace the title component with the heading component.

- should still be a h1 and visually identical
- heading has no margin top, so matches the previous margin_top: 0 option on title

Confession: I've not actually run this locally to check it visually, but I've done this in a lot of applications now and I'm reasonably confident it will work.

## Why

The title component is being decommissioned and we've already removed the margin_top option from it as part of some other work. This means that with the latest changes a big space will suddenly appear above it. But if we switch it to the heading component, it looks exactly the same and won't have this problem.

## Visual changes
None.

Trello card: https://trello.com/c/Y0pDWbHw/390-remove-margintop-option-from-shared-helper