### PR TITLE
Enable team ownership for Publisher repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@alphagov/gov-uk-publishing-developers


### PR DESCRIPTION
This commit prevents anyone outside of the Publishing team involved with the PSQL migration from merging pull requests into Publisher.

https://github.com/orgs/alphagov/teams/gov-uk-publishing-developers

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
