### PR TITLE
Change asset path prefix to match the app name for the branch

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -56,7 +56,7 @@ module Publisher
 
     # Set asset path to be application specific so that we can put all GOV.UK
     # assets into an S3 bucket and distinguish app by path.
-    config.assets.prefix = "/assets/publisher"
+    config.assets.prefix = "/assets/publisher-on-pg"
 
     # allow overriding the asset host with an environment variable, useful for
     # when router is proxying to this app but asset proxying isn't set up.


### PR DESCRIPTION
Update assets prefix to match app name [refer](https://github.com/alphagov/publisher/pull/2521/files), so that [assets upload job](https://github.com/alphagov/govuk-helm-charts/blob/edaaab11b40c24a9f5c7d4bbca99058b9024def1/charts/generic-govuk-app/templates/assets-upload-job.yaml#L3) can pick assets correctly for copy. 


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
