### PR TITLE
Add text to "skip review" page

### DIFF
--- a/app/views/editions/secondary_nav_tabs/_progress_with_comment.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_progress_with_comment.html.erb
@@ -1,7 +1,14 @@
-<%# locals: (form_url:, comment_label_text:, submit_button_text:) %>
+<%# locals: (form_url:, comment_label_text:, submit_button_text:, text: nil) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+
+    <% if text %>
+      <p class="govuk-body">
+        <%= sanitize(text) %>
+      </p>
+    <% end %>
+
     <%= form_for(:edition, url: form_url) do %>
       <%= render "govuk_publishing_components/components/textarea", {
         label: {

--- a/app/views/editions/secondary_nav_tabs/skip_review_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/skip_review_page.html.erb
@@ -5,6 +5,7 @@
 
 <%= render "editions/secondary_nav_tabs/progress_with_comment", {
   form_url: "#{edition_path}/skip_review",
+  text: "You should only skip review in exceptional circumstances, for example if you’re the only person responding to an emergency out of hours call.",
   comment_label_text: "Comment (optional)",
   submit_button_text: "Skip review",
 } %>

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -1455,6 +1455,19 @@ class EditionEditTest < IntegrationTest
         @govuk_requester.permissions << "skip_review"
       end
 
+      should "render the 'Skip review' page" do
+        create_in_review_edition
+
+        visit skip_review_page_edition_path(@in_review_edition)
+
+        assert page.has_content?("Skip review")
+        assert page.has_content?(@in_review_edition.title)
+        assert page.has_content?("You should only skip review in exceptional circumstances")
+        assert page.has_content?("Comment (optional)")
+        assert page.has_button?("Skip review")
+        assert page.has_link?("Cancel")
+      end
+
       should "save comment to edition history" do
         create_in_review_edition
 


### PR DESCRIPTION
This text was missed off in the original implementation.

<img width="762" alt="image" src="https://github.com/user-attachments/assets/8cdc2a9c-1d95-4028-87ed-b90016007de6" />

[Trello card](https://trello.com/c/tb2kCEel/605-skip-review-link-for-answer-and-help-content-types)
