### PR TITLE
Css important note inset text improvement

### DIFF
--- a/app/assets/stylesheets/editions.scss
+++ b/app/assets/stylesheets/editions.scss
@@ -14,3 +14,7 @@
     margin-top: govuk-spacing(3)
   }
 }
+
+.gem-c-notice + .gem-c-inset-text {
+  padding-top: 0;
+}

--- a/app/views/editions/_important_note.html.erb
+++ b/app/views/editions/_important_note.html.erb
@@ -9,4 +9,5 @@
       <time class='govuk-body' datetime='#{note_date}'>#{note_date.to_fs(:govuk_date)}</time></p>
       </div>"),
   show_banner_title: true,
+  margin_bottom: 6,
 } %>

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -23,13 +23,13 @@
     <%= render "govuk_publishing_components/components/summary_list", {
       items: document_summary_items(@resource, @reviewer),
     } %>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
     <% if @edition.important_note %>
       <%= render partial: "important_note" %>
     <% end %>
-  </div>
-
-  <% if @edition.in_review? %>
-    <div class="govuk-grid-column-two-thirds">
+    <% if @edition.in_review? %>
       <%= render "govuk_publishing_components/components/inset_text", {} do %>
         <% if @edition.latest_status_action.requester == current_user %>
           <p class="govuk-body">You've sent this edition to be reviewed</p>
@@ -44,16 +44,14 @@
           <% end %>
         <% end %>
       <% end %>
-    </div>
   <% elsif @edition.ready? || @edition.fact_check? %>
-    <div class="govuk-grid-column-two-thirds">
       <% if current_user.has_editor_permissions?(@edition) %>
         <%= render "govuk_publishing_components/components/inset_text", {} do %>
           <p class="govuk-body"><%= link_to("Request amendments", request_amendments_page_edition_path) %></p>
         <% end %>
       <% end %>
-    </div>
   <% end %>
+  </div>
 </div>
 
 <% if @resource.artefact.state == "archived" %>


### PR DESCRIPTION
## What
A large gap between the Important note element and the Inset text was noticed as part of the desk check for [Fact check - [Request amendments] Answer and Help Page](https://github.com/alphagov/publisher/pull/2663). 
This has now been addressed so that with or without the inset text, the gap below the important note should be 30px. 

## [Trello card](https://trello.com/c/CRzIyejJ)

Out of scope for this is the gap which still exists between the inset text and the summary list which will be addressed as part of a design sweep. 

|Scenario|View|
|-|-|
|New gap between the important note and the inset text|![New gap between the important note and inset text](https://github.com/user-attachments/assets/f15a03ee-9227-4c22-a1ae-07294b7ce7f6)|
|Gap between the important note and tab headers with no inset text|![Gap between the important note and tab headers with no inset text](https://github.com/user-attachments/assets/99fca36c-dee2-463e-990d-0e74f6c86eb0)|
|Important note with larger inset text|![Important note with larger inset text](https://github.com/user-attachments/assets/f6a4f0fb-8afc-4a76-8e99-91181935425b)|
|Inset text with no important note|![Inset text with no important note](https://github.com/user-attachments/assets/84dd301e-733e-4e56-9e83-5ed068e2ce46)|