### PR TITLE
649 schedule for ready edition

### DIFF
--- a/app/helpers/editions_sidebar_buttons_helper.rb
+++ b/app/helpers/editions_sidebar_buttons_helper.rb
@@ -86,6 +86,17 @@ module EditionsSidebarButtonsHelper
         })
       end
       if edition.can_publish?
+        if edition.state == "ready"
+          buttons << render(
+            "govuk_publishing_components/components/button",
+            {
+              text: "Schedule",
+              href: schedule_page_edition_path(edition),
+              secondary_solid: true,
+              margin_bottom: 3,
+            },
+          )
+        end
         buttons << render(
           "govuk_publishing_components/components/button",
           {

--- a/app/views/editions/secondary_nav_tabs/_progress_with_comment.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_progress_with_comment.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (form_url:, comment_label_text:, submit_button_text:, text: nil) %>
+<%# locals: (form_url:, comment_label_text:, submit_button_text:, text: nil, schedule_fields: nil) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -17,8 +17,10 @@
         },
         name: "comment",
         value: params[:comment],
-        rows: 14,
+        rows: schedule_fields == nil ? 14 : 5,
       } %>
+
+      <%= schedule_fields if schedule_fields %>
 
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/editions/secondary_nav_tabs/schedule_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/schedule_page.html.erb
@@ -1,0 +1,56 @@
+<% @edition = @resource %>
+<% content_for :title_context, @edition.title %>
+<% content_for :page_title, "Schedule publication" %>
+<% content_for :title, "Schedule publication" %>
+
+<%= render "editions/secondary_nav_tabs/progress_with_comment", {
+  form_url: schedule_edition_path(@edition),
+  comment_label_text: "Comment (optional)",
+  submit_button_text: "Schedule",
+  schedule_fields: (render "govuk_publishing_components/components/fieldset", {
+    legend_text: "Publication date",
+    heading_size: "m",
+  } do
+    render "govuk_publishing_components/components/date_input", {
+      hint: "For example, 27 4 2025",
+      items: [
+        {
+          label: "Day",
+          name: "publish_at_3i",
+          width: 2,
+        },
+        {
+          label: "Month",
+          name: "publish_at_2i",
+          width: 2,
+        },
+        {
+          label: "Year",
+          name: "publish_at_1i",
+          width: 4,
+        },
+      ],
+    }
+  end) + (render "govuk_publishing_components/components/fieldset", {
+          legend_text: "Publication time",
+          heading_size: "m",
+        } do
+          render "downtimes/time_input", {
+            hint: "For example, 09:30 or 19:30",
+            items: [
+              {
+                label: "Hour",
+                name: "publish_at_4i",
+                value: "00",
+                width: 2,
+              },
+              {
+                label: "Minute",
+                name: "publish_at_5i",
+                value: "01",
+                width: 2,
+              },
+            ],
+          }
+        end),
+} %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,8 @@ Rails.application.routes.draw do
         post "skip_review", to: "editions#skip_review", as: "skip_review"
         get "send_to_publish_page", to: "editions#send_to_publish_page", as: "send_to_publish_page"
         post "send_to_publish"
+        get "schedule_page", to: "editions#schedule_page", as: "schedule_page"
+        post "schedule", to: "editions#schedule", as: "schedule"
         get "cancel_scheduled_publishing_page"
         post "cancel_scheduled_publishing"
         get "metadata"


### PR DESCRIPTION
[Trello](https://trello.com/c/8V0CiJv6/649-schedule-for-ready-edition-answer-and-help-page)

These changes: 
- Adds a "Schedule" button to the Edit page when: 
  - the user has the correct permissions
  - the edition state is 'ready'
- Adds a new "Schedule publication page" page view
- Adds the logic to 
  - progress the edition to the "Schedule for publishing" state
  - add success and error messages as applicable

See screenshots for UI and messaging. 

NB: There are two validations here (checking that date/time fields are not blank and are not set to a date in the past) that have been implemented by using flash messages rather than more standard validation and the error message component. There are complications around validation due to how the Edition Progressor is set up to deal with the current way this works that does not need to make the same validations. This has made the controller a bit clunky within the `schedule` action. This will be dealt with in a future piece of work to use more standard validation here. 

NNB: this is using a partial in the downtimes page to render the time fields which is not ideal. The decision was made to do this for now whilst scheduling some future work to make a date/time component available in the Publishing Components Gem and then use that in both the "Schedule downtimes" and "Schedule publications" pages.

|Page/scenario|View|
|-|-|
|Edit page: edition state is "In review", user has correct permissions. "Schedule" button is rendered|![Screenshot 2025-04-28 at 11 14 15](https://github.com/user-attachments/assets/cfd388fc-2ce2-4789-b21c-84730929c469)|
|Schedule publication page on page load|![Screenshot 2025-04-28 at 15 28 11](https://github.com/user-attachments/assets/582b07e6-6c5c-48bb-a838-0cafaf83d813)|
|Edit page: user without correct permissions attempts to save|![Screenshot 2025-04-28 at 11 18 53](https://github.com/user-attachments/assets/93db6fe1-834b-4935-ae24-9d1bb35d645e)|
|Edit page: user attempts to schedule page that is not in the correct state|![Screenshot 2025-04-28 at 11 22 59](https://github.com/user-attachments/assets/dcf837d7-2de1-4957-a74f-c081765b8132)|
|Schedule publication page: user attempts to save with blank fields|![Screenshot 2025-04-28 at 11 27 11](https://github.com/user-attachments/assets/b1fe73bd-e9c9-497e-9ea1-81f6cfe24844)|
|Schedule publication page: user attempts to save with a date in the past|![Screenshot 2025-04-28 at 11 28 48](https://github.com/user-attachments/assets/1eb55060-05a8-467f-a22b-dd13c749d259)|
|Edit page: user saves successfully|![Screenshot 2025-04-28 at 11 30 05](https://github.com/user-attachments/assets/645d8aaf-9cbd-4903-817f-63cbc6f8c849)|
|Schedule publication page: a server problem occurs|![Screenshot 2025-04-28 at 11 34 29](https://github.com/user-attachments/assets/7fca3a35-37b4-4e77-9cb2-ac1ffbadf3bb)|
