### PR TITLE
Enable toggle for publications page in Design System for Integration

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -10,7 +10,7 @@ Flipflop.configure do
   end
 
   feature :design_system_publications_filter,
-          default: false,
+          default: %w[integration].include?(ENV["GOVUK_ENVIRONMENT"]),
           description: "Update the publications page to use the GOV.UK Design System"
 
   feature :design_system_edit,


### PR DESCRIPTION
[Trello](https://trello.com/c/zZ0nPZDG/725-25-june-go-live-permanently-enable-toggle-for-publications-page-in-design-system)

Enable toggle for publications page in Design System for Integration environment.

