### PR TITLE
602 Update messaging for 2i reviewer and assignee

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -290,7 +290,7 @@ class EditionsController < InheritedResources::Base
       render "secondary_nav_tabs/edit_assignee_page"
     end
   rescue ActionController::ParameterMissing
-    flash.now[:danger] = "Please select a person to assign, or 'None' to unassign the currently assigned person."
+    flash.now[:danger] = "Select a person to assign"
     render "secondary_nav_tabs/edit_assignee_page"
   rescue StandardError => e
     Rails.logger.error "Error #{e.class} #{e.message}"
@@ -311,7 +311,7 @@ class EditionsController < InheritedResources::Base
       if @resource.reviewer == current_user.id.to_s
         flash[:success] = "You are now the 2i reviewer of this edition"
       elsif @resource.reviewer.nil?
-        flash[:success] = "The current 2i reviewer has been unassigned"
+        flash[:success] = "2i reviewer removed"
       else
         reviewer = User.where(id: @resource.reviewer).first
         flash[:success] = "#{reviewer} is now the 2i reviewer of this edition"
@@ -323,7 +323,7 @@ class EditionsController < InheritedResources::Base
       render "secondary_nav_tabs/edit_reviewer_page"
     end
   rescue ActionController::ParameterMissing
-    flash.now[:danger] = "Please select a person to assign, or 'None' to unassign the currently assigned person."
+    flash.now[:danger] = "Select a person to assign"
     render "secondary_nav_tabs/edit_reviewer_page"
   rescue StandardError => e
     Rails.logger.error "Error #{e.class} #{e.message}"

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -1456,7 +1456,7 @@ class EditionsControllerTest < ActionController::TestCase
         patch :update_assignee, params: { id: @edition.id }
 
         assert_template "secondary_nav_tabs/edit_assignee_page"
-        assert_equal "Please select a person to assign, or 'None' to unassign the currently assigned person.", flash[:danger]
+        assert_equal "Select a person to assign", flash[:danger]
       end
 
       should "show error when a non-existent assignee ID is provided" do
@@ -1538,7 +1538,7 @@ class EditionsControllerTest < ActionController::TestCase
         @in_review_edition.reload
 
         assert_nil @in_review_edition.reviewer
-        assert_equal "The current 2i reviewer has been unassigned", flash[:success]
+        assert_equal "2i reviewer removed", flash[:success]
       end
 
       should "show an error when the save fails" do
@@ -1563,7 +1563,7 @@ class EditionsControllerTest < ActionController::TestCase
         patch :update_reviewer, params: { id: @in_review_edition.id }
 
         assert_template "secondary_nav_tabs/edit_reviewer_page"
-        assert_equal "Please select a person to assign, or 'None' to unassign the currently assigned person.", flash[:danger]
+        assert_equal "Select a person to assign", flash[:danger]
       end
 
       context "Welsh editor and Welsh edition" do


### PR DESCRIPTION
[Trello](https://trello.com/c/xT4E3nvr/602-add-2i-reviewer-to-document-summary-edit-page)

The changes here make a few small updates to some of the messaging associated with adding/removing assignees and 21 reviewers to/from editions: 
- 2i reviewer is unassigned: changed from "The current 2i reviewer has been unassigned" to "2i reviewer removed"
- User tries to save new 2i reviewer without selecting an option: changed from "Please select a person to assign, or 'None' to unassign the currently assigned person." to "Select a person to assign"
- User tries to save new assignee without selecting an option: changed from "Please select a person to assign, or 'None' to unassign the currently assigned person." to "Select a person to assign"

See the screenshots below for updated UI.

|Scenario|Before|After|
|-|-|-|
|Assign 2i reviewer: |![Screenshot 2025-04-15 at 12 16 27](https://github.com/user-attachments/assets/b78097e3-8ff8-44dd-a428-02e005425e43)|![Screenshot 2025-04-15 at 12 15 28](https://github.com/user-attachments/assets/d11929b1-a972-4158-8e6b-2e9e67d0aaa8)|
|Assign 2i reviewer: user saves without selecting a person|![Screenshot 2025-04-15 at 12 17 07](https://github.com/user-attachments/assets/3b690852-ef8c-4cb5-9c3d-7999076fac21)|![Screenshot 2025-04-15 at 12 13 09](https://github.com/user-attachments/assets/7502662b-9127-4576-93c3-38792560cbbf)|
|Assign person: user saves without selecting a person|![Screenshot 2025-04-15 at 12 17 49](https://github.com/user-attachments/assets/2e330fe7-6cec-4876-b070-f1dc821c658c)|![Screenshot 2025-04-15 at 12 14 16](https://github.com/user-attachments/assets/299b3fa1-76a3-4e34-aa02-46b9ce44764a)|
