### PR TITLE
745 tagging remove breadcrumb validation

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -117,7 +117,6 @@ class EditionsController < InheritedResources::Base
       elsif !params[:tagging_tagging_update_form][:remove_parent]
         @resource.errors.add(:remove_parent, "Select an option")
         render "secondary_nav_tabs/tagging_remove_breadcrumb_page"
-        # redirect_to tagging_remove_breadcrumb_page_edition_path
       else
         @tagging_update_form_values.publish!
         flash[:success] = success_message

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -111,8 +111,17 @@ class EditionsController < InheritedResources::Base
 
     create_tagging_update_form_values(tagging_update_params)
 
-    if params[:tagging_tagging_update_form][:tagging_type] == "remove_breadcrumb" && params[:tagging_tagging_update_form][:remove_parent] == "no"
-      redirect_to tagging_edition_path
+    if params[:tagging_tagging_update_form][:tagging_type] == "remove_breadcrumb"
+      if params[:tagging_tagging_update_form][:remove_parent] == "no"
+        redirect_to tagging_edition_path
+      elsif !params[:tagging_tagging_update_form][:remove_parent]
+        @resource.errors.add(:remove_parent, "Select an option")
+        render "secondary_nav_tabs/tagging_remove_breadcrumb_page"
+      else
+        @tagging_update_form_values.publish!
+        flash[:success] = success_message
+        redirect_to tagging_edition_path
+      end
     elsif @tagging_update_form_values.valid?
       @tagging_update_form_values.publish!
       flash[:success] = success_message

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -117,6 +117,7 @@ class EditionsController < InheritedResources::Base
       elsif !params[:tagging_tagging_update_form][:remove_parent]
         @resource.errors.add(:remove_parent, "Select an option")
         render "secondary_nav_tabs/tagging_remove_breadcrumb_page"
+        # redirect_to tagging_remove_breadcrumb_page_edition_path
       else
         @tagging_update_form_values.publish!
         flash[:success] = success_message

--- a/app/views/editions/secondary_nav_tabs/tagging_remove_breadcrumb_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/tagging_remove_breadcrumb_page.html.erb
@@ -5,6 +5,21 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% unless @edition.errors.empty? %>
+      <% content_for :error_summary do %>
+        <%= render("govuk_publishing_components/components/error_summary", {
+          id: "error-summary",
+          title: "There is a problem",
+          items: @edition.errors.map do |error|
+            {
+              text: error.message,
+              href: "##{error.attribute.to_s}",
+            }
+          end,
+        }) %>
+      <% end %>
+    <% end %>
+
     <%= form_for @tagging_update_form_values, url: update_tagging_edition_path(@resource) do |f| %>
       <%= f.hidden_field :content_id %>
       <%= f.hidden_field :previous_version %>
@@ -21,7 +36,9 @@
 
       <%= render "govuk_publishing_components/components/radio", {
         name: "#{f.object_name}[remove_parent]",
+        id: "remove_parent",
         hint: "Breadcrumbs are displayed at the top of the page and help users to navigate. There may be some situations where you do not need a breadcrumb to display (for example, on Welsh translation pages).",
+        error_message: @edition.errors.empty? ? nil : @edition.errors.first.message,
         items: [
           {
             value: "yes",

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -601,6 +601,11 @@ class EditionEditTest < IntegrationTest
       end
     end
 
+    should "display an error if the user tries to save with no option selected" do
+      click_button("Save")
+      assert page.has_text?("Select an option")
+    end
+
     should "redirect to tagging tab when Cancel link is clicked" do
       click_link("Cancel")
 


### PR DESCRIPTION
**Jira**: https://gov-uk.atlassian.net/jira/software/c/projects/MAIN/boards/1555?selectedIssue=MAIN-2105

This PR add the validation for remove breadcrumb page when user click on save  button without selecting an option.

**It does the following:**

- Add the validation on save button for remove breadcrumb page to prompt the user to select an option.
- Add the relevant tests

|Existing/updated journey|Current views|Updated views|
|-|-|-|
|Remove breadcrumb page: user clicks on "Save" without selecting an option|<img width="1148" height="433" alt="Screenshot 2025-09-11 at 10 57 14" src="https://github.com/user-attachments/assets/95a104d7-f318-44f6-9f86-c09e98a47a82" />|<img width="1148" height="433" alt="Screenshot 2025-09-11 at 10 57 14" src="https://github.com/user-attachments/assets/4d5aa4df-ce66-458f-85d8-2c950f3061f3" />|
|The user is currently returned to the summary page with a success message.<br /><br />The update displays an error message and the user remains on the Remove breadcrumb page|<img width="1148" height="720" alt="Screenshot 2025-09-11 at 11 02 16" src="https://github.com/user-attachments/assets/6ca45b52-68cd-4401-baba-5ddaa28089f2" />|<img width="1148" height="720" alt="Screenshot 2025-09-11 at 11 03 57" src="https://github.com/user-attachments/assets/343bf63c-1d00-4289-9f83-9e11ed11b3c3" />|