### PR TITLE
Edit page for published editions desk check updates

### DIFF
--- a/app/helpers/editions_sidebar_buttons_helper.rb
+++ b/app/helpers/editions_sidebar_buttons_helper.rb
@@ -10,7 +10,13 @@ module EditionsSidebarButtonsHelper
                    link_to("Edit latest edition", edition_path(edition.in_progress_sibling), class: "govuk-link")
                  end
     end
-    buttons << link_to("View on GOV.UK (opens in new tab)", view_homepage_path, rel: "noreferrer noopener", target: "_blank", class: "govuk-link")
+    buttons << link_to(
+      "View on GOV.UK (opens in new tab)",
+      "#{Plek.website_root}/#{edition.slug}",
+      rel: "noreferrer noopener",
+      target: "_blank",
+      class: "govuk-link",
+    )
   end
 
   def non_published_sidebar_buttons(edition)

--- a/app/helpers/editions_sidebar_buttons_helper.rb
+++ b/app/helpers/editions_sidebar_buttons_helper.rb
@@ -17,6 +17,16 @@ module EditionsSidebarButtonsHelper
     }
   end
 
+  def edit_assignee_buttons(edition)
+    [
+      (render "govuk_publishing_components/components/button", {
+        text: "Save",
+        margin_bottom: 3,
+      }),
+      link_to("Cancel", edition_path(edition), class: "govuk-link govuk-link--no-visited-state"),
+    ]
+  end
+
   def published_sidebar_buttons(edition)
     buttons = []
     if current_user.has_editor_permissions?(edition)

--- a/app/helpers/editions_sidebar_buttons_helper.rb
+++ b/app/helpers/editions_sidebar_buttons_helper.rb
@@ -10,6 +10,13 @@ module EditionsSidebarButtonsHelper
     }
   end
 
+  def sidebar_items_list(items)
+    render "govuk_publishing_components/components/list", {
+      extra_spacing: true,
+      items: items,
+    }
+  end
+
   def published_sidebar_buttons(edition)
     buttons = []
     if current_user.has_editor_permissions?(edition)

--- a/app/helpers/editions_sidebar_buttons_helper.rb
+++ b/app/helpers/editions_sidebar_buttons_helper.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 module EditionsSidebarButtonsHelper
+  def sidebar_options_heading
+    render "govuk_publishing_components/components/heading", {
+      text: "Options",
+      heading_level: 3,
+      font_size: "s",
+      padding: true,
+    }
+  end
+
   def published_sidebar_buttons(edition)
     buttons = []
     if current_user.has_editor_permissions?(edition)

--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -25,7 +25,7 @@
       </div>
     </div>
   <% else %>
-    <%= form_for @resource, as: :edition, url: edition_path(@resource) do |f| %>
+    <%= form_for @resource, as: :edition, url: edition_path(@resource) do %>
       <div class="govuk-grid-column-two-thirds">
         <%= render partial: "editions/secondary_nav_tabs/edit/draft/common_fields", locals: { edition: @resource } %>
 

--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -27,6 +27,7 @@
         } %>
 
         <%= render "govuk_publishing_components/components/list", {
+          extra_spacing: true,
           items: published_sidebar_buttons(@resource),
         } %>
       </div>
@@ -54,6 +55,7 @@
           } %>
 
           <%= render "govuk_publishing_components/components/list", {
+            extra_spacing: true,
             items: non_published_sidebar_buttons(@resource),
           } %>
         </div>

--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -21,10 +21,7 @@
       <div class="sidebar-components">
         <%= sidebar_options_heading %>
 
-        <%= render "govuk_publishing_components/components/list", {
-          extra_spacing: true,
-          items: published_sidebar_buttons(@resource),
-        } %>
+        <%= sidebar_items_list(published_sidebar_buttons(@resource)) %>
       </div>
     </div>
   <% else %>
@@ -44,10 +41,7 @@
         <div class="sidebar-components">
           <%= sidebar_options_heading %>
 
-          <%= render "govuk_publishing_components/components/list", {
-            extra_spacing: true,
-            items: non_published_sidebar_buttons(@resource),
-          } %>
+          <%= sidebar_items_list(non_published_sidebar_buttons(@resource)) %>
         </div>
       </div>
     <% end %>

--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -19,12 +19,7 @@
     </div>
     <div class="govuk-grid-column-one-third options-sidebar">
       <div class="sidebar-components">
-        <%= render "govuk_publishing_components/components/heading", {
-          text: "Options",
-          heading_level: 3,
-          font_size: "s",
-          padding: true,
-        } %>
+        <%= sidebar_options_heading %>
 
         <%= render "govuk_publishing_components/components/list", {
           extra_spacing: true,
@@ -47,12 +42,7 @@
       </div>
       <div class="govuk-grid-column-one-third options-sidebar">
         <div class="sidebar-components">
-          <%= render "govuk_publishing_components/components/heading", {
-            text: "Options",
-            heading_level: 3,
-            font_size: "s",
-            padding: true,
-          } %>
+          <%= sidebar_options_heading %>
 
           <%= render "govuk_publishing_components/components/list", {
             extra_spacing: true,

--- a/app/views/editions/secondary_nav_tabs/_edit_assignee.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit_assignee.html.erb
@@ -17,7 +17,7 @@
       <div class="sidebar-components">
         <%= sidebar_options_heading %>
 
-        <%= sidebar_items_list(edit_assignee_buttons) %>
+        <%= sidebar_items_list(edit_assignee_buttons(@resource)) %>
       </div>
     </div>
   </div>

--- a/app/views/editions/secondary_nav_tabs/_edit_assignee.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit_assignee.html.erb
@@ -17,15 +17,7 @@
       <div class="sidebar-components">
         <%= sidebar_options_heading %>
 
-        <%= render "govuk_publishing_components/components/list", {
-          items: [
-            (render "govuk_publishing_components/components/button", {
-              text: "Save",
-              margin_bottom: 3,
-            }),
-            link_to("Cancel", edition_path(@resource), class: "govuk-link govuk-link--no-visited-state"),
-          ],
-        } %>
+        <%= sidebar_items_list(edit_assignee_buttons) %>
       </div>
     </div>
   </div>

--- a/app/views/editions/secondary_nav_tabs/_edit_assignee.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit_assignee.html.erb
@@ -15,12 +15,7 @@
 
     <div class="govuk-grid-column-one-third options-sidebar">
       <div class="sidebar-components">
-        <%= render "govuk_publishing_components/components/heading", {
-          text: "Options",
-          heading_level: 3,
-          font_size: "s",
-          padding: true,
-        } %>
+        <%= sidebar_options_heading %>
 
         <%= render "govuk_publishing_components/components/list", {
           items: [

--- a/app/views/editions/secondary_nav_tabs/_history.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_history.html.erb
@@ -5,12 +5,7 @@
 
   <div class="govuk-grid-column-one-third options-sidebar">
     <div class="sidebar-components">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: "Options",
-        heading_level: 3,
-        font_size: "s",
-        padding: true,
-      } %>
+      <%= sidebar_options_heading %>
 
       <%= render "govuk_publishing_components/components/list", {
         items: [

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -7,6 +7,7 @@ class EditionsControllerTest < ActionController::TestCase
     test_strategy.switch!(:restrict_access_by_org, false)
     @edition = FactoryBot.create(:edition, :fact_check)
     @welsh_edition = FactoryBot.create(:edition, :fact_check, :welsh)
+    UpdateWorker.stubs(:perform_async)
   end
 
   context "#template_folder_for" do

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -763,10 +763,11 @@ class EditionEditTest < IntegrationTest
         published_edition = FactoryBot.create(
           :answer_edition,
           state: "published",
+          slug: "a-test-slug",
         )
         visit edition_path(published_edition)
 
-        assert page.has_link?("View on GOV.UK (opens in new tab)")
+        assert page.has_link?("View on GOV.UK (opens in new tab)", href: "#{Plek.website_root}/#{published_edition.slug}")
       end
     end
 


### PR DESCRIPTION
Updates following a desk check for [the Trello ticket](https://trello.com/c/5EuyRleF).

- Make the "View on GOV.UK" links link to the edition being viewed, not the GOV.UK homepage.
- Increase spacing between items in the sidebar.
- Some code cleanup.