### PR TITLE
Fix flakey test due to Javascript animation timing

### DIFF
--- a/test/integration/host_content_update_history_test.rb
+++ b/test/integration/host_content_update_history_test.rb
@@ -97,25 +97,29 @@ class HostContentUpdateHistoryTest < LegacyJavascriptIntegrationTest
 
       click_on "Edition 2"
       within "#version2" do
-        within page.all(".action-content-block-update")[0] do
-          assert page.has_content?(Time.zone.parse(@edition2_content_update_event_2["created_at"]).to_fs(:govuk_date))
-          assert page.has_content?("Content block updated by User 1")
-          assert page.has_content?("Email address updated")
-        end
+        within ".collapse.in" do
+          within page.all(".action-content-block-update")[0] do
+            assert page.has_content?(Time.zone.parse(@edition2_content_update_event_2["created_at"]).to_fs(:govuk_date))
+            assert page.has_content?("Content block updated by User 1")
+            assert page.has_content?("Email address updated")
+          end
 
-        within page.all(".action-content-block-update")[1] do
-          assert page.has_content?(Time.zone.parse(@edition2_content_update_event_1["created_at"]).to_fs(:govuk_date))
-          assert page.has_content?("Content block updated by User 2")
-          assert page.has_content?("Email address updated")
+          within page.all(".action-content-block-update")[1] do
+            assert page.has_content?(Time.zone.parse(@edition2_content_update_event_1["created_at"]).to_fs(:govuk_date))
+            assert page.has_content?("Content block updated by User 2")
+            assert page.has_content?("Email address updated")
+          end
         end
       end
 
       click_on "Edition 1"
       within "#version1" do
-        within ".action-content-block-update" do
-          assert page.has_content?(Time.zone.parse(@edition1_content_update_event["created_at"]).to_fs(:govuk_date))
-          assert page.has_content?("Content block updated by User 1")
-          assert page.has_content?("Email address updated")
+        within ".collapse.in" do
+          within ".action-content-block-update" do
+            assert page.has_content?(Time.zone.parse(@edition1_content_update_event["created_at"]).to_fs(:govuk_date))
+            assert page.has_content?("Content block updated by User 1")
+            assert page.has_content?("Email address updated")
+          end
         end
       end
     end


### PR DESCRIPTION
The test fails intermittently with the error:
```
Capybara::ElementNotFound: Unable to find visible css ".action-content-block-update" within #<Capybara::Node::Element tag="div" path="/HTML/BODY[1]/SECTION[1]/MAIN[1]/DIV[1]/DIV[2]/DIV[1]/DIV[4]/DIV[1]/DIV[3]/DIV[2]/DIV[3]">
```

This seems to be because the expanding of the edition panel is not always completing before the check for the "content block update" element occurs. Adding the extra `within` selector for the `.collapse.in` classes to be present (which happens once the "expand" animation has completed) appears to at least make the test more reliable (I can't really be 100% sure it's completely resolved, but I've run the test dozens of times locally now without failure).
