### PR TITLE
Re-enable dependabot  auto merging

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,6 +1,6 @@
 api_version: 2
 defaults:
-  auto_merge: false
+  auto_merge: true
   update_external_dependencies: false # TODO: enable after verifying that this repo meets the conditions
 overrides:
   - dependency: rails # should be upgraded manually, see https://docs.publishing.service.gov.uk/manual/keeping-software-current.html#rails


### PR DESCRIPTION
Now that the migration from Mongo to Postgres is complete, dependabot can be set to auto merge PRs again.

