### PR TITLE
Fix to date format for current important note text

### DIFF
--- a/app/views/editions/_important_note.html.erb
+++ b/app/views/editions/_important_note.html.erb
@@ -1,9 +1,12 @@
 <% note_author_name = User.find_by(id: @edition.important_note&.requester_id).name %>
-<% note_date = @edition.important_note&.created_at&.strftime("%d %B %Y") %>
+<% note_date = @edition.important_note&.created_at&.to_date %>
 <% note_details = @edition.important_note&.comment %>
 <%= render "govuk_publishing_components/components/notice", {
   description_govspeak:
-    sanitize("<p class='govuk-body govuk-!-font-weight-bold govuk-!-text-break-word'>#{h(note_details)}</p>") +
-      sanitize("<p class='govuk-body-m'>#{h(note_author_name)} added an important note on #{h(note_date)}</p>"),
+    sanitize("<div>
+      <p class='govuk-body govuk-!-font-weight-bold govuk-!-text-break-word'>#{h(note_details)}</p>
+      <p class='govuk-body-m'>#{h(note_author_name)} added an important note on
+      <time class='govuk-body' datetime='#{note_date}'>#{note_date.to_fs(:govuk_date)}</time></p>
+      </div>"),
   show_banner_title: true,
 } %>

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -68,6 +68,8 @@ class EditionEditTest < IntegrationTest
       within :css, ".govuk-notification-banner" do
         assert page.has_text?("Important")
         assert page.has_text?(note_text)
+        assert page.has_text?(@govuk_editor.name)
+        assert page.has_text?(Time.zone.today.to_date.to_fs(:govuk_date))
       end
     end
 


### PR DESCRIPTION
Now uses govuk format but only for the date (time is excluded) This follows the format requested on the [Trello card](https://trello.com/c/8Mrwt4nG) for Update Important note. 

![Screenshot 2025-03-17 at 12 49 20](https://github.com/user-attachments/assets/195eda35-e7c3-4441-87bc-302624b3b383)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
