### PR TITLE
Fix send to 2i error messages

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -116,13 +116,13 @@ class EditionsController < InheritedResources::Base
 
   def send_to_2i
     if send_to_2i_for_edition(@resource, params[:comment])
-      # Can't use flash.now because we're redirecting
       flash[:success] = "Sent to 2i"
       redirect_to edition_path(resource)
-    elsif !%w[draft amends_needed].include?(@resource.state)
-      flash[:danger] = "Edition is not in a state where it can be sent to 2i"
+    elsif !@resource.can_request_review?
+      flash.now[:danger] = "Edition is not in a state where it can be sent to 2i"
+      render "secondary_nav_tabs/send_to_2i_page"
     else
-      flash[:danger] = "Due to a service problem, the request could not be made"
+      flash.now[:danger] = "Due to a service problem, the request could not be made"
       render "secondary_nav_tabs/send_to_2i_page"
     end
   end

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -96,8 +96,8 @@ class EditionsController < InheritedResources::Base
 
   def request_amendments
     if request_amendments_for_edition(@resource, params[:comment])
-      flash.now[:success] = "2i amendments requested"
-      render "show"
+      flash[:success] = "2i amendments requested"
+      redirect_to edition_path(resource)
     else
       flash.now[:danger] = "Due to a service problem, the request could not be made"
       render "secondary_nav_tabs/request_amendments_page"
@@ -106,8 +106,8 @@ class EditionsController < InheritedResources::Base
 
   def no_changes_needed
     if no_changes_needed_for_edition(@resource, params[:comment])
-      flash.now[:success] = "2i approved"
-      render "show"
+      flash[:success] = "2i approved"
+      redirect_to edition_path(resource)
     else
       flash.now[:danger] = "Due to a service problem, the request could not be made"
       render "secondary_nav_tabs/no_changes_needed_page"
@@ -129,8 +129,8 @@ class EditionsController < InheritedResources::Base
 
   def skip_review
     if skip_review_for_edition(@resource, params[:comment])
-      flash.now[:success] = "2i review skipped"
-      render "show"
+      flash[:success] = "2i review skipped"
+      redirect_to edition_path(resource) 
     else
       flash.now[:danger] = "Due to a service problem, the request could not be made"
       render "secondary_nav_tabs/skip_review_page"

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -530,7 +530,7 @@ class EditionEditTest < IntegrationTest
       assert_current_path edition_path(@draft_edition.id)
     end
 
-    should "show success message and redirect back to the edit tab when Send to 2i button is pressed" do
+    should "show success message and redirect back to the edit tab on submit" do
       click_button "Send to 2i"
 
       assert_current_path edition_path(@draft_edition.id)
@@ -1632,6 +1632,15 @@ class EditionEditTest < IntegrationTest
       assert page.has_content?("Please make these changes")
     end
 
+    should "show success message and redirect back to the edit tab on submit" do
+      create_in_review_edition
+      visit request_amendments_page_edition_path(@in_review_edition)
+      click_on "Request amendments"
+
+      assert_current_path edition_path(@in_review_edition.id)
+      assert page.has_text?("2i amendments requested")
+    end
+
     context "current user is also the requester" do
       setup do
         login_as(@govuk_requester)
@@ -1662,6 +1671,15 @@ class EditionEditTest < IntegrationTest
       click_on "History and notes"
       assert page.has_content?("Approve review by")
       assert page.has_content?("Looks great")
+    end
+
+    should "show success message and redirect back to the edit tab on submit" do
+      create_in_review_edition
+      visit no_changes_needed_page_edition_path(@in_review_edition)
+      click_button "Approve 2i"
+
+      assert_current_path edition_path(@in_review_edition.id)
+      assert page.has_text?("2i approved")
     end
 
     context "current user is also the requester" do
@@ -1713,6 +1731,15 @@ class EditionEditTest < IntegrationTest
         click_on "History and notes"
         assert page.has_content?("Skip review by Stub requester")
         assert page.has_content?("Looks great")
+      end
+
+      should "show success message and redirect back to the edit tab on submit" do
+        create_in_review_edition
+        visit skip_review_page_edition_path(@in_review_edition)
+        click_button "Skip review"
+
+        assert_current_path edition_path(@in_review_edition.id)
+        assert page.has_text?("2i review skipped")
       end
     end
 


### PR DESCRIPTION
- Ensure redirect takes user back to send to 2i page
- Ensure flash is shown now and not added to hash

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
