### PR TITLE
Revert toggle for design system publications page

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -10,7 +10,7 @@ Flipflop.configure do
   end
 
   feature :design_system_publications_filter,
-          default: true,
+          default: false,
           description: "Update the publications page to use the GOV.UK Design System"
 
   feature :design_system_edit,


### PR DESCRIPTION
Revert design system toggle for the publications page back to false to continue use of legacy bootstrap page until improvements are made.
