### PR TITLE
Cancel scheduling for scheduled edition

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -11,7 +11,7 @@ class EditionsController < InheritedResources::Base
   before_action only: %i[unpublish confirm_unpublish process_unpublish] do
     require_govuk_editor(redirect_path: edition_path(resource))
   end
-  before_action only: %i[progress admin update confirm_destroy edit_assignee update_assignee request_amendments request_amendments_page no_changes_needed no_changes_needed_page send_to_2i send_to_2i_page send_to_publish send_to_publish_page cancel_scheduled_publishing_page] do
+  before_action only: %i[progress admin update confirm_destroy edit_assignee update_assignee request_amendments request_amendments_page no_changes_needed no_changes_needed_page send_to_2i send_to_2i_page send_to_publish send_to_publish_page cancel_scheduled_publishing cancel_scheduled_publishing_page] do
     require_editor_permissions
   end
   before_action only: %i[confirm_destroy destroy] do
@@ -155,6 +155,19 @@ class EditionsController < InheritedResources::Base
     else
       flash.now[:danger] = "Due to a service problem, the request could not be made"
       render "secondary_nav_tabs/send_to_publish_page"
+    end
+  end
+
+  def cancel_scheduled_publishing
+    if !@resource.can_cancel_scheduled_publishing?
+      flash.now[:danger] = "Edition is not in a state where scheduling can be cancelled"
+      render "secondary_nav_tabs/cancel_scheduled_publishing_page"
+    elsif cancel_scheduled_publishing_for_edition(@resource, params[:comment])
+      flash[:success] = "Scheduling cancelled"
+      redirect_to edition_path(@resource)
+    else
+      flash.now[:danger] = "Due to a service problem, the request could not be made"
+      render "secondary_nav_tabs/cancel_scheduled_publishing_page"
     end
   end
 
@@ -306,6 +319,11 @@ private
     publish_succeeded = @command.progress({ request_type: "publish", comment: comment })
     PublishWorker.perform_async(resource.id.to_s) if publish_succeeded
     publish_succeeded
+  end
+
+  def cancel_scheduled_publishing_for_edition(resource, comment)
+    @command = EditionProgressor.new(resource, current_user)
+    @command.progress({ request_type: "cancel_scheduled_publishing", comment: comment })
   end
 
   def unpublish_edition(artefact)

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -11,7 +11,7 @@ class EditionsController < InheritedResources::Base
   before_action only: %i[unpublish confirm_unpublish process_unpublish] do
     require_govuk_editor(redirect_path: edition_path(resource))
   end
-  before_action only: %i[progress admin update confirm_destroy edit_assignee update_assignee request_amendments request_amendments_page no_changes_needed no_changes_needed_page send_to_2i send_to_2i_page send_to_publish send_to_publish_page] do
+  before_action only: %i[progress admin update confirm_destroy edit_assignee update_assignee request_amendments request_amendments_page no_changes_needed no_changes_needed_page send_to_2i send_to_2i_page send_to_publish send_to_publish_page cancel_scheduled_publishing_page] do
     require_editor_permissions
   end
   before_action only: %i[confirm_destroy destroy] do
@@ -58,6 +58,10 @@ class EditionsController < InheritedResources::Base
 
   def send_to_publish_page
     render "secondary_nav_tabs/send_to_publish_page"
+  end
+
+  def cancel_scheduled_publishing_page
+    render "secondary_nav_tabs/cancel_scheduled_publishing_page"
   end
 
   def duplicate

--- a/app/helpers/editions_sidebar_buttons_helper.rb
+++ b/app/helpers/editions_sidebar_buttons_helper.rb
@@ -33,6 +33,15 @@ module EditionsSidebarButtonsHelper
       buttons << render(
         "govuk_publishing_components/components/button",
         {
+          text: "Cancel scheduling",
+          href: cancel_scheduled_publishing_page_edition_path(edition),
+          secondary_solid: true,
+          margin_bottom: 3,
+        },
+      )
+      buttons << render(
+        "govuk_publishing_components/components/button",
+        {
           text: "Publish now",
           href: send_to_publish_page_edition_path(edition),
           secondary_solid: true,

--- a/app/views/editions/secondary_nav_tabs/cancel_scheduled_publishing_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/cancel_scheduled_publishing_page.html.erb
@@ -1,0 +1,10 @@
+<% @edition = @resource %>
+<% content_for :title_context, @edition.title %>
+<% content_for :page_title, "Cancel scheduled publishing" %>
+<% content_for :title, "Cancel scheduled publishing" %>
+
+<%= render "editions/secondary_nav_tabs/progress_with_comment", {
+  form_url: "",
+  comment_label_text: "Comment (optional)" ,
+  submit_button_text: "Cancel scheduled publishing" ,
+} %>

--- a/app/views/editions/secondary_nav_tabs/cancel_scheduled_publishing_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/cancel_scheduled_publishing_page.html.erb
@@ -4,7 +4,7 @@
 <% content_for :title, "Cancel scheduled publishing" %>
 
 <%= render "editions/secondary_nav_tabs/progress_with_comment", {
-  form_url: "",
+  form_url: cancel_scheduled_publishing_edition_path(@edition),
   comment_label_text: "Comment (optional)" ,
   submit_button_text: "Cancel scheduled publishing" ,
 } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
         get "send_to_publish_page", to: "editions#send_to_publish_page", as: "send_to_publish_page"
         post "send_to_publish"
         get "cancel_scheduled_publishing_page"
+        post "cancel_scheduled_publishing"
         get "metadata"
         get "history"
         get "history/add_edition_note", to: "editions#add_edition_note", as: "history/add_edition_note"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
         post "skip_review", to: "editions#skip_review", as: "skip_review"
         get "send_to_publish_page", to: "editions#send_to_publish_page", as: "send_to_publish_page"
         post "send_to_publish"
+        get "cancel_scheduled_publishing_page"
         get "metadata"
         get "history"
         get "history/add_edition_note", to: "editions#add_edition_note", as: "history/add_edition_note"

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -554,6 +554,43 @@ class EditionsControllerTest < ActionController::TestCase
     end
   end
 
+  context "#cancel_scheduled_publishing_page" do
+    context "user has govuk_editor permission" do
+      should "render the 'Cancel scheduled publishing' page" do
+        get :cancel_scheduled_publishing_page, params: { id: @edition.id }
+        assert_template "secondary_nav_tabs/cancel_scheduled_publishing_page"
+      end
+    end
+
+    context "user does not have govuk_editor permission" do
+      setup do
+        user = FactoryBot.create(:user)
+        login_as(user)
+      end
+
+      should "render an error message" do
+        get :cancel_scheduled_publishing_page, params: { id: @edition.id }
+        assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
+      end
+    end
+
+    context "user has welsh_editor permission" do
+      setup do
+        login_as_welsh_editor
+      end
+
+      should "render the 'Cancel scheduled publishing' page when the edition is welsh" do
+        get :cancel_scheduled_publishing_page, params: { id: @welsh_edition.id }
+        assert_template "secondary_nav_tabs/cancel_scheduled_publishing_page"
+      end
+
+      should "render an error message when the edition is not welsh" do
+        get :cancel_scheduled_publishing_page, params: { id: @edition.id }
+        assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
+      end
+    end
+  end
+
   context "#metadata" do
     should "alias to show method" do
       assert_equal EditionsController.new.method(:metadata).super_method.name, :show

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -591,6 +591,76 @@ class EditionsControllerTest < ActionController::TestCase
     end
   end
 
+  context "#cancel_scheduled_publishing" do
+    setup do
+      @requester = FactoryBot.create(:user, :govuk_editor, name: "Stub Requester")
+      @edition = FactoryBot.create(:edition, state: "scheduled_for_publishing", publish_at: Time.zone.now + 1.hour)
+      login_as(@requester)
+    end
+
+    context "user has govuk_editor permission" do
+      should "update the edition status to 'ready' and save the comment" do
+        post :cancel_scheduled_publishing, params: {
+          id: @edition.id,
+          comment: "You shall not pass!",
+        }
+
+        assert_equal "Scheduling cancelled", flash[:success]
+        @edition.reload
+        assert_equal "ready", @edition.state
+        assert_equal "You shall not pass!", @edition.latest_status_action.comment
+        assert_equal @requester.id, @edition.latest_status_action.requester_id
+      end
+
+      should "not update the edition state and render 'cancel_scheduled_publishing' template with an error when an error occurs" do
+        EditionProgressor.any_instance.expects(:progress).returns(false)
+
+        post :cancel_scheduled_publishing, params: {
+          id: @edition.id,
+        }
+
+        assert_template "secondary_nav_tabs/cancel_scheduled_publishing_page"
+        assert_equal "Due to a service problem, the request could not be made", flash[:danger]
+        @edition.reload
+        assert_equal "scheduled_for_publishing", @edition.state
+      end
+    end
+
+    context "user does not have govuk_editor permission" do
+      setup do
+        user = FactoryBot.create(:user)
+        login_as(user)
+      end
+
+      should "render an error message" do
+        post :cancel_scheduled_publishing, params: {
+          id: @edition.id,
+        }
+
+        assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
+      end
+    end
+
+    context "edition is not in a valid state to have scheduling cancelled" do
+      setup do
+        @requester = FactoryBot.create(:user, :govuk_editor, name: "Stub Requester")
+        @edition = FactoryBot.create(:edition, state: "draft")
+      end
+
+      should "not update the edition state and render 'cancel_scheduled_publishing' template with an error" do
+        post :cancel_scheduled_publishing, params: {
+          id: @edition.id,
+        }
+
+        assert_equal "Edition is not in a state where scheduling can be cancelled", flash[:danger]
+
+        assert_template "secondary_nav_tabs/cancel_scheduled_publishing_page"
+        @edition.reload
+        assert_equal "draft", @edition.state
+      end
+    end
+  end
+
   context "#metadata" do
     should "alias to show method" do
       assert_equal EditionsController.new.method(:metadata).super_method.name, :show

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -1044,6 +1044,17 @@ class EditionEditTest < IntegrationTest
         assert page.has_link?("Publish now", href: send_to_publish_page_edition_path(edition))
       end
 
+      should "show a 'cancel scheduling' button in the sidebar when user is a govuk editor" do
+        edition = FactoryBot.create(
+          :edition, state: "scheduled_for_publishing", publish_at: Time.zone.now + 1.hour
+        )
+        login_as_govuk_editor
+
+        visit edition_path(edition)
+
+        assert page.has_link?("Cancel scheduling", href: cancel_scheduled_publishing_page_edition_path(edition))
+      end
+
       context "that is welsh" do
         should "show a 'publish now' button in the sidebar when user is a welsh editor" do
           edition = FactoryBot.create(
@@ -1065,6 +1076,28 @@ class EditionEditTest < IntegrationTest
           visit edition_path(edition)
 
           assert page.has_no_link?("Publish now")
+        end
+
+        should "show a 'cancel scheduling' button in the sidebar when user is a welsh editor" do
+          edition = FactoryBot.create(
+            :edition, :welsh, state: "scheduled_for_publishing", publish_at: Time.zone.now + 1.hour
+          )
+          login_as_welsh_editor
+
+          visit edition_path(edition)
+
+          assert page.has_link?("Cancel scheduling", href: cancel_scheduled_publishing_page_edition_path(edition))
+        end
+
+        should "not show a 'cancel scheduling' button in the sidebar when user is not a welsh editor" do
+          edition = FactoryBot.create(
+            :edition, :welsh, state: "scheduled_for_publishing", publish_at: Time.zone.now + 1.hour
+          )
+          login_as(FactoryBot.create(:user))
+
+          visit edition_path(edition)
+
+          assert page.has_no_link?("Cancel scheduling")
         end
       end
     end

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -1911,6 +1911,31 @@ class EditionEditTest < IntegrationTest
     end
   end
 
+  context "Cancel scheduled publishing page" do
+    should "save comment to edition history" do
+      create_scheduled_for_publishing_edition
+
+      visit cancel_scheduled_publishing_page_edition_path(@scheduled_for_publishing_edition)
+      fill_in "Comment (optional)", with: "Looks great"
+      click_on "Cancel scheduled publishing"
+
+      click_on "History and notes"
+      assert page.has_content?("Cancel scheduled publishing by")
+      assert page.has_content?("Looks great")
+    end
+
+    should "populate comment box with submitted comment when there is an error" do
+      edition = create_draft_edition
+
+      visit cancel_scheduled_publishing_page_edition_path(edition)
+      fill_in "Comment (optional)", with: "Forget about it"
+      click_on "Cancel scheduled publishing"
+
+      assert page.has_content?("Edition is not in a state where scheduling can be cancelled")
+      assert page.has_content?("Forget about it")
+    end
+  end
+
   context "Compare editions" do
     should "render the compare editions page" do
       published_edition = FactoryBot.create(


### PR DESCRIPTION
## Trello
[Trello card](https://trello.com/c/4Fg28ZKf/625-cancel-scheduling-for-scheduled-edition-answer-and-help)

## What
Adds the flow for cancelling the scheduling of a publish of an edition when it is currently scheduled for publishing.

## Screenshots

### Cancel scheduling button
![cancel-scheduling-for-scheduled-edition](https://github.com/user-attachments/assets/48804a0c-aef4-4b3c-b8b8-21a5673a8e03)

### Cancel scheduled publishing page
![cancel-scheduled-publishing-page](https://github.com/user-attachments/assets/8168cbd9-304d-4a4d-9891-c46cb39a3871)

### Cancel scheduling succeeded
![image](https://github.com/user-attachments/assets/bdb1923b-2eb4-4113-adf7-22370b081829)

### Cancel scheduling message saved
![cancel-scheduling-comment-saved](https://github.com/user-attachments/assets/c9c7748f-4c2a-4d8b-a5fe-3756828a01ca)
