### PR TITLE
`#is_for_edition?` is false when not published

### DIFF
--- a/app/models/host_content_update_event.rb
+++ b/app/models/host_content_update_event.rb
@@ -28,7 +28,7 @@ class HostContentUpdateEvent < Data.define(:author, :created_at, :content_id, :c
   def is_for_edition?(edition)
     if edition.published?
       created_at.after?(edition.published_at)
-    elsif edition.archived? && edition.superseded_at
+    elsif edition.archived? && edition.superseded_at && edition.published_at
       created_at.between?(edition.published_at, edition.superseded_at)
     else
       false

--- a/test/models/host_content_update_event_test.rb
+++ b/test/models/host_content_update_event_test.rb
@@ -145,6 +145,13 @@ class HostContentUpdateEventTest < ActiveSupport::TestCase
 
         assert_not event.is_for_edition?(edition)
       end
+
+      it "returns false if the edition was never published" do
+        edition.stubs(:published_at).returns(nil)
+        event = FactoryBot.build(:host_content_update_event, created_at: superseded_at + 1.minute)
+
+        assert_not event.is_for_edition?(edition)
+      end
     end
   end
 


### PR DESCRIPTION
When an edition is archived, but not published, this was raising an error, as `edition.publised_at` was nil. This adds an additional check to see if the edition had ever been published. If not, then we know this update didn’t occur during the lifecycle of this edition, as it was never public.