### PR TITLE
Pin chrome version for integration tests

### DIFF
--- a/.github/workflows/copy-pr-template-to-dependabot-prs.yml
+++ b/.github/workflows/copy-pr-template-to-dependabot-prs.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Post PR template as a comment
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs')

--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -18,11 +18,22 @@ jobs:
     name: Run Minitest
     runs-on: ubuntu-latest
     steps:
+      - uses: nanasess/setup-chromedriver@v2
+        with:
+          chromedriver-version: '128.0.6613.8600'
+          chromeapp: chrome
+      - run: |
+          sudo apt-get purge google-chrome-stable
+
+      - uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: 128
+          install-chromedriver: 'false'
+
       - name: Setup MongoDB
         uses: alphagov/govuk-infrastructure/.github/actions/setup-mongodb@main
         with:
           version: 3.6
-
       - name: Setup Postgres
         id: setup-postgres
         uses: alphagov/govuk-infrastructure/.github/actions/setup-postgres@main

--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -42,13 +42,13 @@ jobs:
         uses: alphagov/govuk-infrastructure/.github/actions/setup-redis@main
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: alphagov/publisher
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Checkout Publishing API (for Content Schemas)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: alphagov/publishing-api
           ref: ${{ inputs.publishingApiRef }}

--- a/test/support/govuk_test.rb
+++ b/test/support/govuk_test.rb
@@ -1,1 +1,14 @@
 GovukTest.configure
+
+Capybara.register_driver :headless_chrome do |app|
+  chrome_options = GovukTest.headless_chrome_selenium_options
+  chrome_options.add_argument("--disable-web-security")
+  chrome_options.add_argument("--no-sandbox")
+  chrome_options.add_argument("--disable-dev-shm-usage")
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    options: chrome_options,
+  )
+end


### PR DESCRIPTION
Use an older version of chrome for integration test runs as there is an ongoing 
issue with more recent versions which is causing random test failures

