### PR TITLE
Add and Edit data in [Mainstream browse pages] summary card

### DIFF
--- a/app/helpers/editions_sidebar_buttons_helper.rb
+++ b/app/helpers/editions_sidebar_buttons_helper.rb
@@ -17,16 +17,6 @@ module EditionsSidebarButtonsHelper
     }
   end
 
-  def edit_assignee_buttons(edition)
-    [
-      (render "govuk_publishing_components/components/button", {
-        text: "Save",
-        margin_bottom: 3,
-      }),
-      link_to("Cancel", edition_path(edition), class: "govuk-link govuk-link--no-visited-state"),
-    ]
-  end
-
   def scheduled_for_publishing_sidebar_buttons(edition)
     buttons = []
     if current_user.has_editor_permissions?(edition)
@@ -125,5 +115,15 @@ module EditionsSidebarButtonsHelper
     end
 
     buttons
+  end
+
+  def base_edition_sidebar_buttons(cancel_link_path)
+    [
+      (render "govuk_publishing_components/components/button", {
+        text: "Save",
+        margin_bottom: 3,
+      }),
+      link_to("Cancel", cancel_link_path, class: "govuk-link govuk-link--no-visited-state"),
+    ]
   end
 end

--- a/app/helpers/tagging_helper.rb
+++ b/app/helpers/tagging_helper.rb
@@ -1,14 +1,14 @@
 module TaggingHelper
-  def tag_summary_rows(type, tagging_update, linkables, key_text)
+  def tag_summary_rows(type, tagging_update_form_values, linkables, key_text)
     case type
     when "breadcrumb"
-      items = breadcrumb(tagging_update.parent, linkables)
+      items = breadcrumb(tagging_update_form_values.parent, linkables)
     when "browse_pages"
-      items = browse_pages(tagging_update.mainstream_browse_pages, linkables)
+      items = browse_pages(tagging_update_form_values.mainstream_browse_pages, linkables)
     when "organisations"
-      items = organisations(tagging_update.organisations, linkables)
+      items = organisations(tagging_update_form_values.organisations, linkables)
     when "related_content"
-      items = related_content(tagging_update.ordered_related_items)
+      items = related_content(tagging_update_form_values.ordered_related_items)
     else
       []
     end

--- a/app/views/editions/secondary_nav_tabs/_tagging.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_tagging.html.erb
@@ -7,7 +7,7 @@
     <% heading_organisations = "Organisations" %>
     <% heading_related_items = "Related content" %>
 
-    <% if @tagging_update.parent == nil %>
+    <% if @tagging_update_form_values.parent == nil %>
       <%= render partial: "secondary_nav_tabs/tagging/summary_card_empty", locals: {
         heading: heading_breadcrumb,
         body: "No breadcrumb set",
@@ -22,22 +22,28 @@
       } %>
     <% end %>
 
-    <% if @tagging_update.mainstream_browse_pages == nil %>
+    <% if @tagging_update_form_values.mainstream_browse_pages == nil %>
       <%= render partial: "secondary_nav_tabs/tagging/summary_card_empty", locals: {
         heading: heading_browse_pages,
         body: "Not tagged to any browse pages",
         link_text: "Tag to a browse page",
-        link_url: "#",
+        link_url: tagging_mainstream_browse_page_edition_path,
       } %>
     <% else %>
       <%= render partial: "secondary_nav_tabs/tagging/summary_card_full", locals: {
         type: "browse_pages",
         heading: heading_browse_pages,
         key_text: "Browse page",
+        actions: [
+          {
+            label: "Edit",
+            href: tagging_mainstream_browse_page_edition_path,
+          },
+        ],
       } %>
     <% end %>
 
-    <% if @tagging_update.organisations == nil %>
+    <% if @tagging_update_form_values.organisations == nil %>
       <%= render partial: "secondary_nav_tabs/tagging/summary_card_empty", locals: {
         heading: heading_organisations,
         body: "Not tagged to any organisations",
@@ -52,7 +58,7 @@
       } %>
     <% end %>
 
-    <% if @tagging_update.ordered_related_items == nil %>
+    <% if @tagging_update_form_values.ordered_related_items == nil %>
       <%= render partial: "secondary_nav_tabs/tagging/summary_card_empty", locals: {
         heading: heading_related_items,
         body: "Not tagged to any related content",

--- a/app/views/editions/secondary_nav_tabs/edit_assignee/_edit_assignee.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit_assignee/_edit_assignee.html.erb
@@ -19,7 +19,7 @@
       <div class="sidebar-components">
         <%= sidebar_options_heading %>
 
-        <%= sidebar_items_list(edit_assignee_buttons(@resource)) %>
+        <%= sidebar_items_list(base_edition_sidebar_buttons(edition_path(@resource))) %>
       </div>
     </div>
   </div>

--- a/app/views/editions/secondary_nav_tabs/tagging/_summary_card_empty.html.erb
+++ b/app/views/editions/secondary_nav_tabs/tagging/_summary_card_empty.html.erb
@@ -9,8 +9,11 @@
       margin_bottom: 4,
     } %>
     <p class="govuk-body"><%= body %></p>
-    <p class="govuk-body">
-      <%= link_to link_text, link_url, class: "govuk-link govuk-link--no-visited-state" %>
-    </p>
+
+    <% if current_user.has_editor_permissions?(@edition) %>
+      <p class="govuk-body">
+        <%= link_to link_text, link_url, class: "govuk-link govuk-link--no-visited-state" %>
+      </p>
+    <% end %>
   </div>
 </div>

--- a/app/views/editions/secondary_nav_tabs/tagging/_summary_card_full.html.erb
+++ b/app/views/editions/secondary_nav_tabs/tagging/_summary_card_full.html.erb
@@ -1,6 +1,7 @@
-<%# locals: (type:, heading:, key_text:) %>
+<%# locals: (type:, heading:, key_text:, actions: []) %>
 
 <%= render "govuk_publishing_components/components/summary_card", {
   title: heading,
-  rows: tag_summary_rows(type, @tagging_update, @linkables, key_text),
+  summary_card_actions: actions,
+  rows: tag_summary_rows(type, @tagging_update_form_values, @linkables, key_text),
 } %>

--- a/app/views/editions/secondary_nav_tabs/tagging_mainstream_browse_page.erb
+++ b/app/views/editions/secondary_nav_tabs/tagging_mainstream_browse_page.erb
@@ -1,0 +1,42 @@
+<% @edition = @resource %>
+<% content_for :title_context, @edition.title %>
+<% content_for :page_title, "Tag browse pages" %>
+<% content_for :title, "Tag browse pages" %>
+<%= form_for @tagging_update_form_values, url: update_tagging_edition_path(@edition) do |f| %>
+  <%= f.hidden_field :content_id %>
+  <%= f.hidden_field :previous_version %>
+  <% Array(@tagging_update_form_values.parent).each do |parent_id| %>
+    <%= f.hidden_field :parent, value: parent_id, multiple: true %>
+  <% end %>
+  <% Array(@tagging_update_form_values.organisations).each do |org_id| %>
+    <%= f.hidden_field :organisations, value: org_id, multiple: true %>
+  <% end %>
+  <% Array(@tagging_update_form_values.ordered_related_items).to_a.map { |item| item["base_path"] }.each do |base_path| %>
+    <%= f.hidden_field :ordered_related_items, value: base_path, multiple: true %>
+  <% end %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/hint", {
+        text: "Select all that apply",
+      } %>
+      <% @checkbox_groups.each do |checkbox_group| %>
+        <%= render "govuk_publishing_components/components/checkboxes", {
+          name: "#{f.object_name}[mainstream_browse_pages][]",
+          heading: checkbox_group[:heading],
+          heading_size: "s",
+          small: true,
+          no_hint_text: true,
+          items: checkbox_group[:items],
+        } %>
+        <% end %>
+    </div>
+
+    <div class="govuk-grid-column-one-third options-sidebar">
+      <div class="sidebar-components">
+        <%= sidebar_options_heading %>
+        <%= sidebar_items_list(base_edition_sidebar_buttons(tagging_edition_path(@edition))) %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,8 @@ Rails.application.routes.draw do
         get "related_external_links"
         patch "update_related_external_links"
         get "tagging", to: "editions#tagging"
+        post "update_tagging", to: "editions#update_tagging", as: "update_tagging"
+        get "tagging_mainstream_browse_page", to: "editions#tagging_mainstream_browse_page", as: "tagging_mainstream_browse_page"
         get "unpublish"
         get "unpublish/confirm-unpublish", to: "editions#confirm_unpublish", as: "confirm_unpublish"
         post "process_unpublish"

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -1399,6 +1399,47 @@ class EditionsControllerTest < ActionController::TestCase
     end
   end
 
+  context "#tagging_mainstream_browse_page" do
+    setup do
+      stub_linkables_with_data
+    end
+
+    context "user has govuk_editor permission" do
+      should "render the 'Tag to a browse page' page" do
+        get :tagging_mainstream_browse_page, params: { id: @edition.id }
+        assert_template "secondary_nav_tabs/tagging_mainstream_browse_page"
+      end
+
+      should "render the tagging tab and display an error message if an error occurs during the request" do
+        Tagging::TaggingUpdateForm.stubs(:build_from_publishing_api).raises(StandardError)
+
+        get :tagging_mainstream_browse_page, params: { id: @edition.id }
+
+        assert_template "show"
+        assert_equal "Due to a service problem, the request could not be made", flash[:danger]
+      end
+    end
+
+    context "user does not have editor permissions" do
+      should "render an error message if the user is not a govuk_editor" do
+        user = FactoryBot.create(:user)
+        login_as(user)
+
+        get :tagging_mainstream_browse_page, params: { id: @edition.id }
+
+        assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
+      end
+
+      should "render an error message if the user is a Welsh editor and non-Welsh edition" do
+        login_as_welsh_editor
+
+        get :tagging_mainstream_browse_page, params: { id: @edition.id }
+
+        assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
+      end
+    end
+  end
+
   context "#metadata" do
     should "alias to show method" do
       assert_equal EditionsController.new.method(:metadata).super_method.name, :show

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -221,6 +221,65 @@ class EditionEditTest < IntegrationTest
           assert page.has_link?("Tag to related content")
         end
       end
+
+      context "User does not have correct permissions" do
+        setup do
+          user = FactoryBot.create(:user, name: "Stub User")
+          login_as(user)
+          visit_draft_edition
+          click_link("Tagging")
+        end
+
+        should "not show the 'Tag to a browse page' link" do
+          within all(".govuk-summary-card")[1] do
+            assert page.has_no_link?("Tag to a browse page")
+          end
+        end
+      end
+
+      context "Adding Tags to a browse page" do
+        setup do
+          click_link("Tag to a browse page")
+        end
+
+        should "show the 'Tag to a browse page' page" do
+          assert page.has_text?(@draft_edition.title)
+          assert page.has_text?("Tag browse pages")
+          assert page.has_text?("Select all that apply")
+          assert page.has_element?("legend", text: "Tax")
+          assert page.has_unchecked_field?("Capital Gains Tax")
+          assert page.has_unchecked_field?("RTI (draft)")
+          assert page.has_unchecked_field?("VAT")
+          assert page.has_element?("legend", text: "Benefits")
+          assert page.has_unchecked_field?("Benefits and financial support for families")
+          assert page.has_unchecked_field?("Benefits and financial support if you're caring for someone")
+          assert page.has_unchecked_field?("Benefits and financial support if you're disabled or have a health condition")
+          assert page.has_text?("Options")
+          assert page.has_button?("Save")
+          assert page.has_link?("Cancel")
+        end
+
+        should "redirect to tagging tab when Cancel link is clicked" do
+          click_link("Cancel")
+
+          assert_current_path tagging_edition_path(@draft_edition.id)
+        end
+
+        should "save the selected tags to the browse page when the form is submitted" do
+          check("Capital Gains Tax")
+          click_button("Save")
+          assert_requested :patch,
+                           "#{Plek.find('publishing-api')}/v2/links/#{@draft_edition.content_id}",
+                           body: { "links": { "organisations": [],
+                                              "meets_user_needs": [],
+                                              "mainstream_browse_pages": %w[CONTENT-ID-CAPITAL],
+                                              "ordered_related_items": [],
+                                              "parent": [] },
+                                   "previous_version": 0 }
+          assert_current_path tagging_edition_path(@draft_edition.id)
+          assert page.has_text?("Tags have been updated!")
+        end
+      end
     end
 
     context "Tagging is set" do
@@ -293,6 +352,47 @@ class EditionEditTest < IntegrationTest
             assert page.has_css?("dt", text: "Related content 4")
             assert page.has_css?("dt", text: "/tax-help")
           end
+        end
+      end
+
+      context "Editing tags for a browse page" do
+        setup do
+          within all(".gem-c-summary-card")[1] do
+            click_link("Edit")
+          end
+        end
+
+        should "show the 'Tag to a browse page' page with preselected options" do
+          assert page.has_text?(@draft_edition.title)
+          assert page.has_text?("Tag browse pages")
+          assert page.has_text?("Select all that apply")
+          assert page.has_element?("legend", text: "Tax")
+          assert page.has_checked_field?("Capital Gains Tax")
+          assert page.has_checked_field?("RTI (draft)")
+          assert page.has_checked_field?("VAT")
+          assert page.has_element?("legend", text: "Benefits")
+          assert page.has_unchecked_field?("Benefits and financial support for families")
+          assert page.has_unchecked_field?("Benefits and financial support if you're caring for someone")
+          assert page.has_unchecked_field?("Benefits and financial support if you're disabled or have a health condition")
+          assert page.has_button?("Save")
+          assert page.has_link?("Cancel")
+        end
+
+        should "update the tags for the browse page when the form is submitted" do
+          uncheck("RTI (draft)")
+          uncheck("VAT")
+          check("Benefits and financial support for families")
+          click_button("Save")
+          assert_requested :patch,
+                           "#{Plek.find('publishing-api')}/v2/links/#{@draft_edition.content_id}",
+                           body: { "links": { "organisations": %w[9a9111aa-1db8-4025-8dd2-e08ec3175e72],
+                                              "meets_user_needs": [],
+                                              "mainstream_browse_pages": %w[CONTENT-ID-FAMILIES CONTENT-ID-CAPITAL],
+                                              "ordered_related_items": %w[830e403b-7d81-45f1-8862-81dcd55b4ec7 5cb58486-0b00-4da8-8076-382e474b4f03 853feaf2-152c-4aa5-8edb-ba84a88860bf 91fef6f6-3a59-42ab-a14d-42c4e5eee1a1],
+                                              "parent": %w[CONTENT-ID-CAPITAL] },
+                                   "previous_version": 1 }
+          assert_current_path tagging_edition_path(@draft_edition.id)
+          assert page.has_text?("Tags have been updated!")
         end
       end
     end

--- a/test/support/tag_test_helpers.rb
+++ b/test/support/tag_test_helpers.rb
@@ -54,7 +54,8 @@ module TagTestHelpers
                   \"content_id\": \"CONTENT-ID-CAPITAL\"
                 }
               ]
-            }
+            },
+          \"version\": 1
         }",
         headers: {},
       )
@@ -69,6 +70,9 @@ module TagTestHelpers
         { base_path: "/browse/tax/capital-gains", internal_name: "Tax / Capital Gains Tax", publication_state: "published", content_id: "CONTENT-ID-CAPITAL" },
         { base_path: "/browse/tax/rti", internal_name: "Tax / RTI", publication_state: "draft", content_id: "CONTENT-ID-RTI" },
         { base_path: "/browse/tax/nil", internal_name: nil, publication_state: "draft", content_id: "CONTENT-ID-NIL" },
+        { base_path: "/browse/benefits/families", internal_name: "Benefits / Benefits and financial support for families", publication_state: "draft", content_id: "CONTENT-ID-FAMILIES" },
+        { base_path: "/browse/benefits/help-for-carers", internal_name: "Benefits / Benefits and financial support if you're caring for someone", publication_state: "draft", content_id: "CONTENT-ID-HELP-FOR-CARERS" },
+        { base_path: "/browse/benefits/disability", internal_name: "Benefits / Benefits and financial support if you're disabled or have a health condition", publication_state: "draft", content_id: "CONTENT-ID-DISABILITY" },
       ],
       document_type: "mainstream_browse_page",
     )
@@ -104,5 +108,12 @@ module TagTestHelpers
       ],
       document_type: "need",
     )
+
+    stub_publishing_api_has_lookups({
+      "/company-tax-returns" => "830e403b-7d81-45f1-8862-81dcd55b4ec7",
+      "/prepare-file-annual-accounts-for-limited-company" => "5cb58486-0b00-4da8-8076-382e474b4f03",
+      "/corporation-tax" => "853feaf2-152c-4aa5-8edb-ba84a88860bf",
+      "/tax-help" => "91fef6f6-3a59-42ab-a14d-42c4e5eee1a1",
+    })
   end
 end

--- a/test/unit/tagging/linkables_test.rb
+++ b/test/unit/tagging/linkables_test.rb
@@ -7,13 +7,16 @@ class LinkablesTest < ActiveSupport::TestCase
 
   test "returns sorted browse pages" do
     assert_equal(
-      {
+      { "Benefits" => [
+          ["Benefits / Benefits and financial support for families (draft)", "CONTENT-ID-FAMILIES"],
+          ["Benefits / Benefits and financial support if you're caring for someone (draft)", "CONTENT-ID-HELP-FOR-CARERS"],
+          ["Benefits / Benefits and financial support if you're disabled or have a health condition (draft)", "CONTENT-ID-DISABILITY"],
+        ],
         "Tax" => [
           ["Tax / Capital Gains Tax", "CONTENT-ID-CAPITAL"],
           ["Tax / RTI (draft)", "CONTENT-ID-RTI"],
           ["Tax / VAT", "CONTENT-ID-VAT"],
-        ],
-      },
+        ] },
       Tagging::Linkables.new.mainstream_browse_pages,
     )
   end


### PR DESCRIPTION
[Trello](https://trello.com/c/ZuaOlmWO/688-tagging-add-and-edit-data-in-mainstream-browse-pages-summary-card)

We have already added a summary page for tagging. This is located at `/editions/:id/tagging` and displays the four separate sections of tags that can be added. 

This work is concerned with the "Mainstream browse pages" section and adds a new view linked to from the "Tag to a browse page" link when the edition has no tagging already applied. This link should not be rendered to users without the correct permissions.

<img width="760" height="178" alt="Screenshot 2025-07-15 at 12 13 27" src="https://github.com/user-attachments/assets/a68c1868-c3e9-4744-8095-3b897c415ea7" />


If the edition does have tagging applied then this section displays those tags and an "Edit" link (also not rendered to users without the correct permissions).

<img width="760" height="275" alt="Screenshot 2025-07-15 at 12 15 18" src="https://github.com/user-attachments/assets/dc096902-73a6-42ed-b34d-f79de3a3040c" />


The view that is linked to here shows all the possible pages that can be tagged to as checkboxes, separated into sections. 

<img width="1148" height="672" alt="Screenshot 2025-07-15 at 12 17 04" src="https://github.com/user-attachments/assets/7d3ab610-d952-4607-8e11-db8d87d03fe3" />


From here the user can add or delete tagged pages and save their choice, returning them to the summary page with a success or error message. 

<img width="1035" height="911" alt="Screenshot 2025-07-15 at 12 19 54" src="https://github.com/user-attachments/assets/4d2d0fa5-eaba-4e84-8ae0-e74fa367fa50" />
