### PR TITLE
fix: remove community alarm service

### DIFF
--- a/data/local_services.csv
+++ b/data/local_services.csv
@@ -44,7 +44,6 @@ LGSL,Description,Providing Tier
 287,Find out about direct payments,county/unitary
 296,Find out about day centres,county/unitary
 297,Find out about local support groups and organisations,all
-313,Find out about community alarm services,district/unitary
 315,Find out about mobile meals service,county/unitary
 328,Find out about the bereavement service,district/unitary
 353,Find out about complaints procedure,all


### PR DESCRIPTION
- LGSL 313 is being retired as a supported service on gov.uk

https://trello.com/c/YDkfN7A3/638-delete-dataset-from-local-links-manager

(This is step 3 in the docs here: https://github.com/alphagov/local-links-manager/blob/main/docs/remove-a-service.md#3-remove-the-lgsl-code-from-publisher)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
