### PR TITLE
Show a "work in progress" message on tagging tab

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -33,10 +33,10 @@ class EditionsController < InheritedResources::Base
     render action: "show"
   end
 
+  alias_method :admin, :show
   alias_method :metadata, :show
   alias_method :tagging, :show
   alias_method :unpublish, :show
-  alias_method :admin, :show
 
   def duplicate
     command = EditionDuplicator.new(@resource, current_user)

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -34,6 +34,7 @@ class EditionsController < InheritedResources::Base
   end
 
   alias_method :metadata, :show
+  alias_method :tagging, :show
   alias_method :unpublish, :show
   alias_method :admin, :show
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
         post "duplicate"
         get "related_external_links"
         patch "update_related_external_links"
-        get "tagging", to: "editions#linking"
+        get "tagging", to: "editions#tagging"
         get "unpublish"
         get "unpublish/confirm-unpublish", to: "editions#confirm_unpublish", as: "confirm_unpublish"
         post "process_unpublish"


### PR DESCRIPTION
For tabs that have not been upgraded to the GOV.UK Design System view yet, it should not give an error, but just show a tab pane consisting of a "Work in progress" message. This was what was originally implemented, but has got broken as the other tabs were fleshed out.

There's no tests for this, since it's just a placeholder, and the whole design system implementation for the show/edit page is behind a feature flag.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
