### PR TITLE
602 edit page edit 2i reviewer

### DIFF
--- a/app/helpers/editions_helper.rb
+++ b/app/helpers/editions_helper.rb
@@ -54,7 +54,9 @@ module EditionsHelper
       end
   end
 
-  def document_summary_items(edition)
+  def document_summary_items(edition, reviewer)
+    reviewer_name = reviewer.nil? ? "Not yet claimed" : reviewer.name
+
     items = [
       {
         field: "Assigned to",
@@ -76,6 +78,14 @@ module EditionsHelper
         value: edition.publish_at.to_fs(:govuk_date).to_s,
       }
     end
+    if edition.in_review?
+      items << {
+        field: "2i reviewer",
+        value: reviewer_name,
+        edit: reviewer_edit_link(edition),
+      }
+    end
+
     items
   end
 

--- a/app/helpers/tabbed_nav_helper.rb
+++ b/app/helpers/tabbed_nav_helper.rb
@@ -43,6 +43,17 @@ module TabbedNavHelper
     end
   end
 
+  def reviewer_edit_link(edition)
+    if current_user.has_editor_permissions?(edition)
+      {
+        href: edit_reviewer_edition_path,
+        link_text: "Edit",
+      }
+    else
+      {}
+    end
+  end
+
 private
 
   def all_tab_names
@@ -90,7 +101,24 @@ private
     items
   end
 
+  def available_reviewer_items(edition)
+    items = []
+    unless edition.reviewer.nil?
+      items << { value: edition.reviewer, text: User.where(id: edition.reviewer).first, checked: true }
+      items << { value: "none", text: "None" }
+      items << :or
+    end
+    User.enabled.order_by([%i[name asc]]).each do |user|
+      items << { value: user.id, text: user.name } unless user.id.to_s == edition.reviewer || !user.has_editor_permissions?(edition)
+    end
+    items
+  end
+
   def can_update_assignee?(resource)
     %w[published archived scheduled_for_publishing].exclude?(resource.state)
+  end
+
+  def can_update_reviewer?(resource)
+    %w[in_review].include?(resource.state)
   end
 end

--- a/app/views/editions/secondary_nav_tabs/edit_assignee/_edit_assignee.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit_assignee/_edit_assignee.html.erb
@@ -1,15 +1,17 @@
-<% content_for :title_context, @resource.title %>
-<% content_for :page_title, "Assign person" %>
-<% content_for :title, "Assign person" %>
+<%# locals: (title:, url:, radio_name:, available_assignees:) %>
 
-<%= form_for @resource, url: update_assignee_edition_path(@resource) do %>
+<% content_for :title_context, @resource.title %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
+
+<%= form_for @resource, url: url do %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <%= render "govuk_publishing_components/components/radio", {
-          name: "assignee_id",
+          name: radio_name,
           heading: "Choose a person to assign",
           visually_hidden_heading: true,
-          items: available_assignee_items(@resource),
+          items: available_assignees,
         } %>
     </div>
 

--- a/app/views/editions/secondary_nav_tabs/edit_assignee_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit_assignee_page.html.erb
@@ -1,0 +1,6 @@
+<%= render partial: "secondary_nav_tabs/edit_assignee/edit_assignee", locals: {
+  title: "Assign person",
+  available_assignees: available_assignee_items(@resource),
+  url: update_assignee_edition_path(@resource),
+  radio_name: "assignee_id",
+} %>

--- a/app/views/editions/secondary_nav_tabs/edit_reviewer_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit_reviewer_page.html.erb
@@ -1,0 +1,6 @@
+<%= render partial: "secondary_nav_tabs/edit_assignee/edit_assignee", locals: {
+  title: "Assign 2i reviewer",
+  available_assignees: available_reviewer_items(@resource),
+  url: update_reviewer_edition_path(@resource),
+  radio_name: "reviewer_id",
+} %>

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -21,7 +21,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds editions__edit__summary">
     <%= render "govuk_publishing_components/components/summary_list", {
-      items: document_summary_items(@resource),
+      items: document_summary_items(@resource, @reviewer),
     } %>
     <% if @edition.important_note %>
       <%= render partial: "important_note" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,8 @@ Rails.application.routes.draw do
         post "progress"
         get "edit_assignee"
         patch "update_assignee"
+        get "edit_reviewer"
+        patch "update_reviewer"
         post "skip_fact_check",
              to: "editions#progress",
              edition: {


### PR DESCRIPTION
[Trello](https://trello.com/c/xT4E3nvr/602-add-2i-reviewer-to-document-summary-edit-page)

Allows the user to assign a person to be the 2i reviewer or to deselect the currently assigned user. This makes the following additions: 
- On the edit page a new row is added to the summary to show 
  - the current 2i reviewer or display a message if this has not been assigned
  - an "Edit" link 
- Creates a new page to edit the 2i reviewer, accessed from the "Edit" link

UI variations are shown below.

|Change to the Edit page|Before|After|
|-|-|-|
|Adds a new row to the summary for "In review" editions|![Screenshot 2025-04-07 at 14 43 37](https://github.com/user-attachments/assets/837c6f63-3e77-4cbd-ab70-8f7dbc72590b)|![Screenshot 2025-04-07 at 14 43 17](https://github.com/user-attachments/assets/6388c167-ef3f-41c9-b0bd-98783e329bc1)|

|Edit reviewer page: scenario|View|
|-|-|
|No 2i reviewer is assigned|![Screenshot 2025-04-07 at 14 58 03](https://github.com/user-attachments/assets/fbde7198-e37c-4a9e-a2da-0f1d93584735)|
|2i reviewer is assigned|![Screenshot 2025-04-07 at 14 59 36](https://github.com/user-attachments/assets/a4da68dc-c231-4774-b377-d673b3beb184)|

|Edit page: success messages|View|
|-|-|
|User assigns themselves as 2i reviewer|![Screenshot 2025-04-07 at 15 02 33](https://github.com/user-attachments/assets/87bc45aa-3537-420e-9638-5d7b5d143727)|
|User assigns another user as 2i reviewer|![Screenshot 2025-04-07 at 15 03 30](https://github.com/user-attachments/assets/407751bb-c8b4-4c4f-882b-057fe8ef4920)|
|User unassigns the current 2i reviewer|![Screenshot 2025-04-07 at 15 04 09](https://github.com/user-attachments/assets/7be4ce6c-9bab-42fa-95ad-9c122505c6ef)|

|Edit reviewer page: error messages|View|
|-|-|
|No selection made|![Screenshot 2025-04-07 at 15 10 25](https://github.com/user-attachments/assets/e8417167-976d-4a0f-8ed2-2e71e93fc6de)|
|Server error|![Screenshot 2025-04-07 at 15 12 01](https://github.com/user-attachments/assets/bbddefea-d4c9-41b2-9dab-129d6c78be14)|