### PR TITLE
Added govuk link styling to links within inset texts to follow conven…

### DIFF
--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -34,13 +34,13 @@
         <% if @edition.latest_status_action.requester == current_user %>
           <p class="govuk-body">You've sent this edition to be reviewed</p>
           <% if current_user.skip_review? %>
-            <p class="govuk-body"><%= link_to("Skip review", skip_review_page_edition_path) %></p>
+            <p class="govuk-body"><%= link_to("Skip review", skip_review_page_edition_path, class: "govuk-link") %></p>
           <% end %>
         <% else %>
           <p class="govuk-body"><%= @edition.latest_status_action.requester.name %> sent this edition to be reviewed</p>
           <% if current_user.has_editor_permissions?(@edition) %>
-            <p class="govuk-body"><%= link_to("Request amendments", request_amendments_page_edition_path) %></p>
-            <p class="govuk-body"><%= link_to("No changes needed", no_changes_needed_page_edition_path) %></p>
+            <p class="govuk-body"><%= link_to("Request amendments", request_amendments_page_edition_path, class: "govuk-link") %></p>
+            <p class="govuk-body"><%= link_to("No changes needed", no_changes_needed_page_edition_path, class: "govuk-link") %></p>
           <% end %>
         <% end %>
       <% end %>
@@ -54,9 +54,9 @@
               <p class="govuk-body"><%= @edition.latest_status_action.requester.name %> requested this edition to be fact checked.
                 We're awaiting a response.</p>
             <% end %>
-            <p class="govuk-body"><%= link_to("Resend fact check email", resend_fact_check_email_page_edition_path) %></p>
+            <p class="govuk-body"><%= link_to("Resend fact check email", resend_fact_check_email_page_edition_path, class: "govuk-link") %></p>
           <% end %>
-          <p class="govuk-body"><%= link_to("Request amendments", request_amendments_page_edition_path) %></p>
+          <p class="govuk-body"><%= link_to("Request amendments", request_amendments_page_edition_path, class: "govuk-link") %></p>
         <% end %>
       <% end %>
   <% end %>


### PR DESCRIPTION
[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/MAIN/boards/1555?selectedIssue=MAIN-4924)

Links within the dynamic inset text component on content item pages now follow [GOV.UK Design System link styling](https://design-system.service.gov.uk/styles/colour/).
