### PR TITLE
feat: exclude archived LocalTransactionEditions from blocking LocalServiceCleaner

### DIFF
--- a/app/lib/local_service_cleaner.rb
+++ b/app/lib/local_service_cleaner.rb
@@ -28,7 +28,7 @@ private
   end
 
   def in_local_transaction?(local_service)
-    LocalTransactionEdition.where(lgsl_code: local_service.lgsl_code).any?
+    LocalTransactionEdition.where(lgsl_code: local_service.lgsl_code).not(state: "archived").any?
   end
 
   def fetch_lgsls_from_csv

--- a/test/unit/lib/local_service_cleaner_test.rb
+++ b/test/unit/lib/local_service_cleaner_test.rb
@@ -45,6 +45,17 @@ class LocalServiceCleanerTest < ActiveSupport::TestCase
           LocalServiceCleaner.new(@input).run
           assert LocalService.where(id: @service.id).any?
         end
+
+        context "but the edition is archived" do
+          setup do
+            Edition.last.update!(state: "archived")
+          end
+
+          should "destroy service" do
+            LocalServiceCleaner.new(@input).run
+            assert_not LocalService.where(id: @service.id).any?
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
- When all LocalTransactionEditions mentioning a given LGSL code are archived, we should allow it to be deleted so that it wont be a valid option for making new editions.
- https://trello.com/c/lGHQaN0h/694-delete-dataset-from-local-links-manager-for-specific-lgsl

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
