### PR TITLE
show Content Block update events on in progress Hosts

### DIFF
--- a/app/models/host_content_update_event.rb
+++ b/app/models/host_content_update_event.rb
@@ -26,10 +26,14 @@ class HostContentUpdateEvent < Data.define(:author, :created_at, :content_id, :c
   end
 
   def is_for_edition?(edition)
-    if edition.published?
-      created_at.after?(edition.published_at)
-    elsif edition.archived? && edition.superseded_at && edition.published_at
-      created_at.between?(edition.published_at, edition.superseded_at)
+    if edition.archived?
+      if edition.superseded_at.present?
+        created_at.between?(edition.created_at, edition.superseded_at)
+      elsif edition.artefact.state == "archived"
+        created_at.between?(edition.created_at, edition.artefact.updated_at)
+      end
+    elsif edition.in_progress? || edition.published? || edition.scheduled_for_publishing?
+      created_at.after?(edition.created_at)
     else
       false
     end


### PR DESCRIPTION
https://trello.com/c/RxmJ0fe2/977-allow-updates-to-objects-to-appear-in-the-history-and-notes-for-mainstream-draft-editions-story

Previously an event would only show in the
Edition's "history and notes" if the event took
place after the Edition had been published (and if
it was not archived/superseded).

We now want to display event if it took place at
any time after an Edition's creation, IF it is not
archived.


---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
