### PR TITLE
642 publish for ready edition

### DIFF
--- a/app/helpers/editions_sidebar_buttons_helper.rb
+++ b/app/helpers/editions_sidebar_buttons_helper.rb
@@ -78,15 +78,18 @@ module EditionsSidebarButtonsHelper
 
   def non_published_sidebar_buttons(edition)
     buttons = []
-    if current_user.has_editor_permissions?(edition) && !edition.retired_format?
-      buttons << (render "govuk_publishing_components/components/button", {
-        text: "Save",
-        margin_bottom: 3,
-      })
-    end
-    buttons << link_to("Preview (opens in new tab)", preview_edition_path(edition), target: "_blank", rel: "noopener", class: "govuk-link")
-    if current_user.has_editor_permissions?(edition) && edition.can_request_review?
-      buttons << link_to("Send to 2i", send_to_2i_page_edition_path(edition), class: "govuk-link")
+
+    if current_user.has_editor_permissions?(edition)
+      unless edition.retired_format?
+        buttons << (render "govuk_publishing_components/components/button", {
+          text: "Save",
+          margin_bottom: 3,
+        })
+      end
+      buttons << link_to("Preview (opens in new tab)", preview_edition_path(edition), target: "_blank", rel: "noopener", class: "govuk-link")
+      if edition.can_request_review?
+        buttons << link_to("Send to 2i", send_to_2i_page_edition_path(edition), class: "govuk-link")
+      end
     end
 
     buttons

--- a/app/helpers/editions_sidebar_buttons_helper.rb
+++ b/app/helpers/editions_sidebar_buttons_helper.rb
@@ -78,7 +78,6 @@ module EditionsSidebarButtonsHelper
 
   def non_published_sidebar_buttons(edition)
     buttons = []
-
     if current_user.has_editor_permissions?(edition)
       unless edition.retired_format?
         buttons << (render "govuk_publishing_components/components/button", {
@@ -86,10 +85,21 @@ module EditionsSidebarButtonsHelper
           margin_bottom: 3,
         })
       end
-      buttons << link_to("Preview (opens in new tab)", preview_edition_path(edition), target: "_blank", rel: "noopener", class: "govuk-link")
-      if edition.can_request_review?
-        buttons << link_to("Send to 2i", send_to_2i_page_edition_path(edition), class: "govuk-link")
+      if edition.can_publish?
+        buttons << render(
+          "govuk_publishing_components/components/button",
+          {
+            text: "Publish",
+            href: send_to_publish_page_edition_path(edition),
+            secondary_solid: true,
+            margin_bottom: 3,
+          },
+        )
       end
+    end
+    buttons << link_to("Preview (opens in new tab)", preview_edition_path(edition), target: "_blank", rel: "noopener", class: "govuk-link")
+    if edition.can_request_review?
+      buttons << link_to("Send to 2i", send_to_2i_page_edition_path(edition), class: "govuk-link")
     end
 
     buttons

--- a/app/helpers/editions_sidebar_buttons_helper.rb
+++ b/app/helpers/editions_sidebar_buttons_helper.rb
@@ -85,7 +85,7 @@ module EditionsSidebarButtonsHelper
       })
     end
     buttons << link_to("Preview (opens in new tab)", preview_edition_path(edition), target: "_blank", rel: "noopener", class: "govuk-link")
-    if current_user.has_editor_permissions?(edition) && %w[draft amends_needed].include?(edition.state)
+    if current_user.has_editor_permissions?(edition) && edition.can_request_review?
       buttons << link_to("Send to 2i", send_to_2i_page_edition_path(edition), class: "govuk-link")
     end
 

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -520,84 +520,166 @@ class EditionsControllerTest < ActionController::TestCase
   end
 
   context "#send_to_publish" do
-    setup do
-      @requester = FactoryBot.create(:user, :govuk_editor, name: "Stub Requester")
-      @edition = FactoryBot.create(:edition, state: "scheduled_for_publishing", publish_at: Time.zone.now + 1.hour)
-      login_as(@requester)
-    end
-
-    context "user has govuk_editor permission" do
-      setup do
-        ScheduledPublisher.stubs(:cancel_scheduled_publishing)
-        PublishWorker.stubs(:perform_async)
-      end
-
-      should "update the edition status to 'published' and save the comment" do
-        post :send_to_publish, params: {
-          id: @edition.id,
-          comment: "Publishing with immediate effect",
-        }
-
-        assert_equal "Published", flash[:success]
-        @edition.reload
-        assert_equal "published", @edition.state
-        assert_equal "Publishing with immediate effect", @edition.latest_status_action.comment
-        assert_equal @requester.id, @edition.latest_status_action.requester_id
-      end
-
-      should "not update the edition state and render 'send_to_publish' template with an error when an error occurs" do
-        EditionProgressor.any_instance.expects(:progress).returns(false)
-
-        post :send_to_publish, params: {
-          id: @edition.id,
-        }
-
-        assert_template "secondary_nav_tabs/send_to_publish_page"
-        assert_equal "Due to a service problem, the request could not be made", flash[:danger]
-        @edition.reload
-        assert_equal "scheduled_for_publishing", @edition.state
-      end
-
-      should "notify the publishing API to publish the edition" do
-        PublishWorker.expects(:perform_async).with(@edition.id.to_s)
-
-        post :send_to_publish, params: {
-          id: @edition.id,
-        }
-      end
-    end
-
-    context "user does not have govuk_editor permission" do
-      setup do
-        user = FactoryBot.create(:user)
-        login_as(user)
-      end
-
-      should "render an error message" do
-        post :send_to_publish, params: {
-          id: @edition.id,
-        }
-
-        assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
-      end
-    end
-
-    context "edition is not in a valid state to be published" do
+    context "edition is in 'scheduled_for_publishing' state" do
       setup do
         @requester = FactoryBot.create(:user, :govuk_editor, name: "Stub Requester")
-        @edition = FactoryBot.create(:edition, state: "draft")
+        @edition = FactoryBot.create(:edition, state: "scheduled_for_publishing", publish_at: Time.zone.now + 1.hour)
+        login_as(@requester)
       end
 
-      should "not update the edition state and render 'send_to_publish' template with an error" do
-        post :send_to_publish, params: {
-          id: @edition.id,
-        }
+      context "user has govuk_editor permission" do
+        setup do
+          ScheduledPublisher.stubs(:cancel_scheduled_publishing)
+          PublishWorker.stubs(:perform_async)
+        end
 
-        assert_equal "Edition is not in a state where it can be published", flash[:danger]
+        should "update the edition status to 'published' and save the comment" do
+          post :send_to_publish, params: {
+            id: @edition.id,
+            comment: "Publishing with immediate effect",
+          }
 
-        assert_template "secondary_nav_tabs/send_to_publish_page"
-        @edition.reload
-        assert_equal "draft", @edition.state
+          assert_equal "Published", flash[:success]
+          @edition.reload
+          assert_equal "published", @edition.state
+          assert_equal "Publishing with immediate effect", @edition.latest_status_action.comment
+          assert_equal @requester.id, @edition.latest_status_action.requester_id
+        end
+
+        should "not update the edition state and render 'send_to_publish' template with an error when an error occurs" do
+          EditionProgressor.any_instance.expects(:progress).returns(false)
+
+          post :send_to_publish, params: {
+            id: @edition.id,
+          }
+
+          assert_template "secondary_nav_tabs/send_to_publish_page"
+          assert_equal "Due to a service problem, the request could not be made", flash[:danger]
+          @edition.reload
+          assert_equal "scheduled_for_publishing", @edition.state
+        end
+
+        should "notify the publishing API to publish the edition" do
+          PublishWorker.expects(:perform_async).with(@edition.id.to_s)
+
+          post :send_to_publish, params: {
+            id: @edition.id,
+          }
+        end
+      end
+
+      context "user does not have govuk_editor permission" do
+        setup do
+          user = FactoryBot.create(:user)
+          login_as(user)
+        end
+
+        should "render an error message" do
+          post :send_to_publish, params: {
+            id: @edition.id,
+          }
+
+          assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
+        end
+      end
+
+      context "edition is not in a valid state to be published" do
+        setup do
+          @requester = FactoryBot.create(:user, :govuk_editor, name: "Stub Requester")
+          @edition = FactoryBot.create(:edition, state: "draft")
+        end
+
+        should "not update the edition state and render 'send_to_publish' template with an error" do
+          post :send_to_publish, params: {
+            id: @edition.id,
+          }
+
+          assert_equal "Edition is not in a state where it can be published", flash[:danger]
+
+          assert_template "secondary_nav_tabs/send_to_publish_page"
+          @edition.reload
+          assert_equal "draft", @edition.state
+        end
+      end
+    end
+
+    context "edition is in 'ready' state" do
+      setup do
+        @edition = FactoryBot.create(:edition, state: "ready")
+        login_as_stub_user
+      end
+
+      context "user has govuk_editor permission" do
+        setup do
+          PublishWorker.stubs(:perform_async)
+        end
+
+        should "update the edition status to 'published' and save the comment" do
+          post :send_to_publish, params: {
+            id: @edition.id,
+            comment: "Publishing this ready edition",
+          }
+
+          assert_equal "Published", flash[:success]
+          @edition.reload
+          assert_equal "published", @edition.state
+          assert_equal "Publishing this ready edition", @edition.latest_status_action.comment
+          assert_equal @user.id, @edition.latest_status_action.requester_id
+        end
+
+        should "not update the edition state and render 'send_to_publish' template with an error when an error occurs" do
+          EditionProgressor.any_instance.expects(:progress).returns(false)
+
+          post :send_to_publish, params: {
+            id: @edition.id,
+          }
+
+          assert_template "secondary_nav_tabs/send_to_publish_page"
+          assert_equal "Due to a service problem, the request could not be made", flash[:danger]
+          @edition.reload
+          assert_equal "ready", @edition.state
+        end
+
+        should "notify the publishing API to publish the edition" do
+          PublishWorker.expects(:perform_async).with(@edition.id.to_s)
+
+          post :send_to_publish, params: {
+            id: @edition.id,
+          }
+        end
+      end
+
+      context "user does not have govuk_editor permissions" do
+        setup do
+          user = FactoryBot.create(:user)
+          login_as(user)
+        end
+
+        should "render an error message" do
+          post :send_to_publish, params: {
+            id: @edition.id,
+          }
+
+          assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
+        end
+      end
+
+      context "edition is not in a valid state to be published" do
+        setup do
+          @edition = FactoryBot.create(:edition, state: "draft")
+        end
+
+        should "not update the edition state and render 'send_to_publish' template with an error" do
+          post :send_to_publish, params: {
+            id: @edition.id,
+          }
+
+          assert_equal "Edition is not in a state where it can be published", flash[:danger]
+
+          assert_template "secondary_nav_tabs/send_to_publish_page"
+          @edition.reload
+          assert_equal "draft", @edition.state
+        end
       end
     end
   end

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -1609,6 +1609,31 @@ class EditionEditTest < IntegrationTest
         end
       end
     end
+
+    context "'Publish' button" do
+      should "show the 'Publish' button if user has govuk_editor permission" do
+        login_as(@govuk_editor)
+        visit_ready_edition
+
+        assert page.has_link?("Publish", href: send_to_publish_page_edition_path(@ready_edition))
+      end
+
+      should "show the 'Publish' button for welsh edition if user has welsh_editor permission" do
+        login_as_welsh_editor
+        welsh_edition = FactoryBot.create(:edition, :welsh, state: "ready")
+        visit edition_path(welsh_edition)
+        assert @user.has_editor_permissions?(welsh_edition)
+
+        assert page.has_link?("Publish", href: send_to_publish_page_edition_path(welsh_edition))
+      end
+
+      should "not show the 'Publish' button if the user does not have permissions" do
+        login_as(FactoryBot.create(:user, name: "Stub User"))
+        visit_ready_edition
+
+        assert_not page.has_link?("Publish", href: send_to_publish_page_edition_path(@ready_edition))
+      end
+    end
   end
 
   context "Related external links tab" do


### PR DESCRIPTION
**WHAT**
Implement Publish button and process for Ready edition.

-------------
[Trello card](https://trello.com/c/ljJbaP3q)

|Scenario|View|
|-|-|
|The Publish button shows when the edition is in a ready state, and user has the right permissions.|![Visible publish button](https://github.com/user-attachments/assets/331891ef-c89a-49ae-bc91-f8f3c3ce640e)|
|Clicking the button sends the user to the send to Publish confirmation page. User can enter optional comments, and click the Send to Publish button to publish the edition. Cancel button takes the user back to the Edit tab.|![Visible publish button and textbox](https://github.com/user-attachments/assets/4f798544-c2ff-4f7c-8dae-81737f845f28)|
|Success message present and edition is in Published state. Edition is now edit-only.|![Edition state updated and success message shows](https://github.com/user-attachments/assets/da8c2ba9-4d78-41bc-9d5a-9f5fdc926029)|


