### PR TITLE
Fix postgres issues related to dependencies and cloning

### DIFF
--- a/app/models/local_transaction_edition.rb
+++ b/app/models/local_transaction_edition.rb
@@ -47,8 +47,11 @@ class LocalTransactionEdition < ApplicationRecord
   def copy_to(new_edition)
     if new_edition.editionable.is_a?(LocalTransactionEdition)
       new_edition.editionable.scotland_availability = scotland_availability.clone
+      new_edition.editionable.scotland_availability.mongo_id = nil
       new_edition.editionable.wales_availability = wales_availability.clone
+      new_edition.editionable.wales_availability.mongo_id = nil
       new_edition.editionable.northern_ireland_availability = northern_ireland_availability.clone
+      new_edition.editionable.northern_ireland_availability.mongo_id = nil
     end
     new_edition
   end

--- a/app/models/parted.rb
+++ b/app/models/parted.rb
@@ -15,7 +15,11 @@ module Parted
     # If the new edition is of the same type or another type that has parts,
     # copy over the parts from this edition
     if new_edition.editionable.respond_to?(:parts)
-      new_edition.editionable.parts = parts.map(&:dup)
+      new_edition.editionable.parts = parts.map do |part|
+        part_copy = part.dup
+        part_copy.mongo_id = nil
+        part_copy
+      end
     end
 
     new_edition

--- a/test/models/edition_test.rb
+++ b/test/models/edition_test.rb
@@ -240,6 +240,23 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal 3, clone1.version_number
   end
 
+  test "cloning an edition should not copy the mongo_id from the previous edition" do
+    edition = FactoryBot.create(
+      :guide_edition,
+      state: "published",
+      panopticon_id: @artefact.id,
+      version_number: 1,
+      title: "Dolly the sheep",
+      overview: "To be cloned",
+      in_beta: true,
+      owning_org_content_ids: %w[org-1],
+      mongo_id: "12345mongo",
+    )
+    clone_edition = edition.build_clone
+
+    assert_nil clone_edition.mongo_id
+  end
+
   # test cloning into different edition types
   Edition.subclasses.permutation(2).each do |source_class, destination_class|
     next if source_class.instance_of?(PopularLinksEdition.class) || destination_class.instance_of?(PopularLinksEdition.class)

--- a/test/models/local_transaction_edition_test.rb
+++ b/test/models/local_transaction_edition_test.rb
@@ -72,4 +72,23 @@ class LocalTransactionEditionTest < ActiveSupport::TestCase
     assert_equal edition.scotland_availability.authority_type, "devolved_administration_service"
     assert_not cloned_edition.editionable.respond_to?(:scotland_availability)
   end
+
+  should "not copy the devolved administration availability mongo_id fields when cloning an edition" do
+    edition = FactoryBot.build(
+      :local_transaction_edition,
+      panopticon_id: @artefact.id,
+      state: "published",
+      scotland_availability: FactoryBot.build(:scotland_availability, alternative_url: "https://test.com", mongo_id: "OldMongoId1"),
+      wales_availability: FactoryBot.build(:wales_availability, alternative_url: "https://test.com", mongo_id: "OldMongoId2"),
+      northern_ireland_availability: FactoryBot.build(:northern_ireland_availability, alternative_url: "https://test.com", mongo_id: "OldMongoId3"),
+    )
+
+    edition.save!(validate: false)
+    cloned_edition = edition.build_clone
+    cloned_edition.save!(validate: false)
+
+    assert_nil cloned_edition.scotland_availability.mongo_id
+    assert_nil cloned_edition.wales_availability.mongo_id
+    assert_nil cloned_edition.northern_ireland_availability.mongo_id
+  end
 end

--- a/test/models/local_transaction_edition_test.rb
+++ b/test/models/local_transaction_edition_test.rb
@@ -35,9 +35,9 @@ class LocalTransactionEditionTest < ActiveSupport::TestCase
       :local_transaction_edition,
       panopticon_id: @artefact.id,
       state: "published",
-      scotland_availability: FactoryBot.build(:scotland_availability, alternative_url: "https://test.com"),
-      wales_availability: FactoryBot.build(:wales_availability, alternative_url: "https://test.com"),
-      northern_ireland_availability: FactoryBot.build(:northern_ireland_availability, alternative_url: "https://test.com"),
+      scotland_availability: FactoryBot.build(:scotland_availability, alternative_url: "https://test.com", authority_type: "local_authority_service"),
+      wales_availability: FactoryBot.build(:wales_availability, alternative_url: "https://test.com", authority_type: "devolved_administration_service"),
+      northern_ireland_availability: FactoryBot.build(:northern_ireland_availability, alternative_url: "https://test.com", authority_type: "unavailable"),
     )
 
     edition.save!(validate: false)
@@ -47,9 +47,12 @@ class LocalTransactionEditionTest < ActiveSupport::TestCase
 
     assert_equal edition.scotland_availability.type, cloned_edition.scotland_availability.type
     assert_equal edition.scotland_availability.alternative_url, cloned_edition.scotland_availability.alternative_url
+    assert_equal edition.scotland_availability.authority_type, cloned_edition.scotland_availability.authority_type
     assert_equal edition.wales_availability.type, cloned_edition.wales_availability.type
     assert_equal edition.wales_availability.alternative_url, cloned_edition.wales_availability.alternative_url
+    assert_equal edition.wales_availability.authority_type, cloned_edition.wales_availability.authority_type
     assert_equal edition.northern_ireland_availability.type, cloned_edition.northern_ireland_availability.type
+    assert_equal edition.northern_ireland_availability.authority_type, cloned_edition.northern_ireland_availability.authority_type
   end
 
   should "not copy the devolved administration availability fields when new edition is not a LocalTransactionEdition" do

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -325,16 +325,37 @@ FactoryBot.define do
   end
 
   factory :guide_edition_with_two_parts, parent: :guide_edition do
-    after :build do |getp|
-      getp.parts.build(
+    after :build do |guide_edition|
+      guide_edition.parts.build(
         title: "PART !",
         body: "This is some version text.",
         slug: "part-one",
+        order: 1,
       )
-      getp.parts.build(
+      guide_edition.parts.build(
         title: "PART !!",
         body: "This is some more version text.",
         slug: "part-two",
+        order: 2,
+      )
+    end
+  end
+
+  factory :guide_edition_and_parts_have_mongo_ids, parent: :guide_edition do
+    after :build do |guide_edition|
+      guide_edition.parts.build(
+        title: "PART !",
+        body: "This is some version text.",
+        slug: "part-one",
+        order: 1,
+        mongo_id: "MongoIsNoMore1",
+      )
+      guide_edition.parts.build(
+        title: "PART !!",
+        body: "This is some more version text.",
+        slug: "part-two",
+        order: 2,
+        mongo_id: "MongoIsNoMore2",
       )
     end
   end

--- a/test/unit/edition_duplicator_test.rb
+++ b/test/unit/edition_duplicator_test.rb
@@ -8,7 +8,7 @@ class EditionDuplicatorTest < ActiveSupport::TestCase
   setup do
     @laura = FactoryBot.create(:user, :govuk_editor)
     @fred  = FactoryBot.create(:user, :govuk_editor)
-    @guide = FactoryBot.create(:guide_edition)
+    @guide = FactoryBot.create(:guide_edition, mongo_id: "MongoIsNoMore1")
     stub_register_published_content
   end
 
@@ -46,6 +46,15 @@ class EditionDuplicatorTest < ActiveSupport::TestCase
     command.duplicate
 
     assert_nil command.new_edition.assigned_to
+  end
+
+  test "should not copy the old mongo ID to the new edition" do
+    publish_item(@guide, @laura)
+
+    command = EditionDuplicator.new(@guide, @laura)
+    command.duplicate
+
+    assert_nil command.new_edition.mongo_id
   end
 
   test "can provide an appropriate error message if new edition failed" do

--- a/test/unit/guide_edition_test.rb
+++ b/test/unit/guide_edition_test.rb
@@ -16,7 +16,7 @@ class GuideEditionTest < ActiveSupport::TestCase
     user = FactoryBot.create(:user, :govuk_editor, uid: "123", name: "Ben")
     other_user = FactoryBot.create(:user, :govuk_editor, uid: "321", name: "James")
 
-    guide = user.create_edition(:guide, panopticon_id: FactoryBot.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title")
+    guide = user.create_edition(:guide, panopticon_id: FactoryBot.create(:artefact).id, overview: "My Overview", title: "My Title", slug: "my-title", mongo_id: "OldMongoId1")
     edition = guide
     request_review(user, edition)
     approve_review(other_user, edition)
@@ -54,6 +54,13 @@ class GuideEditionTest < ActiveSupport::TestCase
 
     new_edition = user.new_version(edition)
     assert_equal edition.overview, new_edition.overview
+  end
+
+  test "cloning a guide should not copy the old mongo_id" do
+    _, guide = publisher_and_guide
+    cloned_edition = guide.published_edition.build_clone
+
+    assert_nil cloned_edition.mongo_id
   end
 
   test "it should trim whitespace from URLs" do

--- a/test/unit/guide_edition_test.rb
+++ b/test/unit/guide_edition_test.rb
@@ -56,11 +56,12 @@ class GuideEditionTest < ActiveSupport::TestCase
     assert_equal edition.overview, new_edition.overview
   end
 
-  test "cloning a guide should not copy the old mongo_id" do
-    _, guide = publisher_and_guide
-    cloned_edition = guide.published_edition.build_clone
+  test "cloning a guide with parts should not copy the old mongo_ids from parts" do
+    mongo_part_edition = FactoryBot.create(:guide_edition_and_parts_have_mongo_ids, panopticon_id: @artefact.id, state: "published")
+    cloned_edition = mongo_part_edition.build_clone
 
-    assert_nil cloned_edition.mongo_id
+    assert_nil cloned_edition.parts[0].mongo_id
+    assert_nil cloned_edition.parts[1].mongo_id
   end
 
   test "it should trim whitespace from URLs" do


### PR DESCRIPTION
- Add tests to ensure that mongo_ids in editions are not copied across when edition is cloned. (New editions do not need a mongo id as they never existed in the mongo db)
- Ensure that mongo ids for parts are not copied over when a guide edition is cloned
- Ensure that mongo ids for devolved administration availabilities are not copied over when a local transaction edition is cloned. 
