### PR TITLE
Tagging refinement

### DIFF
--- a/app/assets/javascripts/legacy_modules/related_content_items_select.js
+++ b/app/assets/javascripts/legacy_modules/related_content_items_select.js
@@ -60,7 +60,7 @@
       var $dragEl = $('<span class="input-group-addon">↕</span>')
       var $inputEl = $('<input />', {
         type: 'text',
-        name: 'tagging_tagging_update_form[ordered_related_items][]',
+        name: 'tagging_legacy_tagging_update_form[ordered_related_items][]',
         value: path,
         class: 'form-control',
         readonly: true

--- a/app/controllers/legacy_editions_controller.rb
+++ b/app/controllers/legacy_editions_controller.rb
@@ -377,7 +377,7 @@ private
   end
 
   def tagging_update_form
-    Tagging::TaggingUpdateForm.build_from_publishing_api(
+    Tagging::LegacyTaggingUpdateForm.build_from_publishing_api(
       @resource.artefact.content_id,
       @resource.artefact.language,
     )
@@ -396,7 +396,7 @@ private
   end
 
   def tagging_update_form_params
-    params[:tagging_tagging_update_form].permit(
+    params[:tagging_legacy_tagging_update_form].permit(
       :content_id,
       :previous_version,
       :parent,

--- a/app/views/shared/_tagging.html.erb
+++ b/app/views/shared/_tagging.html.erb
@@ -83,7 +83,7 @@
             <ul class="list-unstyled js-list-sortable js-base-path-list">
             <% Array(@tagging_update.ordered_related_items).each do |related_item| %>
               <li>
-                <%= text_field_tag "tagging_tagging_update_form[ordered_related_items][]",
+                <%= text_field_tag "tagging_legacy_tagging_update_form[ordered_related_items][]",
                       related_item["base_path"],
                       class: "form-control",
                       data: { title: related_item["title"] } %>
@@ -91,7 +91,7 @@
             <% end %>
             <% 5.times do %>
               <li>
-                <%= text_field_tag "tagging_tagging_update_form[ordered_related_items][]", "",
+                <%= text_field_tag "tagging_legacy_tagging_update_form[ordered_related_items][]", "",
                       class: "form-control" %>
               </li>
             <% end %>

--- a/test/integration/tagging_test.rb
+++ b/test/integration/tagging_test.rb
@@ -97,7 +97,7 @@ class TaggingTest < LegacyJavascriptIntegrationTest
       switch_tab "Tagging"
 
       ordered_related_items_fields = all(
-        'input[name="tagging_tagging_update_form[ordered_related_items][]"]',
+        'input[name="tagging_legacy_tagging_update_form[ordered_related_items][]"]',
       )
 
       assert ordered_related_items_fields[0].value, "/vat-returns"
@@ -109,11 +109,11 @@ class TaggingTest < LegacyJavascriptIntegrationTest
       click_on "Add related item"
 
       within :xpath, '//ul[contains(@class,"js-base-path-list")]/li[1]' do
-        assert page.has_field?("tagging_tagging_update_form[ordered_related_items][]", with: "/vat-returns")
+        assert page.has_field?("tagging_legacy_tagging_update_form[ordered_related_items][]", with: "/vat-returns")
       end
 
       within :xpath, '//ul[contains(@class,"js-base-path-list")]/li[2]' do
-        assert page.has_field?("tagging_tagging_update_form[ordered_related_items][]", with: "/reclaim-vat")
+        assert page.has_field?("tagging_legacy_tagging_update_form[ordered_related_items][]", with: "/reclaim-vat")
       end
 
       stub_publishing_api_has_lookups(
@@ -146,7 +146,6 @@ class TaggingTest < LegacyJavascriptIntegrationTest
     end
 
     should "tag to parent" do
-      skip("Skipping for deployment banners temporarily as causing issues.")
       visit_edition @edition
       switch_tab "Tagging"
 


### PR DESCRIPTION
[Trello](https://trello.com/c/y4G5SwHu/706-tagging-add-and-edit-data-in-related-content-summary-card)

This makes some additional renaming in the legacy controller and associated areas, which was missed in the original PR ([PR#2790](https://github.com/alphagov/publisher/pull/2790)) to implement the tagging for related content. This is necessary because of the creation of a new `UpdateTaggingForm` during that work and the renaming of the existing one to `LegacyUpdateTaggingForm`. 