### PR TITLE
672 fact check resend fact check email

### DIFF
--- a/app/assets/stylesheets/edit.scss
+++ b/app/assets/stylesheets/edit.scss
@@ -4,4 +4,14 @@
       @extend .govuk-body; // stylelint-disable-line scss/at-extend-no-missing-placeholder
     }
   }
+
+  &--resend-fact-check-email-page {
+    &__message {
+      @extend .govuk-body; // stylelint-disable-line scss/at-extend-no-missing-placeholder
+
+      white-space: pre-line;
+      word-break: break-word;
+      overflow-wrap: break-word;
+    }
+  }
 }

--- a/app/views/editions/secondary_nav_tabs/resend_fact_check_email_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/resend_fact_check_email_page.html.erb
@@ -1,0 +1,39 @@
+<% @edition = @resource %>
+<% content_for :title_context, @edition.title %>
+<% content_for :page_title, "Resend fact check email" %>
+<% content_for :title, "Resend fact check email" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds edit--resend-fact-check-email-page">
+    <%= form_for @resource, url: resend_fact_check_email_edition_path(@resource) do %>
+      <section class="govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Email addresses",
+          heading_level: 2,
+          font_size: "s",
+        } %>
+
+        <p class="govuk-body"><%= @edition.latest_status_action.email_addresses %></p>
+      </section>
+
+      <section class="govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Customised message",
+          heading_level: 2,
+          font_size: "s",
+        } %>
+
+        <div class="edit--resend-fact-check-email-page__message">
+          <%= @edition.latest_status_action.customised_message.strip %>
+        </div>
+      </section>
+
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Resend fact check email",
+        } %>
+        <%= link_to("Cancel", edition_path, class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -47,6 +47,10 @@
   <% elsif @edition.ready? || @edition.fact_check? %>
       <% if current_user.has_editor_permissions?(@edition) %>
         <%= render "govuk_publishing_components/components/inset_text", {} do %>
+          <% if @edition.fact_check? %>
+            <p class="govuk-body"><%= link_to("Resend fact check email", resend_fact_check_email_page_edition_path) %></p>
+          <% end %>
+
           <p class="govuk-body"><%= link_to("Request amendments", request_amendments_page_edition_path) %></p>
         <% end %>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
   constraints NewDesignSystemConstraint.new do
     resources :editions do
       member do
+        get "resend_fact_check_email_page", to: "editions#resend_fact_check_email_page", as: "resend_fact_check_email_page"
+        patch "resend_fact_check_email"
         get "request_amendments_page", to: "editions#request_amendments_page", as: "request_amendments_page"
         post "request_amendments", to: "editions#request_amendments", as: "request_amendments"
         get "send_to_2i_page", to: "editions#send_to_2i_page", as: "send_to_2i_page"


### PR DESCRIPTION
[Trello](https://trello.com/c/1WJYlVC2/672-fact-check-resend-fact-check-email-for-answer-and-help-page)

These changes 
- adds a "Resend fact check email" link below the edition summary card of the edition when
  - the edition is in "Fact check" state
  - the user has
    - “govuk_editor” permission
    - “welsh_editor” permission and the edition is Welsh
- adds a new "Resend fact check email" view, displayed when the “Resend fact check email” text link is clicked. This page is a read only page displaying the message added to the fact check email and allowingn the user to resent the email. 

|Page/Scenario|View|
|-|-|
|Edit page, user has appropriate permissions|![Screenshot 2025-05-20 at 08 17 16](https://github.com/user-attachments/assets/a489875a-bf12-4954-a1ac-7859bcbfccc5)|
|Resend fact check email page|![Screenshot 2025-05-20 at 08 25 25](https://github.com/user-attachments/assets/db799467-b9b6-471d-a159-c004589c91db)|
