### PR TITLE
Remove custom hint text from Select component

### DIFF
--- a/app/views/root/_filter.html.erb
+++ b/app/views/root/_filter.html.erb
@@ -34,7 +34,6 @@
       name: "states_filter[]",
       heading: "Status",
       heading_size: "s",
-      hint_text: "Select all that apply",
       items: @presenter.edition_states,
     } %>
 


### PR DESCRIPTION
When we updated the search on the publications page to search the “slug” field of editions we used some custom text for the hint text attribute of the 'Checkbox' component (see [PR#2508](https://github.com/alphagov/publisher/pull/2508)). This was to display the text without the full stop (the default value for hint text in the component). We also raised an [issue](https://github.com/alphagov/govuk_publishing_components/issues/4589) in the Publishing Components to remove the full stop in the default hint text.

The work has now been done to resolve that issue (see [PR#4609](https://github.com/alphagov/govuk_publishing_components/pull/4609)) and the change is now released in the latest version of the Publishing Components gem. 

The change here removes the custom hint text in the rendered 'Checkboxes' component so that the now updated default is used instead (The text is "Select all that apply"). The screenshots below the hint text referenced here which has not changed as a result. (N.B. These are genuine before and after shots!)

|Before|After|
|-|-|
|![Screenshot 2025-02-18 at 12 17 44](https://github.com/user-attachments/assets/64890ca5-1540-4d4e-a764-91288574cccd)|![Screenshot 2025-02-18 at 12 16 47](https://github.com/user-attachments/assets/be489061-14ad-4588-90d5-90ba62faa117)|