### PR TITLE
Disable auto-merging of dependabot PRs

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,6 +1,6 @@
 api_version: 2
 defaults:
-  auto_merge: true
+  auto_merge: false
   update_external_dependencies: false # TODO: enable after verifying that this repo meets the conditions
 overrides:
   - dependency: rails # should be upgraded manually, see https://docs.publishing.service.gov.uk/manual/keeping-software-current.html#rails


### PR DESCRIPTION
We don't want dependabot mergers to occur while we're carrying out database migration work. Temporarily disable auto-merging until we've completed migrations.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️