### PR TITLE
710 Fix metadata permissions

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -1,5 +1,5 @@
 class ArtefactsController < ApplicationController
-  before_action :require_govuk_editor
+  before_action :require_editor_permission
 
   def new
     @artefact = Artefact.new(content_id: SecureRandom.uuid)
@@ -53,5 +53,18 @@ private
 
   def updatable_params
     params.require(:artefact).permit(:id, :slug, :language)
+  end
+
+  def require_editor_permission
+    return if current_user.govuk_editor?
+
+    if params[:action] == "update"
+      flash[:danger] = "You do not have correct editor permissions for this action."
+      artefact = Artefact.find(params[:id])
+      redirect_to edition_path(artefact.latest_edition)
+    else
+      flash[:danger] = "You do not have permission to see this page."
+      redirect_to root_path
+    end
   end
 end

--- a/app/views/editions/secondary_nav_tabs/_metadata.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_metadata.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= header_for("Metadata") %>
 
-    <% if Edition::PUBLISHING_API_DRAFT_STATES.include? publication.state %>
+    <% if Edition::PUBLISHING_API_DRAFT_STATES.include?(publication.state) && current_user.govuk_editor? %>
       <%= form_for(@artefact, :html => { :class => "artefact", :id => "edit_artefact" }) do |f| %>
         <%= f.hidden_field :id, value: @artefact.id %>
 

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -19,5 +19,59 @@ class ArtefactsControllerTest < ActionController::TestCase
       assert_redirected_to root_path
       assert_includes flash[:danger], "do not have permission"
     end
+
+    should "not allow creation if no permissions" do
+      user = FactoryBot.create(:user, name: "Non-editor")
+      login_as(user)
+
+      get :new
+
+      assert_response :redirect
+      assert_redirected_to root_path
+      assert_includes flash[:danger], "do not have permission"
+    end
+  end
+
+  context "#update" do
+    should "allow update if govuk_editor" do
+      edition = FactoryBot.create(:edition)
+      login_as_govuk_editor
+
+      patch :update, params: {
+        id: edition.artefact.id,
+        artefact: {
+          id: edition.artefact.id,
+          slug: edition.artefact.slug,
+          language: "en",
+        },
+      }
+
+      assert_response :redirect
+      assert_redirected_to metadata_edition_path(edition.id)
+      assert_equal "Metadata updated", flash[:notice]
+    end
+
+    should "not allow update even if welsh_editor and Welsh edition" do
+      welsh_edition = FactoryBot.create(:edition, :fact_check, :welsh)
+      login_as_welsh_editor
+
+      patch :update, params: { id: welsh_edition.artefact.id }
+
+      assert_response :redirect
+      assert_redirected_to edition_path(welsh_edition.id)
+      assert_includes flash[:danger], "You do not have correct editor permissions for this action."
+    end
+
+    should "not allow update if no editor permissions" do
+      user = FactoryBot.create(:user, name: "Non-editor")
+      edition = FactoryBot.create(:edition)
+      login_as(user)
+
+      patch :update, params: { id: edition.artefact.id }
+
+      assert_response :redirect
+      assert_redirected_to edition_path(edition.id)
+      assert_includes flash[:danger], "You do not have correct editor permissions for this action."
+    end
   end
 end

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -17,7 +17,7 @@ class ArtefactsControllerTest < ActionController::TestCase
 
       assert_response :redirect
       assert_redirected_to root_path
-      assert_includes flash[:danger], "do not have permission"
+      assert_includes flash[:danger], "You do not have permission to see this page."
     end
 
     should "not allow creation if no permissions" do
@@ -28,7 +28,7 @@ class ArtefactsControllerTest < ActionController::TestCase
 
       assert_response :redirect
       assert_redirected_to root_path
-      assert_includes flash[:danger], "do not have permission"
+      assert_includes flash[:danger], "You do not have permission to see this page."
     end
   end
 

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -178,7 +178,7 @@ class EditionEditTest < IntegrationTest
   end
 
   context "metadata tab" do
-    context "when state is 'draft'" do
+    context "when state is 'draft' and user has govuk editor permissions" do
       setup do
         visit_draft_edition
         click_link("Metadata")
@@ -208,16 +208,69 @@ class EditionEditTest < IntegrationTest
       end
     end
 
+    context "when user has welsh editor permissions" do
+      should "show read-only values and no 'Update' button for welsh edition" do
+        @welsh_edition = FactoryBot.create(
+          :edition,
+          title: "Edit page title",
+          panopticon_id: FactoryBot.create(
+            :artefact,
+            slug: "welsh-language-edition-test",
+            language: "cy",
+          ).id,
+          state: "ready",
+          slug: "welsh-language-edition-test",
+        )
+
+        login_as_welsh_editor
+        visit edition_path(@welsh_edition)
+        click_link("Metadata")
+
+        assert @user.has_editor_permissions?(@welsh_edition)
+        assert page.has_no_field?("artefact[slug]")
+        assert page.has_no_field?("artefact[language]")
+        assert page.has_text?("Slug")
+        assert page.has_text?(/welsh-language-edition-test/)
+        assert page.has_text?("Language")
+        assert page.has_text?(/Welsh/)
+        assert page.has_no_button?("Update")
+      end
+
+      should "show read-only values and no 'Update' button for a non-welsh edition" do
+        visit_draft_edition
+        login_as_welsh_editor
+        click_link("Metadata")
+
+        assert_not @user.has_editor_permissions?(@draft_edition)
+        assert page.has_no_field?("artefact[slug]")
+        assert page.has_no_field?("artefact[language]")
+        assert page.has_text?("Slug")
+        assert page.has_text?("Language")
+        assert page.has_no_button?("Update")
+      end
+    end
+
+    context "when user has no permissions" do
+      should "show read-only values and no 'Update' button" do
+        user = FactoryBot.create(:user, name: "Stub User")
+        login_as(user)
+        visit_draft_edition
+        click_link("Metadata")
+
+        assert_not user.has_editor_permissions?(@draft_edition)
+        assert page.has_no_button?("Update")
+      end
+    end
+
     context "when state is not 'draft'" do
       setup do
         visit_published_edition
         click_link("Metadata")
       end
 
-      should "show un-editable current value for slug and language" do
+      should "show read-only values and no 'Update' button" do
         assert page.has_no_field?("artefact[slug]")
         assert page.has_no_field?("artefact[language]")
-
         assert page.has_text?("Slug")
         assert page.has_text?(/can-i-get-a-driving-licence/)
         assert page.has_text?("Language")

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -275,6 +275,7 @@ class EditionEditTest < IntegrationTest
         assert page.has_text?(/can-i-get-a-driving-licence/)
         assert page.has_text?("Language")
         assert page.has_text?(/English/)
+        assert page.has_no_button?("Update")
       end
     end
   end


### PR DESCRIPTION
## What
Follows the existing permissions for Artefact. This update shows the tab as read-only with no 'update' button if the user does not have the correct permission to update the metadata for the artefact. 

## [Trello card](https://trello.com/c/XPnx8J2j)

|Scenario|View|
|-|-|
|Previous view for all users with any permission|![Screenshot 2025-06-09 at 17 36 31](https://github.com/user-attachments/assets/2c57706e-cb81-4bbd-8623-30ad46efd710)|
|Current view if user does not have permission|![Screenshot 2025-06-09 at 17 21 40](https://github.com/user-attachments/assets/287baef9-f4a5-4367-aed0-d12a9e9bd42f)|