### PR TITLE
Disable fact check processing in maintenance mode

### DIFF
--- a/app/lib/fact_check_email_handler.rb
+++ b/app/lib/fact_check_email_handler.rb
@@ -27,6 +27,11 @@ class FactCheckEmailHandler
 
   # takes an optional block to call after processing each message
   def process
+    if maintenance_mode_enabled?
+      Rails.logger.info "Skipping processing of fact check emails because maintenance mode is enabled."
+      return
+    end
+
     unprocessed_emails_count = 0
 
     mail = get_gmail_inbox
@@ -88,5 +93,10 @@ class FactCheckEmailHandler
       google_id,
       Google::Apis::GmailV1::ModifyMessageRequest.new(remove_label_ids: %w[INBOX UNREAD]),
     )
+  end
+
+  def maintenance_mode_enabled?
+    value = ENV.fetch("MAINTENANCE_MODE", "false")
+    value == "true"
   end
 end

--- a/test/unit/lib/fact_check_email_handler_test.rb
+++ b/test/unit/lib/fact_check_email_handler_test.rb
@@ -48,4 +48,22 @@ class FactCheckEmailHandlerTest < ActiveSupport::TestCase
 
     local_handler.process
   end
+
+  test "#process does not process emails when in maintenance mode" do
+    ClimateControl.modify(MAINTENANCE_MODE: "true") do
+      handler = handler(message)
+      handler.expects(:authenticate_gmail).never
+
+      handler.process
+    end
+  end
+
+  test "#process processes emails when maintenance mode is explicitly disabled" do
+    ClimateControl.modify(MAINTENANCE_MODE: "false") do
+      handler = handler(message)
+      handler.expects(:authenticate_gmail).once
+
+      handler.process
+    end
+  end
 end


### PR DESCRIPTION
Prevent fact check emails from being processed when Publisher is in
 maintenance mode. The whole point of maintenance mode is to prevent
 writes to the database, so we don't want fact check responses to be
 written.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️