### PR TITLE
Update style in Important Note to allow long lines to break

### DIFF
--- a/app/assets/stylesheets/editions.scss
+++ b/app/assets/stylesheets/editions.scss
@@ -12,7 +12,7 @@
   }
 
   &__important-note__details {
-    white-space: pre;
+    white-space: pre-wrap;
   }
 }
 


### PR DESCRIPTION
[Trello](https://trello.com/c/8hBKiuTd/709-issue-publisher-important-notes-do-not-retain-line-breaks)

This is small update to a previous PR ([#2718](https://github.com/alphagov/publisher/pull/2718)) to deal with over-running lines of text in the Important Note box. 

The previous PR added the value of `pre` to the `white-space` CSS attribute so that the white-space in the source text is retained. Whilst this is achieved it does not allow long lines of text (such as long URLs) to wrap. 

This PR updates the value of the `white-space` attribute to `pre-wrap` which retains existing white-space *and* allows lines to wrap as required to fill their containing elements. 

|Current|Updated|
|-|-|
|![Screenshot 2025-06-13 at 11 53 31](https://github.com/user-attachments/assets/c27ce07f-a6d9-437c-8858-56076f3ff5e7)|![Screenshot 2025-06-13 at 11 53 08](https://github.com/user-attachments/assets/6a2d09a8-e8ac-438f-a5bd-fad1c2bf8c4b)|
