### PR TITLE
Fix tests after Maslow code removal

### DIFF
--- a/app/lib/tagging/tagging_update_form.rb
+++ b/app/lib/tagging/tagging_update_form.rb
@@ -10,7 +10,6 @@ module Tagging
         content_id: tagging_update_params["content_id"],
         previous_version: tagging_update_params["previous_version"],
         organisations: tagging_update_params["organisations"],
-        meets_user_needs: tagging_update_params["meets_user_needs"],
         mainstream_browse_pages: tagging_update_params["mainstream_browse_pages"],
         ordered_related_items: tagging_update_params["ordered_related_items"],
         ordered_related_items_destroy: tagging_update_params["ordered_related_items_destroy"],

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -560,7 +560,6 @@ class EditionEditTest < IntegrationTest
         assert_requested :patch,
                          "#{Plek.find('publishing-api')}/v2/links/#{@draft_edition.content_id}",
                          body: { "links": { "organisations": %w[9a9111aa-1db8-4025-8dd2-e08ec3175e72],
-                                            "meets_user_needs": [],
                                             "mainstream_browse_pages": %w[CONTENT-ID-CAPITAL CONTENT-ID-RTI CONTENT-ID-VAT],
                                             "ordered_related_items": %w[91fef6f6-3a59-42ab-a14d-42c4e5eee1a1 853feaf2-152c-4aa5-8edb-ba84a88860bf 830e403b-7d81-45f1-8862-81dcd55b4ec7 5cb58486-0b00-4da8-8076-382e474b4f03],
                                             "parent": %w[CONTENT-ID-CAPITAL] },


### PR DESCRIPTION
PR #2785 removed references to Maslow (via "meets user needs"), but
 there were some extra references added between that PR being raised and
 then being merged. Delete the extra, unnecessary references.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️