### PR TITLE
Add skip review functionality

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -17,6 +17,9 @@ class EditionsController < InheritedResources::Base
   before_action only: %i[confirm_destroy destroy] do
     require_destroyable
   end
+  before_action only: %i[skip_review_page] do
+    require_skip_review_permission
+  end
 
   before_action only: %i[edit_assignee update_assignee] do
     require_assignee_editable
@@ -44,6 +47,10 @@ class EditionsController < InheritedResources::Base
 
   def no_changes_needed_page
     render "secondary_nav_tabs/no_changes_needed_page"
+  end
+
+  def skip_review_page
+    render "secondary_nav_tabs/skip_review_page"
   end
 
   def duplicate
@@ -320,5 +327,12 @@ private
 
     flash.now[:danger] = "Chosen assignee does not have correct editor permissions."
     false
+  end
+
+  def require_skip_review_permission
+    return if current_user.permissions.include?("skip_review")
+
+    flash[:danger] = "You do not have correct editor permissions for this action."
+    redirect_to edition_path(resource)
   end
 end

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -17,10 +17,9 @@ class EditionsController < InheritedResources::Base
   before_action only: %i[confirm_destroy destroy] do
     require_destroyable
   end
-  before_action only: %i[skip_review_page] do
+  before_action only: %i[skip_review skip_review_page] do
     require_skip_review_permission
   end
-
   before_action only: %i[edit_assignee update_assignee] do
     require_assignee_editable
   end
@@ -108,6 +107,16 @@ class EditionsController < InheritedResources::Base
     else
       flash.now[:danger] = "Due to a service problem, the request could not be made"
       render "secondary_nav_tabs/no_changes_needed_page"
+    end
+  end
+
+  def skip_review
+    if skip_review_for_edition(@resource, params[:comment])
+      flash.now[:success] = "2i review skipped"
+      render "show"
+    else
+      flash.now[:danger] = "Due to a service problem, the request could not be made"
+      render "secondary_nav_tabs/skip_review_page"
     end
   end
 
@@ -238,6 +247,11 @@ private
   def no_changes_needed_for_edition(resource, comment)
     @command = EditionProgressor.new(resource, current_user)
     @command.progress({ request_type: "approve_review", comment: comment })
+  end
+
+  def skip_review_for_edition(resource, comment)
+    @command = EditionProgressor.new(resource, current_user)
+    @command.progress({ request_type: "skip_review", comment: comment })
   end
 
   def unpublish_edition(artefact)

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -344,7 +344,7 @@ private
   end
 
   def require_skip_review_permission
-    return if current_user.permissions.include?("skip_review")
+    return if current_user.skip_review?
 
     flash[:danger] = "You do not have correct editor permissions for this action."
     redirect_to edition_path(resource)

--- a/app/helpers/edition_activity_buttons_helper.rb
+++ b/app/helpers/edition_activity_buttons_helper.rb
@@ -78,8 +78,4 @@ module EditionActivityButtonsHelper
       link_to("Preview", preview_edition_path(edition), class: "btn btn-primary btn-large")
     end
   end
-
-  def skip_review?
-    current_user.permissions.include?("skip_review")
-  end
 end

--- a/app/lib/govuk_content_models/action_processors/skip_review_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/skip_review_processor.rb
@@ -2,7 +2,7 @@ module GovukContentModels
   module ActionProcessors
     class SkipReviewProcessor < BaseProcessor
       def process?
-        actor.permissions.include?("skip_review")
+        actor.permissions.include?("skip_review") and !requester_different?
       end
     end
   end

--- a/app/lib/govuk_content_models/action_processors/skip_review_processor.rb
+++ b/app/lib/govuk_content_models/action_processors/skip_review_processor.rb
@@ -2,7 +2,7 @@ module GovukContentModels
   module ActionProcessors
     class SkipReviewProcessor < BaseProcessor
       def process?
-        actor.permissions.include?("skip_review") and !requester_different?
+        actor.skip_review? and !requester_different?
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -95,4 +95,8 @@ class User
   def gds_editor?
     organisation_content_id == PublishService::GDS_ORGANISATION_ID
   end
+
+  def skip_review?
+    permissions.include?("skip_review")
+  end
 end

--- a/app/views/editions/secondary_nav_tabs/skip_review_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/skip_review_page.html.erb
@@ -1,0 +1,10 @@
+<% @edition = @resource %>
+<% content_for :title_context, @edition.title %>
+<% content_for :page_title, "Skip review" %>
+<% content_for :title, "Skip review" %>
+
+<%= render "editions/secondary_nav_tabs/progress_with_comment", {
+  form_url: "#{edition_path}/skip_review",
+  comment_label_text: "Comment (optional)",
+  submit_button_text: "Skip review",
+} %>

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -38,6 +38,16 @@
       </div>
     <% end %>
   <% end %>
+
+  <% if @edition.in_review? && current_user.permissions.include?("skip_review") %>
+    <% if @edition.latest_status_action.requester == current_user %>
+      <div class="govuk-grid-column-two-thirds">
+        <%= render "govuk_publishing_components/components/inset_text", {} do %>
+          <p class="govuk-body"><%= link_to("Skip review", skip_review_page_edition_path) %></p>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
 </div>
 
 <div class="govuk-grid-row">

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -28,25 +28,17 @@
     <% end %>
   </div>
 
-  <% if @edition.in_review? && current_user.has_editor_permissions?(@edition) %>
-    <% unless @edition.latest_status_action.requester == current_user %>
-      <div class="govuk-grid-column-two-thirds">
-        <%= render "govuk_publishing_components/components/inset_text", {} do %>
+  <% if @edition.in_review? %>
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/inset_text", {} do %>
+        <% if @edition.latest_status_action.requester == current_user %>
+          <p class="govuk-body"><%= link_to("Skip review", skip_review_page_edition_path) %></p>
+        <% elsif current_user.has_editor_permissions?(@edition) %>
           <p class="govuk-body"><%= link_to("Request amendments", request_amendments_page_edition_path) %></p>
           <p class="govuk-body"><%= link_to("No changes needed", no_changes_needed_page_edition_path) %></p>
         <% end %>
-      </div>
-    <% end %>
-  <% end %>
-
-  <% if @edition.in_review? && current_user.permissions.include?("skip_review") %>
-    <% if @edition.latest_status_action.requester == current_user %>
-      <div class="govuk-grid-column-two-thirds">
-        <%= render "govuk_publishing_components/components/inset_text", {} do %>
-          <p class="govuk-body"><%= link_to("Skip review", skip_review_page_edition_path) %></p>
-        <% end %>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   <% end %>
 </div>
 

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -32,7 +32,9 @@
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/inset_text", {} do %>
         <% if @edition.latest_status_action.requester == current_user %>
-          <p class="govuk-body"><%= link_to("Skip review", skip_review_page_edition_path) %></p>
+          <% if current_user.skip_review? %>
+            <p class="govuk-body"><%= link_to("Skip review", skip_review_page_edition_path) %></p>
+          <% end %>
         <% elsif current_user.has_editor_permissions?(@edition) %>
           <p class="govuk-body"><%= link_to("Request amendments", request_amendments_page_edition_path) %></p>
           <p class="govuk-body"><%= link_to("No changes needed", no_changes_needed_page_edition_path) %></p>

--- a/app/views/shared/_review.html.erb
+++ b/app/views/shared/_review.html.erb
@@ -2,7 +2,7 @@
   <% if @resource.latest_status_action(Action::REQUEST_REVIEW) %>
     <% if @resource.latest_status_action.requester == current_user %>
       <p>You’ve sent this edition to be reviewed.</p>
-      <% if skip_review? %>
+      <% if current_user.skip_review? %>
         <p><%= build_review_button(@resource, "skip_review", "Skip review").html_safe %></p>
       <% end %>
     <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
         post "request_amendments", to: "editions#request_amendments", as: "request_amendments"
         get "no_changes_needed_page", to: "editions#no_changes_needed_page", as: "no_changes_needed_page"
         post "no_changes_needed", to: "editions#no_changes_needed", as: "no_changes_needed"
+        get "skip_review_page", to: "editions#skip_review_page", as: "skip_review_page"
         get "metadata"
         get "history"
         get "history/add_edition_note", to: "editions#add_edition_note", as: "history/add_edition_note"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
         get "no_changes_needed_page", to: "editions#no_changes_needed_page", as: "no_changes_needed_page"
         post "no_changes_needed", to: "editions#no_changes_needed", as: "no_changes_needed"
         get "skip_review_page", to: "editions#skip_review_page", as: "skip_review_page"
+        post "skip_review", to: "editions#skip_review", as: "skip_review"
         get "metadata"
         get "history"
         get "history/add_edition_note", to: "editions#add_edition_note", as: "history/add_edition_note"

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -208,6 +208,32 @@ class EditionsControllerTest < ActionController::TestCase
     end
   end
 
+  context "#skip_review_page" do
+    context "user has skip_review permission" do
+      setup do
+        user = FactoryBot.create(:user, :skip_review)
+        login_as(user)
+      end
+
+      should "render the 'Skip review' page" do
+        get :skip_review_page, params: { id: @edition.id }
+        assert_template "secondary_nav_tabs/skip_review_page"
+      end
+    end
+
+    context "user does not have skip_review permission" do
+      setup do
+        user = FactoryBot.create(:user)
+        login_as(user)
+      end
+
+      should "render an error message" do
+        get :skip_review_page, params: { id: @edition.id }
+        assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
+      end
+    end
+  end
+
   context "#metadata" do
     should "alias to show method" do
       assert_equal EditionsController.new.method(:metadata).super_method.name, :show

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -65,7 +65,6 @@ class EditionsControllerTest < ActionController::TestCase
 
   context "#request_amendments" do
     setup do
-      @requester = FactoryBot.create(:user, name: "Stub Requester")
       @edition = FactoryBot.create(
         :edition,
         state: "in_review",
@@ -155,7 +154,6 @@ class EditionsControllerTest < ActionController::TestCase
 
   context "#no_changes_needed" do
     setup do
-      @requester = FactoryBot.create(:user, name: "Stub Requester")
       @edition = FactoryBot.create(
         :edition,
         state: "in_review",

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -1387,6 +1387,44 @@ class EditionEditTest < IntegrationTest
     end
   end
 
+  context "Skip review page" do
+    context "current user may skip review" do
+      setup do
+        login_as(@govuk_requester)
+        @govuk_requester.permissions << "skip_review"
+      end
+
+      should "save comment to edition history" do
+        create_in_review_edition
+
+        visit skip_review_page_edition_path(@in_review_edition)
+        fill_in "Comment (optional)", with: "Looks great"
+        click_on "Skip review"
+
+        click_on "History and notes"
+        assert page.has_content?("Skip review by Stub requester")
+        assert page.has_content?("Looks great")
+      end
+    end
+
+    context "current user is not the requester" do
+      setup do
+        @govuk_editor.permissions << "skip_review"
+      end
+
+      should "populate comment box with submitted comment when there is an error" do
+        create_in_review_edition
+
+        visit skip_review_page_edition_path(@in_review_edition)
+        fill_in "Comment (optional)", with: "No review required"
+        click_on "Skip review"
+
+        assert page.has_content?("Due to a service problem, the request could not be made")
+        assert page.has_content?("No review required")
+      end
+    end
+  end
+
 private
 
   def create_draft_edition

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -1079,6 +1079,62 @@ class EditionEditTest < IntegrationTest
       end
     end
 
+    context "Skip review link" do
+      context "edition is not in review" do
+        setup do
+          visit_draft_edition
+        end
+
+        should "not show the 'Skip review' link" do
+          assert page.has_no_link?("Skip review")
+        end
+      end
+
+      context "edition is in review" do
+        context "user does not have the required permissions" do
+          setup do
+            login_as(FactoryBot.create(:user, name: "Stub User"))
+            visit_in_review_edition
+          end
+
+          should "not show the 'Skip review' link" do
+            assert page.has_no_link?("Skip review")
+          end
+        end
+
+        context "user has the required permissions" do
+          context "current user is not the requester" do
+            setup do
+              @govuk_editor.permissions << "skip_review"
+              visit_in_review_edition
+            end
+
+            should "not show the 'Skip review' link" do
+              assert page.has_no_link?("Skip review")
+            end
+          end
+
+          context "current user is the requester" do
+            setup do
+              login_as(@govuk_requester)
+              @govuk_requester.permissions << "skip_review"
+              visit_in_review_edition
+            end
+
+            should "show the 'Skip review' link" do
+              assert page.has_link?("Skip review")
+            end
+
+            should "navigate to 'Skip review' page when link is clicked" do
+              click_link("Skip review")
+
+              assert_current_path skip_review_page_edition_path(@in_review_edition.id)
+            end
+          end
+        end
+      end
+    end
+
     context "edit assignee link" do
       context "user does not have required permissions" do
         setup do

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -1327,10 +1327,8 @@ class EditionEditTest < IntegrationTest
       fill_in "Amendment details (optional)", with: "Please make these changes"
       click_on "Request amendments"
 
-      # TODO: Remove this feature flag toggling once ticket #603 - History and notes tab (excluding sidebar) [Edit page] is complete
-      test_strategy = Flipflop::FeatureSet.current.test!
-      test_strategy.switch!(:design_system_edit, false)
       click_on "History and notes"
+      assert page.has_content?("Request amendments by")
       assert page.has_content?("Please make these changes")
     end
 
@@ -1361,10 +1359,8 @@ class EditionEditTest < IntegrationTest
       fill_in "Comment (optional)", with: "Looks great"
       click_on "Approve 2i"
 
-      # TODO: Remove this feature flag toggling once ticket #603 - History and notes tab (excluding sidebar) [Edit page] is complete
-      test_strategy = Flipflop::FeatureSet.current.test!
-      test_strategy.switch!(:design_system_edit, false)
       click_on "History and notes"
+      assert page.has_content?("Approve review by")
       assert page.has_content?("Looks great")
     end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -57,6 +57,18 @@ class UserTest < ActiveSupport::TestCase
     assert_not user.gds_editor?
   end
 
+  test "#skip_review? is true if user may skip reviews" do
+    user = FactoryBot.create(:user, :skip_review)
+
+    assert user.skip_review?
+  end
+
+  test "#skip_review? is false if user may not skip reviews" do
+    user = FactoryBot.create(:user)
+
+    assert_not user.skip_review?
+  end
+
   test "should convert to string using name by preference" do
     user = User.new(name: "Bob", email: "user@example.com")
     assert_equal "Bob", user.to_s

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -26,6 +26,10 @@ FactoryBot.define do
     trait :departmental_editor do
       permissions { %w[departmental_editor signin] }
     end
+
+    trait :skip_review do
+      permissions { %w[skip_review signin] }
+    end
   end
 
   trait :homepage_editor do


### PR DESCRIPTION
Adds a link to the edit page of an edition that takes the user to a page enabling them to skip the review stage.

The link (and linked page) are only available to users with the "skip_review" permission, and only the person that sent the edition for review can skip the review.