### PR TITLE
Add custom style to important note  text

### DIFF
--- a/app/assets/stylesheets/editions.scss
+++ b/app/assets/stylesheets/editions.scss
@@ -1,18 +1,24 @@
-.editions__edit__summary {
-  .govuk-tag {
-    display: inline;
+.editions {
+  &__edit__summary {
+    .govuk-tag {
+      display: inline;
+    }
+  }
+
+  &__admin__tab {
+    .govuk-link {
+      margin-top: govuk-spacing(3)
+    }
+  }
+
+  &__important-note__details {
+    white-space: pre;
   }
 }
 
 .edit_edition__change_note {
   border-top: 1px solid $govuk-border-colour;
   @include govuk-responsive-padding(4, "top");
-}
-
-.editions__admin__tab {
-  .govuk-link {
-    margin-top: govuk-spacing(3)
-  }
 }
 
 .gem-c-notice + .gem-c-inset-text {

--- a/app/views/editions/_important_note.html.erb
+++ b/app/views/editions/_important_note.html.erb
@@ -3,8 +3,8 @@
 <% note_details = @edition.important_note&.comment %>
 <%= render "govuk_publishing_components/components/notice", {
   description_govspeak:
-    sanitize("<div>
-      <p class='govuk-body govuk-!-font-weight-bold govuk-!-text-break-word'>#{h(note_details)}</p>
+    sanitize("<div class='editions__important-note'>
+      <p class='govuk-body govuk-!-font-weight-bold govuk-!-text-break-word editions__important-note__details'>#{h(note_details)}</p>
       <p class='govuk-body-m'>#{h(note_author_name)} added an important note on
       <time class='govuk-body' datetime='#{note_date}'>#{note_date.to_fs(:govuk_date)}</time></p>
       </div>"),


### PR DESCRIPTION
[Trello](https://trello.com/c/8hBKiuTd/709-issue-publisher-important-notes-do-not-retain-line-breaks)

The problem here is that when an Important Note, whose content includes formatting such as line-breaks, is saved it is rendered on the page with that formatting removed. 

This PR adds a custom style to the text displayed within Important Notes which adds a `white-space` value of `pre` to the text. This ensures that this content retains any formatting when it is rendered. 

Additionally it also rationalises the existing SCSS a little bit to group together a few styles with common naming. These changes do not have any visual effect. 

|Current|Updated|
|-|-|
|![Screenshot 2025-06-12 at 15 17 15](https://github.com/user-attachments/assets/cce65930-28ab-44b8-a280-ec32301f9dce)|![Screenshot 2025-06-12 at 15 16 52](https://github.com/user-attachments/assets/4b13e5fa-6cf0-413f-b4a9-fb113f16bd2e)|

