### PR TITLE
Fix flakey test in PrimaryListingPresenterTest

### DIFF
--- a/test/unit/primary_listing_presenter_test.rb
+++ b/test/unit/primary_listing_presenter_test.rb
@@ -150,13 +150,13 @@ class PrimaryListingPresenterTest < ActiveSupport::TestCase
     assert c.draft?
 
     presenter = PrimaryListingPresenter.new(Edition, bob)
-    assert_equal [b, c].sort_by(&:title), presenter.draft.to_a.sort_by(&:title)
+    assert_same_elements [b, c], presenter.draft.to_a
 
     presenter = PrimaryListingPresenter.new(Edition, :nobody)
-    assert_equal [a], presenter.draft.to_a
+    assert_same_elements [a], presenter.draft.to_a
 
     presenter = PrimaryListingPresenter.new(Edition, :all)
-    assert_equal [a, b, c].sort_by(&:title), presenter.draft.to_a.sort_by(&:title)
+    assert_same_elements [a, b, c], presenter.draft.to_a
   end
 
   test "can filter publications by title substring" do


### PR DESCRIPTION
The test only seems to care that the same items are returned, irregardless of order (since the sorting for both arrays is done in the test). Since all three editions that are created will have the same, default, title, sorting by title is non-deterministic—use the `assert_same_elements` matcher instead of sorting and using the `assert_equal` one.