### PR TITLE
671 remove the 6 default status checkbox

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -15,16 +15,10 @@ class RootController < ApplicationController
     archived
   ].freeze
 
-  DEFAULT_FILTER_STATES = %w[draft amends_needed in_review fact_check fact_check_received ready].freeze
-
   def index
     filter_params_hash = filter_params.to_h
     states_filter_params = filter_params_hash[:states_filter]
-    sanitised_states_filter_params = if user_has_submitted_filters?
-                                       states_filter_params&.select { |fp| PERMITTED_FILTER_STATES.include?(fp) }
-                                     else
-                                       DEFAULT_FILTER_STATES
-                                     end
+    sanitised_states_filter_params = states_filter_params&.select { |fp| PERMITTED_FILTER_STATES.include?(fp) }
     session[:assignee_filter] = assignee_filter
     content_type_filter = filter_params_hash[:content_type_filter]
     search_text = filter_params_hash[:search_text]
@@ -39,10 +33,6 @@ class RootController < ApplicationController
   end
 
 private
-
-  def user_has_submitted_filters?
-    filter_params.to_h[:search_text]
-  end
 
   def assignee_filter
     filter_params_hash = filter_params.to_h

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -13,7 +13,7 @@ class RootControllerTest < ActionController::TestCase
       assert_template "root/index"
     end
 
-    should "default the state filter checkboxes to unchecked when no filters are specified" do
+    should "default all state filter checkboxes to unchecked" do
       get :index
 
       assert_select "input.govuk-checkboxes__input", 9
@@ -32,7 +32,7 @@ class RootControllerTest < ActionController::TestCase
       assert_select "input.govuk-checkboxes__input[value='archived']"
     end
 
-    should "default the applied state filters when no filters are specified" do
+    should "default the applied state filters" do
       FactoryBot.create(:edition, state: "draft", assigned_to: @user)
       FactoryBot.create(:edition, state: "in_review", review_requested_at: 1.hour.ago, assigned_to: @user)
       FactoryBot.create(:edition, state: "amends_needed", assigned_to: @user)
@@ -78,7 +78,7 @@ class RootControllerTest < ActionController::TestCase
       assert_select "#assignee_filter > option[value='#{@user.id}'][selected]"
     end
 
-    should "default to filtering to publications assigned to the current user" do
+    should "default filtering to publications assigned to the current user" do
       anna = FactoryBot.create(:user, name: "Anna")
       FactoryBot.create(:edition, title: "Assigned to Anna", assigned_to: anna)
       FactoryBot.create(:edition, title: "Assigned to Stub User", assigned_to: @user)

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -16,24 +16,26 @@ class RootControllerTest < ActionController::TestCase
     should "default the state filter checkboxes to unchecked when no filters are specified" do
       get :index
 
-      assert_select "input.govuk-checkboxes__input[value='draft'][checked]", false
-      assert_select "input.govuk-checkboxes__input[value='amends_needed'][checked]", false
-      assert_select "input.govuk-checkboxes__input[value='in_review'][checked]", false
-      assert_select "input.govuk-checkboxes__input[value='fact_check'][checked]", false
-      assert_select "input.govuk-checkboxes__input[value='fact_check_received'][checked]", false
-      assert_select "input.govuk-checkboxes__input[value='ready'][checked]", false
+      assert_select "input.govuk-checkboxes__input", 9
+      assert_select "input.govuk-checkboxes__input" do
+        assert_select "[checked]", false
+      end
+
+      assert_select "input.govuk-checkboxes__input[value='draft']"
+      assert_select "input.govuk-checkboxes__input[value='amends_needed']"
+      assert_select "input.govuk-checkboxes__input[value='in_review']"
+      assert_select "input.govuk-checkboxes__input[value='fact_check']"
+      assert_select "input.govuk-checkboxes__input[value='fact_check_received']"
+      assert_select "input.govuk-checkboxes__input[value='ready']"
       assert_select "input.govuk-checkboxes__input[value='scheduled_for_publishing']"
-      assert_select "input.govuk-checkboxes__input[value='scheduled_for_publishing'][checked]", false
       assert_select "input.govuk-checkboxes__input[value='published']"
-      assert_select "input.govuk-checkboxes__input[value='published'][checked]", false
       assert_select "input.govuk-checkboxes__input[value='archived']"
-      assert_select "input.govuk-checkboxes__input[value='archived'][checked]", false
     end
 
     should "default the applied state filters when no filters are specified" do
       FactoryBot.create(:edition, state: "draft", assigned_to: @user)
-      FactoryBot.create(:edition, state: "amends_needed", assigned_to: @user)
       FactoryBot.create(:edition, state: "in_review", review_requested_at: 1.hour.ago, assigned_to: @user)
+      FactoryBot.create(:edition, state: "amends_needed", assigned_to: @user)
       fact_check_edition = FactoryBot.create(:edition, state: "fact_check", title: "Check yo fax", assigned_to: @user)
       fact_check_edition.new_action(FactoryBot.create(:user), "send_fact_check")
       FactoryBot.create(:edition, state: "fact_check_received", assigned_to: @user)
@@ -59,12 +61,14 @@ class RootControllerTest < ActionController::TestCase
     should "filter publications by state" do
       FactoryBot.create(:guide_edition, state: "draft", assigned_to: @user)
       FactoryBot.create(:guide_edition, state: "published", assigned_to: @user)
+      FactoryBot.create(:edition, state: "ready", assigned_to: @user)
 
-      get :index, params: { states_filter: %w[draft] }
+      get :index, params: { states_filter: %w[draft published] }
 
       assert_response :ok
-      assert_select "p.publications-table__heading", "1 document(s)"
+      assert_select "p.publications-table__heading", "2 document(s)"
       assert_select "td.govuk-table__cell", "Draft"
+      assert_select "td.govuk-table__cell", "Published"
     end
 
     should "default the assignee to the current user" do

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -13,18 +13,15 @@ class RootControllerTest < ActionController::TestCase
       assert_template "root/index"
     end
 
-    should "default the state filter checkboxes when no filters are specified" do
+    should "default the state filter checkboxes to unchecked when no filters are specified" do
       get :index
 
-      # These filters should be 'checked'
-      assert_select "input.govuk-checkboxes__input[value='draft'][checked]"
-      assert_select "input.govuk-checkboxes__input[value='amends_needed'][checked]"
-      assert_select "input.govuk-checkboxes__input[value='in_review'][checked]"
-      assert_select "input.govuk-checkboxes__input[value='fact_check'][checked]"
-      assert_select "input.govuk-checkboxes__input[value='fact_check_received'][checked]"
-      assert_select "input.govuk-checkboxes__input[value='ready'][checked]"
-
-      # These filters should NOT be 'checked'
+      assert_select "input.govuk-checkboxes__input[value='draft'][checked]", false
+      assert_select "input.govuk-checkboxes__input[value='amends_needed'][checked]", false
+      assert_select "input.govuk-checkboxes__input[value='in_review'][checked]", false
+      assert_select "input.govuk-checkboxes__input[value='fact_check'][checked]", false
+      assert_select "input.govuk-checkboxes__input[value='fact_check_received'][checked]", false
+      assert_select "input.govuk-checkboxes__input[value='ready'][checked]", false
       assert_select "input.govuk-checkboxes__input[value='scheduled_for_publishing']"
       assert_select "input.govuk-checkboxes__input[value='scheduled_for_publishing'][checked]", false
       assert_select "input.govuk-checkboxes__input[value='published']"
@@ -41,19 +38,22 @@ class RootControllerTest < ActionController::TestCase
       fact_check_edition.new_action(FactoryBot.create(:user), "send_fact_check")
       FactoryBot.create(:edition, state: "fact_check_received", assigned_to: @user)
       FactoryBot.create(:edition, state: "ready", assigned_to: @user)
-      FactoryBot.create(:edition, state: "scheduled_for_publishing", publish_at: Time.zone.now + 1.hour)
+      FactoryBot.create(:edition, state: "scheduled_for_publishing", publish_at: Time.zone.now + 1.hour, assigned_to: @user)
       FactoryBot.create(:edition, state: "published", assigned_to: @user)
       FactoryBot.create(:edition, state: "archived", assigned_to: @user)
 
       get :index
 
-      assert_select "p.publications-table__heading", "6 document(s)"
+      assert_select "p.publications-table__heading", "9 document(s)"
       assert_select "span.govuk-tag--draft", "Draft"
-      assert_select "span.govuk-tag--amends_needed", "Amends needed"
       assert_select "span.govuk-tag--in_review", "In review"
+      assert_select "span.govuk-tag--amends_needed", "Amends needed"
       assert_select "span.govuk-tag--fact_check", "Fact check"
       assert_select "span.govuk-tag--fact_check_received", "Fact check received"
       assert_select "span.govuk-tag--ready", "Ready"
+      assert_select "span.govuk-tag--scheduled_for_publishing", "Scheduled for publishing"
+      assert_select "span.govuk-tag--published", "Published"
+      assert_select "span.govuk-tag--archived", "Archived"
     end
 
     should "filter publications by state" do


### PR DESCRIPTION
## What
Change the default from 6 of the 9 status checkboxes selected to all 9 of them unselected. This affects the initial view and the 'Reset all fields' link. Further manual testing is required to ensure that there are no regressions for the Browser extension. 

## [Trello card](https://trello.com/c/w4LP1YRC)

| |Original|New|
|-|-|-|
|Default (initial view) with no user changes|![6 checkboxes checked - current user selected](https://github.com/user-attachments/assets/8ff97fbe-bd46-47a9-bf0e-7a8e1d0e4155)|![No checkboxes checked -current user selected](https://github.com/user-attachments/assets/5807ee4c-6bf6-49e4-9cb5-081faa94025f)|
|Reset all fields if assignee changed|![6_checkboxes_selected](https://github.com/user-attachments/assets/40da310b-d1e3-4d48-915b-5ca12c82053e)|![no checkboxes selected](https://github.com/user-attachments/assets/a1a565a3-385f-4b13-a188-57dc171494b9)|
|View when navigating from browser extension|![8 checkboxes selected](https://github.com/user-attachments/assets/ba999d43-bc6f-4cb7-86d5-8772891f6f66)|![8 checkboxes selected](https://github.com/user-attachments/assets/d885d1a7-0d41-4f60-ae92-561ac1a9b6f7)|
