### PR TITLE
MAIN-4927 - Send to 2i guidance link in new tab

### DIFF
--- a/app/views/editions/secondary_nav_tabs/_progress_with_comment.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_progress_with_comment.html.erb
@@ -5,7 +5,7 @@
 
     <% if text %>
       <p class="govuk-body">
-        <%= sanitize(text) %>
+        <%= sanitize(text, attributes: %w[href target class]) %>
       </p>
     <% end %>
 

--- a/app/views/editions/secondary_nav_tabs/send_to_2i_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/send_to_2i_page.html.erb
@@ -7,7 +7,7 @@
   form_url: send_to_2i_edition_path(@edition),
   text: "Explain what changes you did or did not make and why. Include a link to the relevant Zendesk ticket and Trello card.
     If you’ve added a change note already, you do not need to add another one.
-      <a target='_blank' rel='noopener noreferrer' href='https://gov-uk.atlassian.net/l/cp/dwn06raQ' class='govuk-link govuk-link--no-visited-state'>Read guidance on writing good change notes (opens in new tab)</a>.",
+    #{link_to("Read guidance on writing good change notes (opens in new tab)", "https://gov-uk.atlassian.net/l/cp/dwn06raQ", target: "_blank", rel: "noopener noreferrer", class: "govuk-link govuk-link--no-visited-state")}".html_safe,
   comment_label_text: "Comment (optional)" ,
   submit_button_text: "Send to 2i",
 } %>


### PR DESCRIPTION
[MAIN-4927](https://gov-uk.atlassian.net/jira/software/c/projects/MAIN/boards/1555?selectedIssue=MAIN-4927)

This PR makes sure that the link to the new page in the send to 2i page is properly opening in a new tab by correcting the `progress with comment` component that was stripping the target attribute from the link

[MAIN-4927]: https://gov-uk.atlassian.net/browse/MAIN-4927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ