### PR TITLE
Main 7352 ga4 form error events

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,6 +8,7 @@
 //= require govuk_publishing_components/components/table
 
 // Analytics modules
+//= require govuk_publishing_components/analytics-ga4/ga4-auto-tracker
 //= require govuk_publishing_components/analytics-ga4/ga4-ecommerce-tracker
 //= require govuk_publishing_components/analytics-ga4/ga4-form-change-tracker
 //= require govuk_publishing_components/analytics-ga4/ga4-search-tracker

--- a/app/views/editions/secondary_nav_tabs/confirm_unpublish.html.erb
+++ b/app/views/editions/secondary_nav_tabs/confirm_unpublish.html.erb
@@ -4,18 +4,7 @@
 <% content_for :title, "Unpublish" %>
 <div class="govuk-grid-row">
   <% unless @edition.errors.empty? %>
-    <% content_for :error_summary do %>
-      <%= render("govuk_publishing_components/components/error_summary", {
-        id: "error-summary",
-        title: "There is a problem",
-        items: @edition.errors.map do |error|
-          {
-            text: error.message,
-            href: "##{error.attribute.to_s}",
-          }
-        end,
-      }) %>
-    <% end %>
+    <% content_for :error_summary, render("shared/error_summary", { object: @edition, full_messages: false }) %>
   <% end %>
 
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/editions/secondary_nav_tabs/edit/editable/components/_title.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/editable/components/_title.html.erb
@@ -2,7 +2,7 @@
   label: {
     text: "Title",
   },
-  id: "title",
+  id: "edition_title",
   name: "edition[title]",
   value: edition.title,
   heading_size: "s",

--- a/app/views/editions/secondary_nav_tabs/tagging_related_content_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/tagging_related_content_page.html.erb
@@ -5,17 +5,7 @@
 
 <% if !@tagging_update_form_values.errors.empty? %>
   <div class="govuk-grid-row">
-    <% content_for :error_summary do %>
-      <%= render("govuk_publishing_components/components/error_summary", {
-        id: "error-summary",
-        title: "There is a problem",
-        items: @tagging_update_form_values.errors.map do |error|
-          {
-            text: error.message,
-          }
-        end,
-      }) %>
-    <% end %>
+    <% content_for :error_summary, render("shared/error_summary", { object: @tagging_update_form_values, full_messages: false }) %>
   </div>
 <% end %>
 

--- a/app/views/editions/secondary_nav_tabs/tagging_remove_breadcrumb_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/tagging_remove_breadcrumb_page.html.erb
@@ -6,18 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% unless @edition.errors.empty? %>
-      <% content_for :error_summary do %>
-        <%= render("govuk_publishing_components/components/error_summary", {
-          id: "error-summary",
-          title: "There is a problem",
-          items: @edition.errors.map do |error|
-            {
-              text: error.message,
-              href: "##{error.attribute.to_s}",
-            }
-          end,
-        }) %>
-      <% end %>
+      <% content_for :error_summary, render("shared/error_summary", { object: @edition, full_messages: false }) %>
     <% end %>
 
     <%= form_with model: @tagging_update_form_values, url: remove_breadcrumb_edition_path(@resource), data: { module: "" } do |f| %>
@@ -28,7 +17,7 @@
         heading: "Are you sure you want to remove the breadcrumb?",
         heading_level: 0,
         visually_hidden_heading: true,
-        id: "remove_parent",
+        id: "edition_remove_parent",
         hint: "Breadcrumbs are displayed at the top of the page and help users to navigate. There may be some situations where you do not need a breadcrumb to display (for example, on Welsh translation pages).",
         error_message: @edition.errors.empty? ? nil : @edition.errors.first.message,
         items: [

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -4,18 +4,7 @@
 <% content_for :title, @edition.title %>
 
 <% unless @edition.errors.empty? %>
-  <% content_for :error_summary do %>
-    <%= render("govuk_publishing_components/components/error_summary", {
-      id: "error-summary",
-      title: "There is a problem",
-      items: @edition.errors.map do |error|
-        {
-          text: error.message,
-          href: "##{error.attribute.to_s}",
-        }
-      end,
-    }) %>
-  <% end %>
+  <% content_for :error_summary, render("shared/error_summary", { object: @edition, full_messages: false }) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/guide_parts/_part_page.html.erb
+++ b/app/views/guide_parts/_part_page.html.erb
@@ -5,18 +5,7 @@
 <% content_for :title, edition.title %>
 
 <% if !edition.errors.empty? || !part.errors.empty? %>
-  <% content_for :error_summary do %>
-    <%= render("govuk_publishing_components/components/error_summary", {
-      id: "error-summary",
-      title: "There is a problem",
-      items: part.errors.map do |error|
-        {
-          text: error.message,
-          href: "##{error.attribute.to_s}",
-        }
-      end,
-    }) %>
-  <% end %>
+  <% content_for :error_summary, render("shared/error_summary", { object: part, full_messages: false }) %>
 <% end %>
 
 <%= render partial: "document_summary", locals: { edition:, reviewer: } %>
@@ -40,12 +29,12 @@
 <%= form_with url: form_url, method: form_method, data: { module: "unsaved-changes-prompt" } do %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <div data-module="slug-autofill" data-title-input-id="title" data-slug-input-id="slug">
+      <div data-module="slug-autofill" data-title-input-id="part_title" data-slug-input-id="part_slug">
         <%= render "govuk_publishing_components/components/input", {
           label: {
             text: "Title",
           },
-          id: "title",
+          id: "part_title",
           name: "part[title]",
           value: part.title,
           heading_size: "s",
@@ -57,7 +46,7 @@
           label: {
             text: "Slug",
           },
-          id: "slug",
+          id: "part_slug",
           name: "part[slug]",
           value: part.slug,
           heading_size: "s",

--- a/app/views/shared/_error_summary.html.erb
+++ b/app/views/shared/_error_summary.html.erb
@@ -5,9 +5,21 @@
     title: "There is a problem",
     items: object.errors.map do |error|
       model = object.class
+ 
       {
         text: full_messages ? error.full_message : error.message,
         href: "##{model.to_s.underscore + "_" + error.attribute.to_s}",
+        data_attributes: {
+          module: ga4_form_tracking? ? "ga4-auto-tracker" : nil,
+          "ga4-auto": {
+            event_name: "form_error",
+            type: "Edit edition",
+            text: error.message,
+            section: error.attribute.to_s.humanize,
+            action: "error",
+            tool_name: @edition ? @edition.format : "Publisher",
+          },
+        },
       }
     end,
   } %>

--- a/test/integration/edition_edit_tab/edit_draft_edition_test.rb
+++ b/test/integration/edition_edit_tab/edit_draft_edition_test.rb
@@ -670,10 +670,10 @@ class EditDraftEditionTest < IntegrationTest
 
             within ".govuk-error-summary" do
               assert_text "There is a problem"
-              assert_link "Enter a title for Chapter 1", href: "#part_1_title"
-              assert_link "Enter a slug for Chapter 1", href: "#part_1_slug"
-              assert_link "Enter a title for Chapter 2", href: "#part_2_title"
-              assert_link "Slug for Chapter 2 can only consist of lower case characters, numbers and hyphens", href: "#part_2_slug"
+              assert_link "Enter a title for Chapter 1", href: "#edition_part_1_title"
+              assert_link "Enter a slug for Chapter 1", href: "#edition_part_1_slug"
+              assert_link "Enter a title for Chapter 2", href: "#edition_part_2_title"
+              assert_link "Slug for Chapter 2 can only consist of lower case characters, numbers and hyphens", href: "#edition_part_2_slug"
             end
           end
 
@@ -696,7 +696,7 @@ class EditDraftEditionTest < IntegrationTest
 
             within ".govuk-error-summary" do
               assert_text "There is a problem"
-              assert_link "Enter a title for Chapter 2", href: "#part_2_title"
+              assert_link "Enter a title for Chapter 2", href: "#edition_part_2_title"
             end
           end
 
@@ -719,7 +719,7 @@ class EditDraftEditionTest < IntegrationTest
 
             within ".govuk-error-summary" do
               assert_text "There is a problem"
-              assert_link "Enter a slug for Chapter 2", href: "#part_2_slug"
+              assert_link "Enter a slug for Chapter 2", href: "#edition_part_2_slug"
             end
           end
 
@@ -742,7 +742,7 @@ class EditDraftEditionTest < IntegrationTest
 
             within ".govuk-error-summary" do
               assert_text "There is a problem"
-              assert_link "Slug for Chapter 2 can only consist of lower case characters, numbers and hyphens", href: "#part_2_slug"
+              assert_link "Slug for Chapter 2 can only consist of lower case characters, numbers and hyphens", href: "#edition_part_2_slug"
             end
           end
 

--- a/test/integration/edition_edit_tab/edit_draft_guide_edition_js_test.rb
+++ b/test/integration/edition_edit_tab/edit_draft_guide_edition_js_test.rb
@@ -99,7 +99,7 @@ class EditDraftGuideEditionJsTest < JavascriptIntegrationTest
 
       within ".govuk-error-summary" do
         assert_text "There is a problem"
-        assert_link "Enter a title for Chapter 1", href: "#part_1_title"
+        assert_link "Enter a title for Chapter 1", href: "#edition_part_1_title"
       end
 
       within all(".govuk-accordion__section")[0] do

--- a/test/integration/ga4_tracking_add_artefact_test.rb
+++ b/test/integration/ga4_tracking_add_artefact_test.rb
@@ -1,0 +1,79 @@
+require "integration_test_helper"
+require "support/ga4_test_helpers"
+
+class Ga4TrackingAddArtefactTest < JavascriptIntegrationTest
+  include Ga4TestHelpers
+
+  setup do
+    setup_users
+
+    @test_strategy.switch!(:ga4_form_tracking, true)
+  end
+
+  context "Create new content page one" do
+    setup do
+      visit new_artefact_path
+    end
+
+    should "push the correct values to the dataLayer when a form error is triggered" do
+      click_button "Continue"
+
+      assert page.has_css?("h1", text: "Create new content")
+
+      event_data = get_event_data
+
+      assert_equal "error", event_data[0]["action"]
+      assert_equal "form_error", event_data[0]["event_name"]
+      assert_equal "Edit edition", event_data[0]["type"]
+      assert_equal "Select a content type", event_data[0]["text"]
+      assert_equal "Kind", event_data[0]["section"]
+      assert_equal "Publisher", event_data[0]["tool_name"]
+    end
+  end
+
+  context "Create new content page two" do
+    setup do
+      FactoryBot.create(:local_service, lgsl_code: 1)
+
+      visit new_artefact_path
+      find("label", text: "Local transaction").click
+      click_button "Continue"
+    end
+
+    should "push the correct values to the dataLayer when a form error is triggered" do
+      click_button "Create content"
+
+      assert page.has_css?(".gem-c-heading__context", text: "Create new content")
+
+      event_data = get_event_data
+
+      assert_equal "error", event_data[0]["action"]
+      assert_equal "form_error", event_data[0]["event_name"]
+      assert_equal "Edit edition", event_data[0]["type"]
+      assert_equal "Enter a title", event_data[0]["text"]
+      assert_equal "Name", event_data[0]["section"]
+      assert_equal "Publisher", event_data[0]["tool_name"]
+
+      assert_equal "error", event_data[1]["action"]
+      assert_equal "form_error", event_data[1]["event_name"]
+      assert_equal "Edit edition", event_data[1]["type"]
+      assert_equal "Enter a slug", event_data[1]["text"]
+      assert_equal "Slug", event_data[1]["section"]
+      assert_equal "Publisher", event_data[1]["tool_name"]
+
+      assert_equal "error", event_data[2]["action"]
+      assert_equal "form_error", event_data[2]["event_name"]
+      assert_equal "Edit edition", event_data[2]["type"]
+      assert_equal "Enter a LGSL code", event_data[2]["text"]
+      assert_equal "Lgsl code", event_data[2]["section"]
+      assert_equal "Publisher", event_data[2]["tool_name"]
+
+      assert_equal "error", event_data[3]["action"]
+      assert_equal "form_error", event_data[3]["event_name"]
+      assert_equal "Edit edition", event_data[3]["type"]
+      assert_equal "Enter a LGIL code", event_data[3]["text"]
+      assert_equal "Lgil code", event_data[3]["section"]
+      assert_equal "Publisher", event_data[3]["tool_name"]
+    end
+  end
+end

--- a/test/integration/ga4_tracking_downtime_test.rb
+++ b/test/integration/ga4_tracking_downtime_test.rb
@@ -1,0 +1,89 @@
+require "integration_test_helper"
+require "support/ga4_test_helpers"
+
+class Ga4DowntimeTest < JavascriptIntegrationTest
+  include Ga4TestHelpers
+
+  setup do
+    setup_users
+    @edition = FactoryBot.create(:transaction_edition, :published)
+    @test_strategy.switch!(:ga4_form_tracking, true)
+  end
+
+  context "Add downtime message" do
+    setup do
+      visit root_path
+      click_link "Downtime messages"
+      click_link "Add downtime"
+    end
+
+    should "push the correct values to the dataLayer when a form error is triggered" do
+      click_button "Save"
+
+      event_data = get_event_data
+
+      assert page.has_css?("h1", text: "Add downtime message")
+
+      assert_equal "error", event_data[0]["action"]
+      assert_equal "form_error", event_data[0]["event_name"]
+      assert_equal "Edit edition", event_data[0]["type"]
+      assert_equal "can't be blank", event_data[0]["text"]
+      assert_equal "Message", event_data[0]["section"]
+      assert_equal "Transaction", event_data[0]["tool_name"]
+
+      assert_equal "error", event_data[1]["action"]
+      assert_equal "form_error", event_data[1]["event_name"]
+      assert_equal "Edit edition", event_data[1]["type"]
+      assert_equal "format is invalid", event_data[1]["text"]
+      assert_equal "Start time", event_data[1]["section"]
+      assert_equal "Transaction", event_data[1]["tool_name"]
+
+      assert_equal "error", event_data[2]["action"]
+      assert_equal "form_error", event_data[2]["event_name"]
+      assert_equal "Edit edition", event_data[2]["type"]
+      assert_equal "format is invalid", event_data[2]["text"]
+      assert_equal "End time", event_data[2]["section"]
+      assert_equal "Transaction", event_data[2]["tool_name"]
+    end
+  end
+
+  context "Edit downtime message" do
+    setup do
+      Downtime.create!(artefact_id: @edition.artefact.id, start_time: 1.day.ago, end_time: 1.day.from_now, message: "The message")
+
+      visit root_path
+      click_link "Downtime messages"
+      click_link "Edit downtime"
+    end
+
+    should "push the correct values to the dataLayer when a form error is triggered" do
+      within all(".gem-c-date-input")[0] do
+        fill_in "Day", with: ""
+      end
+
+      within all(".gem-c-date-input")[2] do
+        fill_in "Day", with: ""
+      end
+
+      click_button "Save"
+
+      assert page.has_css?("h1", text: "Edit downtime message")
+
+      event_data = get_event_data
+
+      assert_equal "error", event_data[0]["action"]
+      assert_equal "form_error", event_data[0]["event_name"]
+      assert_equal "Edit edition", event_data[0]["type"]
+      assert_equal "format is invalid", event_data[0]["text"]
+      assert_equal "Start time", event_data[0]["section"]
+      assert_equal "Transaction", event_data[0]["tool_name"]
+
+      assert_equal "error", event_data[1]["action"]
+      assert_equal "form_error", event_data[1]["event_name"]
+      assert_equal "Edit edition", event_data[1]["type"]
+      assert_equal "format is invalid", event_data[1]["text"]
+      assert_equal "End time", event_data[1]["section"]
+      assert_equal "Transaction", event_data[1]["tool_name"]
+    end
+  end
+end

--- a/test/integration/ga4_tracking_edit_test.rb
+++ b/test/integration/ga4_tracking_edit_test.rb
@@ -8,6 +8,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
     setup_users
 
     @edition = FactoryBot.create(:answer_edition, title: "Answer edition")
+    @guide_edition = FactoryBot.create(:guide_edition, title: "Guide edition")
     @assigned_edition = FactoryBot.create(:edition, assigned_to: @author, created_at: 5.days.ago)
     @in_review_edition = FactoryBot.create(:edition, :in_review, reviewer: @reviewer, created_at: 6.days.ago)
 
@@ -20,10 +21,11 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
   context "Edit page" do
     setup do
       visit edition_path(@edition)
-      disable_form_submit
     end
 
     should "push the correct values to the dataLayer when events are triggered" do
+      disable_form_submit
+
       fill_in "Title", with: "The title"
       fill_in "Meta tag description", with: "the-meta-tag-description"
       fill_in "Body", with: "The body text"
@@ -74,6 +76,54 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
       assert_equal "{\"Title\":\"9\",\"Meta tag description\":\"24\",\"Body\":\"13\",\"Is this beta content?\":\"No\"}", event_data[5]["text"]
       assert_equal "Answer", event_data[5]["tool_name"]
       assert_equal "edit", event_data[5]["type"]
+    end
+
+    should "push the correct values to the dataLayer when a form error is triggered" do
+      fill_in "Title", with: ""
+      click_button "Save"
+
+      assert page.has_css?("h2", text: "Edit")
+
+      event_data = get_event_data
+
+      assert_equal "error", event_data[0]["action"]
+      assert_equal "form_error", event_data[0]["event_name"]
+      assert_equal "Edit edition", event_data[0]["type"]
+      assert_equal "Enter a title", event_data[0]["text"]
+      assert_equal "Title", event_data[0]["section"]
+      assert_equal "Answer", event_data[0]["tool_name"]
+    end
+  end
+
+  context "Edit a guide page" do
+    setup do
+      visit edition_path(@guide_edition)
+      click_on "Add a new chapter"
+    end
+
+    should "push the correct values to the dataLayer when a form error is triggered on a Guide part page" do
+      login_as_govuk_editor
+      fill_in "Title", with: ""
+      fill_in "Slug", with: ""
+      click_button "Save"
+
+      assert page.has_css?(".gem-c-heading__context", text: "Guide")
+
+      event_data = get_event_data
+
+      assert_equal "error", event_data[0]["action"]
+      assert_equal "form_error", event_data[0]["event_name"]
+      assert_equal "Edit edition", event_data[0]["type"]
+      assert_equal "Enter a title", event_data[0]["text"]
+      assert_equal "Title", event_data[0]["section"]
+      assert_equal "Guide", event_data[0]["tool_name"]
+
+      assert_equal "error", event_data[1]["action"]
+      assert_equal "form_error", event_data[1]["event_name"]
+      assert_equal "Edit edition", event_data[1]["type"]
+      assert_equal "Enter a slug", event_data[1]["text"]
+      assert_equal "Slug", event_data[1]["section"]
+      assert_equal "Guide", event_data[1]["tool_name"]
     end
   end
 

--- a/test/integration/ga4_tracking_tagging_test.rb
+++ b/test/integration/ga4_tracking_tagging_test.rb
@@ -57,11 +57,13 @@ class Ga4TrackingTaggingTest < JavascriptIntegrationTest
   context "Remove GOVUK breadcrumb page" do
     setup do
       stub_linkables_with_data
-      visit tagging_remove_breadcrumb_page_edition_path(@edition)
-      disable_form_submit
+      visit tagging_edition_path(@edition)
+      click_on("Remove")
     end
 
     should "add breadcrumb removal events to the dataLayer" do
+      disable_form_submit
+
       # Select an option
       find("label", text: "Yes, remove the breadcrumb").click
       # Select a different option
@@ -94,6 +96,21 @@ class Ga4TrackingTaggingTest < JavascriptIntegrationTest
       assert_equal "{\"Are you sure you want to remove the breadcrumb?\":\"No, keep the breadcrumb\"}", event_data[2]["text"]
       assert_equal "Answer", event_data[2]["tool_name"]
       assert_equal "edit", event_data[2]["type"]
+    end
+
+    should "push the correct values to the dataLayer when a form error is triggered" do
+      click_button "Save"
+
+      assert page.has_css?("h1", text: "Are you sure you want to remove the breadcrumb?")
+
+      event_data = get_event_data
+
+      assert_equal "error", event_data[0]["action"]
+      assert_equal "form_error", event_data[0]["event_name"]
+      assert_equal "Edit edition", event_data[0]["type"]
+      assert_equal "Select an option", event_data[0]["text"]
+      assert_equal "Remove parent", event_data[0]["section"]
+      assert_equal "Answer", event_data[0]["tool_name"]
     end
   end
 
@@ -235,11 +252,13 @@ class Ga4TrackingTaggingTest < JavascriptIntegrationTest
   context "Tag to related content page" do
     setup do
       stub_linkables
-      visit tagging_related_content_page_edition_path(@edition)
-      disable_form_submit
+      visit tagging_edition_path(@edition)
+      click_on("Tag to related content")
     end
 
     should "add related content selection events to the dataLayer" do
+      disable_form_submit
+
       # Fill in value for Related content 1
       within all(".js-add-another__fieldset")[0] do
         fill_in "URL or path", with: "/pay-vat"
@@ -335,6 +354,24 @@ class Ga4TrackingTaggingTest < JavascriptIntegrationTest
       # assert_equal "{\"Tag related content\":\"17,20\"}", event_data[6]["text"]
       assert_equal "Answer", event_data[6]["tool_name"]
       assert_equal "edit", event_data[6]["type"]
+    end
+
+    should "push the correct values to the dataLayer when a form error is triggered" do
+      within all(".js-add-another__fieldset")[0] do
+        fill_in "URL or path", with: "/an-invalid-value"
+      end
+      click_button "Save"
+
+      assert page.has_css?("h1", text: "Tag related content")
+
+      event_data = get_event_data
+
+      assert_equal "error", event_data[0]["action"]
+      assert_equal "form_error", event_data[0]["event_name"]
+      assert_equal "Edit edition", event_data[0]["type"]
+      assert_equal "/an-invalid-value is not a known URL on GOV.UK, check URL or path is correctly entered.", event_data[0]["text"]
+      assert_equal "Ordered related items", event_data[0]["section"]
+      assert_equal "Answer", event_data[0]["tool_name"]
     end
   end
 

--- a/test/integration/ga4_tracking_unpublish_test.rb
+++ b/test/integration/ga4_tracking_unpublish_test.rb
@@ -13,10 +13,11 @@ class Ga4TrackingUnpublishTest < JavascriptIntegrationTest
   context "Unpublish tab" do
     setup do
       visit unpublish_edition_path(@edition)
-      disable_form_submit
     end
 
     should "add unpublish events to the dataLayer" do
+      disable_form_submit
+
       fill_in "Redirect to URL", with: "https://www.gov.uk/redirect"
       click_button "Continue"
 
@@ -35,6 +36,23 @@ class Ga4TrackingUnpublishTest < JavascriptIntegrationTest
       assert_equal "{\"Redirect to URL\":\"27\"}", event_data[1]["text"]
       assert_equal "Answer", event_data[1]["tool_name"]
       assert_equal "edit", event_data[1]["type"]
+    end
+
+    should "push the correct values to the dataLayer when a form error is triggered" do
+      stub_linkables_with_data
+      fill_in "Redirect to URL", with: "an-invalid-value"
+      click_button "Continue"
+
+      assert page.has_css?("h2", text: "Unpublish")
+
+      event_data = get_event_data
+
+      assert_equal "error", event_data[0]["action"]
+      assert_equal "form_error", event_data[0]["event_name"]
+      assert_equal "Edit edition", event_data[0]["type"]
+      assert_equal "Redirect path is invalid. Answer can not be unpublished.", event_data[0]["text"]
+      assert_equal "Redirect URL", event_data[0]["section"]
+      assert_equal "Answer", event_data[0]["tool_name"]
     end
   end
 end


### PR DESCRIPTION
[MAIN-7352](https://gov-uk.atlassian.net/browse/MAIN-7352)

This adds GA4 tracking for form_error events and involves the changes below. Primarily it
- puts all instances of the "Error summary" component into the single existing `error_summary` partial
- updates the `error_summary` partial to add the required data-attributes, also putting the `ga4-auto-tracker` module behind the `GA4 Form Tracking` feature flag
- makes some small changes to the views involved to use consistent values for input fields required by use of the partial
- references the required `ga4-auto-tracker` module
- updates existing integration tests to add tests for data fired by error messages
- adds new integration tests for areas not so far covered

Expected data values are listed in the Jira ticket. 

Tracking can be tested locally with these steps: 
- ensure that the "Ga4 form tracking" feature is set to "On" via FlipFlop
- run `window.dataLayer` in the browser console after submitting the form. The console will display all the data that will be sent to be tracked when the user submits the form. In this work we are interested in the "event_data" events. There should be one of these for each error listed in the error summary.

[MAIN-7352]: https://gov-uk.atlassian.net/browse/MAIN-7352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ