### PR TITLE
Refactor send to 2i page to use partial

### DIFF
--- a/app/views/editions/secondary_nav_tabs/no_changes_needed_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/no_changes_needed_page.html.erb
@@ -4,7 +4,7 @@
 <% content_for :title, "No changes needed" %>
 
 <%= render "editions/secondary_nav_tabs/progress_with_comment", {
-  form_url: "#{edition_path}/no_changes_needed",
+  form_url: no_changes_needed_edition_path(@edition),
   comment_label_text: "Comment (optional)",
   submit_button_text: "Approve 2i",
 } %>

--- a/app/views/editions/secondary_nav_tabs/request_amendments_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/request_amendments_page.html.erb
@@ -4,7 +4,7 @@
 <% content_for :title, "Request amendments" %>
 
 <%= render "editions/secondary_nav_tabs/progress_with_comment", {
-  form_url: "#{edition_path}/request_amendments",
+  form_url: request_amendments_edition_path(@edition),
   comment_label_text: "Amendment details (optional)",
   submit_button_text: "Request amendments",
 } %>

--- a/app/views/editions/secondary_nav_tabs/send_to_2i_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/send_to_2i_page.html.erb
@@ -4,7 +4,7 @@
 <% content_for :title, "Send to 2i" %>
 
 <%= render "editions/secondary_nav_tabs/progress_with_comment", {
-  form_url: "#{edition_path}/send_to_2i",
+  form_url: send_to_2i_edition_path(@edition),
   text: "Explain what changes you did or did not make and why. Include a link to the relevant Zendesk ticket and Trello card.
     If you’ve added a change note already, you do not need to add another one.
       <a target='_blank' rel='noopener noreferrer' href='https://gov-uk.atlassian.net/l/cp/dwn06raQ' class='govuk-link govuk-link--no-visited-state'>Read guidance on writing good change notes (opens in new tab)</a>.",

--- a/app/views/editions/secondary_nav_tabs/send_to_2i_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/send_to_2i_page.html.erb
@@ -7,7 +7,7 @@
   form_url: "#{edition_path}/send_to_2i",
   text: "Explain what changes you did or did not make and why. Include a link to the relevant Zendesk ticket and Trello card.
     If you’ve added a change note already, you do not need to add another one.
-      <a target='_blank' rel='noopener noreferrer' href='https://gov-uk.atlassian.net/l/cp/dwn06raQ'>Read guidance on writing good change notes (opens in new tab)</a>.",
-  comment_label_text: "" ,
+      <a target='_blank' rel='noopener noreferrer' href='https://gov-uk.atlassian.net/l/cp/dwn06raQ' class='govuk-link govuk-link--no-visited-state'>Read guidance on writing good change notes (opens in new tab)</a>.",
+  comment_label_text: "Comment (optional)" ,
   submit_button_text: "Send to 2i",
 } %>

--- a/app/views/editions/secondary_nav_tabs/send_to_2i_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/send_to_2i_page.html.erb
@@ -3,28 +3,11 @@
 <% content_for :page_title, "Send to 2i" %>
 <% content_for :title, "Send to 2i" %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">
-      Explain what changes you did or did not make and why. Include a link to the relevant Zendesk ticket and Trello card.
-      If you’ve added a change note already, you do not need to add another one.
-      <a target="_blank" rel="noopener noreferrer" href="https://gov-uk.atlassian.net/l/cp/dwn06raQ">Read guidance on writing good change notes (opens in new tab)</a>.
-    </p>
-
-    <%= form_for(:edition, url: "#{send_to_2i_edition_path(@edition)}") do %>
-      <%= hidden_field_tag :edition_id, @edition.id %>
-
-      <%= render "govuk_publishing_components/components/textarea", {
-        name: "comment",
-        rows: 14,
-      } %>
-
-      <div class="govuk-button-group">
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Send to 2i",
-        } %>
-        <%= link_to("Cancel", edition_path, class: "govuk-link govuk-link--no-visited-state") %>
-      </div>
-    <% end %>
-  </div>
-</div>
+<%= render "editions/secondary_nav_tabs/progress_with_comment", {
+  form_url: "#{edition_path}/send_to_2i",
+  text: "Explain what changes you did or did not make and why. Include a link to the relevant Zendesk ticket and Trello card.
+    If you’ve added a change note already, you do not need to add another one.
+      <a target='_blank' rel='noopener noreferrer' href='https://gov-uk.atlassian.net/l/cp/dwn06raQ'>Read guidance on writing good change notes (opens in new tab)</a>.",
+  comment_label_text: "" ,
+  submit_button_text: "Send to 2i",
+} %>

--- a/app/views/editions/secondary_nav_tabs/skip_review_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/skip_review_page.html.erb
@@ -4,7 +4,7 @@
 <% content_for :title, "Skip review" %>
 
 <%= render "editions/secondary_nav_tabs/progress_with_comment", {
-  form_url: "#{edition_path}/skip_review",
+  form_url: skip_review_edition_path(@edition),
   text: "You should only skip review in exceptional circumstances, for example if you’re the only person responding to an emergency out of hours call.",
   comment_label_text: "Comment (optional)",
   submit_button_text: "Skip review",


### PR DESCRIPTION
This was prompted by a discussion during the Desk Check for [Trello Card]( https://trello.com/c/dQepazi0)
In order to simplify the code, encourage reuse (make it DRY) and to make future formatting changes easier, the Send to 2i page has been adapted to use the same partial as 'Request amendments', 'Skip review' and 'No changes needed' pages. 

Also, in response to the feedback from the 'Send to 2i' desk check: 
- A label has been added to the comment textfield for the Send to 2i page
- The link in the copy above the textfield has been changed to the GOV.UK style