### PR TITLE
Implement "no changes needed" link for "In review" editions

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -11,7 +11,7 @@ class EditionsController < InheritedResources::Base
   before_action only: %i[unpublish confirm_unpublish process_unpublish] do
     require_govuk_editor(redirect_path: edition_path(resource))
   end
-  before_action only: %i[progress admin update confirm_destroy edit_assignee update_assignee request_amendments request_amendments_page] do
+  before_action only: %i[progress admin update confirm_destroy edit_assignee update_assignee request_amendments request_amendments_page no_changes_needed_page] do
     require_editor_permissions
   end
   before_action only: %i[confirm_destroy destroy] do
@@ -40,6 +40,10 @@ class EditionsController < InheritedResources::Base
 
   def request_amendments_page
     render "secondary_nav_tabs/request_amendments_page"
+  end
+
+  def no_changes_needed_page
+    render "secondary_nav_tabs/no_changes_needed_page"
   end
 
   def duplicate

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -11,7 +11,7 @@ class EditionsController < InheritedResources::Base
   before_action only: %i[unpublish confirm_unpublish process_unpublish] do
     require_govuk_editor(redirect_path: edition_path(resource))
   end
-  before_action only: %i[progress admin update confirm_destroy edit_assignee update_assignee request_amendments request_amendments_page no_changes_needed_page] do
+  before_action only: %i[progress admin update confirm_destroy edit_assignee update_assignee request_amendments request_amendments_page no_changes_needed no_changes_needed_page] do
     require_editor_permissions
   end
   before_action only: %i[confirm_destroy destroy] do
@@ -91,6 +91,16 @@ class EditionsController < InheritedResources::Base
     else
       flash.now[:danger] = "Due to a service problem, the request could not be made"
       render "secondary_nav_tabs/request_amendments_page"
+    end
+  end
+
+  def no_changes_needed
+    if no_changes_needed_for_edition(@resource, params[:comment])
+      flash.now[:success] = "2i approved"
+      render "show"
+    else
+      flash.now[:danger] = "Due to a service problem, the request could not be made"
+      render "secondary_nav_tabs/no_changes_needed_page"
     end
   end
 
@@ -214,6 +224,11 @@ private
   def request_amendments_for_edition(resource, comment)
     @command = EditionProgressor.new(resource, current_user)
     @command.progress({ request_type: "request_amendments", comment: comment })
+  end
+
+  def no_changes_needed_for_edition(resource, comment)
+    @command = EditionProgressor.new(resource, current_user)
+    @command.progress({ request_type: "approve_review", comment: comment })
   end
 
   def unpublish_edition(artefact)

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -85,7 +85,7 @@ class EditionsController < InheritedResources::Base
   end
 
   def request_amendments
-    if request_amendments_for_edition(@resource, params[:amendment_comment])
+    if request_amendments_for_edition(@resource, params[:comment])
       flash.now[:success] = "2i amendments requested"
       render "show"
     else

--- a/app/lib/edition_progressor.rb
+++ b/app/lib/edition_progressor.rb
@@ -30,6 +30,7 @@ class EditionProgressor
       true
     else
       self.status_message = failure_message(action)
+      Rails.logger.warn "Unable to carry out action '#{action}' for edition #{edition.id}: #{status_message}"
       false
     end
   end

--- a/app/views/editions/secondary_nav_tabs/_progress_with_comment.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_progress_with_comment.html.erb
@@ -1,0 +1,23 @@
+<%# locals: (form_url:, comment_label_text:, submit_button_text:) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(:edition, url: form_url) do %>
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          heading_size: "m",
+          text: comment_label_text,
+        },
+        name: "comment",
+        rows: 14,
+      } %>
+
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: submit_button_text,
+        } %>
+        <%= link_to("Cancel", edition_path, class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/editions/secondary_nav_tabs/_progress_with_comment.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_progress_with_comment.html.erb
@@ -9,6 +9,7 @@
           text: comment_label_text,
         },
         name: "comment",
+        value: params[:comment],
         rows: 14,
       } %>
 

--- a/app/views/editions/secondary_nav_tabs/no_changes_needed_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/no_changes_needed_page.html.erb
@@ -1,0 +1,26 @@
+<% @edition = @resource %>
+<% content_for :title_context, @edition.title %>
+<% content_for :page_title, "No changes needed" %>
+<% content_for :title, "No changes needed" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(:edition, url: "#{edition_path}/no_changes_needed") do |f| %>
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          heading_size: "m",
+          text: "Comment (optional)",
+        },
+        name: "comment",
+        rows: 14,
+      } %>
+
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Approve 2i",
+        } %>
+        <%= link_to("Cancel", edition_path, class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/editions/secondary_nav_tabs/no_changes_needed_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/no_changes_needed_page.html.erb
@@ -3,24 +3,8 @@
 <% content_for :page_title, "No changes needed" %>
 <% content_for :title, "No changes needed" %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_for(:edition, url: "#{edition_path}/no_changes_needed") do |f| %>
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          heading_size: "m",
-          text: "Comment (optional)",
-        },
-        name: "comment",
-        rows: 14,
-      } %>
-
-      <div class="govuk-button-group">
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Approve 2i",
-        } %>
-        <%= link_to("Cancel", edition_path, class: "govuk-link govuk-link--no-visited-state") %>
-      </div>
-    <% end %>
-  </div>
-</div>
+<%= render "editions/secondary_nav_tabs/progress_with_comment", {
+  form_url: "#{edition_path}/no_changes_needed",
+  comment_label_text: "Comment (optional)",
+  submit_button_text: "Approve 2i",
+} %>

--- a/app/views/editions/secondary_nav_tabs/request_amendments_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/request_amendments_page.html.erb
@@ -11,7 +11,7 @@
           heading_size: "m",
           text: "Amendment details (optional)",
         },
-        name: "amendment_comment",
+        name: "comment",
         rows: 14,
       } %>
 

--- a/app/views/editions/secondary_nav_tabs/request_amendments_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/request_amendments_page.html.erb
@@ -3,24 +3,8 @@
 <% content_for :page_title, "Request amendments" %>
 <% content_for :title, "Request amendments" %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_for(:edition, url: "#{edition_path}/request_amendments") do |f| %>
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          heading_size: "m",
-          text: "Amendment details (optional)",
-        },
-        name: "comment",
-        rows: 14,
-      } %>
-
-      <div class="govuk-button-group">
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Request amendments",
-        } %>
-        <%= link_to("Cancel", edition_path, class: "govuk-link govuk-link--no-visited-state") %>
-      </div>
-    <% end %>
-  </div>
-</div>
+<%= render "editions/secondary_nav_tabs/progress_with_comment", {
+  form_url: "#{edition_path}/request_amendments",
+  comment_label_text: "Amendment details (optional)",
+  submit_button_text: "Request amendments",
+} %>

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -33,6 +33,7 @@
       <div class="govuk-grid-column-two-thirds">
         <%= render "govuk_publishing_components/components/inset_text", {} do %>
           <p class="govuk-body"><%= link_to("Request amendments", request_amendments_page_edition_path) %></p>
+          <p class="govuk-body"><%= link_to("No changes needed", no_changes_needed_page_edition_path) %></p>
         <% end %>
       </div>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
       member do
         get "request_amendments_page", to: "editions#request_amendments_page", as: "request_amendments_page"
         post "request_amendments", to: "editions#request_amendments", as: "request_amendments"
+        get "no_changes_needed_page", to: "editions#no_changes_needed_page", as: "no_changes_needed_page"
         get "metadata"
         get "history"
         get "history/add_edition_note", to: "editions#add_edition_note", as: "history/add_edition_note"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
         get "request_amendments_page", to: "editions#request_amendments_page", as: "request_amendments_page"
         post "request_amendments", to: "editions#request_amendments", as: "request_amendments"
         get "no_changes_needed_page", to: "editions#no_changes_needed_page", as: "no_changes_needed_page"
+        post "no_changes_needed", to: "editions#no_changes_needed", as: "no_changes_needed"
         get "metadata"
         get "history"
         get "history/add_edition_note", to: "editions#add_edition_note", as: "history/add_edition_note"

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -75,7 +75,7 @@ class EditionsControllerTest < ActionController::TestCase
       should "update the edition status to 'amends_needed' and save the comment" do
         post :request_amendments, params: {
           id: @edition.id,
-          amendment_comment: "This is a comment",
+          comment: "This is a comment",
         }
 
         assert_equal "2i amendments requested", flash[:success]

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -116,6 +116,43 @@ class EditionsControllerTest < ActionController::TestCase
     end
   end
 
+  context "#no_changes_needed_page" do
+    context "user has govuk_editor permission" do
+      should "render the 'No changes needed' page" do
+        get :no_changes_needed_page, params: { id: @edition.id }
+        assert_template "secondary_nav_tabs/no_changes_needed_page"
+      end
+    end
+
+    context "user does not have govuk_editor permission" do
+      setup do
+        user = FactoryBot.create(:user)
+        login_as(user)
+      end
+
+      should "render an error message" do
+        get :no_changes_needed_page, params: { id: @edition.id }
+        assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
+      end
+    end
+
+    context "user has welsh_editor permission" do
+      setup do
+        login_as_welsh_editor
+      end
+
+      should "render the 'No changes needed' page when the edition is Welsh" do
+        get :no_changes_needed_page, params: { id: @welsh_edition.id }
+        assert_template "secondary_nav_tabs/no_changes_needed_page"
+      end
+
+      should "render an error message when the edition is not Welsh" do
+        get :no_changes_needed_page, params: { id: @edition.id }
+        assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
+      end
+    end
+  end
+
   context "#metadata" do
     should "alias to show method" do
       assert_equal EditionsController.new.method(:metadata).super_method.name, :show

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -89,7 +89,6 @@ class EditionsControllerTest < ActionController::TestCase
 
         post :request_amendments, params: {
           id: @edition.id,
-          amendment_comment: "This is a comment",
         }
 
         assert_template "secondary_nav_tabs/request_amendments_page"
@@ -108,7 +107,6 @@ class EditionsControllerTest < ActionController::TestCase
       should "render an error message" do
         post :request_amendments, params: {
           id: @edition.id,
-          amendment_comment: "This is a comment",
         }
 
         assert_equal "You do not have correct editor permissions for this action.", flash[:danger]

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -1135,6 +1135,22 @@ class EditionEditTest < IntegrationTest
     end
   end
 
+  context "Request amendments page" do
+    should "save comment to edition history" do
+      create_in_review_edition
+
+      visit request_amendments_page_edition_path(@in_review_edition)
+      fill_in "Amendment details (optional)", with: "Please make these changes"
+      click_on "Request amendments"
+
+      # TODO: Remove this feature flag toggling once ticket #603 - History and notes tab (excluding sidebar) [Edit page] is complete
+      test_strategy = Flipflop::FeatureSet.current.test!
+      test_strategy.switch!(:design_system_edit, false)
+      click_on "History and notes"
+      assert page.has_content?("Please make these changes")
+    end
+  end
+
   context "No changes needed page" do
     should "save comment to edition history" do
       create_in_review_edition

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -1149,6 +1149,24 @@ class EditionEditTest < IntegrationTest
       click_on "History and notes"
       assert page.has_content?("Please make these changes")
     end
+
+    context "current user is also the requester" do
+      setup do
+        login_as(@govuk_requester)
+      end
+
+      should "populate comment box with submitted comment when there is an error" do
+        create_in_review_edition
+        login_as(@in_review_edition.latest_status_action.requester)
+
+        visit request_amendments_page_edition_path(@in_review_edition)
+        fill_in "Amendment details (optional)", with: "Please make these changes"
+        click_on "Request amendments"
+
+        assert page.has_content?("Due to a service problem, the request could not be made")
+        assert page.has_content?("Please make these changes")
+      end
+    end
   end
 
   context "No changes needed page" do
@@ -1164,6 +1182,24 @@ class EditionEditTest < IntegrationTest
       test_strategy.switch!(:design_system_edit, false)
       click_on "History and notes"
       assert page.has_content?("Looks great")
+    end
+
+    context "current user is also the requester" do
+      setup do
+        login_as(@govuk_requester)
+      end
+
+      should "populate comment box with submitted comment when there is an error" do
+        create_in_review_edition
+        login_as(@in_review_edition.latest_status_action.requester)
+
+        visit no_changes_needed_page_edition_path(@in_review_edition)
+        fill_in "Comment (optional)", with: "Great job!"
+        click_on "Approve 2i"
+
+        assert page.has_content?("Due to a service problem, the request could not be made")
+        assert page.has_content?("Great job!")
+      end
     end
   end
 

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -833,6 +833,68 @@ class EditionEditTest < IntegrationTest
       end
     end
 
+    context "No changes needed link" do
+      context "edition is not in review" do
+        setup do
+          visit_draft_edition
+        end
+
+        should "not show the 'No changes needed' link" do
+          assert page.has_no_link?("No changes needed")
+        end
+      end
+
+      context "edition is in review" do
+        context "user does not have the required permissions" do
+          setup do
+            login_as(FactoryBot.create(:user, name: "Stub User"))
+            visit_in_review_edition
+          end
+
+          should "not show the 'No changes needed' link" do
+            assert page.has_no_link?("No changes needed")
+          end
+
+          should "not show 'No changes needed' link when user is a welsh editor and the edition is not welsh" do
+            login_as(FactoryBot.create(:user, :welsh_editor, name: "Stub User"))
+            visit_in_review_edition
+
+            assert page.has_no_link?("No changes needed")
+          end
+        end
+
+        context "user has the required permissions" do
+          context "current user is also the requester" do
+            setup do
+              login_as(@govuk_requester)
+              visit_in_review_edition
+            end
+
+            should "not show the 'No changes needed' link" do
+              assert page.has_no_link?("No changes needed")
+            end
+          end
+
+          context "current user is not the requester" do
+            setup do
+              login_as(@govuk_editor)
+              visit_in_review_edition
+            end
+
+            should "show the 'No changes needed' link" do
+              assert page.has_link?("No changes needed")
+            end
+
+            should "navigate to 'No changes needed' page when link is clicked" do
+              click_link("No changes needed")
+
+              assert_current_path no_changes_needed_page_edition_path(@in_review_edition.id)
+            end
+          end
+        end
+      end
+    end
+
     context "edit assignee link" do
       context "user does not have required permissions" do
         setup do


### PR DESCRIPTION
[Trello card](https://trello.com/c/gohxJSrY)

Add a "no changes needed" link to the show view of editions when the user has the relevant permissions.

| Scenario  | View |
| --- | --- |
| Viewing an "in review" edition before the changes in this PR  | ![image](https://github.com/user-attachments/assets/6334b4b9-66c7-4b8e-a3d5-60a05e118f24) |
| Viewing an "in review" edition with the changes in this PR | ![image](https://github.com/user-attachments/assets/d1f87d80-303c-49ea-8187-8eed1c11ff28) |
| The view displayed after clicking the "no changes needed" link  | ![no-changes-needed-page](https://github.com/user-attachments/assets/332e3d84-5bb5-4f72-82cb-7ee799224c73) |
| Viewing an edition after the "no changes needed" page has been submitted | ![image](https://github.com/user-attachments/assets/06a1665d-02ec-4d99-a815-041b57ca82a2) |