### PR TITLE
Fix permissions for the external links tab

### DIFF
--- a/app/views/editions/secondary_nav_tabs/_related_external_links.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_related_external_links.html.erb
@@ -18,21 +18,23 @@
         end
       %>
 
-      <%= render "govuk_publishing_components/components/add_another", {
-        fieldset_legend: "Link",
-        add_button_text: "Add related external link",
-        empty_fields: true,
-        items: items,
-        empty: empty,
-      } %>
+      <% if current_user.has_editor_permissions?(@resource) %>
+        <%= render "govuk_publishing_components/components/add_another", {
+          fieldset_legend: "Link",
+          add_button_text: "Add related external link",
+          empty_fields: true,
+          items: items,
+          empty: empty,
+        } %>
 
-      <%= render "govuk_publishing_components/components/inset_text", {
-        text: "After saving, changes to related external links will be visible on the site the next time this publication is published.",
-      } %>
+        <%= render "govuk_publishing_components/components/inset_text", {
+          text: "After saving, changes to related external links will be visible on the site the next time this publication is published.",
+        } %>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Save",
-      } %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
+        } %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/editions/secondary_nav_tabs/related_external_links/_add-another_checkbox.html.erb
+++ b/app/views/editions/secondary_nav_tabs/related_external_links/_add-another_checkbox.html.erb
@@ -1,5 +1,7 @@
-<%= render "govuk_publishing_components/components/checkboxes", { 
-  name: "artefact[external_links_attributes][#{index}][_destroy]",
-  id: "artefact_external_links_attributes_#{index}__destroy",
-  items: [{label: "Delete", value: "1" }],
-} %>
+<% if current_user.has_editor_permissions?(@resource) %>
+  <%= render "govuk_publishing_components/components/checkboxes", { 
+    name: "artefact[external_links_attributes][#{index}][_destroy]",
+    id: "artefact_external_links_attributes_#{index}__destroy",
+    items: [{label: "Delete", value: "1" }],
+  } %>
+<% end %>

--- a/test/integration/edition_external_links_test.rb
+++ b/test/integration/edition_external_links_test.rb
@@ -79,6 +79,25 @@ class EditionExternalLinksTest < JavascriptIntegrationTest
       assert page.has_no_css?("label[for='artefact_external_links_attributes_1_url']")
       assert page.has_css?("button", text: "Add related external link")
     end
+
+    context "User does not have editor permissions" do
+      setup do
+        user = FactoryBot.create(:user, name: "Stub User")
+        login_as(user)
+        visit_draft_edition
+        @draft_edition.artefact.external_links = [{ title: "Link one", url: "https://one.com" }]
+        click_link "Related external links"
+      end
+
+      should "not have access to the editor actions" do
+        within :css, ".gem-c-add-another .js-add-another__fieldset" do
+          assert page.has_no_css?("button", text: "Delete")
+        end
+        assert page.has_no_css?("button", text: "Add related external link")
+        assert page.has_no_css?("button", text: "Save")
+        assert page.has_no_text?("After saving, changes to related external links will be visible on the site the next time this publication is published.")
+      end
+    end
   end
 
 private


### PR DESCRIPTION
User can no longer see the Add, Delete, or Save options. Also hidden the advisory
text indicating that a save can occur to avoid confusion for the user.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
