### PR TITLE
Postgres downtime notification (WIP)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,6 +10,7 @@ $govuk-page-width: 1140px;
 @import 'govuk_publishing_components/components/date-input';
 @import 'govuk_publishing_components/components/details';
 @import 'govuk_publishing_components/components/document-list';
+@import 'govuk_publishing_components/components/emergency-banner';
 @import 'govuk_publishing_components/components/error-alert';
 @import 'govuk_publishing_components/components/error-message';
 @import 'govuk_publishing_components/components/error-summary';

--- a/app/middleware/maintenance_mode.rb
+++ b/app/middleware/maintenance_mode.rb
@@ -1,0 +1,28 @@
+class MaintenanceMode
+    def initialize(app)
+      @app = app
+    end
+  
+    def call(env)
+      if maintenance_enabled?
+        return [503, { "Content-Type" => "text/html" }, [maintenance_page]]
+      end
+  
+      @app.call(env)
+    end
+  
+    private
+  
+    def maintenance_enabled?
+      # File.exist?(Rails.root.join("tmp", "maintenance.txt"))
+      # true
+      # ENV['MAINTENANCE_MODE'] == 'true'
+      value = ENV["MAINTENANCE_MODE"]
+  Rails.logger.info "ENV['MAINTENANCE_MODE'] = #{value.inspect}"
+  value == "true"
+    end
+  
+    def maintenance_page
+      ApplicationController.render(template: "maintenance/index", layout: false)
+    end
+end

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -18,6 +18,11 @@
 
   <div data-module="ga4-page-view-tracking" data-attributes='<%= track_analytics_data_on_load(sanitized_title) %>'></div>
 
+  <%= render partial: "/shared/maintenance_banner", locals: { 
+  heading: "Planned downtime",
+  content: "Publisher will be unavailable on Friday 1 August due to a planned database migration.",
+} %>
+
   <%= render "govuk_publishing_components/components/skip_link" %>
 
   <%= render "govuk_publishing_components/components/layout_header", {

--- a/app/views/layouts/legacy_application.html.erb
+++ b/app/views/layouts/legacy_application.html.erb
@@ -11,6 +11,12 @@
 <% end %>
 <% render "layouts/google_tag_manager" %>
 
+<%= render partial: "/shared/maintenance_banner", locals: { 
+  heading: "Planned downtime",
+  content: "Publisher will be unavailable on Friday 1 August due to a planned database migration.",
+} %>
+
+
 <% content_for :body_start do %>
   <%= render "govuk_publishing_components/components/skip_link" %>
 <% end %>

--- a/app/views/maintenance/index.html.erb
+++ b/app/views/maintenance/index.html.erb
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>We will be back soon</title>
+    <style>
+      body { font-family: sans-serif; text-align: center; padding-top: 100px; background: #f4f4f4; }
+      h1 { font-size: 3em; }
+      p { color: #666; }
+    </style>
+  </head>
+  <body>
+    <h1> Maintenance in Progress</h1>
+    <p>Our system is temporarily unavailable while we upgrade the database.<br>
+       We'll be back shortly. Thank you for your patience!</p>
+  </body>
+</html>

--- a/app/views/shared/_maintenance_banner.html.erb
+++ b/app/views/shared/_maintenance_banner.html.erb
@@ -1,0 +1,16 @@
+<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      <%= heading || "Important" %>
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-body"><%= content %></p>
+  </div>
+</div>
+
+<%= render "govuk_publishing_components/components/emergency_banner", {
+  campaign_class: "national-emergency",
+  heading: "Planned downtime",
+  short_description: "Publisher will be unavailable on Friday 1 August due to a planned database migration.",
+} %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ require "rails/test_unit/railtie"
 
 require "open-uri"
 require "builder"
+require_relative "../app/middleware/maintenance_mode"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -108,5 +109,8 @@ module Publisher
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.autoload_paths << Rails.root.join("app/middleware")
+    config.middleware.use MaintenanceMode
   end
 end


### PR DESCRIPTION
Add changes to display downtime notification due postgres migration to both Design System & Legacy (bootstrap)

[Trello card](https://trello.com/c/RYv7BCU3/760-mongo-to-postgres-migrations-downtime-information-banner)

