### PR TITLE
Local setup readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,83 @@ This is a Rails application and should follow [our Rails app conventions](https:
 
 You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) to run the application and its tests with all the necessary dependencies.  Follow [the usage instructions](https://github.com/alphagov/govuk-docker#usage) to get started.
 
-**Use GOV.UK Docker to run any commands that follow.**
+### Setting up Publisher
+**You will need the [GDS CLI installed and configured](https://docs.publishing.service.gov.uk/manual/get-started.html#7-install-and-configure-the-gds-cli) for these instructions.**
 
+
+You can use GOV.UK Docker to run Publisher locally in your web browser. Some additional setup is required to populate the database and properly connect to the Publishing API for features such as tagging.
+
+After following the instructions above to set up GOV.UK Docker, navigate to `~/govuk/govuk-docker` and then pull and build Publisher and all its dependencies using:
+```sh
+make publisher
+```
+This step only needs doing once, after this it will pick up changes to your local branches.
+
+Still in the `~/govuk/govuk-docker` folder, you can download a copy of the Publisher database with test data and install it to your Publisher container with:
+
+```sh
+govuk-docker run publisher-lite bundle exec rake db:drop 
+``` 
+(optional, but recommended if you're not working from a blank slate)
+```sh
+govuk-docker run publisher-lite bundle exec rake db:setup
+``` 
+```sh
+gds aws govuk-integration-developer ./bin/replicate-mongodb.sh publisher
+``` 
+
+The test user `James Stewart` does not have any permissions by default, so you will need to add them. Open the rails console with:
+```sh
+govuk-docker run publisher-lite bundle exec rails c
+ ```
+And then run:
+
+```ruby
+u = User.first
+```
+```ruby
+u.permissions.append("govuk_editor", "skip_review", "welsh_editor")
+```
+```ruby
+u.save
+```
+and finally `exit` out of the console.
+
+### Setting up Publishing API
+Some features such as tagging also require Publishing API to have a fully populated database.
+
+First off, go into your Docker settings and under Resources increase the disk usage maximum limit. The default 128gb is not enough to properly run both Publisher and Publisher API. 
+
+Increasing the CPU and Memory limits is also recommended to make the resource heavy processing steps quicker. Memory and CPU can be reduced if needed once everything is set up.
+
+Make sure that you're still in the `~/govuk/govuk-docker` folder and, similarly to publisher, run:
+
+```sh
+govuk-docker run publishing-api-lite bundle exec rake db:drop 
+```
+```sh
+govuk-docker run publishing-api-lite bundle exec rake db:setup
+``` 
+```sh
+gds aws govuk-integration-developer ./bin/replicate-postgresql.sh publishing-api
+``` 
+The file for Publishing API is significantly larger than Publisher itself (approx 70gb). Depending on your internet connection, it will likely take over an hour to download, and slightly longer than that again to install.
+
+While the database is building after the download, the shell output for that step isn't fully accurate. It will reach 100%, and then appear to hang in the terminal. Looking directly at the logs in the `govuk-docker` postgres container will show it still working. Be patient, and the process will eventually  finish and exit on its own.
+
+If you experience an interruption during this process, your database will be left in a corrupted state. If this happens, re-run the `rake db:drop` and `rake db:setup` steps followed by `make publishing-api`. It will re-use the downloaded dump file as part of this command.
+
+### Running Locally
+With both databases set up, the app can now be run locally. In one terminal tab run:
+```sh
+govuk-docker up publishing-api-app
+```
+
+And then  in a second:
+```sh
+govuk-docker up publisher-app
+```
+You can now access your local Publisher at http://publisher.dev.gov.uk/
 ### Testing
 
 The default `rake` task runs all the tests:

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ You can now access your local Publisher at http://publisher.dev.gov.uk/
 The default `rake` task runs all the tests:
 
 ```sh
-bundle exec rake
+govuk-docker run publisher-lite bundle exec rake
 ```
 
 ### State machine
@@ -127,7 +127,7 @@ A diagram of the current state machine can be seen here: [state machine diagram]
 The diagram can be (re)generated using the [state_machines-graphviz gem](https://github.com/state-machines/state_machines-graphviz), by doing:
 
 ```sh
-bundle exec rake state_machines:draw CLASS=Edition TARGET=docs
+govuk-docker run publisher-lite bundle exec rake state_machines:draw CLASS=Edition TARGET=docs
 ```
 
 This will generate a diagram in the `docs/state_machines` folder.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ This is a Rails application and should follow [our Rails app conventions](https:
 
 You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) to run the application and its tests with all the necessary dependencies.  Follow [the usage instructions](https://github.com/alphagov/govuk-docker#usage) to get started.
 
+The current up-to-date version of GOV.UK Docker has been noted to have some compatibility issues with Publisher. For a known working version, after cloning the repository run:
+
+```shell
+git checkout 1b19821
+```
+
 ### Setting up Publisher
 **You will need the [GDS CLI installed and configured](https://docs.publishing.service.gov.uk/manual/get-started.html#7-install-and-configure-the-gds-cli) for these instructions.**
 


### PR DESCRIPTION
This PR is to capture and record the steup instructions I've been given to get my local copy of publisher working properly in the readme, to make that setup easier in the future for other new starters.

It updates the setup instructions in README.md to go into more depth on how to set up a properly working version Publisher, with fully populated test databases for Publisher itself and Publishing API.