### PR TITLE
Simplify chrome version pinning in minitest action

### DIFF
--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -18,17 +18,14 @@ jobs:
     name: Run Minitest
     runs-on: ubuntu-latest
     steps:
-      - uses: nanasess/setup-chromedriver@v2
-        with:
-          chromedriver-version: '128.0.6613.8600'
-          chromeapp: chrome
-      - run: |
-          sudo apt-get purge google-chrome-stable
+      - name: Remove image-bundled Chrome
+        run: sudo apt-get purge google-chrome-stable
 
-      - uses: browser-actions/setup-chrome@v1
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@c785b87e244131f27c9f19c1a33e2ead956ab7ce # v1.7.3
         with:
           chrome-version: 128
-          install-chromedriver: 'false'
+          install-chromedriver: true
 
       - name: Setup MongoDB
         uses: alphagov/govuk-infrastructure/.github/actions/setup-mongodb@main


### PR DESCRIPTION
Remove the use of a GitHub action from an unverified publisher, and just
 use the "setup-chrome" action from a verified one.

Also pins the version of the action referenced to a specific sha as a
 security precaution, as recommended by the [developer docs](https://gds-way.digital.cabinet-office.gov.uk/standards/source-code/use-github.html#using-github-actions-and-workflows).
