### PR TITLE
Edit page for ready state edition

### DIFF
--- a/app/views/editions/secondary_nav_tabs/edit/draft/_body.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/draft/_body.html.erb
@@ -6,5 +6,5 @@
   name: "edition[body]",
   value: edition.body,
   rows: 14,
-  hint: ("Refer to #{link_to("Refer to the Govspeak guidance (opens in new tab)", "https://govspeak-preview.publishing.service.gov.uk/guide", target: "_blank", rel: "noopener", class: "govuk-link")}").html_safe,
+  hint: ("Refer to the #{link_to("Govspeak guidance (opens in new tab)", "https://govspeak-preview.publishing.service.gov.uk/guide", target: "_blank", rel: "noopener", class: "govuk-link")}").html_safe,
 } %>

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -45,6 +45,14 @@
         <% end %>
       <% end %>
     </div>
+  <% elsif @edition.ready? %>
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/inset_text", {} do %>
+        <% if current_user.has_editor_permissions?(@edition) %>
+          <p class="govuk-body"><%= link_to("Request amendments", request_amendments_page_edition_path) %></p>
+        <% end %>
+      <% end %>
+    </div>
   <% end %>
 </div>
 

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -1331,6 +1331,35 @@ class EditionEditTest < IntegrationTest
           assert_current_path request_amendments_page_edition_path(@in_review_edition.id)
         end
       end
+
+      context "edition is ready" do
+        should "not show the link to non-editors" do
+          login_as(FactoryBot.create(:user, name: "Stub User"))
+          visit_ready_edition
+          assert page.has_no_link?("Request amendments")
+        end
+
+        should "not show the link to welsh editors viewing a non-welsh edition" do
+          login_as(FactoryBot.create(:user, :welsh_editor, name: "Stub User"))
+          visit_ready_edition
+          assert page.has_no_link?("Request amendments")
+        end
+
+        should "show the link to editors" do
+          login_as(@govuk_editor)
+          visit_ready_edition
+          assert page.has_link?("Request amendments")
+        end
+
+        should "navigate to the 'Request amendments' page when the link is clicked" do
+          login_as(@govuk_editor)
+          visit_ready_edition
+
+          click_link("Request amendments")
+
+          assert_current_path request_amendments_page_edition_path(@ready_edition.id)
+        end
+      end
     end
 
     context "No changes needed link" do

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -1290,124 +1290,90 @@ class EditionEditTest < IntegrationTest
 
     context "Request amendments link" do
       context "edition is not in review" do
-        setup do
+        should "not show the link" do
           visit_draft_edition
-        end
-
-        should "not show the 'Request amendments' link" do
           assert page.has_no_link?("Request amendments")
         end
       end
 
       context "edition is in review" do
-        context "user does not have the required permissions" do
-          setup do
-            login_as(FactoryBot.create(:user, name: "Stub User"))
-            visit_in_review_edition
-          end
-
-          should "not show the 'Request amendments' link" do
-            assert page.has_no_link?("Request amendments")
-          end
-
-          should "not show 'Request amendments' link when user is a welsh editor and the edition is not welsh" do
-            login_as(FactoryBot.create(:user, :welsh_editor, name: "Stub User"))
-            visit_in_review_edition
-
-            assert page.has_no_link?("Request amendments")
-          end
+        should "not show the link to non-editors" do
+          login_as(FactoryBot.create(:user, name: "Stub User"))
+          visit_in_review_edition
+          assert page.has_no_link?("Request amendments")
         end
 
-        context "user has the required permissions" do
-          context "current user is also the requester" do
-            setup do
-              login_as(@govuk_requester)
-              visit_in_review_edition
-            end
+        should "not show the link to welsh editors viewing a non-welsh edition" do
+          login_as(FactoryBot.create(:user, :welsh_editor, name: "Stub User"))
+          visit_in_review_edition
 
-            should "not show the 'Request amendments' link" do
-              assert page.has_no_link?("Request amendments")
-            end
-          end
+          assert page.has_no_link?("Request amendments")
+        end
 
-          context "current user is not the requester" do
-            setup do
-              login_as(@govuk_editor)
-              visit_in_review_edition
-            end
+        should "not show the link to the requester" do
+          login_as(@govuk_requester)
+          visit_in_review_edition
+          assert page.has_no_link?("Request amendments")
+        end
 
-            should "show the 'Request amendments' link" do
-              assert page.has_link?("Request amendments")
-            end
+        should "show the link to editors who are not the requester" do
+          login_as(@govuk_editor)
+          visit_in_review_edition
+          assert page.has_link?("Request amendments")
+        end
 
-            should "navigate to 'Request amendments' page when link is clicked" do
-              click_link("Request amendments")
+        should "navigate to the 'Request amendments' page when the link is clicked" do
+          login_as(@govuk_editor)
+          visit_in_review_edition
 
-              assert_current_path request_amendments_page_edition_path(@in_review_edition.id)
-            end
-          end
+          click_link("Request amendments")
+
+          assert_current_path request_amendments_page_edition_path(@in_review_edition.id)
         end
       end
     end
 
     context "No changes needed link" do
       context "edition is not in review" do
-        setup do
+        should "not show the link" do
           visit_draft_edition
-        end
-
-        should "not show the 'No changes needed' link" do
           assert page.has_no_link?("No changes needed")
         end
       end
 
       context "edition is in review" do
-        context "user does not have the required permissions" do
-          setup do
-            login_as(FactoryBot.create(:user, name: "Stub User"))
-            visit_in_review_edition
-          end
-
-          should "not show the 'No changes needed' link" do
-            assert page.has_no_link?("No changes needed")
-          end
-
-          should "not show 'No changes needed' link when user is a welsh editor and the edition is not welsh" do
-            login_as(FactoryBot.create(:user, :welsh_editor, name: "Stub User"))
-            visit_in_review_edition
-
-            assert page.has_no_link?("No changes needed")
-          end
+        should "not show the link to non-editors" do
+          login_as(FactoryBot.create(:user, name: "Stub User"))
+          visit_in_review_edition
+          assert page.has_no_link?("No changes needed")
         end
 
-        context "user has the required permissions" do
-          context "current user is also the requester" do
-            setup do
-              login_as(@govuk_requester)
-              visit_in_review_edition
-            end
+        should "not show the link to welsh editors viewing a non-welsh edition" do
+          login_as(FactoryBot.create(:user, :welsh_editor, name: "Stub User"))
+          visit_in_review_edition
 
-            should "not show the 'No changes needed' link" do
-              assert page.has_no_link?("No changes needed")
-            end
-          end
+          assert page.has_no_link?("No changes needed")
+        end
 
-          context "current user is not the requester" do
-            setup do
-              login_as(@govuk_editor)
-              visit_in_review_edition
-            end
+        should "not show the link to the requester" do
+          login_as(@govuk_requester)
+          visit_in_review_edition
+          assert page.has_no_link?("No changes needed")
+        end
 
-            should "show the 'No changes needed' link" do
-              assert page.has_link?("No changes needed")
-            end
+        should "show the link to editors who are not the requester" do
+          login_as(@govuk_editor)
+          visit_in_review_edition
+          assert page.has_link?("No changes needed")
+        end
 
-            should "navigate to 'No changes needed' page when link is clicked" do
-              click_link("No changes needed")
+        should "navigate to the 'No changes needed' page when the link is clicked" do
+          login_as(@govuk_editor)
+          visit_in_review_edition
 
-              assert_current_path no_changes_needed_page_edition_path(@in_review_edition.id)
-            end
-          end
+          click_link("No changes needed")
+
+          assert_current_path no_changes_needed_page_edition_path(@in_review_edition.id)
         end
       end
     end


### PR DESCRIPTION
## Trello
[Trello card](https://trello.com/c/HNQxpjxy/644-edit-page-for-ready-state-edition-answer-and-help-page)

## What
Add a "request amendments" link below the document summary and above the tabs, on the edition "show" view.

Also fixes some duplicated text appearing in a link.

## Screenshots
### Request amendments link
![image](https://github.com/user-attachments/assets/3393f570-1d20-44ab-9f1a-9b14433a7095)

### Link before change
![image](https://github.com/user-attachments/assets/544e1a2c-b06a-4408-81f1-77a47a11d5dd)

### Link after change
![image](https://github.com/user-attachments/assets/8d992d58-e91b-43e3-82f7-750208917104)
