### PR TITLE
Content Block and HTML Renderer service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem "rails", "8.1.3"
 gem "aws-sdk-s3", "~> 1"
 gem "bootsnap", require: false
 gem "bootstrap-kaminari-views"
+gem "content_block_tools"
 gem "csv"
 gem "dartsass-rails"
 gem "diffy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,12 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.6)
     connection_pool (2.5.5)
+    content_block_tools (1.10.0)
+      actionview (>= 6, < 8.1.3)
+      gds-api-adapters (>= 101.0, < 102.1)
+      govspeak (>= 10.6.3)
+      rails (>= 6, < 8.1.3)
+      view_component (~> 4)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -922,6 +928,10 @@ GEM
     uri (1.1.1)
     useragent (0.16.11)
     version_gem (1.1.9)
+    view_component (4.5.0)
+      actionview (>= 7.1.0)
+      activesupport (>= 7.1.0)
+      concurrent-ruby (~> 1)
     warden (1.2.9)
       rack (>= 2.0.9)
     warden-oauth2 (0.0.1)
@@ -955,6 +965,7 @@ DEPENDENCIES
   capybara-select-2
   ci_reporter_minitest
   climate_control
+  content_block_tools
   csv
   dartsass-rails
   diffy

--- a/app/lib/gds_api/fact_check_manager.rb
+++ b/app/lib/gds_api/fact_check_manager.rb
@@ -10,8 +10,13 @@ class GdsApi::FactCheckManager < GdsApi::Base
   # @option [string] source_url The url locating the content on the source application
   # @param [string] requester_name The username of the source app user submitting the request
   # @param [string] requester_email The email address of the source app user submitting the request
-  # @param [hash] current_content Hash containing HTML content being fact checked
-  # @option [hash] previous_content Hash containing HTML content of previous content version to check against
+  # @param [hash] current_content Hash of current content to be compared in HTML format
+  #   For simple single-part documents format: { id: { heading: "heading string", body: "HTML content string" } }
+  #   For complex multi-part/multi-chapter documents format: { id: { heading: "heading string", body: "HTML content string" }, id2: { heading: "heading string", body: "HTML content string" }, ...}.
+  #   Heading or body may change between current_content and previous_content, but the ID for the parts must match to allow for comparison.
+  #   If a part has been deleted entirely, do not provide its ID in current_content.
+  # @option [hash] previous_content Same format as current_content
+  #   If a new part has been added to the document, do not provide its ID in previous_content.
   # @option [string] deadline Date a response is requested by. Use iso8601 date format: "2026-02-09"
   # @param [array] recipients Array of emails to be notified of the request
   # @option [uuid] draft_auth_bypass_id The edition's auth_bypass_id for draft origin preview access
@@ -58,7 +63,10 @@ class GdsApi::FactCheckManager < GdsApi::Base
   # Keyword Arguments:
   # @param [string] source_app identifier for the application sending the request
   # @param [uuid] source_id The unique ID for the content
-  # @param [hash] current_content
+  # @param [hash] current_content Hash of current content to be compared in HTML format
+  #   For simple single-part documents format: { id: { heading: "heading string", body: "HTML content string" } }
+  #   For complex multi-part/multi-chapter documents format: { id: { heading: "heading string", body: "HTML content string" }, id2: { heading: "heading string", body: "HTML content string" }, ...}.
+  #   If a part has been deleted entirely, do not provide its ID in current_content.
   # @option [string] source_title The title of the content (optional)
   # @option [uuid] draft_auth_bypass_id The edition's auth_bypass_id for draft origin preview access (optional)
   # @option [string] draft_slug The edition's slug for the draft origin preview URL path (optional)

--- a/app/presenters/formats/generic_edition_presenter.rb
+++ b/app/presenters/formats/generic_edition_presenter.rb
@@ -3,7 +3,7 @@ module Formats
     def render_for_fact_check_manager_api
       return unless @edition.respond_to?(:whole_body)
 
-      { body: @edition.whole_body.presence || "" }
+      HtmlRenderer.render_hash({ content: { heading: "Body", body: @edition.whole_body.presence } })
     end
 
   private

--- a/app/services/html_renderer.rb
+++ b/app/services/html_renderer.rb
@@ -1,0 +1,20 @@
+class HtmlRenderer
+  def self.render_hash(hash)
+    hash.each_value do |part|
+      part[:body] = render_html(part[:body])
+    end
+  end
+
+  def self.render_html(document)
+    return "" if document.blank?
+
+    html_content = Govspeak::Document.new(document).to_html
+
+    ContentBlockTools::ContentBlockReference.find_all_in_document(html_content).each do |content_block|
+      code = content_block.embed_code
+      html_content.gsub!(code, ContentBlockTools::ContentBlock.from_embed_code(code).render)
+    end
+
+    html_content.strip
+  end
+end

--- a/test/unit/presenters/formats/generic_edition_presenter_test.rb
+++ b/test/unit/presenters/formats/generic_edition_presenter_test.rb
@@ -116,13 +116,13 @@ class GenericEditionPresenterTest < ActiveSupport::TestCase
     end
   end
 
-  context ".render_for_fact_check_api" do
+  context ".render_for_fact_check_manager_api" do
     should "return a hash with the body content if present" do
       edition = FactoryBot.create(:edition, body: "Move your body")
 
       presenter = Formats::GenericEditionPresenter.new(edition)
 
-      assert_equal({ body: "Move your body" }, presenter.render_for_fact_check_manager_api)
+      assert_equal({ content: { heading: "Body", body: "<p>Move your body</p>" } }, presenter.render_for_fact_check_manager_api)
     end
 
     should "return nil if edition does not respond to whole_body" do
@@ -138,7 +138,7 @@ class GenericEditionPresenterTest < ActiveSupport::TestCase
       edition = FactoryBot.create(:edition, body: nil)
       presenter = Formats::GenericEditionPresenter.new(edition)
 
-      assert_equal({ body: "" }, presenter.render_for_fact_check_manager_api)
+      assert_equal({ content: { heading: "Body", body: "" } }, presenter.render_for_fact_check_manager_api)
     end
   end
 end

--- a/test/unit/services/fact_check_manager_api_service_test.rb
+++ b/test/unit/services/fact_check_manager_api_service_test.rb
@@ -29,7 +29,7 @@ class FactCheckManagerApiServiceTest < ActiveSupport::TestCase
   context ".update_fact_check_content" do
     should "call the fact check manager api adapter" do
       Services.fact_check_manager_api.expects(:patch_update_content)
-              .with(source_app: "publisher", source_id: @edition.id, source_title: "New Title", current_content: { body: "some body" }, draft_auth_bypass_id: @edition.auth_bypass_id, draft_slug: @edition.slug)
+              .with(source_app: "publisher", source_id: @edition.id, source_title: "New Title", current_content: { content: { heading: "Body", body: "<p>some body</p>" }}, draft_auth_bypass_id: @edition.auth_bypass_id, draft_slug: @edition.slug)
               .returns("stub response")
 
       FactCheckManagerApiService.update_fact_check_content(@edition)
@@ -47,8 +47,8 @@ class FactCheckManagerApiServiceTest < ActiveSupport::TestCase
                              source_url: "#{Plek.find('publisher')}/editions/#{@edition.id}",
                              requester_name: "Ben",
                              requester_email: "joe1@bloggs.com",
-                             current_content: { body: "some body" },
-                             previous_content: {},
+                             current_content: { content: { heading: "Body", body: "<p>some body</p>" } },
+                             previous_content: nil,
                              deadline: "2026-02-09",
                              recipients: ["stub@email.com"],
                              draft_content_id: @edition.content_id,
@@ -64,7 +64,7 @@ class FactCheckManagerApiServiceTest < ActiveSupport::TestCase
       edition2 = edition1.build_clone
 
       payload = FactCheckManagerApiService.build_post_payload(edition2, @user, "stub@email.com")
-      expected_hash = { body: "some body" }
+      expected_hash = { content: { heading: "Body", body: "<p>some body</p>" } }
       assert_equal expected_hash, payload[:previous_content]
     end
 

--- a/test/unit/services/fact_check_manager_api_service_test.rb
+++ b/test/unit/services/fact_check_manager_api_service_test.rb
@@ -29,7 +29,7 @@ class FactCheckManagerApiServiceTest < ActiveSupport::TestCase
   context ".update_fact_check_content" do
     should "call the fact check manager api adapter" do
       Services.fact_check_manager_api.expects(:patch_update_content)
-              .with(source_app: "publisher", source_id: @edition.id, source_title: "New Title", current_content: { content: { heading: "Body", body: "<p>some body</p>" }}, draft_auth_bypass_id: @edition.auth_bypass_id, draft_slug: @edition.slug)
+              .with(source_app: "publisher", source_id: @edition.id, source_title: "New Title", current_content: { content: { heading: "Body", body: "<p>some body</p>" } }, draft_auth_bypass_id: @edition.auth_bypass_id, draft_slug: @edition.slug)
               .returns("stub response")
 
       FactCheckManagerApiService.update_fact_check_content(@edition)
@@ -43,16 +43,16 @@ class FactCheckManagerApiServiceTest < ActiveSupport::TestCase
 
         expected_payload = { source_app: "publisher",
                              source_id: @edition.id,
-                             source_title: "New Title",
                              source_url: "#{Plek.find('publisher')}/editions/#{@edition.id}",
+                             source_title: "New Title",
                              requester_name: "Ben",
                              requester_email: "joe1@bloggs.com",
                              current_content: { content: { heading: "Body", body: "<p>some body</p>" } },
-                             previous_content: nil,
+                             previous_content: {},
                              deadline: "2026-02-09",
                              recipients: ["stub@email.com"],
-                             draft_content_id: @edition.content_id,
                              draft_auth_bypass_id: @edition.auth_bypass_id,
+                             draft_content_id: @edition.content_id,
                              draft_slug: @edition.slug }
 
         assert_equal expected_payload, payload

--- a/test/unit/services/html_renderer_test.rb
+++ b/test/unit/services/html_renderer_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+
+class HtmlRendererTest < ActiveSupport::TestCase
+  context ".render_hash" do
+    should "call render_html once for a single-item hash" do
+      expected_output = { content: { 'body': "<p>foo</p>" } }
+
+      output = HtmlRenderer.render_hash({ content: { 'body': "foo" } })
+
+      assert_equal expected_output, output
+    end
+
+    should "call render_html for each item in a multi-item hash" do
+      expected_output = { '0': { 'body': "<p>foo</p>" }, '1': { 'body': "<p>foo 2</p>" }, '2': { 'body': "<p>foo 3</p>" } }
+
+      output = HtmlRenderer.render_hash({ '0': { 'body': "foo" }, '1': { 'body': "foo 2" }, '2': { 'body': "foo 3" } })
+
+      assert_equal expected_output, output
+    end
+  end
+
+  context ".render_html" do
+    should "correctly process simple govspeak into html" do
+      input = "Hello World!"
+
+      assert_equal "<p>Hello World!</p>", HtmlRenderer.render_html(input)
+    end
+
+    should "correctly process complex govspeak into html" do
+      input = <<~GOV_SPEAK
+        %warning callout%
+
+        ^useful information^
+
+        paragraph
+
+        - [link text](href)
+        - li
+      GOV_SPEAK
+
+      expected_output = <<~HTML.strip
+        <div role="note" aria-label="Warning" class="application-notice help-notice">
+        <p>warning callout</p>
+        </div>
+
+        <div role="note" aria-label="Information" class="application-notice info-notice">
+          <p>useful information</p>
+        </div>
+
+        <p>paragraph</p>
+
+        <ul>
+          <li><a href="href\">link text</a></li>
+          <li>li</li>
+        </ul>
+      HTML
+
+      assert_equal expected_output, HtmlRenderer.render_html(input)
+    end
+
+    should "call ContentBlockTools::ContentBlock.from_embed_code when a content block embed code is present" do
+      input = "Before block, {{embed:content_block_contact:content-item}}, after block"
+
+      # ContentBlockTools has some internal logic and an API call that need stubbing out here
+      mock_content_block = Minitest::Mock.new
+      mock_content_block.expect(:render, "block content")
+      ContentBlockTools::ContentBlock.expects(:from_embed_code).with("{{embed:content_block_contact:content-item}}").returns(mock_content_block)
+
+      assert_equal "<p>Before block, block content, after block</p>", HtmlRenderer.render_html(input)
+    end
+
+    should "return an empty string when given an empty document" do
+      assert_equal "", HtmlRenderer.render_html("")
+    end
+  end
+end


### PR DESCRIPTION
[MAIN-7277](https://gov-uk.atlassian.net/browse/MAIN-7277)

This PR creates a new HtmlRenderer service class which can take in a govspeak document, use Govspeak::Document to render it as HTML, and then use ContentBlockTools to replace all valid content block embed codes with their HTML value.

The GenericEditionPresenter is also updated to use this new service class, and the FCM Api Adapters have been updated with new documentation detailing the payload standard for current_content and previous_content.

This should not be merged before [MAIN-7353](https://gov-uk.atlassian.net/browse/MAIN-7353), otherwise it will prevent valid test data from being sent over.

[MAIN-7277]: https://gov-uk.atlassian.net/browse/MAIN-7277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAIN-7353]: https://gov-uk.atlassian.net/browse/MAIN-7353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ