### PR TITLE
Make the maintenance mode message more generic

### DIFF
--- a/app/views/maintenance/index.html.erb
+++ b/app/views/maintenance/index.html.erb
@@ -9,8 +9,6 @@
     </style>
   </head>
   <body>
-    <h1> Maintenance in Progress</h1>
-    <p>Our system is temporarily unavailable.<br>
-       We expect it to be back on Tuesday, 5 August 10:00am.</p>
+    <h1>Publisher is currently down to enable testing</h1>
   </body>
 </html>


### PR DESCRIPTION
Since the date/times for maintenance are in flux, keep the maintenance
 message more generic so we don't need to keep changing it.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
