### PR TITLE
Disable auto-merge of dependabot updates

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,6 +1,6 @@
 api_version: 2
 defaults:
-  auto_merge: true
+  auto_merge: false
   update_external_dependencies: false # TODO: enable after verifying that this repo meets the conditions
 overrides:
   - dependency: rails # should be upgraded manually, see https://docs.publishing.service.gov.uk/manual/keeping-software-current.html#rails


### PR DESCRIPTION
Prevent auto-merges so that deployments don't get triggered while we migrate data from MongoDB to PostgreSQL