### PR TITLE
Edit page for published editions

### DIFF
--- a/app/helpers/editions_sidebar_buttons_helper.rb
+++ b/app/helpers/editions_sidebar_buttons_helper.rb
@@ -10,4 +10,15 @@ module EditionsSidebarButtonsHelper
                end
     buttons << link_to("View on GOV.UK (opens in new tab)", view_homepage_path, rel: "noreferrer noopener", target: "_blank", class: "govuk-link")
   end
+
+  def non_published_sidebar_buttons(edition)
+    buttons = []
+    if current_user.has_editor_permissions?(edition) && !edition.retired_format?
+      buttons << (render "govuk_publishing_components/components/button", {
+        text: "Save",
+        margin_bottom: 3,
+      })
+    end
+    buttons << link_to("Preview (opens in new tab)", preview_edition_path(edition), target: "_blank", rel: "noopener", class: "govuk-link")
+  end
 end

--- a/app/helpers/editions_sidebar_buttons_helper.rb
+++ b/app/helpers/editions_sidebar_buttons_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module EditionsSidebarButtonsHelper
+  def published_sidebar_buttons(edition)
+    buttons = []
+    buttons << if edition.can_create_new_edition?
+                 primary_button_for(edition, duplicate_edition_path(edition), "Create new edition")
+               else
+                 link_to("Edit latest edition", edition_path(edition.in_progress_sibling), class: "govuk-link")
+               end
+    buttons << link_to("View on GOV.UK (opens in new tab)", view_homepage_path, rel: "noreferrer noopener", target: "_blank", class: "govuk-link")
+  end
+end

--- a/app/helpers/editions_sidebar_buttons_helper.rb
+++ b/app/helpers/editions_sidebar_buttons_helper.rb
@@ -3,11 +3,13 @@
 module EditionsSidebarButtonsHelper
   def published_sidebar_buttons(edition)
     buttons = []
-    buttons << if edition.can_create_new_edition?
-                 primary_button_for(edition, duplicate_edition_path(edition), "Create new edition")
-               else
-                 link_to("Edit latest edition", edition_path(edition.in_progress_sibling), class: "govuk-link")
-               end
+    if current_user.has_editor_permissions?(edition)
+      buttons << if edition.can_create_new_edition?
+                   primary_button_for(edition, duplicate_edition_path(edition), "Create new edition")
+                 else
+                   link_to("Edit latest edition", edition_path(edition.in_progress_sibling), class: "govuk-link")
+                 end
+    end
     buttons << link_to("View on GOV.UK (opens in new tab)", view_homepage_path, rel: "noreferrer noopener", target: "_blank", class: "govuk-link")
   end
 

--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -11,7 +11,11 @@
 <%= form_for @resource, as: :edition, url: edition_path(@resource) do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render partial: "editions/secondary_nav_tabs/edit/draft/common_fields", locals: { edition: @resource } %>
+      <% if @resource.published? %>
+        <%= render partial: "editions/secondary_nav_tabs/edit/published/common_fields", locals: { edition: @resource } %>
+      <% else %>
+        <%= render partial: "editions/secondary_nav_tabs/edit/draft/common_fields", locals: { edition: @resource } %>
+      <% end %>
 
       <%= render "govuk_publishing_components/components/textarea", {
         label: {

--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -8,16 +8,28 @@
   </div>
 </div>
 
-<%= form_for @resource, as: :edition, url: edition_path(@resource) do |f| %>
-  <div class="govuk-grid-row">
+<div class="govuk-grid-row">
+  <% if @resource.published? %>
     <div class="govuk-grid-column-two-thirds">
-      <% if @resource.published? %>
-        <%= render partial: "editions/secondary_nav_tabs/edit/published/common_fields", locals: { edition: @resource } %>
+      <%= render partial: "editions/secondary_nav_tabs/edit/published/common_fields", locals: { edition: @resource } %>
 
-        <%= render partial: "editions/secondary_nav_tabs/edit/published/body", locals: { edition: @resource } %>
+      <%= render partial: "editions/secondary_nav_tabs/edit/published/body", locals: { edition: @resource } %>
 
-        <%= render partial: "editions/secondary_nav_tabs/edit/published/public_change_note", locals: { edition: @resource } %>
-      <% else %>
+      <%= render partial: "editions/secondary_nav_tabs/edit/published/public_change_note", locals: { edition: @resource } %>
+    </div>
+    <div class="govuk-grid-column-one-third options-sidebar">
+      <div class="sidebar-components">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Options",
+          heading_level: 3,
+          font_size: "s",
+          padding: true,
+        } %>
+      </div>
+    </div>
+  <% else %>
+    <%= form_for @resource, as: :edition, url: edition_path(@resource) do |f| %>
+      <div class="govuk-grid-column-two-thirds">
         <%= render partial: "editions/secondary_nav_tabs/edit/draft/common_fields", locals: { edition: @resource } %>
 
         <%= render partial: "editions/secondary_nav_tabs/edit/draft/body", locals: { edition: @resource } %>
@@ -27,13 +39,8 @@
             <%= render partial: "editions/secondary_nav_tabs/edit/draft/public_change_note", locals: { edition: @resource } %>
           </div>
         <% end %>
-      <% end %>
-    </div>
-
-    <div class="govuk-grid-column-one-third options-sidebar">
-      <% if @resource.locked_for_edits? %>
-        <p class="govuk-body"><%= @resource.error_description %> can't be changed.</p>
-      <% else %>
+      </div>
+      <div class="govuk-grid-column-one-third options-sidebar">
         <div class="sidebar-components">
           <%= render "govuk_publishing_components/components/heading", {
             text: "Options",
@@ -48,11 +55,11 @@
                 text: "Save",
                 margin_bottom: 3,
               } if current_user.has_editor_permissions?(@resource) && !@resource.retired_format?),
-            link_to("Preview (opens in new tab)", preview_edition_path(@resource), target: "_blank", rel: "noopener", class: "govuk-link"),
+              link_to("Preview (opens in new tab)", preview_edition_path(@resource), target: "_blank", rel: "noopener", class: "govuk-link"),
             ],
           } %>
         </div>
-      <% end %>
-    </div>
-  </div>
-<% end %>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -11,45 +11,7 @@
 <%= form_for @resource, as: :edition, url: edition_path(@resource) do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Title",
-        },
-        id: "title",
-        name: "edition[title]",
-        value: @resource.title,
-        heading_size: "m",
-        error_items: errors_for(@edition.errors, "title".to_sym, use_full_message: false),
-      } %>
-
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          heading_size: "m",
-          text: "Meta tag description",
-        },
-        name: "edition[overview]",
-        hint: "Some search engines will display this if they cannot find what they need in the main text",
-        value: @resource.overview,
-      } %>
-
-      <%= render "govuk_publishing_components/components/radio", {
-        heading: "Is this beta content?",
-        name: "edition[in_beta]",
-        inline: true,
-        heading_size: "m",
-        items: [
-          {
-            value: 1,
-            text: "Yes",
-            checked: @resource.in_beta,
-          },
-          {
-            value: 0,
-            text: "No",
-            checked: !@resource.in_beta,
-          },
-        ],
-      } %>
+      <%= render partial: "editions/secondary_nav_tabs/edit/draft/common_fields", locals: { edition: @resource } %>
 
       <%= render "govuk_publishing_components/components/textarea", {
         label: {

--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -25,6 +25,10 @@
           font_size: "s",
           padding: true,
         } %>
+
+        <% if @resource.can_create_new_edition? %>
+          <%= primary_button_for(@resource, duplicate_edition_path(@resource), "Create new edition") %>
+        <% end %>
       </div>
     </div>
   <% else %>

--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -13,20 +13,13 @@
     <div class="govuk-grid-column-two-thirds">
       <% if @resource.published? %>
         <%= render partial: "editions/secondary_nav_tabs/edit/published/common_fields", locals: { edition: @resource } %>
+
+        <%= render partial: "editions/secondary_nav_tabs/edit/published/body", locals: { edition: @resource } %>
       <% else %>
         <%= render partial: "editions/secondary_nav_tabs/edit/draft/common_fields", locals: { edition: @resource } %>
-      <% end %>
 
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          heading_size: "m",
-          text: "Body",
-        },
-        name: "edition[body]",
-        value: @resource.body,
-        rows: 14,
-        hint: ("Refer to #{link_to("Refer to the Govspeak guidance (opens in new tab)", "https://govspeak-preview.publishing.service.gov.uk/guide", target: "_blank", rel: "noopener", class: "govuk-link")}").html_safe,
-      } %>
+        <%= render partial: "editions/secondary_nav_tabs/edit/draft/body", locals: { edition: @resource } %>
+      <% end %>
 
       <% if @resource.published_edition %>
         <div class="edit_edition__change_note">

--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -54,13 +54,7 @@
           } %>
 
           <%= render "govuk_publishing_components/components/list", {
-            items: [
-              (render "govuk_publishing_components/components/button", {
-                text: "Save",
-                margin_bottom: 3,
-              } if current_user.has_editor_permissions?(@resource) && !@resource.retired_format?),
-              link_to("Preview (opens in new tab)", preview_edition_path(@resource), target: "_blank", rel: "noopener", class: "govuk-link"),
-            ],
+            items: non_published_sidebar_buttons(@resource),
           } %>
         </div>
       </div>

--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -28,6 +28,12 @@
 
         <% if @resource.can_create_new_edition? %>
           <%= primary_button_for(@resource, duplicate_edition_path(@resource), "Create new edition") %>
+        <% else %>
+          <%= render "govuk_publishing_components/components/list", {
+            items: [
+              link_to("Edit latest edition", edition_path(@resource.in_progress_sibling), class: "govuk-link")
+            ],
+          } %>
         <% end %>
       </div>
     </div>

--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -35,6 +35,7 @@
             ],
           } %>
         <% end %>
+        <%= link_to("View on GOV.UK (opens in new tab)", view_homepage_path, rel:"noreferrer noopener", target:"_blank", class: "govuk-link") %>
       </div>
     </div>
   <% else %>

--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -26,16 +26,9 @@
           padding: true,
         } %>
 
-        <% if @resource.can_create_new_edition? %>
-          <%= primary_button_for(@resource, duplicate_edition_path(@resource), "Create new edition") %>
-        <% else %>
-          <%= render "govuk_publishing_components/components/list", {
-            items: [
-              link_to("Edit latest edition", edition_path(@resource.in_progress_sibling), class: "govuk-link")
-            ],
-          } %>
-        <% end %>
-        <%= link_to("View on GOV.UK (opens in new tab)", view_homepage_path, rel:"noreferrer noopener", target:"_blank", class: "govuk-link") %>
+        <%= render "govuk_publishing_components/components/list", {
+          items: published_sidebar_buttons(@resource),
+        } %>
       </div>
     </div>
   <% else %>

--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -15,50 +15,18 @@
         <%= render partial: "editions/secondary_nav_tabs/edit/published/common_fields", locals: { edition: @resource } %>
 
         <%= render partial: "editions/secondary_nav_tabs/edit/published/body", locals: { edition: @resource } %>
+
+        <%= render partial: "editions/secondary_nav_tabs/edit/published/public_change_note", locals: { edition: @resource } %>
       <% else %>
         <%= render partial: "editions/secondary_nav_tabs/edit/draft/common_fields", locals: { edition: @resource } %>
 
         <%= render partial: "editions/secondary_nav_tabs/edit/draft/body", locals: { edition: @resource } %>
-      <% end %>
 
-      <% if @resource.published_edition %>
-        <div class="edit_edition__change_note">
-          <%= render "govuk_publishing_components/components/details", {
-            title: "Add a public change note",
-          } do %>
-            <%= render "govuk_publishing_components/components/radio", {
-              heading: "Add a public change note",
-              heading_level: 3,
-              heading_size: "m",
-              name: "edition[major_change]",
-              hint: "Telling users when published information has changed is important for transparency.",
-              items: [
-                {
-                  hint_text: "A change note will be published on the page and emailed to users subscribed to email alerts. The ‘last updated’ date will change.",
-                  text: "Yes - information has been added, updated or removed.",
-                  checked: @resource.major_change,
-                  bold: true,
-                  value: true,
-                  conditional: render("govuk_publishing_components/components/textarea", {
-                    label: {
-                      text: "Describe the change for users",
-                      bold: true,
-                    },
-                    name: "edition[change_note]",
-                    value: @resource.change_note,
-                    hint: ("<p class=\"govuk-!-margin-0\">Tell users what has changed, where and why. Write in full sentences, leading with the most important words. For example, \"College A has been removed from the registered sponsors list because its licence has been suspended.\"</p><a href=\"https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes\" target=\"_blank\">Guidance on change notes (opens in a new tab)</a>").html_safe,
-                  }),
-                },
-                {
-                  value: false,
-                  text: "No",
-                  bold: true,
-                  checked: !@resource.major_change,
-                },
-              ],
-            } %>
-          <% end %>
-        </div>
+        <% if @resource.published_edition %>
+          <div class="edit_edition__change_note">
+            <%= render partial: "editions/secondary_nav_tabs/edit/draft/public_change_note", locals: { edition: @resource } %>
+          </div>
+        <% end %>
       <% end %>
     </div>
 

--- a/app/views/editions/secondary_nav_tabs/edit/draft/_body.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/draft/_body.html.erb
@@ -1,0 +1,10 @@
+<%= render "govuk_publishing_components/components/textarea", {
+  label: {
+    heading_size: "m",
+    text: "Body",
+  },
+  name: "edition[body]",
+  value: edition.body,
+  rows: 14,
+  hint: ("Refer to #{link_to("Refer to the Govspeak guidance (opens in new tab)", "https://govspeak-preview.publishing.service.gov.uk/guide", target: "_blank", rel: "noopener", class: "govuk-link")}").html_safe,
+} %>

--- a/app/views/editions/secondary_nav_tabs/edit/draft/_common_fields.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/draft/_common_fields.html.erb
@@ -1,0 +1,39 @@
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: "Title",
+  },
+  id: "title",
+  name: "edition[title]",
+  value: edition.title,
+  heading_size: "m",
+  error_items: errors_for(edition.errors, "title".to_sym, use_full_message: false),
+} %>
+
+<%= render "govuk_publishing_components/components/textarea", {
+  label: {
+    heading_size: "m",
+    text: "Meta tag description",
+  },
+  name: "edition[overview]",
+  hint: "Some search engines will display this if they cannot find what they need in the main text",
+  value: edition.overview,
+} %>
+
+<%= render "govuk_publishing_components/components/radio", {
+  heading: "Is this beta content?",
+  name: "edition[in_beta]",
+  inline: true,
+  heading_size: "m",
+  items: [
+    {
+      value: 1,
+      text: "Yes",
+      checked: edition.in_beta,
+    },
+    {
+      value: 0,
+      text: "No",
+      checked: !edition.in_beta,
+    },
+  ],
+} %>

--- a/app/views/editions/secondary_nav_tabs/edit/draft/_public_change_note.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/draft/_public_change_note.html.erb
@@ -1,0 +1,35 @@
+<%= render "govuk_publishing_components/components/details", {
+  title: "Add a public change note",
+} do %>
+  <%= render "govuk_publishing_components/components/radio", {
+    heading: "Add a public change note",
+    heading_level: 3,
+    heading_size: "m",
+    name: "edition[major_change]",
+    hint: "Telling users when published information has changed is important for transparency.",
+    items: [
+      {
+        hint_text: "A change note will be published on the page and emailed to users subscribed to email alerts. The ‘last updated’ date will change.",
+        text: "Yes - information has been added, updated or removed.",
+        checked: edition.major_change,
+        bold: true,
+        value: true,
+        conditional: render("govuk_publishing_components/components/textarea", {
+          label: {
+            text: "Describe the change for users",
+            bold: true,
+          },
+          name: "edition[change_note]",
+          value: edition.change_note,
+          hint: ("<p class=\"govuk-!-margin-0\">Tell users what has changed, where and why. Write in full sentences, leading with the most important words. For example, \"College A has been removed from the registered sponsors list because its licence has been suspended.\"</p><a href=\"https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes\" target=\"_blank\">Guidance on change notes (opens in a new tab)</a>").html_safe,
+        }),
+      },
+      {
+        value: false,
+        text: "No",
+        bold: true,
+        checked: !edition.major_change,
+      },
+    ],
+  } %>
+<% end %>

--- a/app/views/editions/secondary_nav_tabs/edit/published/_body.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/published/_body.html.erb
@@ -1,0 +1,8 @@
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Body",
+  heading_level: 3,
+  font_size: "m",
+} %>
+<div class="govuk-body">
+  <%= simple_format(edition.body) %>
+</div>

--- a/app/views/editions/secondary_nav_tabs/edit/published/_common_fields.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/published/_common_fields.html.erb
@@ -1,0 +1,29 @@
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Title",
+  heading_level: 3,
+  font_size: "m",
+} %>
+
+<p class="govuk-body">
+  <%= edition.title %>
+</p>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Meta tag description",
+  heading_level: 3,
+  font_size: "m",
+} %>
+
+<p class="govuk-body">
+  <%= edition.overview %>
+</p>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Is this beta content?",
+  heading_level: 3,
+  font_size: "m",
+} %>
+
+<p class="govuk-body">
+  <%= edition.in_beta ? "Yes" : "No" %>
+</p>

--- a/app/views/editions/secondary_nav_tabs/edit/published/_public_change_note.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/published/_public_change_note.html.erb
@@ -1,0 +1,12 @@
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Public change note",
+  heading_level: 3,
+  font_size: "m",
+} %>
+<p class="govuk-body">
+  <% if edition.major_change %>
+    <%= edition.change_note %>
+  <% else %>
+    None added
+  <% end %>
+</p>

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -497,6 +497,33 @@ class EditionEditTest < IntegrationTest
       end
     end
 
+    context "published edition" do
+      should "show common content-type fields" do
+        published_edition = FactoryBot.create(
+          :edition,
+          state: "published",
+          title: "Some test title",
+          overview: "Some overview text",
+          in_beta: true,
+        )
+        visit edition_path(published_edition)
+
+        within "form" do
+          assert page.has_css?("h3", text: "Title")
+          assert page.has_css?("p.govuk-body", text: published_edition.title)
+          assert page.has_css?("h3", text: "Meta tag description")
+          assert page.has_css?("p.govuk-body", text: published_edition.overview)
+          assert page.has_css?("h3", text: "Is this beta content?")
+          assert page.has_css?("p.govuk-body", text: "Yes")
+
+          published_edition.in_beta = false
+          published_edition.save!(validate: false)
+          visit edition_path(published_edition)
+          assert page.has_css?("p.govuk-body", text: "No")
+        end
+      end
+    end
+
     context "Request amendments link" do
       context "edition is not in review" do
         setup do

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -536,6 +536,28 @@ class EditionEditTest < IntegrationTest
           assert page.has_css?("div", text: published_edition.body)
         end
       end
+
+      should "show public change field" do
+        published_edition = FactoryBot.create(
+          :answer_edition,
+          state: "published",
+          in_beta: true,
+          major_change: false,
+        )
+        visit edition_path(published_edition)
+
+        within "form" do
+          assert page.has_css?("h3", text: "Public change note")
+          assert page.has_text?("None added")
+
+          published_edition.major_change = true
+          published_edition.change_note = "Change note for test"
+          published_edition.save!(validate: false)
+          visit edition_path(published_edition)
+
+          assert page.has_text?(published_edition.change_note)
+        end
+      end
     end
 
     context "Request amendments link" do

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -522,6 +522,20 @@ class EditionEditTest < IntegrationTest
           assert page.has_css?("p.govuk-body", text: "No")
         end
       end
+
+      should "show body field" do
+        published_edition = FactoryBot.create(
+          :answer_edition,
+          state: "published",
+          body: "## Some body text",
+        )
+        visit edition_path(published_edition)
+
+        within "form" do
+          assert page.has_css?("h3", text: "Body")
+          assert page.has_css?("div", text: published_edition.body)
+        end
+      end
     end
 
     context "Request amendments link" do

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -552,6 +552,21 @@ class EditionEditTest < IntegrationTest
 
         assert page.has_text?(published_edition.change_note)
       end
+
+      should "show a 'create new edition' button when there isn't an existing draft edition" do
+        published_edition = FactoryBot.create(
+          :answer_edition,
+          state: "published",
+        )
+        visit edition_path(published_edition)
+
+        assert page.has_button?("Create new edition")
+
+        FactoryBot.create(:answer_edition, panopticon_id: published_edition.artefact.id, state: "draft")
+        visit edition_path(published_edition)
+
+        assert page.has_no_button?("Create new edition")
+      end
     end
 
     context "Request amendments link" do

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -561,11 +561,19 @@ class EditionEditTest < IntegrationTest
         visit edition_path(published_edition)
 
         assert page.has_button?("Create new edition")
+        assert page.has_no_link?("Edit latest edition")
+      end
 
+      should "show a 'edit latest edition' link when there is an existing draft edition" do
+        published_edition = FactoryBot.create(
+          :answer_edition,
+          state: "published",
+        )
         FactoryBot.create(:answer_edition, panopticon_id: published_edition.artefact.id, state: "draft")
         visit edition_path(published_edition)
 
         assert page.has_no_button?("Create new edition")
+        assert page.has_link?("Edit latest edition")
       end
     end
 

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -508,19 +508,17 @@ class EditionEditTest < IntegrationTest
         )
         visit edition_path(published_edition)
 
-        within "form" do
-          assert page.has_css?("h3", text: "Title")
-          assert page.has_css?("p.govuk-body", text: published_edition.title)
-          assert page.has_css?("h3", text: "Meta tag description")
-          assert page.has_css?("p.govuk-body", text: published_edition.overview)
-          assert page.has_css?("h3", text: "Is this beta content?")
-          assert page.has_css?("p.govuk-body", text: "Yes")
+        assert page.has_css?("h3", text: "Title")
+        assert page.has_css?("p.govuk-body", text: published_edition.title)
+        assert page.has_css?("h3", text: "Meta tag description")
+        assert page.has_css?("p.govuk-body", text: published_edition.overview)
+        assert page.has_css?("h3", text: "Is this beta content?")
+        assert page.has_css?("p.govuk-body", text: "Yes")
 
-          published_edition.in_beta = false
-          published_edition.save!(validate: false)
-          visit edition_path(published_edition)
-          assert page.has_css?("p.govuk-body", text: "No")
-        end
+        published_edition.in_beta = false
+        published_edition.save!(validate: false)
+        visit edition_path(published_edition)
+        assert page.has_css?("p.govuk-body", text: "No")
       end
 
       should "show body field" do
@@ -531,10 +529,8 @@ class EditionEditTest < IntegrationTest
         )
         visit edition_path(published_edition)
 
-        within "form" do
-          assert page.has_css?("h3", text: "Body")
-          assert page.has_css?("div", text: published_edition.body)
-        end
+        assert page.has_css?("h3", text: "Body")
+        assert page.has_css?("div", text: published_edition.body)
       end
 
       should "show public change field" do
@@ -546,17 +542,15 @@ class EditionEditTest < IntegrationTest
         )
         visit edition_path(published_edition)
 
-        within "form" do
-          assert page.has_css?("h3", text: "Public change note")
-          assert page.has_text?("None added")
+        assert page.has_css?("h3", text: "Public change note")
+        assert page.has_css?("p.govuk-body", text: "None added")
 
-          published_edition.major_change = true
-          published_edition.change_note = "Change note for test"
-          published_edition.save!(validate: false)
-          visit edition_path(published_edition)
+        published_edition.major_change = true
+        published_edition.change_note = "Change note for test"
+        published_edition.save!(validate: false)
+        visit edition_path(published_edition)
 
-          assert page.has_text?(published_edition.change_note)
-        end
+        assert page.has_text?(published_edition.change_note)
       end
     end
 

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -575,6 +575,16 @@ class EditionEditTest < IntegrationTest
         assert page.has_no_button?("Create new edition")
         assert page.has_link?("Edit latest edition")
       end
+
+      should "show a 'view on GOV.UK' link" do
+        published_edition = FactoryBot.create(
+          :answer_edition,
+          state: "published",
+        )
+        visit edition_path(published_edition)
+
+        assert page.has_link?("View on GOV.UK (opens in new tab)")
+      end
     end
 
     context "Request amendments link" do


### PR DESCRIPTION
[Trello card](https://trello.com/c/5EuyRleF)

Display a published edition's content as read-only on the "edit" tab when viewing an edition.

Also implements a sidebar, allowing users to view a later draft edition (if one exists), or create a new draft edition (if one doesn't already exist), and also view the published page on GOV.UK.

|Scenario|View|
|-|-|
|Viewing a published edition before the changes in this PR|![published-view-before](https://github.com/user-attachments/assets/eba09f0b-7afb-4ab1-81ba-98f34d451eda)|
|Viewing a published edition when a draft edition does not exist|![published-view-after-no-later-draft](https://github.com/user-attachments/assets/90100237-a2ff-447a-b804-a081b56d533c)|
|Viewing a published edition when a draft edition exists|![published-view-after-with-later-draft](https://github.com/user-attachments/assets/5a975b92-2a80-40b6-8953-dc24121f6729)|
