### PR TITLE
Update page structure so row is contained within form

### DIFF
--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -8,8 +8,8 @@
   </div>
 </div>
 
-<div class="govuk-grid-row edit--<%= @resource.state %>">
-  <% if @resource.published? || @resource.archived? %>
+<% if @resource.published? || @resource.archived? %>
+  <div class="govuk-grid-row edit--<%= @resource.state %>">
     <div class="govuk-grid-column-two-thirds">
       <%= render partial: "editions/secondary_nav_tabs/edit/published/common_fields", locals: { edition: @resource } %>
 
@@ -26,8 +26,10 @@
         </div>
       </div>
     <% end %>
-  <% else %>
-    <%= form_for @resource, as: :edition, url: edition_path(@resource) do %>
+  </div>
+<% else %>
+  <%= form_for @resource, as: :edition, url: edition_path(@resource) do %>
+    <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <%= render partial: "editions/secondary_nav_tabs/edit/draft/common_fields", locals: { edition: @resource } %>
 
@@ -46,6 +48,6 @@
           <%= sidebar_items_list(non_published_sidebar_buttons(@resource)) %>
         </div>
       </div>
-    <% end %>
+    </div>
   <% end %>
-</div>
+<% end %>


### PR DESCRIPTION
This PR makes a small change to the markup structure of the Edit page to fix the sticky sidebar (which currently is not sticky). 

In order to function the CSS attribute `position: sticky` requires the element to which it is applied and its immediate sibling from which its offset position is calculated to both be direct descendants of their "nearest scrolling ancestor", i.e. the parent `govuk-grid-row` element. In this case the `<form>` element is the direct ancestor of both elements. The fix here is to ensure that the `govuk-grid-row` is inside, rather than outside, the `<form>` element. 

Additionally the `edit--<state>` class has been deleted from the row within the `<form>` since this is only required when the content is read-only, i.e. editions whose state is either 'published' or 'archived'. 