### PR TITLE
688 tagging mainstream browse pages updates

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -92,6 +92,8 @@ class EditionsController < InheritedResources::Base
 
     success_message = if params[:tagging_tagging_update_form][:tagging_type] == "related_content"
                         "Related content updated"
+                      elsif params[:tagging_tagging_update_form][:tagging_type] == "mainstream_browse_page"
+                        "Mainstream browse pages updated"
                       else
                         "Tags have been updated!"
                       end

--- a/app/views/editions/secondary_nav_tabs/tagging_mainstream_browse_page.erb
+++ b/app/views/editions/secondary_nav_tabs/tagging_mainstream_browse_page.erb
@@ -15,6 +15,7 @@
     <%= f.hidden_field :ordered_related_items, value: base_path, multiple: true %>
   <% end %>
   <%= f.hidden_field :ordered_related_items_destroy, value: [], multiple: true %>
+  <%= f.hidden_field :tagging_type, value: "mainstream_browse_page" %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -25,7 +26,7 @@
         <%= render "govuk_publishing_components/components/checkboxes", {
           name: "#{f.object_name}[mainstream_browse_pages][]",
           heading: checkbox_group[:heading],
-          heading_size: "s",
+          heading_size: "m",
           small: true,
           no_hint_text: true,
           items: checkbox_group[:items],

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -389,7 +389,7 @@ class EditionEditTest < IntegrationTest
                                             "parent": [] },
                                  "previous_version": 0 }
         assert_current_path tagging_edition_path(@draft_edition.id)
-        assert page.has_text?("Tags have been updated!")
+        assert page.has_text?("Mainstream browse pages updated")
       end
     end
 
@@ -433,7 +433,7 @@ class EditionEditTest < IntegrationTest
                                             "parent": %w[CONTENT-ID-CAPITAL] },
                                  "previous_version": 1 }
         assert_current_path tagging_edition_path(@draft_edition.id)
-        assert page.has_text?("Tags have been updated!")
+        assert page.has_text?("Mainstream browse pages updated")
       end
     end
   end


### PR DESCRIPTION
[Trello](https://trello.com/c/ZuaOlmWO/688-tagging-add-and-edit-data-in-mainstream-browse-pages-summary-card)

This makes a couple of small updates to tagging on the mainstream browse pages: 
- Increases the font size on the checkbox labels
- Updates the success message to the required value