### PR TITLE
Add documentation for GA4 tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ For details on how feature flags are managed in Publisher, see the [feature flag
 
 For instructions on how to add a new type of promotion to Completed Transactions, see the ["adding a promotion" documentation](docs/adding-a-promotion-to-a-completed-transaction.md).
 
+### GA4 tracking
+
+For details on the tracking that is applied to Publisher, see the [GA4 tracking documentation](docs/ga4-tracking.md).
+
 ## Further documentation
 
 - [Fact Checking](docs/fact-checking.md)

--- a/docs/ga4-tracking.md
+++ b/docs/ga4-tracking.md
@@ -2,7 +2,7 @@
 
 Tracking is added to Publisher via GA4. The full documentation is avaialable in [GA4 Publishing Implementation guide](https://docs.google.com/document/d/19RaqZttDTZXsgX4k87wAAOhsol1STM3iTPPPKNlXRl0/edit?tab=t.0#heading=h.eo3rk3rxuz4n).
 
-Via this means we are tracking:
+Via GA4 we are tracking:
 - Page views
 - Navigation
 - Form interactions
@@ -13,10 +13,10 @@ Most of the code exists in the govuk_publishing_components gem. On publisher we 
 
 Tracking can be tested locally with these steps:
 - ensure that the "Ga4 form tracking" feature is set to "On" via FlipFlop
-- ensure that "Preserve log" is set to "On" in the browser console
+- run `document.querySelector('form').addEventListener('submit',function(e){e.preventDefault()})` in the browser console. This will disable form submissions so the full set of data from user interactions can be observed without leaving the page and saving any changes. 
 - run `window.GOVUK.analyticsGa4.showDebug = true` in the browser console. The console will then display the tracking data for all user interactions with the form as they occur.
 
-Running `window.dataLayer` in the browser console at any point will display the data that has been collected during user interactions with the page. In this work we are interested in the "event_data" events. There should be one of these for each user event with the form since the page was loaded.
+Running `window.dataLayer` in the browser console after performing a save will display the data that has been collected during user interactions with the page. In this work we are interested in the "event_data" events. There should be one of these for each user event with the form since the page was loaded.
 
 ## Automated tests
 

--- a/docs/ga4-tracking.md
+++ b/docs/ga4-tracking.md
@@ -1,0 +1,28 @@
+# GA4 tracking
+
+Tracking is added to Publisher via GA4. The full documentation is avaialable in [GA4 Publishing Implementation guide](https://docs.google.com/document/d/19RaqZttDTZXsgX4k87wAAOhsol1STM3iTPPPKNlXRl0/edit?tab=t.0#heading=h.eo3rk3rxuz4n).
+
+Via this means we are tracking:
+- Page views
+- Navigation
+- Form interactions
+
+Most of the code exists in the govuk_publishing_components gem. On publisher we are setting up various parameters on elements to make use of this. Our approach is to add these dynamically on page load via JavaScript set-up modules.
+
+## Testing locally
+
+Tracking can be tested locally with these steps:
+- ensure that the "Ga4 form tracking" feature is set to "On" via FlipFlop
+- ensure that "Preserve log" is set to "On" in the browser console
+- run `window.GOVUK.analyticsGa4.showDebug = true` in the browser console. The console will then display the tracking data for all user interactions with the form as they occur.
+
+Running `window.dataLayer` in the browser console at any point will display the data that has been collected during user interactions with the page. In this work we are interested in the "event_data" events. There should be one of these for each user event with the form since the page was loaded.
+
+## Automated tests
+
+There are:
+- JavaScript Unit Tests for each set-up module:
+  - spec/javascripts/spec/ga4-form-setup.spec.js
+  - spec/javascripts/spec/ga4-index-section-setup.spec.js
+- Rails integration tests for each page that uses the set-up modules:
+  - test/integration/ga4_tracking_test.rb


### PR DESCRIPTION
This adds some documentation for the GA4 tracking work on Publisher. It is a work in progress: it covers what has been added so far and will expand as more features are added. Most usefully it covers how to test the work locally in a section that can be referenced in future PRs.