### PR TITLE
497 use updated add another component

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,7 +256,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (50.0.1)
+    govuk_publishing_components (51.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/views/editions/secondary_nav_tabs/_related_external_links.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_related_external_links.html.erb
@@ -5,11 +5,8 @@
     <%= form_for @edition.artefact, url: update_related_external_links_edition_path(@resource) do %>
       <%
         if @edition.artefact.external_links.count == 0
-          items = [{
-            fields: render(partial: "secondary_nav_tabs/related_external_links/add-another_fieldset", locals: { index: 0, id: nil }),
-            destroy_checkbox: render(partial: "secondary_nav_tabs/related_external_links/add-another_checkbox", locals: {index: 0}),
-          }]
-          empty = render(partial: "secondary_nav_tabs/related_external_links/add-another_fieldset", locals: { index: 1, id: nil })
+          items = []
+          empty = render(partial: "secondary_nav_tabs/related_external_links/add-another_fieldset", locals: { index: 0, id: nil })
         else
           items = @edition.artefact.external_links.each_with_index.map do | external_link, index |
             {
@@ -23,7 +20,8 @@
 
       <%= render "govuk_publishing_components/components/add_another", {
         fieldset_legend: "Link",
-        add_button_text: "Add another link",
+        add_button_text: "Add related external link",
+        empty_fields: true,
         items: items,
         empty: empty,
       } %>

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -604,20 +604,11 @@ class EditionEditTest < IntegrationTest
       end
 
       should "render an empty 'Add another' form" do
-        # Link 1
         assert page.has_css?("legend", text: "Link 1")
-        assert page.has_css?("input[name='artefact[external_links_attributes][0][_destroy]']")
         assert_equal "Title", page.find("label[for='artefact_external_links_attributes_0_title']").text
         assert_equal "URL", page.find("label[for='artefact_external_links_attributes_0_url']").text
         assert_equal "", page.find("input[name='artefact[external_links_attributes][0][title]']").value
         assert_equal "", page.find("input[name='artefact[external_links_attributes][0][url]']").value
-
-        # Link 2 (empty fields)
-        assert page.has_css?("legend", text: "Link 2")
-        assert_equal "Title", page.find("label[for='artefact_external_links_attributes_1_title']").text
-        assert_equal "URL", page.find("label[for='artefact_external_links_attributes_1_url']").text
-        assert_equal "", page.find("input[name='artefact[external_links_attributes][1][title]']").value
-        assert_equal "", page.find("input[name='artefact[external_links_attributes][1][url]']").value
       end
     end
 
@@ -653,7 +644,7 @@ class EditionEditTest < IntegrationTest
       end
 
       should "render a pre-populated 'Add another' form" do
-        within :css, ".gem-c-add-another .js-add-another__fieldset:first-of-type" do
+        within :css, ".gem-c-add-another .js-add-another__empty" do
           fill_in "Title", with: "A new external link"
           fill_in "URL", with: "https://foo.com"
         end
@@ -691,20 +682,11 @@ class EditionEditTest < IntegrationTest
 
         click_button("Save")
 
-        # Link 1
         assert page.has_css?("legend", text: "Link 1")
-        assert page.has_css?("input[name='artefact[external_links_attributes][0][_destroy]']")
         assert_equal "Title", page.find("label[for='artefact_external_links_attributes_0_title']").text
         assert_equal "URL", page.find("label[for='artefact_external_links_attributes_0_url']").text
         assert_equal "", page.find("input[name='artefact[external_links_attributes][0][title]']").value
         assert_equal "", page.find("input[name='artefact[external_links_attributes][0][url]']").value
-
-        # Link 2
-        assert page.has_css?("legend", text: "Link 2")
-        assert_equal "Title", page.find("label[for='artefact_external_links_attributes_1_title']").text
-        assert_equal "URL", page.find("label[for='artefact_external_links_attributes_1_url']").text
-        assert_equal "", page.find("input[name='artefact[external_links_attributes][1][title]']").value
-        assert_equal "", page.find("input[name='artefact[external_links_attributes][1][url]']").value
       end
     end
   end

--- a/test/integration/edition_external_links_test.rb
+++ b/test/integration/edition_external_links_test.rb
@@ -21,14 +21,14 @@ class EditionExternalLinksTest < JavascriptIntegrationTest
     end
 
     context "Edition does not already have related external links" do
-      should "render an empty 'Add another' form when the page loads" do
-        assert page.has_css?("legend", text: "Link 1")
+      should "render the form containing just the 'Add related external link' button when the page loads" do
+        assert page.has_no_css?("legend", text: "Link 1")
         assert page.has_no_css?("input[name='artefact[external_links_attributes][0][_destroy]']")
-        assert_equal "Title", page.find("label[for='artefact_external_links_attributes_0_title']").text
-        assert_equal "URL", page.find("label[for='artefact_external_links_attributes_0_url']").text
-        assert_equal "", page.find("input[name='artefact[external_links_attributes][0][title]']").value
-        assert_equal "", page.find("input[name='artefact[external_links_attributes][0][url]']").value
-        assert page.has_css?("button", text: "Add another link")
+        assert page.has_no_css?("label[for='artefact_external_links_attributes_0_title']")
+        assert page.has_no_css?("label[for='artefact_external_links_attributes_0_url']")
+        assert page.has_no_css?("input[name='artefact[external_links_attributes][0][title]']")
+        assert page.has_no_css?("input[name='artefact[external_links_attributes][0][url]']")
+        assert page.has_css?("button", text: "Add related external link")
       end
     end
 
@@ -46,12 +46,12 @@ class EditionExternalLinksTest < JavascriptIntegrationTest
         assert_equal "URL", page.find("label[for='artefact_external_links_attributes_0_url']").text
         assert_equal "Link one", page.find("input[name='artefact[external_links_attributes][0][title]']").value
         assert_equal "https://one.com", page.find("input[name='artefact[external_links_attributes][0][url]']").value
-        assert page.has_css?("button", text: "Add another link")
+        assert page.has_css?("button", text: "Add related external link")
       end
     end
 
-    should "display 'Delete' buttons and a second set of inputs when 'Add another link' is clicked" do
-      click_button("Add another link")
+    should "display a 'Delete' button and a set of inputs when the Add button is clicked" do
+      click_button("Add related external link")
 
       assert page.has_css?("legend", text: "Link 1")
       assert page.has_no_css?("input[name='artefact[external_links_attributes][0][_destroy]']")
@@ -59,37 +59,25 @@ class EditionExternalLinksTest < JavascriptIntegrationTest
       assert_equal "URL", page.find("label[for='artefact_external_links_attributes_0_url']").text
       assert_equal "", page.find("input[name='artefact[external_links_attributes][0][title]']").value
       assert_equal "", page.find("input[name='artefact[external_links_attributes][0][url]']").value
-      assert page.has_css?("legend", text: "Link 2")
-      assert page.has_no_css?("input[name='artefact[external_links_attributes][1][_destroy]']")
-      assert_equal "Title", page.find("label[for='artefact_external_links_attributes_1_title']").text
-      assert_equal "URL", page.find("label[for='artefact_external_links_attributes_1_url']").text
-      assert_equal "", page.find("input[name='artefact[external_links_attributes][1][title]']").value
-      assert_equal "", page.find("input[name='artefact[external_links_attributes][1][url]']").value
-      assert page.has_css?("button", text: "Add another link")
-      within :css, ".gem-c-add-another .js-add-another__fieldset:nth-of-type(1)" do
-        assert page.has_css?("button", text: "Delete")
-      end
-      within :css, ".gem-c-add-another .js-add-another__fieldset:nth-of-type(2)" do
+      assert page.has_css?("button", text: "Add related external link")
+      within :css, ".gem-c-add-another .js-add-another__fieldset" do
         assert page.has_css?("button", text: "Delete")
       end
     end
 
-    should "delete the first set of fields when the user clicks the first “Delete” button" do
-      click_button("Add another link")
+    should "delete the set of fields when the user clicks the 'Delete' button" do
+      click_button("Add related external link")
 
-      within :css, ".gem-c-add-another .js-add-another__fieldset:nth-of-type(1)" do
+      within :css, ".gem-c-add-another .js-add-another__fieldset" do
         click_button("Delete")
       end
 
-      assert page.has_css?("legend", text: "Link 1")
+      assert page.has_no_css?("legend", text: "Link 1")
       assert page.has_no_css?("label[for='artefact_external_links_attributes_0_title']")
       assert page.has_no_css?("label[for='artefact_external_links_attributes_0_url']")
-      assert_equal "Title", page.find("label[for='artefact_external_links_attributes_1_title']").text
-      assert_equal "URL", page.find("label[for='artefact_external_links_attributes_1_url']").text
-      assert page.has_css?("button", text: "Add another link")
-      within :css, ".gem-c-add-another .js-add-another__fieldset:nth-of-type(2)" do
-        assert page.has_css?("button", text: "Delete")
-      end
+      assert page.has_no_css?("label[for='artefact_external_links_attributes_1_title']")
+      assert page.has_no_css?("label[for='artefact_external_links_attributes_1_url']")
+      assert page.has_css?("button", text: "Add related external link")
     end
   end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/0eYge9vM)

The changes here implement the latest release of the Publishing Components gem (version 51.0.0) that contains the configuration option added to the "Add another" component that allows its use on Mainstream as required. This adds the parameter `empty_fields` to the component, which, when set to "true" ensures that no form fields are displayed when the component loads if no content is specified. Additionally these changes update the tests for the changed UI.

They also update the button text from "Add another link" to "Add related external link".

The primary differences between this implementation and the current one are shown in the screenshots below. 

|Scenario|Current implementation|Latest component version|
|-|-|-|
|Loads with no links specified (without JavaScript)|![Screenshot 2025-01-28 at 14 47 39](https://github.com/user-attachments/assets/3c2ed645-8eaf-49ad-b91e-22603f1d700a)|![Screenshot 2025-01-28 at 14 47 48](https://github.com/user-attachments/assets/b749f53e-0332-469b-a167-90dc6eba0b27)|
|Loads with one link specified (without JavaScript)|![Screenshot 2025-01-28 at 14 49 54](https://github.com/user-attachments/assets/f5ef761d-453d-4009-ab27-10038144a0fa)|![Screenshot 2025-01-28 at 14 50 02](https://github.com/user-attachments/assets/9f5b6b21-d79d-445f-be46-65aac1820209)|
|Loads with no links specified (with JavaScript)|![Screenshot 2025-01-28 at 14 29 12](https://github.com/user-attachments/assets/dd592a08-5509-4944-9009-d0598db788a3)|![Screenshot 2025-01-28 at 14 30 30](https://github.com/user-attachments/assets/eae460f4-ea49-49f8-b25a-b48c7fd58164)|
|"Add" button clicked (with JavaScript)|![Screenshot 2025-01-28 at 14 33 53](https://github.com/user-attachments/assets/a4921cc8-0522-4ced-b5f1-b076061904c8)|![Screenshot 2025-01-28 at 14 34 12](https://github.com/user-attachments/assets/0992e43f-8995-4ad9-a341-88e363c9c181)|
|Loads with one link specified (with JavaScript)|![Screenshot 2025-01-28 at 14 37 19](https://github.com/user-attachments/assets/4304c4f1-e5b8-4dd2-84b8-5f61658947fc)|![Screenshot 2025-01-28 at 14 37 09](https://github.com/user-attachments/assets/78ca626d-0392-4920-9d14-90ad5e7d2c08)|
|"Add" button clicked (with JavaScript)|![Screenshot 2025-01-28 at 14 40 30](https://github.com/user-attachments/assets/9630e55b-3c08-40a1-848a-7df77672cdc6)|![Screenshot 2025-01-28 at 14 40 42](https://github.com/user-attachments/assets/db0b86d7-530f-4afa-a066-50c8d1e9fbd6)|