### PR TITLE
Fix permissions on history and notes tab

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -34,7 +34,9 @@ class EditionsController < InheritedResources::Base
                          send_to_fact_check
                          send_to_fact_check_page
                          resend_fact_check_email_page
-                         resend_fact_check_email] do
+                         resend_fact_check_email
+                         add_edition_note
+                         update_important_note] do
     require_editor_permissions
   end
   before_action only: %i[confirm_destroy destroy] do

--- a/app/views/editions/secondary_nav_tabs/_history.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_history.html.erb
@@ -33,25 +33,27 @@
     </div>
   </div>
 
-  <div class="govuk-grid-column-one-third options-sidebar">
-    <div class="sidebar-components">
-      <%= sidebar_options_heading %>
+  <% if current_user.has_editor_permissions?(@resource) %>
+    <div class="govuk-grid-column-one-third options-sidebar">
+      <div class="sidebar-components">
+        <%= sidebar_options_heading %>
 
-      <%= render "govuk_publishing_components/components/list", {
-        items: [
-          (render "govuk_publishing_components/components/button", {
-            text: "Add edition note",
-            margin_bottom: 3,
-            href: history_add_edition_note_edition_path,
-          }),
-          (render "govuk_publishing_components/components/button", {
-            text: "Update important note",
-            margin_bottom: 3,
-            secondary_solid: true,
-            href: history_update_important_note_edition_path,
-          }),
-        ],
-      } %>
+        <%= render "govuk_publishing_components/components/list", {
+          items: [
+            (render "govuk_publishing_components/components/button", {
+              text: "Add edition note",
+              margin_bottom: 3,
+              href: history_add_edition_note_edition_path,
+            }),
+            (render "govuk_publishing_components/components/button", {
+              text: "Update important note",
+              margin_bottom: 3,
+              secondary_solid: true,
+              href: history_update_important_note_edition_path,
+            }),
+          ],
+        } %>
+      </div>
     </div>
-  </div>
+  <% end %>
 </div>

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -156,6 +156,48 @@ class EditionsControllerTest < ActionController::TestCase
     end
   end
 
+  context "#add_edition_note" do
+    context "user has govuk_editor permission" do
+      should "render the 'Add Edition Note' page" do
+        get :add_edition_note, params: { id: @edition.id }
+        assert_template "secondary_nav_tabs/add_edition_note"
+      end
+    end
+
+    context "user does not have govuk_editor permission" do
+      setup do
+        user = FactoryBot.create(:user)
+        login_as(user)
+      end
+
+      should "render an error message" do
+        get :add_edition_note, params: { id: @edition.id }
+        assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
+      end
+    end
+  end
+
+  context "#update_important_note" do
+    context "user has govuk_editor permission" do
+      should "render the 'Update Important Note' page" do
+        get :update_important_note, params: { id: @edition.id }
+        assert_template "secondary_nav_tabs/update_important_note"
+      end
+    end
+
+    context "user does not have govuk_editor permission" do
+      setup do
+        user = FactoryBot.create(:user)
+        login_as(user)
+      end
+
+      should "render an error message" do
+        get :update_important_note, params: { id: @edition.id }
+        assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
+      end
+    end
+  end
+
   context "#request_amendments_page" do
     context "user has govuk_editor permission" do
       should "render the 'Request amendments' page" do

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -441,6 +441,45 @@ class EditionEditTest < IntegrationTest
       assert_current_path history_update_important_note_edition_path(@draft_edition.id)
     end
 
+    context "when the user has no permissions" do
+      should "hide the note action buttons from the user" do
+        user = FactoryBot.create(:user, name: "Stub User")
+        login_as(user)
+        visit_draft_edition
+        click_link("History and notes")
+
+        assert_not user.has_editor_permissions?(@draft_edition)
+        assert_not page.has_content?("Add edition note")
+        assert_not page.has_content?("Update important note")
+      end
+    end
+
+    context "when the user has welsh editor permissions" do
+      setup do
+        @user = FactoryBot.create(:user, :welsh_editor, name: "Stub User")
+        login_as(@user)
+      end
+
+      should "hide the note action buttons from the user on a non welsh document" do
+        visit_draft_edition
+        click_link("History and notes")
+
+        assert_not @user.has_editor_permissions?(@draft_edition)
+        assert_not page.has_content?("Add edition note")
+        assert_not page.has_content?("Update important note")
+      end
+
+      should "show the note action buttons for the user on a welsh document" do
+        edition = FactoryBot.create(:answer_edition, :fact_check, :welsh)
+        visit edition_path(edition)
+        click_link("History and notes")
+
+        assert @user.has_editor_permissions?(edition)
+        assert page.has_content?("Add edition note")
+        assert page.has_content?("Update important note")
+      end
+    end
+
     context "Edition displays the correct data for actions" do
       setup do
         @edition = FactoryBot.create(:edition, created_at: "2024-01-23")


### PR DESCRIPTION
Adds the permissions check for the Update Important Note and Add Note
buttons in the History and Notes tab. Should prevent any users without
permissions from easily accessing the relevant pages down the stack.

Also redirects users without permissions from the pages if they somehow
managed to find the URL.
https://trello.com/c/NpSphqXO/712-issue-publisher-fix-permissions-on-history-and-notes-tab

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
