### PR TITLE
Publications index page changes

### DIFF
--- a/app/presenters/filtered_editions_presenter.rb
+++ b/app/presenters/filtered_editions_presenter.rb
@@ -89,7 +89,7 @@ private
 
   def state_names
     {
-      draft: "Drafts",
+      draft: "Draft",
       in_review: "In review",
       amends_needed: "Amends needed",
       fact_check: "Out for fact check",

--- a/app/views/root/_filter.html.erb
+++ b/app/views/root/_filter.html.erb
@@ -34,6 +34,7 @@
       name: "states_filter[]",
       heading: "Status",
       heading_size: "s",
+      small: true,
       items: @presenter.edition_states,
     } %>
 

--- a/app/views/root/_filter.html.erb
+++ b/app/views/root/_filter.html.erb
@@ -7,10 +7,9 @@
 
     <%= render "govuk_publishing_components/components/input", {
       label: {
-        text: "Search",
+        text: "Title or slug",
         bold: true,
       },
-      hint: "Search by title or slug",
       name: "search_text",
       id: "search_text",
       value: @presenter.search_text,

--- a/app/views/root/_table.html.erb
+++ b/app/views/root/_table.html.erb
@@ -1,5 +1,5 @@
 <div class="publications-table" data-module="publications-table">
-  <p class="govuk-heading-m govuk-!-margin-bottom-3 publications-table__heading"><%= @presenter.editions.length %> document(s)</p>
+  <p class="govuk-heading-m govuk-!-margin-bottom-3 publications-table__heading"><%= pluralize(number_with_delimiter(@presenter.editions.length), "document" ) %></p>
 
   <%= render "govuk_publishing_components/components/table", {
     head: [

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -46,7 +46,7 @@ class RootControllerTest < ActionController::TestCase
 
       get :index
 
-      assert_select "p.publications-table__heading", "9 document(s)"
+      assert_select "p.publications-table__heading", "9 documents"
       assert_select "span.govuk-tag--draft", "Draft"
       assert_select "span.govuk-tag--in_review", "In review"
       assert_select "span.govuk-tag--amends_needed", "Amends needed"
@@ -66,7 +66,7 @@ class RootControllerTest < ActionController::TestCase
       get :index, params: { states_filter: %w[draft published] }
 
       assert_response :ok
-      assert_select "p.publications-table__heading", "2 document(s)"
+      assert_select "p.publications-table__heading", "2 documents"
       assert_select "td.govuk-table__cell", "Draft"
       assert_select "td.govuk-table__cell", "Published"
     end
@@ -86,7 +86,7 @@ class RootControllerTest < ActionController::TestCase
       get :index
 
       assert_response :ok
-      assert_select "p.publications-table__heading", "1 document(s)"
+      assert_select "p.publications-table__heading", "1 document"
       assert_select "td.govuk-table__cell", "Stub User"
     end
 
@@ -108,7 +108,7 @@ class RootControllerTest < ActionController::TestCase
       get :index, params: { assignee_filter: anna.id }
 
       assert_response :ok
-      assert_select "p.publications-table__heading", "1 document(s)"
+      assert_select "p.publications-table__heading", "1 document"
       assert_select "td.govuk-table__cell", "Anna"
     end
 
@@ -138,7 +138,7 @@ class RootControllerTest < ActionController::TestCase
       get :index, params: { content_type_filter: "guide" }
 
       assert_response :ok
-      assert_select "p.publications-table__heading", "1 document(s)"
+      assert_select "p.publications-table__heading", "1 document"
       assert_select "dd.govuk-summary-list__value", "Guide"
     end
 
@@ -149,7 +149,7 @@ class RootControllerTest < ActionController::TestCase
       get :index, params: { search_text: "zombie" }
 
       assert_response :ok
-      assert_select "p.publications-table__heading", "1 document(s)"
+      assert_select "p.publications-table__heading", "1 document"
       assert_select "p.title", /What to do in the event of a zombie apocalypse/
     end
 
@@ -177,7 +177,7 @@ class RootControllerTest < ActionController::TestCase
       get :index
 
       assert_response :ok
-      assert_select "p.publications-table__heading", "#{FilteredEditionsPresenter::ITEMS_PER_PAGE + 1} document(s)"
+      assert_select "p.publications-table__heading", "#{FilteredEditionsPresenter::ITEMS_PER_PAGE + 1} documents"
       assert_select ".govuk-table__row .title", FilteredEditionsPresenter::ITEMS_PER_PAGE
     end
 
@@ -189,7 +189,7 @@ class RootControllerTest < ActionController::TestCase
       get :index, params: { page: 2 }
 
       assert_response :ok
-      assert_select "p.publications-table__heading", "#{FilteredEditionsPresenter::ITEMS_PER_PAGE + 1} document(s)"
+      assert_select "p.publications-table__heading", "#{FilteredEditionsPresenter::ITEMS_PER_PAGE + 1} documents"
       assert_select ".govuk-table__row .title", 1
     end
   end

--- a/test/integration/get_content_by_content_id_test.rb
+++ b/test/integration/get_content_by_content_id_test.rb
@@ -16,7 +16,7 @@ class GetContentByContentIdTest < IntegrationTest
       create_draft_edition
       visit "by-content-id/#{@draft_edition.content_id}"
 
-      assert_content("1 document(s)")
+      assert_content("1 document")
       assert page.has_content?("some title")
     end
 
@@ -24,7 +24,7 @@ class GetContentByContentIdTest < IntegrationTest
       create_published_edition
       visit "by-content-id/#{@published_edition.content_id}"
 
-      assert_content("1 document(s)")
+      assert_content("1 document")
       assert page.has_content?("some title")
     end
 
@@ -33,7 +33,7 @@ class GetContentByContentIdTest < IntegrationTest
       create_draft_edition
       visit "by-content-id/#{@published_edition.content_id}"
 
-      assert_content("2 document(s)")
+      assert_content("2 documents")
       assert page.has_content?("some title")
     end
   end

--- a/test/integration/root_overview_test.rb
+++ b/test/integration/root_overview_test.rb
@@ -12,21 +12,52 @@ class RootOverviewTest < IntegrationTest
     test_strategy.switch!(:design_system_publications_filter, true)
   end
 
+  should "show number of documents in pluralized format if there are multiple results" do
+    FactoryBot.create(:user, :govuk_editor)
+    FactoryBot.create(:guide_edition, title: "XXX", slug: "xxx")
+    FactoryBot.create(:guide_edition, title: "YYY", slug: "yyy")
+
+    visit "/"
+    filter_by_user("All")
+
+    assert_content("2 documents")
+  end
+
+  should "show number of documents in singular format if there is a single result" do
+    FactoryBot.create(:user, :govuk_editor)
+    FactoryBot.create(:guide_edition, title: "XXX", slug: "xxx")
+
+    visit "/"
+    filter_by_user("All")
+
+    assert_content("1 document")
+  end
+
+  should "show number of documents formatted to include a comma if there are more than a 1000 results" do
+    FactoryBot.create(:user, :govuk_editor)
+    FactoryBot.create_list(:guide_edition, 1000)
+
+    visit "/"
+    filter_by_user("All")
+
+    assert_content("1,000 documents")
+  end
+
   should "be able to view different pages of results" do
     alice = FactoryBot.create(:user, :govuk_editor, name: "Alice", uid: "alice")
     FactoryBot.create(:guide_edition, title: "Guides and Gals", assigned_to: alice)
     FactoryBot.create_list(:guide_edition, FilteredEditionsPresenter::ITEMS_PER_PAGE, assigned_to: alice)
 
     visit "/"
-    assert_content("21 document(s)")
+    assert_content("21 documents")
     assert_no_content("Guides and Gals")
 
     click_on "Next"
-    assert_content("21 document(s)")
+    assert_content("21 documents")
     assert_content("Guides and Gals")
 
     click_on "Prev"
-    assert_content("21 document(s)")
+    assert_content("21 documents")
     assert_no_content("Guides and Gals")
   end
 

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -39,7 +39,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
 
   def search_by_title_or_slug(substring)
     within ".publications-filter form" do
-      fill_in "Search", with: substring
+      fill_in "Title or slug", with: substring
       click_on "Search"
     end
   end

--- a/test/unit/presenters/filtered_editions_presenter_test.rb
+++ b/test/unit/presenters/filtered_editions_presenter_test.rb
@@ -40,7 +40,7 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       states = FilteredEditionsPresenter.new(a_gds_user).edition_states
 
       assert_equal(9, states.count)
-      assert_includes(states, { label: "Drafts", value: :draft })
+      assert_includes(states, { label: "Draft", value: :draft })
       assert_includes(states, { label: "In review", value: :in_review })
       assert_includes(states, { label: "Amends needed", value: :amends_needed })
       assert_includes(states, { label: "Out for fact check", value: :fact_check })


### PR DESCRIPTION
[Trello](https://trello.com/c/GaaZPBIN)

Apply following updates to the Publications index page:

- Reduce the size of the checkboxes in accordance with the design

- Pluralize the number of documents statement correctly

- Update title for filter to 'Title or slug'

- Add thousands comma for number of documents statement

<img width="875" alt="Publications Index Page New" src="https://github.com/user-attachments/assets/b90fdbcf-dc57-4391-a3ae-5dd88140a2c4" />
