### PR TITLE
Undo the Chrome version pinning in CI

### DIFF
--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -18,15 +18,6 @@ jobs:
     name: Run Minitest
     runs-on: ubuntu-latest
     steps:
-      - name: Remove image-bundled Chrome
-        run: sudo apt-get purge google-chrome-stable
-
-      - name: Setup Chrome
-        uses: browser-actions/setup-chrome@c785b87e244131f27c9f19c1a33e2ead956ab7ce # v1.7.3
-        with:
-          chrome-version: 128
-          install-chromedriver: true
-
       - name: Setup MongoDB
         uses: alphagov/govuk-infrastructure/.github/actions/setup-mongodb@main
         with:


### PR DESCRIPTION
This was introduced as a temporary measure until the issues with the latest version of Chrome have been resolved.
