### PR TITLE
Revert "Merge pull request #2802…"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,7 +256,7 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    govspeak (10.6.0)
+    govspeak (10.4.1)
       actionview (>= 6, < 8.0.3)
       addressable (>= 2.3.8, < 2.8.8)
       govuk_publishing_components (>= 43)


### PR DESCRIPTION
The publisher app fails to start with this updated govspeak gem.

This reverts commit 522116b022bedd1e86364bcaebb468e83d13690b, reversing changes made to 7a8838bd38ff51d630356a80eca424d30bbc0175.