### PR TITLE
Remove config for the publisher-on-pg app

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -105,7 +105,6 @@ Rails.application.configure do
   # Enable DNS rebinding protection and other `Host` header attacks.
   config.hosts = [
     /publisher\..*\.gov.uk/,
-    /publisher-on-pg\..*\.gov.uk/,
   ]
 
   # Skip DNS rebinding protection for the default health check endpoint.


### PR DESCRIPTION
Now that the app has been deleted (following the completion of the migration work from MongoDB to PostgreSQL), we no longer need this configuration.