### PR TITLE
727 bug fact check toggle

### DIFF
--- a/app/assets/javascripts/modules/history_and_notes.js
+++ b/app/assets/javascripts/modules/history_and_notes.js
@@ -17,7 +17,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
     let i = 1
 
     actions.forEach(element => {
-      const commentEarlier = element.querySelector('.action--receive_fact_check--earlier') || null
+      const commentEarlier = element.querySelector('.js-earlier') || null
 
       if (commentEarlier) {
         const toggle = document.createElement('button')
@@ -37,15 +37,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
           const hiddenClass = 'govuk-!-display-none'
           const toggle = e.target
-          const earlierSection = toggle.parentNode.querySelector('.action--receive_fact_check--earlier')
+          const earlierSection = toggle.parentNode.querySelector('.js-earlier')
 
           if (earlierSection.classList.contains('govuk-!-display-none')) {
             earlierSection.classList.remove(hiddenClass)
-            toggle.text = this.toggleHideText
+            toggle.textContent = this.toggleHideText
             toggle.setAttribute('aria-expanded', true)
           } else {
             earlierSection.classList.add(hiddenClass)
-            toggle.text = this.toggleShowText
+            toggle.textContent = this.toggleShowText
             toggle.setAttribute('aria-expanded', false)
           }
         })

--- a/app/helpers/action_helper.rb
+++ b/app/helpers/action_helper.rb
@@ -107,7 +107,7 @@ module ActionHelper
     unless email_parts.empty?
       formatted_email_parts << tag.div(
         format_and_auto_link_plain_text(email_parts.join("")),
-        class: "action--receive_fact_check--earlier",
+        class: "js-earlier",
       )
     end
 

--- a/spec/javascripts/spec/history_and_notes.spec.js
+++ b/spec/javascripts/spec/history_and_notes.spec.js
@@ -11,23 +11,23 @@ describe('History and Notes component', function () {
       `<ul>
         <li>
           <div>
-            <div class="action--note__content">
+            <div>
               <p>A current message</p>
             </div>
           </div>
         </li>
         <li>
           <div>
-            <div class="action--receive_fact_check__content">
+            <div>
               <p>A current message</p>
             </div>
           </div>
         </li>
         <li>
           <div>
-            <div class="action--receive_fact_check__content">
+            <div>
               <p>A current message</p>
-              <div class="action--receive_fact_check--earlier">
+              <div class="js-earlier">
                 <p>An earlier message</p>
                 <p>Another earlier message</p>
               </div>
@@ -36,9 +36,9 @@ describe('History and Notes component', function () {
         </li>
         <li>
           <div>
-            <div class="action--receive_fact_check__content">
+            <div>
               <p>A current message</p>
-              <div class="action--receive_fact_check--earlier">
+              <div class="js-earlier">
                 <p>An earlier message</p>
                 <p>Another earlier message</p>
               </div>
@@ -62,13 +62,13 @@ describe('History and Notes component', function () {
   })
 
   describe('"Receive fact check" actions', function () {
-    it('should hide "action--receive_fact_check--earlier" sections where they exist', function () {
+    it('should hide "js-earlier" sections where they exist', function () {
       const actions = module.querySelectorAll('li')
 
-      expect(actions[0].querySelector('.action--receive_fact_check--earlier')).toBe(null)
-      expect(actions[1].querySelector('.action--receive_fact_check--earlier')).toBe(null)
-      expect(actions[2].querySelector('.action--receive_fact_check--earlier').classList.contains('govuk-!-display-none')).toBe(true)
-      expect(actions[3].querySelector('.action--receive_fact_check--earlier').classList.contains('govuk-!-display-none')).toBe(true)
+      expect(actions[0].querySelector('.js-earlier')).toBe(null)
+      expect(actions[1].querySelector('.js-earlier')).toBe(null)
+      expect(actions[2].querySelector('.js-earlier').classList.contains('govuk-!-display-none')).toBe(true)
+      expect(actions[3].querySelector('.js-earlier').classList.contains('govuk-!-display-none')).toBe(true)
     })
 
     it('should display "Show earlier messages" buttons where there is a hidden section', function () {
@@ -87,8 +87,8 @@ describe('History and Notes component', function () {
     it('should add IDs to the hidden sections', function () {
       const actions = module.querySelectorAll('li')
 
-      expect(actions[2].querySelector('.action--receive_fact_check--earlier').id).toEqual('toggledContent_1')
-      expect(actions[3].querySelector('.action--receive_fact_check--earlier').id).toEqual('toggledContent_2')
+      expect(actions[2].querySelector('.js-earlier').id).toEqual('toggledContent_1')
+      expect(actions[3].querySelector('.js-earlier').id).toEqual('toggledContent_2')
     })
 
     it('should toggle the display of the hidden section when the "Show earlier messages" link is clicked', function () {
@@ -98,14 +98,14 @@ describe('History and Notes component', function () {
 
       toggle.dispatchEvent(click)
 
-      expect(action.querySelector('.action--receive_fact_check--earlier').classList.contains('govuk-!-display-none')).toBe(false)
-      expect(toggle.text).toEqual('Hide earlier messages')
+      expect(action.querySelector('.js-earlier').classList.contains('govuk-!-display-none')).toBe(false)
+      expect(toggle.textContent).toEqual('Hide earlier messages')
       expect(toggle.getAttribute('aria-expanded')).toEqual('true')
 
       toggle.dispatchEvent(click)
 
-      expect(action.querySelector('.action--receive_fact_check--earlier').classList.contains('govuk-!-display-none')).toBe(true)
-      expect(toggle.text).toEqual('Show earlier messages')
+      expect(action.querySelector('.js-earlier').classList.contains('govuk-!-display-none')).toBe(true)
+      expect(toggle.textContent).toEqual('Show earlier messages')
       expect(toggle.getAttribute('aria-expanded')).toEqual('false')
     })
   })

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -566,7 +566,7 @@ class EditionEditTest < IntegrationTest
 
         within :css, ".history__action--receive_fact_check__content" do
           assert page.has_text?("We’re happy for you to publish.")
-          assert page.has_css?("div.action--receive_fact_check--earlier", text: "Reply and confirm the content is correct.")
+          assert page.has_css?("div.js-earlier", text: "Reply and confirm the content is correct.")
           assert page.has_text?("We found some potentially harmful content in this email which has been automatically removed. Please check the content of the message in case any text has been deleted as well.")
         end
       end


### PR DESCRIPTION
[Trello](https://trello.com/c/XeUFymb8/727-bug-show-earlier-messages-toggle-should-change-to-hide-earlier-messages-when-selected)

This deals with a bug on the "History and Notes" tab. Where there are "Receive fact check by GOV.UK Bot" actions listed, there is a toggle in the email text  that reads "Show earlier messages". When clicked this should expand the section below that contains extra content and should then read "Hide earlier messages". The bug is that the text of the toggle was not changing. 

The main problem was that some class names of elements were being used for both styling and behaviour. Some of these were changed for style purposes co that they were no longer useable by the JavaScript module. To follow best practice on this those have been changed so that the JS refers to one set of classes and the CSS another. 

Instances of `text` have also been updated to `textContent` within the module. This may have been a reason for the failure since `text` is not a valid property and may not have been being set as required. 

The screenshots below show the toggle on load, expanded and contracted. The only change is in the text of the toggle itself: either "Show earlier messages" or "Hide earlier messages".

Scenario|Current|Updated|
|-|-|-|
|Fact check action on load|![Screenshot 2025-06-16 at 16 45 20](https://github.com/user-attachments/assets/404c5dbf-1bf9-4dc1-9617-9bb79e071cfd)|![Screenshot 2025-06-16 at 16 41 41](https://github.com/user-attachments/assets/35cf438b-326c-4b2c-92ce-8baaa4722f5b)|
|Fact check action when expanded|![Screenshot 2025-06-16 at 16 45 25](https://github.com/user-attachments/assets/6ad33065-a2f4-41db-9c2c-4ab4f7395031)|![Screenshot 2025-06-16 at 16 41 32](https://github.com/user-attachments/assets/9031c4a8-4bd0-40bc-a6cc-dbe388de6b7b)|
|Fact check action when contracted|![Screenshot 2025-06-16 at 16 45 30](https://github.com/user-attachments/assets/7b828391-021e-4d43-bcc9-0d79cfa04b14)|![Screenshot 2025-06-16 at 16 41 55](https://github.com/user-attachments/assets/3c064eec-8fe6-48a3-ba6e-05826d3727d7)|