### PR TITLE
MAIN-4930 fact check received options

### DIFF
--- a/app/views/editions/secondary_nav_tabs/approve_fact_check_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/approve_fact_check_page.html.erb
@@ -1,0 +1,10 @@
+<% @edition = @resource %>
+<% content_for :title_context, @edition.title %>
+<% content_for :page_title, "Approve fact check" %>
+<% content_for :title, "Approve fact check" %>
+
+<%= render "editions/secondary_nav_tabs/progress_with_comment", {
+  form_url: approve_fact_check_edition_path(@edition),
+  comment_label_text: "Comment (optional)",
+  submit_button_text: "Approve fact check",
+} %>

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -59,6 +59,15 @@
           <p class="govuk-body"><%= link_to("Request amendments", request_amendments_page_edition_path, class: "govuk-link") %></p>
         <% end %>
       <% end %>
+  <% elsif @edition.fact_check_received? %>
+      <% if current_user.has_editor_permissions?(@edition) %>
+        <%= render "govuk_publishing_components/components/inset_text", {} do %>
+          <p class="govuk-body">We have received a fact check response for this edition.</p>
+          <p class="govuk-body">Please check the response in History and notes and select an action below.</p>
+          <p class="govuk-body"><%= link_to("Request amendments", request_amendments_page_edition_path, class: "govuk-link govuk-link--no-visited-state") %></p>
+          <p class="govuk-body"><%= link_to("No changes needed", approve_fact_check_page_edition_path, class: "govuk-link govuk-link--no-visited-state") %></p>
+        <% end %>
+      <% end %>
   <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
         post "send_to_fact_check"
         get "resend_fact_check_email_page"
         patch "resend_fact_check_email"
+        get "approve_fact_check_page"
+        post "approve_fact_check"
         get "request_amendments_page"
         post "request_amendments"
         get "send_to_2i_page"


### PR DESCRIPTION
This PR implements the 'Request amendments' (`request_amendments` state action) and the 'No changes needed' (`approve_fact_check` state action) buttons for when an edition is in the `fact_check_received` states, creating a new view for the approve fact check page.

|Scenario|Screenshot|
|-|-|
|Inset text|<img width="1226" height="593" alt="image" src="https://github.com/user-attachments/assets/7ab31e38-df44-4dfc-b742-316f14c6af16" />|
|Approve message|<img width="873" height="630" alt="image" src="https://github.com/user-attachments/assets/9ea96222-cd8c-4251-a54e-2fbabc2d732a" />|
|Success banner|<img width="1186" height="430" alt="image" src="https://github.com/user-attachments/assets/9ffa812f-34df-48c7-a4fc-c0b60d4f0d3a" />|
|Message in history|<img width="624" height="432" alt="image" src="https://github.com/user-attachments/assets/8aa1f69c-9b36-457c-99c4-1f1fad4365dc" />|
|State Error|<img width="1213" height="729" alt="image" src="https://github.com/user-attachments/assets/17dd63d1-d3ba-40e5-994a-e1730134edf8" />|


