### PR TITLE
Updates behaviour for users without govuk_editor permissions

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -11,7 +11,7 @@ class EditionsController < InheritedResources::Base
   before_action only: %i[unpublish confirm_unpublish process_unpublish] do
     require_govuk_editor(redirect_path: edition_path(resource))
   end
-  before_action only: %i[progress admin update confirm_destroy edit_assignee update_assignee] do
+  before_action only: %i[progress admin update confirm_destroy edit_assignee update_assignee request_amendments request_amendments_page] do
     require_editor_permissions
   end
   before_action only: %i[confirm_destroy destroy] do


### PR DESCRIPTION
[Trello](https://trello.com/c/IZQtoxMn/608-2i-reviewer-actions-request-amendments-for-answer-and-help-content-types)

Updates the controller to prevent users without the `govuk_editor` permission from 
- accessing the 'Request amendments' page
- being able to save an amendment request

This matches (and slightly extends) the current behaviour which
- allows a user without govuk_editor permission to access the form (which is an overlay on the same page)
- does not allow that user to save a request

|Scenario|Bootstrap UI|Design System UI|
|-|-|-|
|User on the Edit page without govuk_editor permission clicks on 'Request amendment' button|![Screenshot 2025-02-20 at 12 37 56](https://github.com/user-attachments/assets/ecb0d018-6f33-4c54-bee8-241b689dacd9)|![Screenshot 2025-02-20 at 12 37 03](https://github.com/user-attachments/assets/9f13dc4c-abf0-42e4-8f75-1501376d3bf4)|
|User without govuk_editor permission clicks on 'Request amendments' button to submit the form|![Screenshot 2025-02-20 at 12 40 24](https://github.com/user-attachments/assets/4dccd7ea-9720-4b92-a62e-1bc9137be33f)|![Screenshot 2025-02-20 at 12 41 31](https://github.com/user-attachments/assets/76b198f9-b32e-4d04-9d8b-0f2d0845816d)|