### PR TITLE
Fix saving of local transaction editions

### DIFF
--- a/app/controllers/legacy_editions_controller.rb
+++ b/app/controllers/legacy_editions_controller.rb
@@ -268,9 +268,9 @@ protected
         :introduction,
         :more_information,
         :need_to_know,
-        { scotland_availability_attributes: %i[type alternative_url] },
-        { wales_availability_attributes: %i[type alternative_url] },
-        { northern_ireland_availability_attributes: %i[type alternative_url] },
+        { scotland_availability_attributes: %i[authority_type alternative_url] },
+        { wales_availability_attributes: %i[authority_type alternative_url] },
+        { northern_ireland_availability_attributes: %i[authority_type alternative_url] },
       ]
     when :place_edition
       %i[

--- a/app/views/local_transactions/_devolved_administrations.html.erb
+++ b/app/views/local_transactions/_devolved_administrations.html.erb
@@ -10,7 +10,7 @@
     <div class="form-group">
       <div class="radio">
         <%= f.label :type_local_authority_service, class: "control-label" do %>
-          <%= f.radio_button :type, "local_authority_service", disabled: @resource.locked_for_edits? %>
+          <%= f.radio_button :authority_type, "local_authority_service", disabled: @resource.locked_for_edits? %>
           Service available from local council
         <% end %>
       </div>
@@ -19,7 +19,7 @@
     <div class="form-group">
       <div class="radio">
         <%= f.label :type_devolved_administration_service, class: "control-label" do %>
-          <%= f.radio_button :type, "devolved_administration_service", disabled: @resource.locked_for_edits? %>
+          <%= f.radio_button :authority_type, "devolved_administration_service", disabled: @resource.locked_for_edits? %>
           Service available from devolved administration (or a similar service is available)
         <% end %>
       </div>
@@ -32,7 +32,7 @@
     <div class="form-group">
       <div class="radio">
         <%= f.label :type_unavailable, class: "control-label" do %>
-          <%= f.radio_button :type, "unavailable", disabled: @resource.locked_for_edits? %>
+          <%= f.radio_button :authority_type, "unavailable", disabled: @resource.locked_for_edits? %>
           Service not available
         <% end %>
       </div>

--- a/test/integration/local_transaction_create_edit_test.rb
+++ b/test/integration/local_transaction_create_edit_test.rb
@@ -121,6 +121,25 @@ class LocalTransactionCreateEditTest < LegacyJavascriptIntegrationTest
 
       save_edition_and_assert_error("Enter a title", "#edition_title")
     end
+
+    should "save devolved administration availability fields" do
+      edition = FactoryBot.create(
+        :local_transaction_edition,
+        panopticon_id: @artefact.id,
+        slug: @artefact.slug,
+        title: "Foo transaction",
+        lgsl_code: 1,
+        lgil_code: 2,
+      )
+
+      visit_edition edition
+      choose "Service available from local council", name: "edition[scotland_availability_attributes][authority_type]"
+      choose "Service available from devolved administration (or a similar service is available)", name: "edition[wales_availability_attributes][authority_type]"
+      fill_in "Enter the URL of the devolved administration website page", with: "https://test", name: "edition[wales_availability_attributes][alternative_url]"
+      choose "Service not available", name: "edition[northern_ireland_availability_attributes][authority_type]"
+
+      save_edition_and_assert_success
+    end
   end
 
   should "disable fields for a published edition" do


### PR DESCRIPTION
- Type field was previously renamed to 'authority_type' but radio buttons had not been updated to match.
- Added missing test coverage to catch this in future
