### PR TITLE
Enable the deployment of publisher-on-pg app to production environment

### DIFF
--- a/.github/workflows/deploy_mongo_to_pg.yml
+++ b/.github/workflows/deploy_mongo_to_pg.yml
@@ -16,6 +16,7 @@ on:
         options:
         - integration
         - staging
+        - production
         default: 'integration'
   release:
     types: [released]


### PR DESCRIPTION
The deployment is necessary for our final migration to PostgreSQL (from Mongo). 