### PR TITLE
Add 'Request amendments link' for editions in fact check state

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -111,7 +111,7 @@ class EditionsController < InheritedResources::Base
       flash.now[:danger] = "Edition is not in a state where amendments can be requested"
       render "secondary_nav_tabs/request_amendments_page"
     elsif request_amendments_for_edition(@resource, params[:comment])
-      flash[:success] = "2i amendments requested"
+      flash[:success] = "Amendments requested"
       redirect_to edition_path(resource)
     else
       flash.now[:danger] = "Due to a service problem, the request could not be made"

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -45,10 +45,10 @@
         <% end %>
       <% end %>
     </div>
-  <% elsif @edition.ready? %>
+  <% elsif @edition.ready? || @edition.fact_check? %>
     <div class="govuk-grid-column-two-thirds">
-      <%= render "govuk_publishing_components/components/inset_text", {} do %>
-        <% if current_user.has_editor_permissions?(@edition) %>
+      <% if current_user.has_editor_permissions?(@edition) %>
+        <%= render "govuk_publishing_components/components/inset_text", {} do %>
           <p class="govuk-body"><%= link_to("Request amendments", request_amendments_page_edition_path) %></p>
         <% end %>
       <% end %>

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -99,7 +99,7 @@ class EditionsControllerTest < ActionController::TestCase
               comment: "This is a comment",
             }
 
-            assert_equal "2i amendments requested", flash[:success]
+            assert_equal "Amendments requested", flash[:success]
             @edition.reload
             assert_equal "This is a comment", @edition.latest_status_action.comment
             assert_equal "amends_needed", @edition.state

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -1956,7 +1956,7 @@ class EditionEditTest < IntegrationTest
       click_on "Request amendments"
 
       assert_current_path edition_path(@in_review_edition.id)
-      assert page.has_text?("2i amendments requested")
+      assert page.has_text?("Amendments requested")
     end
 
     context "current user is also the requester" do

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -1324,7 +1324,7 @@ class EditionEditTest < IntegrationTest
 
     context "Request amendments link" do
       context "edition is not in review" do
-        should "not show the link" do
+        should "not show the link for a draft edition" do
           visit_draft_edition
           assert page.has_no_link?("Request amendments")
         end
@@ -1388,10 +1388,48 @@ class EditionEditTest < IntegrationTest
         should "navigate to the 'Request amendments' page when the link is clicked" do
           login_as(@govuk_editor)
           visit_ready_edition
-
           click_link("Request amendments")
 
           assert_current_path request_amendments_page_edition_path(@ready_edition.id)
+        end
+      end
+
+      context "edition is out for fact check" do
+        should "not show the link to non editors" do
+          login_as(FactoryBot.create(:user, name: "Stub User"))
+          visit_fact_check_edition
+
+          assert page.has_no_link?("Request amendments")
+        end
+
+        should "not show the link to welsh editors viewing a non-welsh edition" do
+          login_as(FactoryBot.create(:user, :welsh_editor, name: "Stub User"))
+          visit_fact_check_edition
+
+          assert page.has_no_link?("Request amendments")
+        end
+
+        should "show the link to editors" do
+          login_as(@govuk_editor)
+          visit_fact_check_edition
+
+          assert page.has_link?("Request amendments")
+        end
+
+        should "show the link to welsh editors viewing a welsh edition" do
+          login_as_welsh_editor
+          welsh_edition = FactoryBot.create(:edition, :welsh, state: "ready")
+          visit edition_path(welsh_edition)
+
+          assert page.has_link?("Request amendments")
+        end
+
+        should "navigate to the 'Request amendments' page when the link is clicked" do
+          login_as(@govuk_editor)
+          visit_fact_check_edition
+          click_link("Request amendments")
+
+          assert_current_path request_amendments_page_edition_path(@fact_check_edition.id)
         end
       end
     end


### PR DESCRIPTION
## What
A link to 'Request amendments' for editions that are out for fact check. The existing Request amendments page is then displayed when the link is clicked, a comment can be saved by the user and the edition is changed to 'Amends needed' state.

## [Trello card](https://trello.com/c/CRzIyejJ)

|Current|Updated|
|-|-|
|![Existing edit page for an edition in fact check state with no link](https://github.com/user-attachments/assets/092643bd-85db-498c-9668-8fc2e292e6ff)|![New edit page with 'Request amendments' link for fact check state](https://github.com/user-attachments/assets/f5bd3b4b-4467-4312-b022-eec6ec3d106d)|

- **NOTE:** The success message has been changed to a more generic 'Amendments requested' to cover all conditions/state changes 

|Scenario|View|
|-|-|
|User clicks 'Request amendments' link and is taken to the new 'Request amendments' page|![Screenshot 2025-02-17 at 17 02 58](https://github.com/user-attachments/assets/6d726652-81ea-404d-a4a5-e968c51dbcc5)|
|User clicks 'Request amendments' button and an error occurs|![Screenshot 2025-02-17 at 17 06 19](https://github.com/user-attachments/assets/cb324967-d7c1-4a0b-99de-a4754aab15d8)|
|User clicks 'Request amendments' button and the request is successful|![Screenshot 2025-04-30 at 11 29 15](https://github.com/user-attachments/assets/54c900c7-7628-4ae3-b6fc-6d04ecdd5c96)|