### PR TITLE
624 edit page archived edition

### DIFF
--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -9,7 +9,7 @@
 </div>
 
 <div class="govuk-grid-row">
-  <% if @resource.published? %>
+  <% if @resource.published? || @resource.archived? %>
     <div class="govuk-grid-column-two-thirds">
       <%= render partial: "editions/secondary_nav_tabs/edit/published/common_fields", locals: { edition: @resource } %>
 
@@ -17,13 +17,15 @@
 
       <%= render partial: "editions/secondary_nav_tabs/edit/published/public_change_note", locals: { edition: @resource } %>
     </div>
-    <div class="govuk-grid-column-one-third options-sidebar">
-      <div class="sidebar-components">
-        <%= sidebar_options_heading %>
+    <% unless @resource.archived? %>
+      <div class="govuk-grid-column-one-third options-sidebar">
+        <div class="sidebar-components">
+          <%= sidebar_options_heading %>
 
-        <%= sidebar_items_list(published_sidebar_buttons(@resource)) %>
+          <%= sidebar_items_list(published_sidebar_buttons(@resource)) %>
+        </div>
       </div>
-    </div>
+    <% end %>
   <% else %>
     <%= form_for @resource, as: :edition, url: edition_path(@resource) do %>
       <div class="govuk-grid-column-two-thirds">

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -40,6 +40,16 @@
   <% end %>
 </div>
 
+<% if @resource.artefact.state == "archived" %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: "This content has been unpublished and is no longer available on the website. All editions have been archived.",
+      } %>
+    </div>
+  </div>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render partial: "secondary_navigation" %>


### PR DESCRIPTION
[Trello](https://trello.com/c/oOBPngB2/624-edit-page-for-archived-edition-answer-and-help)

This implements the Edit page for an 'Archived' edition. Essentially it displays the data in read only mode rather than in form fields, using the same headings: 
- Edit
- Title
- Meta tag description
- Is this beta content?
- Body
- Public change note

Additional requirements are
- The 'Unpublish' tab should not be displayed in this scenario. This has already been implemented in a previous piece of work so there are no changes for that requirement here. 
- A message should be displayed to the user when all editions have been unpublished

![Screenshot 2025-03-20 at 10 52 42](https://github.com/user-attachments/assets/061547a5-2874-446a-a83b-2017debb8bba)
