### PR TITLE
(CM-441) Update links to new Content Block Manager

### DIFF
--- a/app/models/host_content_update_event/action.rb
+++ b/app/models/host_content_update_event/action.rb
@@ -28,8 +28,7 @@ class HostContentUpdateEvent
 
     def block_url
       [
-        Plek.external_url_for("whitehall-admin"),
-        "content-block-manager",
+        Plek.external_url_for("content-block-manager"),
         "content-block",
         "content-id",
         host_content_update_event.content_id,

--- a/app/views/legacy_editions/_content_block_guidance.html.erb
+++ b/app/views/legacy_editions/_content_block_guidance.html.erb
@@ -3,6 +3,6 @@
 <div class="well">
   <p>
     To create, edit and use standardised content, go to the
-    <%= link_to "Content Block Manager (opens in new tab)", "#{Plek.external_url_for('whitehall-admin')}/content-block-manager", target: "_blank", rel: "noopener" %>.
+    <%= link_to "Content Block Manager (opens in new tab)", "#{Plek.external_url_for('content-block-manager')}", target: "_blank", rel: "noopener" %>.
   </p>
 </div>

--- a/test/models/host_content_update_event/action_test.rb
+++ b/test/models/host_content_update_event/action_test.rb
@@ -14,7 +14,7 @@ class HostContentUpdateEvent::ActionTest < ActiveSupport::TestCase
     assert_equal action.requester, host_content_update_event.author
     assert_equal action.to_s, "Content block updated"
     assert_equal action.comment, "Email address updated"
-    assert_equal action.block_url, "#{Plek.external_url_for('whitehall-admin')}/content-block-manager/content-block/content-id/#{content_id}"
+    assert_equal action.block_url, "#{Plek.external_url_for('content-block-manager')}/content-block/content-id/#{content_id}"
     assert_equal action.comment_sanitized, false
     assert_equal action.is_fact_check_request?, false
     assert_equal action.recipient_id, nil


### PR DESCRIPTION
We are moving Content Block Manager to its own app, so we need to update the URLs.

~~I'll leave this in draft until the move is complete.~~