### PR TITLE
MAIN-4925 - Edit page readonly formatting bug

### DIFF
--- a/app/assets/stylesheets/edit.scss
+++ b/app/assets/stylesheets/edit.scss
@@ -2,6 +2,7 @@
   &--readonly {
     section > p {
       @extend .govuk-body; // stylelint-disable-line scss/at-extend-no-missing-placeholder
+      white-space: pre-line;
     }
   }
 

--- a/app/views/editions/secondary_nav_tabs/edit/readonly/_completed_transaction.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/readonly/_completed_transaction.html.erb
@@ -8,8 +8,7 @@
     heading_level: 3,
     font_size: "s",
   } %>
-  <p>
-    <%= case edition.promotion_choice.presence.to_sym when :promotion_choice
+  <p><%= case edition.promotion_choice.presence.to_sym when :promotion_choice
         when :organ_donor
           "Organ donation"
         when :bring_id_to_vote
@@ -21,8 +20,7 @@
         else
           "None added"
         end
-    %>
-  </p>
+    %></p>
 </section>
 
 <% if edition.promotion_choice != "none" %>
@@ -32,9 +30,7 @@
       heading_level: 3,
       font_size: "s",
     } %>
-    <p>
-      <%= edition.promotion_choice_url.presence || "None added" %>
-    </p>
+    <p><%= edition.promotion_choice_url.presence || "None added" %></p>
   </section>
 <% end %>
 
@@ -45,9 +41,7 @@
       heading_level: 3,
       font_size: "s",
     } %>
-    <p>
-      <%= edition.promotion_choice_opt_in_url.presence || "None added" %>
-    </p>
+    <p><%= edition.promotion_choice_opt_in_url.presence || "None added" %></p>
   </section>
 
   <section>

--- a/app/views/editions/secondary_nav_tabs/edit/readonly/_place.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/readonly/_place.html.erb
@@ -19,9 +19,7 @@
   heading_level: 3,
   font_size: "s",
 } %>
-  <p>
-    <%= edition.introduction.presence || "None added" %>
-  </p>
+  <p><%= edition.introduction.presence || "None added" %></p>
 </section>
 
 <section>
@@ -30,9 +28,7 @@
   heading_level: 3,
   font_size: "s",
 } %>
-  <p>
-    <%= edition.more_information.presence || "None added" %>
-  </p>
+  <p><%= edition.more_information.presence || "None added" %></p>
 </section>
 
 <section>
@@ -41,7 +37,5 @@
   heading_level: 3,
   font_size: "s",
 } %>
-  <p>
-    <%= edition.need_to_know.presence || "None added" %>
-  </p>
+  <p><%= edition.need_to_know.presence || "None added" %></p>
 </section>

--- a/app/views/editions/secondary_nav_tabs/edit/readonly/_transaction.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/readonly/_transaction.html.erb
@@ -8,9 +8,7 @@
     heading_level: 3,
     font_size: "s",
   } %>
-  <p>
-    <%= edition.introduction.presence || "None added" %>
-  </p>
+  <p><%= edition.introduction.presence || "None added" %></p>
 </section>
 
 <section>
@@ -19,9 +17,7 @@
     heading_level: 3,
     font_size: "s",
   } %>
-  <p>
-    <%= edition.start_button_text %>
-  </p>
+  <p><%= edition.start_button_text %></p>
 </section>
 
 <section>
@@ -30,9 +26,7 @@
     heading_level: 3,
     font_size: "s",
   } %>
-  <p>
-    <%= edition.will_continue_on.presence || "None added" %>
-  </p>
+  <p><%= edition.will_continue_on.presence || "None added" %></p>
 </section>
 
 <section>
@@ -41,9 +35,7 @@
     heading_level: 3,
     font_size: "s",
   } %>
-  <p>
-    <%= edition.link.presence || "None added" %>
-  </p>
+  <p><%= edition.link.presence || "None added" %></p>
 </section>
 
 <section>
@@ -52,9 +44,7 @@
     heading_level: 3,
     font_size: "s",
   } %>
-  <p>
-    <%= edition.more_information.presence || "None added" %>
-  </p>
+  <p><%= edition.more_information.presence || "None added" %></p>
 </section>
 
 <section>
@@ -63,9 +53,7 @@
     heading_level: 3,
     font_size: "s",
   } %>
-  <p>
-    <%= edition.alternate_methods.presence || "None added" %>
-  </p>
+  <p><%= edition.alternate_methods.presence || "None added" %></p>
 </section>
 
 <section>
@@ -74,7 +62,5 @@
     heading_level: 3,
     font_size: "s",
   } %>
-  <p>
-    <%= edition.need_to_know.presence || "None added" %>
-  </p>
+  <p><%= edition.need_to_know.presence || "None added" %></p>
 </section>

--- a/app/views/editions/secondary_nav_tabs/edit/readonly/components/_public_change_note.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/readonly/components/_public_change_note.html.erb
@@ -4,11 +4,10 @@
     heading_level: 3,
     font_size: "s",
   } %>
-  <p>
-    <% if edition.major_change %>
-      <%= edition.change_note %>
-    <% else %>
-      None added
-    <% end %>
-  </p>
+  <% if edition.major_change %>
+    <p><%= edition.change_note %></p>
+  <% else %>
+    <p>None added</p>
+  <% end %>
+
 </section>


### PR DESCRIPTION
This PR updates `edit.scss` to add whitespace back into output where appropriate, and tidies up formatting of some of the newly created views to remove unwanted whitespace above the first line (`AnswerEdition`, `HelpPageEdition`, `PlaceEdition`, `TransactionEdition` and `CompletedTransactionEdition`)

|Content Type|Screenshot|
|-|-|
|Answer|<img width="787" height="865" alt="image" src="https://github.com/user-attachments/assets/e6508c30-8066-4ed3-9418-1a2b1167c8bd" />|
|Help Page|<img width="720" height="769" alt="image" src="https://github.com/user-attachments/assets/0c34ec1a-68dc-47dc-988a-3329da9c7674" />|
|Place|<img width="613" height="859" alt="image" src="https://github.com/user-attachments/assets/00e88c5d-34aa-4df1-aded-884a9168ec66" />|
|Transaction|<img width="555" height="933" alt="image" src="https://github.com/user-attachments/assets/895eb7d8-89d2-4a34-8523-c48df78d1d62" />|
|Completed Transaction|<img width="547" height="543" alt="image" src="https://github.com/user-attachments/assets/728ae9d7-b7c8-43e5-afbd-1b5d2db3d130" />|