### PR TITLE
Add `novalidate` option to form on "Send to fact check" page

### DIFF
--- a/app/views/editions/secondary_nav_tabs/send_to_fact_check_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/send_to_fact_check_page.html.erb
@@ -7,7 +7,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <%= form_for(:edition, url: send_to_fact_check_edition_path(@edition)) do %>
+    <%= form_for(:edition, url: send_to_fact_check_edition_path(@edition), html: { novalidate: "novalidate" }) do %>
       <%= render "govuk_publishing_components/components/input", {
         label: {
           heading_size: "m",


### PR DESCRIPTION
[Trello](https://trello.com/c/Scdl2DBF/724-issue-allow-a-fact-check-to-be-sent-to-multiple-email-addresses)

This deals with a problem whereby the user is prevented from entering multiple email addresses on the "Send to fact check" page. 

This is caused by HTML5 native browser validation, a feature that we generally do not use on Publisher. It is activated here because the field we are concerned with has the "type" attribute of "email". There are a few ways we could deal with this: 
1. Set the form to not use native validation
2. Remove the “email” type from the input so native validation is not triggered
3. Add a “multiple” attribute to the input so that native validation accepts multiple email addresses

I have implemented Option 1 here as the one that makes most sense. My thinking is: 
- Since we are generally not using client-side validation anywhere else and this form validates email addresses server-side we can safely remove any client-side validation
- It would be useful to retain `type=email` on the field since this is useful for accessibility and for mobile users
- adding the `multiple` attribute to the field would retain client-side validation which is not necessary/desirable for the reasons stated above. 

|Native browser validation triggered on the page on submit, preventing the user from submitting the page|Page submitted with the fix in place|
|-|-|
|![Screenshot 2025-06-12 at 10 04 03](https://github.com/user-attachments/assets/c36b4d4e-f6cb-40df-8969-9b0742fa3b40)|![Screenshot 2025-06-12 at 10 00 18](https://github.com/user-attachments/assets/020fe576-2950-482a-a741-50b92ee3604b)|