### PR TITLE
[MAIN-7358] Bug fix - "In review" message

### DIFF
--- a/app/traits/recordable_actions.rb
+++ b/app/traits/recordable_actions.rb
@@ -7,9 +7,9 @@ module RecordableActions
 
     def latest_status_action(type = nil)
       if type
-        actions.where(request_type: type).last
+        actions.where(request_type: type).order(created_at: :desc).first
       else
-        most_recent_action(&:status_action?)
+        actions.where(request_type: Action::STATUS_ACTIONS).order(created_at: :desc).first
       end
     end
 

--- a/app/views/editions/secondary_nav_tabs/resend_fact_check_email_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/resend_fact_check_email_page.html.erb
@@ -13,7 +13,7 @@
           font_size: "s",
         } %>
 
-        <p class="govuk-body"><%= @edition.latest_status_action.email_addresses %></p>
+        <p class="govuk-body"><%= @edition.latest_status_action(Action::SEND_FACT_CHECK)&.email_addresses %></p>
       </section>
 
       <% unless Flipflop.enabled?(:fact_check_manager_api) %>
@@ -25,7 +25,7 @@
           } %>
 
           <div class="edit--resend-fact-check-email-page__message">
-            <%= @edition.latest_status_action.customised_message.strip %>
+            <%= @edition.latest_status_action(Action::SEND_FACT_CHECK)&.customised_message&.strip %>
           </div>
         </section>
       <% end %>

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -30,14 +30,15 @@
       <%= render partial: "important_note" %>
     <% end %>
     <% if @edition.in_review? %>
+      <% latest_request_review_action = @edition.latest_status_action(Action::REQUEST_REVIEW) %>
       <%= render "govuk_publishing_components/components/inset_text", {} do %>
-        <% if @edition.latest_status_action.requester == current_user %>
+        <% if latest_request_review_action&.requester == current_user %>
           <p class="govuk-body">You've sent this edition to be reviewed</p>
           <% if current_user.skip_review? %>
             <p class="govuk-body"><%= link_to("Skip review", skip_review_page_edition_path, class: "govuk-link govuk-link--no-visited-state") %></p>
           <% end %>
         <% else %>
-          <p class="govuk-body"><%= @edition.latest_status_action.requester&.name %> sent this edition to be reviewed</p>
+          <p class="govuk-body"><%= latest_request_review_action&.requester&.name %> sent this edition to be reviewed</p>
           <% if current_user.has_editor_permissions?(@edition) %>
             <p class="govuk-body"><%= link_to("Request amendments", request_amendments_page_edition_path, class: "govuk-link govuk-link--no-visited-state") %></p>
             <p class="govuk-body"><%= link_to("No changes needed", no_changes_needed_page_edition_path, class: "govuk-link govuk-link--no-visited-state") %></p>
@@ -48,10 +49,11 @@
       <% if current_user.has_editor_permissions?(@edition) %>
         <%= render "govuk_publishing_components/components/inset_text", {} do %>
           <% if @edition.fact_check? %>
-            <% if @edition.latest_status_action.requester == current_user %>
+            <% latest_send_fact_check_action = @edition.latest_status_action(Action::SEND_FACT_CHECK) %>
+            <% if latest_send_fact_check_action&.requester == current_user %>
               <p class="govuk-body">You've requested this edition to be fact checked. We're awaiting a response.</p>
             <% else %>
-              <p class="govuk-body"><%= @edition.latest_status_action.requester&.name %> requested this edition to be fact checked.
+              <p class="govuk-body"><%= latest_send_fact_check_action&.requester&.name %> requested this edition to be fact checked.
                 We're awaiting a response.</p>
             <% end %>
             <p class="govuk-body"><%= link_to("Resend fact check email", resend_fact_check_email_page_edition_path, class: "govuk-link govuk-link--no-visited-state") %></p>

--- a/app/views/shared/_fact_check.html.erb
+++ b/app/views/shared/_fact_check.html.erb
@@ -1,6 +1,6 @@
 <div class="alert alert-info">
-  <% if @resource.latest_status_action %>
-    <p><%= @resource.latest_status_action.requester&.name %> requested this edition be fact checked. We&rsquo;re awaiting a response.</p>
+  <% if latest_send_fact_check_action = @resource.latest_status_action(Action::SEND_FACT_CHECK) %>
+    <p><%= latest_send_fact_check_action&.requester&.name %> requested this edition be fact checked. We&rsquo;re awaiting a response.</p>
     <% if current_user.has_editor_permissions?(@resource) %>
       <%= resend_fact_check_buttons(@resource) %>
     <% end %>

--- a/app/views/shared/_review.html.erb
+++ b/app/views/shared/_review.html.erb
@@ -1,12 +1,12 @@
 <div class="alert alert-info">
-  <% if @resource.latest_status_action(Action::REQUEST_REVIEW) %>
-    <% if @resource.latest_status_action.requester == current_user %>
+  <% if latest_request_review_action = @resource.latest_status_action(Action::REQUEST_REVIEW) %>
+    <% if latest_request_review_action.requester == current_user %>
       <p>You’ve sent this edition to be reviewed.</p>
       <% if current_user.skip_review? %>
         <p><%= build_review_button(@resource, "skip_review", "Skip review").html_safe %></p>
       <% end %>
     <% else %>
-      <p><%= @resource.latest_status_action(Action::REQUEST_REVIEW).requester.name %> has sent this edition to be reviewed.</p>
+      <p><%= latest_request_review_action.requester&.name %> has sent this edition to be reviewed.</p>
       <div class="workflow-buttons">
         <%= review_buttons(@resource) %>
       </div>

--- a/db/migrate/20260402151145_add_composite_index_to_actions.rb
+++ b/db/migrate/20260402151145_add_composite_index_to_actions.rb
@@ -1,0 +1,11 @@
+class AddCompositeIndexToActions < ActiveRecord::Migration[8.1]
+  # This is required to perform the migration concurrently, which prevents write locks
+  # on the table whilst the index is being built
+  disable_ddl_transaction!
+
+  def change
+    add_index :actions, %i[edition_id request_type created_at],
+              name: "index_actions_on_edition_id_request_type_created_at",
+              algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_16_133713) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_02_151145) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -31,6 +31,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_16_133713) do
     t.bigint "requester_id"
     t.string "requester_name"
     t.datetime "updated_at", null: false
+    t.index ["edition_id", "request_type", "created_at"], name: "index_actions_on_edition_id_request_type_created_at"
     t.index ["edition_id"], name: "index_actions_on_edition_id"
     t.index ["recipient_id"], name: "index_actions_on_recipient_id"
     t.index ["requester_id"], name: "index_actions_on_requester_id"

--- a/test/integration/edition_edit_tab/edit_fact_check_edition_test.rb
+++ b/test/integration/edition_edit_tab/edit_fact_check_edition_test.rb
@@ -42,6 +42,15 @@ class EditFactCheckEditionTest < IntegrationTest
     assert_current_path request_amendments_page_edition_path(@fact_check_edition.id)
   end
 
+  context "when a newer status action by a different requester exists" do
+    should "indicate the user that requested a review" do
+      FactoryBot.create(:action, edition: @fact_check_edition, requester: @govuk_requester, request_type: Action::REQUEST_REVIEW)
+      visit edition_path(@fact_check_edition)
+
+      assert page.has_text?("You've requested this edition to be fact checked. We're awaiting a response.")
+    end
+  end
+
   context "when a welsh editor" do
     setup do
       @welsh_editor = FactoryBot.create(:user, :welsh_editor, name: "Stub User")
@@ -66,6 +75,15 @@ class EditFactCheckEditionTest < IntegrationTest
       should "navigate to the 'Request amendments' page when the link is clicked" do
         click_link("Request amendments")
         assert_current_path request_amendments_page_edition_path(@welsh_edition.id)
+      end
+
+      context "when a newer status action by a different requester exists" do
+        should "indicate the user that requested a review" do
+          FactoryBot.create(:action, edition: @welsh_edition, requester: @govuk_editor, request_type: Action::REQUEST_REVIEW)
+          visit edition_path(@welsh_edition)
+
+          assert page.has_text?("You've requested this edition to be fact checked. We're awaiting a response.")
+        end
       end
     end
 

--- a/test/integration/edition_edit_tab/edit_in_review_edition_test.rb
+++ b/test/integration/edition_edit_tab/edit_in_review_edition_test.rb
@@ -64,6 +64,15 @@ class EditInReviewEditionTest < IntegrationTest
       should "not show the 'Skip review' link when the user does not have the 'skip_review' permission" do
         assert page.has_no_link?("Skip review")
       end
+
+      context "when a newer status action by a different requester exists" do
+        should "indicate the user that requested a review" do
+          FactoryBot.create(:action, edition: @in_review_edition, requester: @govuk_editor, request_type: Action::SEND_FACT_CHECK)
+          visit edition_path(@in_review_edition)
+
+          assert page.has_text?("You've sent this edition to be reviewed")
+        end
+      end
     end
 
     context "current user is not the requester" do
@@ -112,6 +121,16 @@ class EditInReviewEditionTest < IntegrationTest
         visit edition_path(@in_review_edition)
 
         assert page.has_no_link?("Skip review")
+      end
+
+      context "when a newer status action by a different requester exists" do
+        should "indicate the user that requested a review" do
+          FactoryBot.create(:action, edition: @in_review_edition, requester: @govuk_editor, request_type: Action::SEND_FACT_CHECK)
+
+          visit edition_path(@in_review_edition)
+
+          assert page.has_text?("Stub requester sent this edition to be reviewed")
+        end
       end
     end
   end
@@ -207,6 +226,16 @@ class EditInReviewEditionTest < IntegrationTest
       should "not show the 'Skip review' link when the user does not have the 'skip_review' permission" do
         assert page.has_no_link?("Skip review")
       end
+
+      context "when a newer status action by a different requester exists" do
+        should "indicate the user that requested a review" do
+          FactoryBot.create(:action, edition: @welsh_edition, requester: @govuk_editor, request_type: Action::SEND_FACT_CHECK)
+
+          visit edition_path(@welsh_edition)
+
+          assert page.has_text?("You've sent this edition to be reviewed")
+        end
+      end
     end
 
     context "when viewing a welsh edition as a non-requester" do
@@ -254,6 +283,16 @@ class EditInReviewEditionTest < IntegrationTest
         visit edition_path(@welsh_edition)
 
         assert page.has_no_link?("Skip review")
+      end
+
+      context "when a newer status action by a different requester exists" do
+        should "indicate the user that requested a review" do
+          FactoryBot.create(:action, edition: @welsh_edition, requester: @govuk_editor, request_type: Action::SEND_FACT_CHECK)
+
+          visit edition_path(@welsh_edition)
+
+          assert page.has_text?("Stub requester sent this edition to be reviewed")
+        end
       end
     end
 

--- a/test/traits/recordable_actions_test.rb
+++ b/test/traits/recordable_actions_test.rb
@@ -63,4 +63,28 @@ class RecordableActionsTest < ActiveSupport::TestCase
       assert_nil object_under_test.superseded_at
     end
   end
+
+  describe "#latest_status_action" do
+    it "returns the action of that type even when a newer action of a different type exists" do
+      edition = FactoryBot.create(:edition, :in_review)
+      edition.new_action(user, Action::SEND_FACT_CHECK)
+
+      assert_equal Action::REQUEST_REVIEW, edition.latest_status_action(Action::REQUEST_REVIEW).request_type
+    end
+
+    it "returns nil when no action of that type exists" do
+      edition = FactoryBot.create(:edition, :in_review)
+
+      assert_nil edition.latest_status_action(Action::SEND_FACT_CHECK)
+    end
+
+    it "returns the latest status action when no type argument provided" do
+      edition = FactoryBot.create(:edition, :in_review)
+      edition.new_action(user, Action::SEND_FACT_CHECK)
+      edition.new_action(user, Action::REQUEST_AMENDMENTS)
+      edition.new_action(user, Action::IMPORTANT_NOTE)
+
+      assert_equal Action::REQUEST_AMENDMENTS, edition.latest_status_action.request_type
+    end
+  end
 end


### PR DESCRIPTION
[MAIN-7358](https://gov-uk.atlassian.net/browse/MAIN-7358)

### Changes

In places, the view code calling `latest_status_action` assumes that the action returned has a certain `request_type` and associated attributes, when this is not always the
case. This ensures that the most recent action of the assumed
`request_type` is retrieved, preventing errors and incorrectly displayed messages (e.g. "blank sent this to be reviewed").

A [composite index](https://www.postgresql.org/docs/current/indexes-multicolumn.html) is added to the `actions` table on the columns: `edition_id`, `request_type` and `created_at`. [The index is added using `algorithm: :concurrently` to prevent write-locks whilst it is being built](https://thoughtbot.com/blog/how-to-create-postgres-indexes-concurrently-in). Queries using the following combinations of these columns should benefit from this index:
- `edition_id`
- `edition_id` and `request_type`
- `edition_id`, `request_type` and `created_at`.

The `latest_status_action` method is updated to leverage this new index. It also uses `order(:created_at)` rather than the default ordering via ID (the IDs are sequential so the ordering should be the same but I was able to find some records for which this was not the case in integration, possibly due to timing issues when they were imported from mongodb).

[MAIN-7358]: https://gov-uk.atlassian.net/browse/MAIN-7358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ