### PR TITLE
745 tagging remove breadcrumb

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -41,7 +41,8 @@ class EditionsController < InheritedResources::Base
                          tagging_reorder_related_content_page
                          tagging_related_content_page
                          tagging_organisations_page
-                         tagging_breadcrumb_page] do
+                         tagging_breadcrumb_page
+                         tagging_remove_breadcrumb_page] do
     require_editor_permissions
   end
   before_action only: %i[confirm_destroy destroy] do
@@ -102,13 +103,17 @@ class EditionsController < InheritedResources::Base
                         "Organisations updated"
                       when "breadcrumb"
                         "GOV.UK breadcrumbs updated"
+                      when "remove_breadcrumb"
+                        "GOV.UK breadcrumb removed"
                       else
                         "Tags have been updated!"
                       end
 
     create_tagging_update_form_values(tagging_update_params)
 
-    if @tagging_update_form_values.valid?
+    if params[:tagging_tagging_update_form][:tagging_type] == "remove_breadcrumb" && params[:tagging_tagging_update_form][:remove_parent] == "no"
+      redirect_to tagging_edition_path
+    elsif @tagging_update_form_values.valid?
       @tagging_update_form_values.publish!
       flash[:success] = success_message
       redirect_to tagging_edition_path
@@ -134,6 +139,11 @@ class EditionsController < InheritedResources::Base
     Rails.logger.error "Error #{e.class} #{e.message}"
     flash.now[:danger] = SERVICE_REQUEST_ERROR_MESSAGE
     render "show"
+  end
+
+  def tagging_remove_breadcrumb_page
+    populate_tagging_form_values_from_publishing_api
+    render "secondary_nav_tabs/tagging_remove_breadcrumb_page"
   end
 
   def tagging_mainstream_browse_page

--- a/app/views/editions/secondary_nav_tabs/_tagging.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_tagging.html.erb
@@ -19,6 +19,10 @@
         <% actions =
           [
             {
+              label: "Remove",
+              href: tagging_remove_breadcrumb_page_edition_path,
+            },
+            {
               label: "Edit",
               href: tagging_breadcrumb_page_edition_path,
             },

--- a/app/views/editions/secondary_nav_tabs/tagging_remove_breadcrumb_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/tagging_remove_breadcrumb_page.html.erb
@@ -1,0 +1,45 @@
+<% @edition = @resource %>
+<% content_for :title_context, @edition.title %>
+<% content_for :title, "Are you sure you want to remove the breadcumb?" %>
+<% content_for :page_title, "Are you sure you want to remove the breadcumb?" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @tagging_update_form_values, url: update_tagging_edition_path(@resource) do |f| %>
+      <%= f.hidden_field :content_id %>
+      <%= f.hidden_field :previous_version %>
+      <%= f.hidden_field :tagging_type, value: "remove_breadcrumb" %>
+      <% Array(@tagging_update_form_values.ordered_related_items).to_a.map { |item| item["base_path"] }.each do |base_path| %>
+        <%= f.hidden_field :ordered_related_items, value: base_path, multiple: true %>
+      <% end %>
+      <% Array(@tagging_update_form_values.mainstream_browse_pages).each do |page_id| %>
+        <%= f.hidden_field :mainstream_browse_pages, value: page_id, multiple: true %>
+      <% end %>
+      <% Array(@tagging_update_form_values.organisations).each do |org_id| %>
+        <%= f.hidden_field :organisations, value: org_id, multiple: true %>
+      <% end %>
+
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "#{f.object_name}[remove_parent]",
+        hint: "Breadcrumbs are displayed at the top of the page and help users to navigate. There may be some situations where you do not need a breadcrumb to display (for example, on Welsh translation pages).",
+        items: [
+          {
+            value: "yes",
+            text: "Yes, remove the breadcrumb",
+          },
+          {
+            value: "no",
+            text: "No, keep the breadcrumb",
+          },
+        ],
+      } %>
+
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
+        } %>
+        <%= link_to("Cancel", tagging_edition_path(@edition), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Rails.application.routes.draw do
         get "tagging_reorder_related_content_page"
         get "tagging_organisations_page"
         get "tagging_breadcrumb_page"
+        get "tagging_remove_breadcrumb_page"
         get "unpublish"
         get "unpublish/confirm-unpublish", to: "editions#confirm_unpublish", as: "confirm_unpublish"
         post "process_unpublish"

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -1616,6 +1616,55 @@ class EditionsControllerTest < ActionController::TestCase
     end
   end
 
+  context "#tagging_remove_breadcrumb_page" do
+    setup do
+      stub_linkables_with_data
+    end
+
+    context "user has govuk_editor permission" do
+      should "render the remove breadcrumb page" do
+        get :tagging_remove_breadcrumb_page, params: { id: @edition.id }
+        assert_template "secondary_nav_tabs/tagging_remove_breadcrumb_page"
+      end
+    end
+
+    context "user does not have editor permissions" do
+      should "render an error message if the user is not a govuk_editor" do
+        user = FactoryBot.create(:user)
+        login_as(user)
+
+        get :tagging_remove_breadcrumb_page, params: { id: @edition.id }
+
+        assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
+      end
+
+      should "render an error message if the user has welsh_editor permission and the edition is not Welsh" do
+        login_as_welsh_editor
+
+        get :tagging_remove_breadcrumb_page, params: { id: @edition.id }
+
+        assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
+      end
+
+      should "render an error message if the user is not a govuk_editor and tries to remove breadcrumb" do
+        user = FactoryBot.create(:user)
+        login_as(user)
+
+        get :tagging_remove_breadcrumb_page, params: { id: @edition.id }
+
+        assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
+      end
+
+      should "render an error message if the user has welsh_editor permission and the edition is not Welsh and tries to remove breadcrumb" do
+        login_as_welsh_editor
+
+        get :tagging_remove_breadcrumb_page, params: { id: @edition.id }
+
+        assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
+      end
+    end
+  end
+
   context "#metadata" do
     should "alias to show method" do
       assert_equal EditionsController.new.method(:metadata).super_method.name, :show


### PR DESCRIPTION
**Trello :** https://trello.com/c/spnGIi5w/745-tagging-remove-breadcrumb-in-govuk-breadcrumb-summary-card

This PR enables the user to remove breadcrumb from the "Set GOV.UK breadcrumb" summary card. It involves

- Adding new remove breadcrumb page.
- Updating the controller to remove breadcrumb and show appropriate message.
- Add the relevant tests.

|Page/scenario|Screenshot|
|-|-|
|Tagging summary page: when a breadcrumb is set a "Remove" link is added to the summary card|<img width="758" height="178" alt="Screenshot 2025-08-22 at 14 55 54" src="https://github.com/user-attachments/assets/a1240b46-5c67-4b68-af6a-66a681329008" />|
|Clicking the "Remove" link takes the user to the newly created "Are you sure you want to remove the breadcumb?" page|<img width="758" height="428" alt="Screenshot 2025-08-22 at 14 57 44" src="https://github.com/user-attachments/assets/d8a25c1e-68af-4ff5-b083-fdcd8cf17ecc" />|
|Clicking the "Cancel" link or selecting "No, keep the breadcrumb" and clicking "Save" takes the user back to the summary page, which still displays the saved breadcrumb and the "Remove" llink|<img width="758" height="288" alt="Screenshot 2025-08-22 at 15 00 53" src="https://github.com/user-attachments/assets/ac1b9d27-7c27-437a-aeb4-7c9ab22f8515" />|
|Selecting "Yes, remove the breadcrumb" and clicking "Save" takes the user back to the summary page displaying a success message and an empty summary card|<img width="1148" height="782" alt="Screenshot 2025-08-22 at 15 03 18" src="https://github.com/user-attachments/assets/b7d18ab1-927a-425f-90f9-11d3de5a60cd" />|
