### PR TITLE
Change default to true for restrict_access_by_org feature

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -18,7 +18,7 @@ Flipflop.configure do
           description: "Update the publications edit page to use the GOV.UK Design System"
 
   feature :restrict_access_by_org,
-          default: false,
+          default: true,
           description: "Restrict access to editions based on the user's org and which org(s) own the edition"
 
   feature :show_link_to_content_block_manager,

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -4,7 +4,7 @@ class EditionsControllerTest < ActionController::TestCase
   setup do
     login_as_stub_user
     test_strategy = Flipflop::FeatureSet.current.test!
-    test_strategy.switch!(:restrict_access_by_org, false)
+    test_strategy.switch!(:restrict_access_by_org, true)
     @edition = FactoryBot.create(:edition, :fact_check)
     @welsh_edition = FactoryBot.create(:edition, :fact_check, :welsh)
     UpdateWorker.stubs(:perform_async)
@@ -123,6 +123,16 @@ class EditionsControllerTest < ActionController::TestCase
   end
 
   context "when 'restrict_access_by_org' feature toggle is disabled" do
+    setup do
+      test_strategy = Flipflop::FeatureSet.current.test!
+      test_strategy.switch!(:restrict_access_by_org, false)
+    end
+
+    teardown do
+      test_strategy = Flipflop::FeatureSet.current.test!
+      test_strategy.switch!(:restrict_access_by_org, true)
+    end
+
     %i[show metadata history related_external_links].each do |action|
       context "##{action}" do
         setup do
@@ -149,16 +159,6 @@ class EditionsControllerTest < ActionController::TestCase
   end
 
   context "when 'restrict_access_by_org' feature toggle is enabled" do
-    setup do
-      test_strategy = Flipflop::FeatureSet.current.test!
-      test_strategy.switch!(:restrict_access_by_org, true)
-    end
-
-    teardown do
-      test_strategy = Flipflop::FeatureSet.current.test!
-      test_strategy.switch!(:restrict_access_by_org, false)
-    end
-
     %i[show metadata history admin related_external_links unpublish].each do |action|
       context "##{action}" do
         setup do

--- a/test/functional/legacy_editions_controller_test.rb
+++ b/test/functional/legacy_editions_controller_test.rb
@@ -9,7 +9,7 @@ class LegacyEditionsControllerTest < ActionController::TestCase
     stub_users_from_signon_api
 
     test_strategy = Flipflop::FeatureSet.current.test!
-    test_strategy.switch!(:restrict_access_by_org, false)
+    test_strategy.switch!(:restrict_access_by_org, true)
   end
 
   context "#create" do
@@ -1311,6 +1311,16 @@ class LegacyEditionsControllerTest < ActionController::TestCase
   end
 
   context "when 'restrict_access_by_org' feature toggle is disabled" do
+    setup do
+      test_strategy = Flipflop::FeatureSet.current.test!
+      test_strategy.switch!(:restrict_access_by_org, false)
+    end
+
+    teardown do
+      test_strategy = Flipflop::FeatureSet.current.test!
+      test_strategy.switch!(:restrict_access_by_org, true)
+    end
+
     %i[metadata history].each do |action|
       context "##{action}" do
         setup do
@@ -1337,16 +1347,6 @@ class LegacyEditionsControllerTest < ActionController::TestCase
   end
 
   context "when 'restrict_access_by_org' feature toggle is enabled" do
-    setup do
-      test_strategy = Flipflop::FeatureSet.current.test!
-      test_strategy.switch!(:restrict_access_by_org, true)
-    end
-
-    teardown do
-      test_strategy = Flipflop::FeatureSet.current.test!
-      test_strategy.switch!(:restrict_access_by_org, false)
-    end
-
     %i[show metadata history admin unpublish].each do |action|
       context "##{action}" do
         setup do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -52,7 +52,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "#gds_editor? is false if user's organisation is not GDS" do
-    user = FactoryBot.create(:user, organisation_slug: "some-other-org")
+    user = FactoryBot.create(:user, organisation_slug: "some-other-org", organisation_content_id: "some-other-org-id")
 
     assert_not user.gds_editor?
   end

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     sequence(:uid) { |n| "uid-#{n}" }
     sequence(:name) { |n| "Joe Bloggs #{n}" }
     sequence(:email) { |n| "joe#{n}@bloggs.com" }
+    organisation_content_id { PublishService::GDS_ORGANISATION_ID }
 
     if defined?(GDS::SSO::Config)
       # Grant permission to signin to the app using the gem


### PR DESCRIPTION
[Trello card] (https://trello.com/c/HQmmcxJl/599-access-permissions-add-departmentaleditor-permission)

This will restrict access to Mainstream content for specified users outside of GDS.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
