### PR TITLE
Revert "Enable toggle for publications page in Design System for Inte…

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -10,7 +10,7 @@ Flipflop.configure do
   end
 
   feature :design_system_publications_filter,
-          default: %w[integration].include?(ENV["GOVUK_ENVIRONMENT"]),
+          default: false,
           description: "Update the publications page to use the GOV.UK Design System"
 
   feature :design_system_edit,


### PR DESCRIPTION
Revert "Enable toggle for publications page in Design System for Integration environment."
This reverts commit 48f06cba0dc7b651b5576fc3b37a46bcb51fbad6.

This needs to be reverted as the e2e tests are failing. The e2e tests will be updated before we re-add this change.