### PR TITLE
Convert HomepagePopularLinksTest to an IntegrationTest

### DIFF
--- a/test/integration/homepage_popular_links_test.rb
+++ b/test/integration/homepage_popular_links_test.rb
@@ -1,6 +1,6 @@
 require "integration_test_helper"
 
-class HomepagePopularLinksTest < JavascriptIntegrationTest
+class HomepagePopularLinksTest < IntegrationTest
   context "no homepage editor access" do
     setup do
       login_as(FactoryBot.create(:user, name: "Stub User"))


### PR DESCRIPTION
HomepagePopularLinksTest is currently a JavascriptIntegrationTest despite having no Javascript required testing. Some of the tests intermittently fail in CI and locally. Converting this will mean the Selenium driver is used and theoretically remove the flakiness

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
