### PR TITLE
608 2i reviewer request amendments

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -38,6 +38,10 @@ class EditionsController < InheritedResources::Base
   alias_method :tagging, :show
   alias_method :unpublish, :show
 
+  def request_amendments_page
+    render "secondary_nav_tabs/request_amendments_page"
+  end
+
   def duplicate
     command = EditionDuplicator.new(@resource, current_user)
     target_edition_class_name = "#{params[:to]}_edition".classify if params[:to]
@@ -74,6 +78,16 @@ class EditionsController < InheritedResources::Base
     @resource.errors.add(:show, "Due to a service problem, the edition couldn't be updated")
   ensure
     render "show"
+  end
+
+  def request_amendments
+    if request_amendments_for_edition(@resource, params[:amendment_comment])
+      flash.now[:success] = "2i amendments requested"
+      render "show"
+    else
+      flash.now[:danger] = "Due to a service problem, the request could not be made"
+      render "secondary_nav_tabs/request_amendments_page"
+    end
   end
 
   def history
@@ -187,6 +201,11 @@ private
   def progress_edition(resource, activity_params)
     @command = EditionProgressor.new(resource, current_user)
     @command.progress(squash_multiparameter_datetime_attributes(activity_params.to_h, %w[publish_at]))
+  end
+
+  def request_amendments_for_edition(resource, comment)
+    @command = EditionProgressor.new(resource, current_user)
+    @command.progress({ request_type: "request_amendments", comment: comment })
   end
 
   def unpublish_edition(artefact)

--- a/app/views/editions/secondary_nav_tabs/request_amendments_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/request_amendments_page.html.erb
@@ -1,0 +1,26 @@
+<% @edition = @resource %>
+<% content_for :title_context, @edition.title %>
+<% content_for :page_title, "Request amendments" %>
+<% content_for :title, "Request amendments" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(:edition, url: "#{edition_path}/request_amendments") do |f| %>
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          heading_size: "m",
+          text: "Amendment details (optional)",
+        },
+        name: "amendment_comment",
+        rows: 14,
+      } %>
+
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Request amendments",
+        } %>
+        <%= link_to("Cancel", edition_path, class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -24,6 +24,16 @@
       items: document_summary_items(@resource),
     } %>
   </div>
+
+  <% if @edition.in_review? && current_user.has_editor_permissions?(@edition) %>
+    <% unless @edition.latest_status_action.requester == current_user %>
+      <div class="govuk-grid-column-two-thirds">
+        <%= render "govuk_publishing_components/components/inset_text", {} do %>
+          <p class="govuk-body"><%= link_to("Request amendments", request_amendments_page_edition_path) %></p>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
 </div>
 
 <div class="govuk-grid-row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
   constraints NewDesignSystemConstraint.new do
     resources :editions do
       member do
+        get "request_amendments_page", to: "editions#request_amendments_page", as: "request_amendments_page"
+        post "request_amendments", to: "editions#request_amendments", as: "request_amendments"
         get "metadata"
         get "history"
         get "history/add_edition_note", to: "editions#add_edition_note", as: "history/add_edition_note"


### PR DESCRIPTION
[Trello](https://trello.com/c/IZQtoxMn/608-2i-reviewer-actions-request-amendments-for-answer-and-help-content-types)

These changes: 
- Adds a 'Request amendments' link to the Edit page if
  - the document is "In Review"
  - the current user is not also the 2i requester 

|Edit page (current)|Edit page (updated)|
|-|-|
|![Screenshot 2025-02-17 at 16 58 17](https://github.com/user-attachments/assets/83e5a244-41bc-483a-8ea2-a03112445c66)|![Screenshot 2025-02-17 at 16 58 00](https://github.com/user-attachments/assets/4cb61513-8649-474e-9f85-23d8909fdd31)|

- Creates a new 'Request amendments' page for the user to add an option comment and request amendments to an edition.

|Scenario|View|
|-|-|
|User clicks 'Request amendments' link and is taken to the new 'Request amendments' page|![Screenshot 2025-02-17 at 17 02 58](https://github.com/user-attachments/assets/6d726652-81ea-404d-a4a5-e968c51dbcc5)|
|User clicks 'Request amendments' button and an error occurs|![Screenshot 2025-02-17 at 17 06 19](https://github.com/user-attachments/assets/cb324967-d7c1-4a0b-99de-a4754aab15d8)|
|User clicks 'Request amendments' button and the request is successful|![Screenshot 2025-02-17 at 17 09 36](https://github.com/user-attachments/assets/4cb38d74-7776-4469-972c-d8cb03a24d45)|