### PR TITLE
Fix redirect - take users back to metadata tab

### DIFF
--- a/app/controllers/artefacts_controller.rb
+++ b/app/controllers/artefacts_controller.rb
@@ -59,9 +59,9 @@ private
     return if current_user.govuk_editor?
 
     if params[:action] == "update"
-      flash[:danger] = "You do not have correct editor permissions for this action."
+      flash[:danger] = "You do not have permissions to update this page"
       artefact = Artefact.find(params[:id])
-      redirect_to edition_path(artefact.latest_edition)
+      redirect_to metadata_edition_path(artefact.latest_edition)
     else
       flash[:danger] = "You do not have permission to see this page."
       redirect_to root_path

--- a/test/functional/artefacts_controller_test.rb
+++ b/test/functional/artefacts_controller_test.rb
@@ -58,8 +58,8 @@ class ArtefactsControllerTest < ActionController::TestCase
       patch :update, params: { id: welsh_edition.artefact.id }
 
       assert_response :redirect
-      assert_redirected_to edition_path(welsh_edition.id)
-      assert_includes flash[:danger], "You do not have correct editor permissions for this action."
+      assert_redirected_to metadata_edition_path(welsh_edition.id)
+      assert_includes flash[:danger], "You do not have permissions to update this page"
     end
 
     should "not allow update if no editor permissions" do
@@ -70,8 +70,8 @@ class ArtefactsControllerTest < ActionController::TestCase
       patch :update, params: { id: edition.artefact.id }
 
       assert_response :redirect
-      assert_redirected_to edition_path(edition.id)
-      assert_includes flash[:danger], "You do not have correct editor permissions for this action."
+      assert_redirected_to metadata_edition_path(edition.id)
+      assert_includes flash[:danger], "You do not have permissions to update this page"
     end
   end
 end


### PR DESCRIPTION
Small fix for Metadata tab permission issue [Trello card](https://trello.com/c/XPnx8J2j)
- If update fails due to permissions, redirect back to metadata tab not edit tab
- Show correct error message
