### PR TITLE
744 tagging add edit data in breadcrumb summary card

### DIFF
--- a/app/views/editions/secondary_nav_tabs/_tagging.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_tagging.html.erb
@@ -12,13 +12,27 @@
         heading: heading_breadcrumb,
         body: "No breadcrumb set",
         link_text: "Set GOV.UK breadcrumb",
-        link_url: "#",
+        link_url: tagging_breadcrumb_page_edition_path,
       } %>
     <% else %>
+      <% if current_user.has_editor_permissions?(@edition) %>
+        <% actions =
+          [
+            {
+              label: "Edit",
+              href: tagging_breadcrumb_page_edition_path,
+            },
+          ]
+        %>
+      <% else %>
+        <% actions = [] %>
+      <% end %>
+
       <%= render partial: "secondary_nav_tabs/tagging/summary_card_full", locals: {
         type: "breadcrumb",
         heading: heading_breadcrumb,
         key_text: "Breadcrumb",
+        actions: actions,
       } %>
     <% end %>
 

--- a/app/views/editions/secondary_nav_tabs/tagging_breadcrumb_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/tagging_breadcrumb_page.html.erb
@@ -1,0 +1,44 @@
+<% @edition = @resource %>
+<% content_for :title_context, @edition.title %>
+<% content_for :page_title, "Set GOV.UK breadcrumb" %>
+<% content_for :title, "Set GOV.UK breadcrumb" %>
+
+<%= form_for (@tagging_update_form_values), url: update_tagging_edition_path(@resource) do |f| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/hint", {
+        text: "Select the browse page you want to appear in the breadcrumb",
+      } %>
+
+      <%= f.hidden_field :content_id %>
+      <%= f.hidden_field :previous_version %>
+      <%= f.hidden_field :tagging_type, value: "breadcrumb" %>
+      <% Array(@tagging_update_form_values.ordered_related_items).to_a.map { |item| item["base_path"] }.each do |base_path| %>
+        <%= f.hidden_field :ordered_related_items, value: base_path, multiple: true %>
+      <% end %>
+      <% Array(@tagging_update_form_values.mainstream_browse_pages).each do |page_id| %>
+        <%= f.hidden_field :mainstream_browse_pages, value: page_id, multiple: true %>
+      <% end %>
+      <% Array(@tagging_update_form_values.organisations).each do |org_id| %>
+        <%= f.hidden_field :organisations, value: org_id, multiple: true %>
+      <% end %>
+
+      <% @radio_groups.each do |radio_group| %>
+        <%= render "govuk_publishing_components/components/radio", {
+          name: "#{f.object_name}[parent][]",
+          heading: radio_group[:heading],
+          heading_size: "m",
+          small: true,
+          items: radio_group[:items],
+        } %>
+      <% end %>
+    </div>
+
+    <div class="govuk-grid-column-one-third options-sidebar">
+      <div class="sidebar-components">
+        <%= sidebar_options_heading %>
+        <%= sidebar_items_list(base_edition_sidebar_buttons(tagging_edition_path(@edition))) %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
         get "tagging_mainstream_browse_page"
         get "tagging_related_content_page"
         get "tagging_organisations_page"
+        get "tagging_breadcrumb_page"
         get "unpublish"
         get "unpublish/confirm-unpublish", to: "editions#confirm_unpublish", as: "confirm_unpublish"
         post "process_unpublish"

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -1525,6 +1525,47 @@ class EditionsControllerTest < ActionController::TestCase
     end
   end
 
+  context "#tagging_breadcrumb_page" do
+    setup do
+      stub_linkables_with_data
+    end
+
+    context "user has govuk_editor permission" do
+      should "render the 'Set GOV.UK breadcrumb' page" do
+        get :tagging_breadcrumb_page, params: { id: @edition.id }
+        assert_template "secondary_nav_tabs/tagging_breadcrumb_page"
+      end
+
+      should "render the tagging tab and display an error message if an error occurs during the request" do
+        Tagging::TaggingUpdateForm.stubs(:build_from_publishing_api).raises(StandardError)
+
+        get :tagging_breadcrumb_page, params: { id: @edition.id }
+
+        assert_template "show"
+        assert_equal "Due to a service problem, the request could not be made", flash[:danger]
+      end
+    end
+
+    context "user does not have editor permissions" do
+      should "render an error message if the user is not a govuk_editor" do
+        user = FactoryBot.create(:user)
+        login_as(user)
+
+        get :tagging_breadcrumb_page, params: { id: @edition.id }
+
+        assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
+      end
+
+      should "render an error message if the user has welsh_editor permission and the edition is not Welsh" do
+        login_as_welsh_editor
+
+        get :tagging_breadcrumb_page, params: { id: @edition.id }
+
+        assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
+      end
+    end
+  end
+
   context "#metadata" do
     should "alias to show method" do
       assert_equal EditionsController.new.method(:metadata).super_method.name, :show


### PR DESCRIPTION
[Trello](https://trello.com/c/D9X36Y7R/744-tagging-add-and-edit-data-in-set-govuk-breadcrumb-summary-card)

This work enables the user to add and edit data in the "Set GOV.UK breadcrumb" summary card. It involves: 
- Adding a new "Set GOV.UK breadcrumb" page that displays all available pages that can be set as a breadcrumb
- Linking this page to the summary page via the "Set GOV.UK breadcrumb" link
- Updating the controller to save the selected breadcrumb and display the correct success message
- Displaying the saved breadcrumb data in the summary card on the summary page
- Add the "Edit" link in the breadcrumb summary card to facilitate editing of the breadcrumb

|Page/scenario|Screenshot|
|-|-|
|Summary page, empty state: user clicks on "Set GOV.UK breadcrumb"|<img width="760" height="288" alt="Screenshot 2025-08-18 at 10 10 28" src="https://github.com/user-attachments/assets/53ff9826-8053-4853-98fb-6741a7fe7e8d" />|
|User is taken to the new "Set GOV.UK breadcrumb" page, displaying available browse pages with none selected|<img width="1150" height="937" alt="publisher dev gov uk_editions_6890ca8b6ad08b0029723191_tagging_breadcrumb_page" src="https://github.com/user-attachments/assets/a69a6b9d-260f-4373-8d43-6ec5d8e5433f" />|
|User selects a breadcrumb and saves. Theya re returned to the Summary page which shows a success banner and an updated summary card including an "Edit" link|<img width="1151" height="783" alt="Screenshot 2025-08-18 at 10 17 06" src="https://github.com/user-attachments/assets/b4a9f215-475c-4db3-ab8e-8abdfc903e54" />|
|User clicks on "Edit" and is taken back to the "Set GOV.UK breadcrumb" page with the selected breadcrumb displayed|<img width="1151" height="940" alt="Screenshot 2025-08-18 at 10 21 05" src="https://github.com/user-attachments/assets/787ec403-1b9e-48bf-87f9-9e66380f7e06" />|