### PR TITLE
624 edit page add custom styles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -38,6 +38,7 @@ $govuk-page-width: 1140px;
 @import 'govuk_publishing_components/components/textarea';
 @import 'govuk_publishing_components/components/warning-text';
 @import "downtimes";
+@import "edit";
 @import "editions";
 @import "history";
 @import "options_sidebar";

--- a/app/assets/stylesheets/edit.scss
+++ b/app/assets/stylesheets/edit.scss
@@ -1,0 +1,7 @@
+.edit {
+  &--published, &--archived {
+    section > p {
+      @extend .govuk-body; // stylelint-disable-line scss/at-extend-no-missing-placeholder
+    }
+  }
+}

--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -8,7 +8,7 @@
   </div>
 </div>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row edit--<%= @resource.state %>">
   <% if @resource.published? || @resource.archived? %>
     <div class="govuk-grid-column-two-thirds">
       <%= render partial: "editions/secondary_nav_tabs/edit/published/common_fields", locals: { edition: @resource } %>

--- a/app/views/editions/secondary_nav_tabs/edit/published/_body.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/published/_body.html.erb
@@ -1,8 +1,9 @@
-<%= render "govuk_publishing_components/components/heading", {
-  text: "Body",
-  heading_level: 3,
-  font_size: "m",
-} %>
-<div class="govuk-body">
+<section>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Body",
+    heading_level: 3,
+    font_size: "m",
+  } %>
+
   <%= simple_format(edition.body) %>
-</div>
+</section>

--- a/app/views/editions/secondary_nav_tabs/edit/published/_common_fields.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/published/_common_fields.html.erb
@@ -1,29 +1,29 @@
-<%= render "govuk_publishing_components/components/heading", {
-  text: "Title",
-  heading_level: 3,
-  font_size: "m",
-} %>
+<section>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Title",
+    heading_level: 3,
+    font_size: "m",
+  } %>
 
-<p class="govuk-body">
-  <%= edition.title %>
-</p>
+  <p><%= edition.title %></p>
+</section>
 
-<%= render "govuk_publishing_components/components/heading", {
-  text: "Meta tag description",
-  heading_level: 3,
-  font_size: "m",
-} %>
+<section>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Meta tag description",
+    heading_level: 3,
+    font_size: "m",
+  } %>
 
-<p class="govuk-body">
-  <%= edition.overview %>
-</p>
+  <p><%= edition.overview %></p>
+</section>
 
-<%= render "govuk_publishing_components/components/heading", {
-  text: "Is this beta content?",
-  heading_level: 3,
-  font_size: "m",
-} %>
+<section>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Is this beta content?",
+    heading_level: 3,
+    font_size: "m",
+  } %>
 
-<p class="govuk-body">
-  <%= edition.in_beta ? "Yes" : "No" %>
-</p>
+  <p><%= edition.in_beta ? "Yes" : "No" %></p>
+</section>

--- a/app/views/editions/secondary_nav_tabs/edit/published/_public_change_note.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/published/_public_change_note.html.erb
@@ -1,12 +1,14 @@
-<%= render "govuk_publishing_components/components/heading", {
-  text: "Public change note",
-  heading_level: 3,
-  font_size: "m",
-} %>
-<p class="govuk-body">
-  <% if edition.major_change %>
-    <%= edition.change_note %>
-  <% else %>
-    None added
-  <% end %>
-</p>
+<section>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Public change note",
+    heading_level: 3,
+    font_size: "m",
+  } %>
+  <p>
+    <% if edition.major_change %>
+      <%= edition.change_note %>
+    <% else %>
+      None added
+    <% end %>
+  </p>
+</section>

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -794,16 +794,16 @@ class EditionEditTest < IntegrationTest
         visit edition_path(published_edition)
 
         assert page.has_css?("h3", text: "Title")
-        assert page.has_css?("p.govuk-body", text: published_edition.title)
+        assert page.has_css?("p", text: published_edition.title)
         assert page.has_css?("h3", text: "Meta tag description")
-        assert page.has_css?("p.govuk-body", text: published_edition.overview)
+        assert page.has_css?("p", text: published_edition.overview)
         assert page.has_css?("h3", text: "Is this beta content?")
-        assert page.has_css?("p.govuk-body", text: "Yes")
+        assert page.has_css?("p", text: "Yes")
 
         published_edition.in_beta = false
         published_edition.save!(validate: false)
         visit edition_path(published_edition)
-        assert page.has_css?("p.govuk-body", text: "No")
+        assert page.has_css?("p", text: "No")
       end
 
       should "show body field" do
@@ -828,7 +828,7 @@ class EditionEditTest < IntegrationTest
         visit edition_path(published_edition)
 
         assert page.has_css?("h3", text: "Public change note")
-        assert page.has_css?("p.govuk-body", text: "None added")
+        assert page.has_css?("p", text: "None added")
 
         published_edition.major_change = true
         published_edition.change_note = "Change note for test"
@@ -1001,16 +1001,16 @@ class EditionEditTest < IntegrationTest
         visit edition_path(archived_edition)
 
         assert page.has_css?("h3", text: "Title")
-        assert page.has_css?("p.govuk-body", text: archived_edition.title)
+        assert page.has_css?("p", text: archived_edition.title)
         assert page.has_css?("h3", text: "Meta tag description")
-        assert page.has_css?("p.govuk-body", text: archived_edition.overview)
+        assert page.has_css?("p", text: archived_edition.overview)
         assert page.has_css?("h3", text: "Is this beta content?")
-        assert page.has_css?("p.govuk-body", text: "Yes")
+        assert page.has_css?("p", text: "Yes")
 
         archived_edition.in_beta = false
         archived_edition.save!(validate: false)
         visit edition_path(archived_edition)
-        assert page.has_css?("p.govuk-body", text: "No")
+        assert page.has_css?("p", text: "No")
       end
 
       should "show body field" do
@@ -1035,7 +1035,7 @@ class EditionEditTest < IntegrationTest
         visit edition_path(archived_edition)
 
         assert page.has_css?("h3", text: "Public change note")
-        assert page.has_css?("p.govuk-body", text: "None added")
+        assert page.has_css?("p", text: "None added")
 
         archived_edition.major_change = true
         archived_edition.change_note = "Change note for test"


### PR DESCRIPTION
[Trello](https://trello.com/c/oOBPngB2/624-edit-page-for-archived-edition-answer-and-help)

The changes here (somewhat circuitously) updates how `govuk-body` styles are applied to all `<p>` elements within the read-only content on the Edit page for editions in 'Published' and 'Archived' states. This is necessary to remove the browser-applied top margin to these elements, specifically on the 'body' section. We can only do this by applying the `govuk-body` style directly to the `<p>` element rather than to its parent as it is currently implemented. Since this cannot be done in the 'body' section the alternative approach is to apply the style via a custom stylesheet. 

This is achieved by
- removing the `govuk-body` class from elements on the page
- grouping sections together with the `<section>` element (not strictly necessary but feels a semantically more elegant)
- adding a class name to the parent container to reflect the edition's state, e.g `edit--published`
- adding a custom stylesheet to extend. the `govuk-body` class to `<p>` elements within this container for editions whose state is either 'published' or 'archived'.

|Before|After|
|-|-|
|![Screenshot 2025-03-26 at 13 02 03](https://github.com/user-attachments/assets/0939f723-9860-4dea-82f7-acbd17980ee8)|![Screenshot 2025-03-26 at 13 02 42](https://github.com/user-attachments/assets/2645ce43-ba65-4922-a7d3-e62cd09eb835)|