### PR TITLE
Fix sidebar buttons helper to return button array

### DIFF
--- a/app/helpers/editions_sidebar_buttons_helper.rb
+++ b/app/helpers/editions_sidebar_buttons_helper.rb
@@ -57,5 +57,7 @@ module EditionsSidebarButtonsHelper
     if current_user.has_editor_permissions?(edition) && %w[draft amends_needed].include?(edition.state)
       buttons << link_to("Send to 2i", send_to_2i_page_edition_path(edition), class: "govuk-link")
     end
+
+    buttons
   end
 end

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -546,6 +546,11 @@ class EditionEditTest < IntegrationTest
           visit_in_review_edition("request_review", @govuk_requester)
         end
 
+        should "display Save button and preview link" do
+          assert page.has_button?("Save"), "No save button present"
+          assert page.has_link?("Preview (opens in new tab)"), "No preview link present"
+        end
+
         should "indicate that the current user requested a review" do
           assert page.has_text?("You've sent this edition to be reviewed")
         end
@@ -560,6 +565,11 @@ class EditionEditTest < IntegrationTest
         setup do
           login_as(@govuk_editor)
           visit_in_review_edition("request_review", @govuk_requester)
+        end
+
+        should "display Save button and preview link" do
+          assert page.has_button?("Save"), "No save button present"
+          assert page.has_link?("Preview (opens in new tab)"), "No preview link present"
         end
 
         should "indicate which other user requested a review" do


### PR DESCRIPTION
Applies a fix for the missing sidebar buttons for an in-review edition, caused by [Send to 2i link and page](https://trello.com/c/dQepazi0) https://github.com/alphagov/publisher/pull/2618

Adds tests for an edition in the 'in review' (Sent to 2i) state to hopefully catch any similar issues in future. 