### PR TITLE
Enabling design system toggle for integration

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -10,7 +10,7 @@ Flipflop.configure do
   end
 
   feature :design_system_publications_filter,
-          default: false,
+          default: %w[integration].include?(ENV["GOVUK_ENVIRONMENT"]),
           description: "Update the publications page to use the GOV.UK Design System"
 
   feature :design_system_edit,


### PR DESCRIPTION

Enabling design system toggle for integration before deployment, to check it deploys proper with e2e tests.