### PR TITLE
Exclude healthcheck endpoints from maintenance mode

### DIFF
--- a/app/middleware/maintenance_mode.rb
+++ b/app/middleware/maintenance_mode.rb
@@ -4,7 +4,7 @@ class MaintenanceMode
   end
 
   def call(env)
-    if maintenance_enabled?
+    if maintenance_enabled? && !healthcheck_request?(env)
       return [503, { "Content-Type" => "text/html" }, [maintenance_page]]
     end
 
@@ -12,6 +12,10 @@ class MaintenanceMode
   end
 
 private
+
+  def healthcheck_request?(env)
+    env.fetch("PATH_INFO").start_with?("/healthcheck")
+  end
 
   def maintenance_enabled?
     value = ENV["MAINTENANCE_MODE"]

--- a/test/integration/healthcheck_test.rb
+++ b/test/integration/healthcheck_test.rb
@@ -5,6 +5,48 @@ class HealthcheckTest < LegacyIntegrationTest
     JSON.parse(response.body)
   end
 
+  context "live check" do
+    should "return a 200 OK when maintenance mode is implicitly disabled" do
+      get "/healthcheck/live"
+      assert_response :success
+    end
+
+    should "return a 200 OK when maintenance mode is explicitly disabled" do
+      ClimateControl.modify MAINTENANCE_MODE: "false" do
+        get "/healthcheck/live", env: { "MAINTENANCE_MODE" => "false" }
+        assert_response :success
+      end
+    end
+
+    should "return a 200 OK when maintenance mode is enabled" do
+      ClimateControl.modify MAINTENANCE_MODE: "true" do
+        get "/healthcheck/live"
+        assert_response :success
+      end
+    end
+  end
+
+  context "ready check" do
+    should "return a 200 OK when maintenance mode is implicitly disabled" do
+      get "/healthcheck/ready"
+      assert_response :success
+    end
+
+    should "return a 200 OK when maintenance mode is explicitly disabled" do
+      ClimateControl.modify MAINTENANCE_MODE: "false" do
+        get "/healthcheck/ready", env: { "MAINTENANCE_MODE" => "false" }
+        assert_response :success
+      end
+    end
+
+    should "return a 200 OK when maintenance mode is enabled" do
+      ClimateControl.modify MAINTENANCE_MODE: "true" do
+        get "/healthcheck/ready"
+        assert_response :success
+      end
+    end
+  end
+
   context "scheduled count matches queue length" do
     setup do
       Edition.stubs(:scheduled_for_publishing).returns(stub(count: 0))


### PR DESCRIPTION
If the healthcheck endpoints return an error, then the kubernetes pods will be treated as unhealthy and restarted automatically, which will cause an infinite loop of restarts—ensure the healthcheck endpoints return a happy status even when maintenance mode is enabled.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️