### PR TITLE
Editions reviewer fix

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -38,7 +38,7 @@ class EditionsController < InheritedResources::Base
 
   def show
     @artefact = @resource.artefact
-    @reviewer = User.where(id: @resource.reviewer).first
+    @reviewer = User.where(name: @resource.reviewer).first
     render action: "show"
   end
 

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -29,6 +29,9 @@ class EditionsController < InheritedResources::Base
   before_action only: %i[schedule_page] do
     require_schedulable
   end
+  before_action only: %i[show admin metadata tagging history related_external_links unpublish] do
+    @reviewer = User.where(name: @resource.reviewer).first if @resource.reviewer.present?
+  end
 
   helper_method :locale_to_language
 
@@ -38,7 +41,6 @@ class EditionsController < InheritedResources::Base
 
   def show
     @artefact = @resource.artefact
-    @reviewer = User.where(name: @resource.reviewer).first
     render action: "show"
   end
 

--- a/app/helpers/tabbed_nav_helper.rb
+++ b/app/helpers/tabbed_nav_helper.rb
@@ -104,12 +104,12 @@ private
   def available_reviewer_items(edition)
     items = []
     unless edition.reviewer.nil?
-      items << { value: edition.reviewer, text: User.where(id: edition.reviewer).first, checked: true }
+      items << { value: edition.reviewer, text: User.where(name: edition.reviewer).first, checked: true }
       items << { value: "none", text: "None" }
       items << :or
     end
     User.enabled.order_by([%i[name asc]]).each do |user|
-      items << { value: user.id, text: user.name } unless user.id.to_s == edition.reviewer || !user.has_editor_permissions?(edition)
+      items << { value: user.name, text: user.name } unless user.name.to_s == edition.reviewer || !user.has_editor_permissions?(edition)
     end
     items
   end

--- a/app/views/root/_table.html.erb
+++ b/app/views/root/_table.html.erb
@@ -31,7 +31,7 @@
                     {field: "Format", value: format(publication)},
                     *([{field: "Important Note", value: important_note(publication)}] if important_note(publication)),
                     *([{field: "Awaiting review", value: awaiting_review(publication)}] if awaiting_review(publication)),
-                    # *([{field: "2i reviewer", value: reviewer(publication, current_user)}] if reviewer(publication, current_user)),
+                    *([{field: "2i reviewer", value: reviewer(publication, current_user)}] if reviewer(publication, current_user)),
                     *([{field: "Sent Out", value: sent_out(publication)}] if sent_out(publication)),
                     *([{field: "Scheduled", value: scheduled(publication)}] if scheduled(publication)),
                     *([{field: "Published by", value: published_by(publication)}] if published_by(publication)),

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -122,7 +122,7 @@ class EditionEditTest < IntegrationTest
     end
 
     should "show the 2i reviewer row in the summary correctly if the edition state is 'in_review' and a reviewer is assigned" do
-      edition = FactoryBot.create(:answer_edition, state: "in_review", title: "An edition with a reviewer assigned", review_requested_at: 1.hour.ago, reviewer: @govuk_editor.id)
+      edition = FactoryBot.create(:answer_edition, state: "in_review", title: "An edition with a reviewer assigned", review_requested_at: 1.hour.ago, reviewer: @govuk_editor.name)
       edition.actions.create!(
         request_type: Action::REQUEST_AMENDMENTS,
         requester_id: @govuk_requester.id,

--- a/test/integration/root_overview_test.rb
+++ b/test/integration/root_overview_test.rb
@@ -180,8 +180,6 @@ class RootOverviewTest < IntegrationTest
   end
 
   should "allow a user to claim 2i" do
-    skip("Temporarily skipped due to the removal of the 2i feature because of a bug: https://trello.com/c/mHCUk2wD/715-hide-option-to-claim-2i-on-publications-page")
-
     stub_linkables
     stub_holidays_used_by_fact_check
 
@@ -210,32 +208,7 @@ class RootOverviewTest < IntegrationTest
     assert page.has_select?("Assigned to", selected: assignee.name)
   end
 
-  should "not show claim 2i button on publications page for editions out for 2nd pair of eye" do
-    stub_linkables
-    stub_holidays_used_by_fact_check
-
-    assignee = FactoryBot.create(:user, :govuk_editor)
-    FactoryBot.create(
-      :guide_edition,
-      title: "XXX",
-      state: "in_review",
-      review_requested_at: Time.zone.now,
-      assigned_to: assignee,
-    )
-
-    visit "/"
-    filter_by_user("All")
-    filter_by_status("In review")
-    find(".publications-table tr:first-child details").click
-
-    within(".publications-table tr:first-child details") do
-      assert_not page.has_button?("Claim 2i")
-    end
-  end
-
   should "prevent the current user from claiming 2i when the publication is already claimed and allow the user to claim 2i when the publication is not claimed for 2i" do
-    skip("Temporarily skipped due to the removal of the 2i feature because of a bug: https://trello.com/c/mHCUk2wD/715-hide-option-to-claim-2i-on-publications-page")
-
     stub_linkables
     stub_holidays_used_by_fact_check
 
@@ -302,8 +275,6 @@ class RootOverviewTest < IntegrationTest
   end
 
   should "allow Welsh editors to see claim 2i button in Welsh editions" do
-    skip("Temporarily skipped due to the removal of the 2i feature because of a bug: https://trello.com/c/fHyxwDZz/669-hide-option-to-claim-2i-on-publications-page")
-
     stub_linkables
     stub_holidays_used_by_fact_check
 


### PR DESCRIPTION
[Trello](https://trello.com/c/PpxCshge/718-fix-reviewer-issue-to-work-with-both-new-design-system-and-bootstrap)

- Fix claiming 2i by saving name of the user instead of id, as it was always saved by name and not id.
- fetch reviewer from db to show correctly for history and notes and related external links tab.
- Undo the changes to hide claim 2i changes in https://github.com/alphagov/publisher/pull/2698

