### PR TITLE
Edit page for scheduled edition

### DIFF
--- a/app/assets/stylesheets/edit.scss
+++ b/app/assets/stylesheets/edit.scss
@@ -1,5 +1,5 @@
 .edit {
-  &--published, &--archived {
+  &--scheduled_for_publishing, &--published, &--archived {
     section > p {
       @extend .govuk-body; // stylelint-disable-line scss/at-extend-no-missing-placeholder
     }

--- a/app/helpers/editions_helper.rb
+++ b/app/helpers/editions_helper.rb
@@ -55,7 +55,7 @@ module EditionsHelper
   end
 
   def document_summary_items(edition)
-    [
+    items = [
       {
         field: "Assigned to",
         value: edition.assigned_to || "None",
@@ -70,6 +70,13 @@ module EditionsHelper
         value: edition_version_and_state_tag(edition),
       },
     ]
+    if edition.scheduled_for_publishing?
+      items << {
+        field: "Scheduled",
+        value: edition.publish_at.to_fs(:govuk_date).to_s,
+      }
+    end
+    items
   end
 
   def edition_version_and_state_tag(edition)

--- a/app/helpers/editions_sidebar_buttons_helper.rb
+++ b/app/helpers/editions_sidebar_buttons_helper.rb
@@ -27,6 +27,18 @@ module EditionsSidebarButtonsHelper
     ]
   end
 
+  def scheduled_for_publishing_sidebar_buttons(edition)
+    [
+      link_to(
+        "Preview (opens in new tab)",
+        preview_edition_path(edition),
+        target: "_blank",
+        rel: "noopener",
+        class: "govuk-link",
+      ),
+    ]
+  end
+
   def published_sidebar_buttons(edition)
     buttons = []
     if current_user.has_editor_permissions?(edition)

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -122,10 +122,14 @@ module Workflow
     actions.where(request_type: Action::APPROVE_FACT_CHECK).count.positive?
   end
 
-  def status_text
+  def legacy_status_text
     text = human_state_name.capitalize
     text += " on #{publish_at.strftime('%d/%m/%Y %H:%M')}" if scheduled_for_publishing?
     text
+  end
+
+  def status_text
+    human_state_name.capitalize
   end
 
   def denormalise_users!

--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -8,7 +8,7 @@
   </div>
 </div>
 
-<% if @resource.published? || @resource.archived? %>
+<% if @resource.scheduled_for_publishing? || @resource.published? || @resource.archived? %>
   <div class="govuk-grid-row edit--<%= @resource.state %>">
     <div class="govuk-grid-column-two-thirds">
       <%= render partial: "editions/secondary_nav_tabs/edit/published/common_fields", locals: { edition: @resource } %>
@@ -17,7 +17,7 @@
 
       <%= render partial: "editions/secondary_nav_tabs/edit/published/public_change_note", locals: { edition: @resource } %>
     </div>
-    <% unless @resource.archived? %>
+    <% if @resource.published? %>
       <div class="govuk-grid-column-one-third options-sidebar">
         <div class="sidebar-components">
           <%= sidebar_options_heading %>

--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -17,7 +17,15 @@
 
       <%= render partial: "editions/secondary_nav_tabs/edit/published/public_change_note", locals: { edition: @resource } %>
     </div>
-    <% if @resource.published? %>
+    <% if @resource.scheduled_for_publishing? %>
+      <div class="govuk-grid-column-one-third options-sidebar">
+        <div class="sidebar-components">
+          <%= sidebar_options_heading %>
+
+          <%= sidebar_items_list(scheduled_for_publishing_sidebar_buttons(@resource)) %>
+        </div>
+      </div>
+    <% elsif @resource.published? %>
       <div class="govuk-grid-column-one-third options-sidebar">
         <div class="sidebar-components">
           <%= sidebar_options_heading %>

--- a/app/views/shared/_edition_header.html.erb
+++ b/app/views/shared/_edition_header.html.erb
@@ -5,7 +5,7 @@
   <span class="lead">
     <span class="label label-default" title="Edition">#<%= @resource.version_number %></span>
     <span class="label label-default" title="Format"><%= @resource.format.underscore.humanize %></span>
-    <span class="label label-info" title="Status"><%= @resource.status_text %></span>
+    <span class="label label-info" title="Status"><%= @resource.legacy_status_text %></span>
   </span>
 </div>
 <% important_note = @resource.important_note %>

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -41,6 +41,49 @@ class EditionEditTest < IntegrationTest
       assert row[2].has_text?("Published")
     end
 
+    should "show scheduled date and time when an edition is scheduled for publishing" do
+      travel_to Time.zone.local(2025, 3, 4, 17, 16, 15)
+      scheduled_for_publishing_edition = FactoryBot.create(
+        :edition,
+        :scheduled_for_publishing,
+        publish_at: Time.zone.now,
+      )
+
+      visit edition_path(scheduled_for_publishing_edition)
+
+      row = find_all(".govuk-summary-list__row")
+      assert_equal 4, row.count, "Expected four rows in the summary"
+      assert row[2].has_text?(/Scheduled for publishing$/)
+      assert row[3].has_text?("Scheduled")
+      assert row[3].has_text?("5:16pm, 4 March 2025")
+    end
+
+    %i[draft amends_needed fact_check_received ready archived published].each do |state|
+      should "not show a scheduled row when an edition is in the '#{state}' state" do
+        edition = FactoryBot.create(:edition, state:)
+
+        visit edition_path(edition)
+
+        row = find_all(".govuk-summary-list__row")
+        assert_equal 3, row.count, "Expected three rows in the summary"
+        assert page.has_no_content?("Scheduled")
+      end
+    end
+
+    should "not show a scheduled row when an edition is in the 'in_review' state" do
+      edition = FactoryBot.create(:edition, state: "in_review", review_requested_at: 1.hour.ago)
+      edition.actions.create!(
+        request_type: Action::REQUEST_AMENDMENTS,
+        requester_id: @govuk_requester.id,
+      )
+
+      visit edition_path(edition)
+
+      row = find_all(".govuk-summary-list__row")
+      assert_equal 3, row.count, "Expected three rows in the summary"
+      assert page.has_no_content?("Scheduled")
+    end
+
     should "indicate when an edition does not have an assignee" do
       visit_published_edition
 

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -969,6 +969,66 @@ class EditionEditTest < IntegrationTest
       end
     end
 
+    context "scheduled_for_publishing edition" do
+      should "show common content-type fields" do
+        edition = FactoryBot.create(
+          :edition,
+          state: "scheduled_for_publishing",
+          title: "Some test title",
+          overview: "Some overview text",
+          in_beta: true,
+          publish_at: Time.zone.now + 1.day,
+        )
+        visit edition_path(edition)
+
+        assert page.has_css?("h3", text: "Title")
+        assert page.has_css?("p", text: edition.title)
+        assert page.has_css?("h3", text: "Meta tag description")
+        assert page.has_css?("p", text: edition.overview)
+        assert page.has_css?("h3", text: "Is this beta content?")
+        assert page.has_css?("p", text: "Yes")
+
+        edition.in_beta = false
+        edition.save!(validate: false)
+        visit edition_path(edition)
+        assert page.has_css?("p", text: "No")
+      end
+
+      should "show body field" do
+        edition = FactoryBot.create(
+          :answer_edition,
+          state: "scheduled_for_publishing",
+          body: "## Some body text",
+          publish_at: Time.zone.now + 1.day,
+        )
+        visit edition_path(edition)
+
+        assert page.has_css?("h3", text: "Body")
+        assert page.has_css?("div", text: edition.body)
+      end
+
+      should "show public change field" do
+        edition = FactoryBot.create(
+          :answer_edition,
+          state: "scheduled_for_publishing",
+          in_beta: true,
+          major_change: false,
+          publish_at: Time.zone.now + 1.day,
+        )
+        visit edition_path(edition)
+
+        assert page.has_css?("h3", text: "Public change note")
+        assert page.has_css?("p", text: "None added")
+
+        edition.major_change = true
+        edition.change_note = "Change note for test"
+        edition.save!(validate: false)
+        visit edition_path(edition)
+
+        assert page.has_text?(edition.change_note)
+      end
+    end
+
     context "published edition" do
       should "show common content-type fields" do
         published_edition = FactoryBot.create(

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -1027,6 +1027,11 @@ class EditionEditTest < IntegrationTest
 
         assert page.has_text?(edition.change_note)
       end
+
+      should "show a preview link in the sidebar" do
+        visit_scheduled_for_publishing_edition
+        assert page.has_link?("Preview (opens in new tab)")
+      end
     end
 
     context "published edition" do

--- a/test/models/workflow_test.rb
+++ b/test/models/workflow_test.rb
@@ -57,14 +57,27 @@ class WorkflowTest < ActiveSupport::TestCase
     [user, transaction]
   end
 
-  context "#status_text" do
+  context "#legacy_status_text" do
     should "return a capitalized text representation of the state" do
-      assert_equal "Ready", FactoryBot.build(:edition, state: "ready").status_text
+      assert_equal "Ready", FactoryBot.build(:edition, state: "ready").legacy_status_text
     end
 
     should "also return scheduled publishing time when the state is scheduled for publishing" do
       edition = FactoryBot.build(:edition, :scheduled_for_publishing)
       expected_status_text = "Scheduled for publishing on #{edition.publish_at.strftime('%d/%m/%Y %H:%M')}"
+
+      assert_equal expected_status_text, edition.legacy_status_text
+    end
+  end
+
+  context "#status_text" do
+    should "return a capitalized text representation of the state" do
+      assert_equal "Ready", FactoryBot.build(:edition, state: "ready").status_text
+    end
+
+    should "not return scheduled publishing time when the state is scheduled for publishing" do
+      edition = FactoryBot.build(:edition, :scheduled_for_publishing)
+      expected_status_text = "Scheduled for publishing"
 
       assert_equal expected_status_text, edition.status_text
     end


### PR DESCRIPTION
## Trello
[Trello card](https://trello.com/c/kOQyhYC9)

## What
Implement the content of the "edit" tab when viewing an edition that is scheduled for publishing so that the content is read-only (using paragraph elements instead of form controls to display the field values).

Also implements a few other related changes:
- removes the date and time that the edition is scheduled to be published at from the tag displayed on the "edition" row of the document summary
- adds a "scheduled" row to the document summary to show the date and time that the edition is scheduled to be published at
- adds a "preview" link to the sidebar.

## Screenshot
![edit-page-scheduled-edition](https://github.com/user-attachments/assets/30a9b0a9-1241-4af5-9445-4267d8369a41)
