### PR TITLE
MAIN-4928 scheduled publishing hint date

### DIFF
--- a/app/views/editions/secondary_nav_tabs/schedule_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/schedule_page.html.erb
@@ -12,7 +12,7 @@
     heading_size: "m",
   } do
     render "govuk_publishing_components/components/date_input", {
-      hint: "For example, 27 4 2025",
+      hint: "For example, #{(Time.zone.now + 3.months).strftime("%-d %-m %Y")}",
       items: [
         {
           label: "Day",

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -2390,7 +2390,6 @@ class EditionEditTest < IntegrationTest
 
         within all(".govuk-fieldset")[0] do
           assert page.has_css?("legend", text: "Publication date")
-          assert page.has_css?(".govuk-hint", text: "For example, 27 4 2025")
           assert page.has_css?(".govuk-label", text: "Day")
           assert page.has_css?("input[name='publish_at_3i']")
           assert page.has_css?(".govuk-label", text: "Month")
@@ -2409,6 +2408,13 @@ class EditionEditTest < IntegrationTest
 
         assert page.has_button?("Schedule")
         assert page.has_link?("Cancel")
+      end
+
+      should "generate a date hint test 3 months in the future" do
+        travel_to Time.zone.local(2025, 10, 1, 0, 0, 0)
+        visit schedule_page_edition_path(@ready_edition.id)
+
+        assert page.has_css?(".govuk-hint", text: "For example, 1 1 2026")
       end
 
       should "redirect to edit tab when Cancel button is pressed on Send to 2i page" do


### PR DESCRIPTION
[MAIN-4928](https://gov-uk.atlassian.net/browse/MAIN-4928)

This PR changes the scheduled publishing page to dynamically generate a date three months in the future for the hint text, rather than the existing static date

<img width="324" height="195" alt="image" src="https://github.com/user-attachments/assets/d0c7b841-a325-47ea-9bdd-2f33a219f769" />

I've followed https://www.gov.uk/guidance/style-guide/a-to-z#dates and other examples on not including padding 0's (i.e. 6 1 2026 rather than 06 01 2026)


[MAIN-4928]: https://gov-uk.atlassian.net/browse/MAIN-4928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ