### PR TITLE
Install MongoDB tools in container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,14 @@ RUN rails assets:precompile && rm -fr log node_modules
 
 FROM --platform=$TARGETPLATFORM $base_image
 
+# Install MongoDB tools
+
+RUN install_packages curl gnupg && \
+    curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | \
+    gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg --dearmor && \
+    echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/8.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-8.0.list && \
+    install_packages mongodb-org-tools
+
 ENV GOVUK_APP_NAME=publisher
 
 WORKDIR $APP_HOME


### PR DESCRIPTION
This is temporary changes to enable us to install mongo tool that has library for mongoexport.
We need mongoexport to copy data we need for mongo to postgres migration

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
