### PR TITLE
Update bootstrap UI to use correct counts

### DIFF
--- a/app/helpers/base_helper.rb
+++ b/app/helpers/base_helper.rb
@@ -19,7 +19,7 @@ module BaseHelper
         url = root_path(scope_path_options(scope))
 
         tag.a(href: url) do
-          h("#{status_label} ") + tag.span(presenter.send(scope).length, class: "badge pull-right")
+          h("#{status_label} ") + tag.span(presenter.send(scope).total_count, class: "badge pull-right")
         end
       end
     end

--- a/test/functional/legacy_root_controller_test.rb
+++ b/test/functional/legacy_root_controller_test.rb
@@ -61,4 +61,17 @@ class LegacyRootControllerTest < ActionController::TestCase
     )
     assert_select "td.title", /Stuff/i
   end
+
+  test "it shows a correct count in the 'filter by status' list when there are more than a page of results" do
+    FactoryBot.create_list(:edition, FilteredEditionsPresenter::ITEMS_PER_PAGE, :draft)
+    get(
+      :index,
+      params: {
+        user_filter: "all",
+      },
+    )
+
+    # There will be one more than created above, as there's a guide created in the setup
+    assert_select ".status-option.drafts", "Drafts #{FilteredEditionsPresenter::ITEMS_PER_PAGE + 1}"
+  end
 end

--- a/test/unit/presenters/filtered_editions_presenter_test.rb
+++ b/test/unit/presenters/filtered_editions_presenter_test.rb
@@ -181,6 +181,14 @@ class FilteredEditionsPresenterTest < ActiveSupport::TestCase
       assert_equal(FilteredEditionsPresenter::ITEMS_PER_PAGE, filtered_editions.count)
     end
 
+    should "make the total number of editions available when there's more than one page of results" do
+      FactoryBot.create_list(:guide_edition, FilteredEditionsPresenter::ITEMS_PER_PAGE + 1)
+
+      filtered_editions = FilteredEditionsPresenter.new(a_gds_user).editions
+
+      assert_equal(FilteredEditionsPresenter::ITEMS_PER_PAGE + 1, filtered_editions.total_count)
+    end
+
     should "return the specified 'page' of results" do
       FactoryBot.create_list(:guide_edition, FilteredEditionsPresenter::ITEMS_PER_PAGE + 1)
 


### PR DESCRIPTION
The counts used in the "Filter by status" box in the top left corner of the publications page were incorrectly showing the number of editions in a page rather than the total count when there were more than a page's worth of editions in a state. Update to get the total count instead.