### PR TITLE
Improve GA4 Form Error tests

### DIFF
--- a/test/integration/ga4_tracking_add_artefact_test.rb
+++ b/test/integration/ga4_tracking_add_artefact_test.rb
@@ -18,7 +18,7 @@ class Ga4TrackingAddArtefactTest < JavascriptIntegrationTest
     should "push the correct values to the dataLayer when a form error is triggered" do
       click_button "Continue"
 
-      assert page.has_css?("h1", text: "Create new content")
+      assert page.has_css?(".gem-c-error-summary")
 
       event_data = get_event_data
 
@@ -43,7 +43,7 @@ class Ga4TrackingAddArtefactTest < JavascriptIntegrationTest
     should "push the correct values to the dataLayer when a form error is triggered" do
       click_button "Create content"
 
-      assert page.has_css?(".gem-c-heading__context", text: "Create new content")
+      assert page.has_css?(".gem-c-error-summary")
 
       event_data = get_event_data
 

--- a/test/integration/ga4_tracking_downtime_test.rb
+++ b/test/integration/ga4_tracking_downtime_test.rb
@@ -20,9 +20,9 @@ class Ga4DowntimeTest < JavascriptIntegrationTest
     should "push the correct values to the dataLayer when a form error is triggered" do
       click_button "Save"
 
-      event_data = get_event_data
+      assert page.has_css?(".gem-c-error-summary")
 
-      assert page.has_css?("h1", text: "Add downtime message")
+      event_data = get_event_data
 
       assert_equal "error", event_data[0]["action"]
       assert_equal "form_error", event_data[0]["event_name"]
@@ -67,7 +67,7 @@ class Ga4DowntimeTest < JavascriptIntegrationTest
 
       click_button "Save"
 
-      assert page.has_css?("h1", text: "Edit downtime message")
+      assert page.has_css?(".gem-c-error-summary")
 
       event_data = get_event_data
 

--- a/test/integration/ga4_tracking_edit_test.rb
+++ b/test/integration/ga4_tracking_edit_test.rb
@@ -82,7 +82,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
       fill_in "Title", with: ""
       click_button "Save"
 
-      assert page.has_css?("h2", text: "Edit")
+      assert page.has_css?(".gem-c-error-summary")
 
       event_data = get_event_data
 
@@ -107,7 +107,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
       fill_in "Slug", with: ""
       click_button "Save"
 
-      assert page.has_css?(".gem-c-heading__context", text: "Guide")
+      assert page.has_css?(".gem-c-error-summary")
 
       event_data = get_event_data
 

--- a/test/integration/ga4_tracking_tagging_test.rb
+++ b/test/integration/ga4_tracking_tagging_test.rb
@@ -101,7 +101,7 @@ class Ga4TrackingTaggingTest < JavascriptIntegrationTest
     should "push the correct values to the dataLayer when a form error is triggered" do
       click_button "Save"
 
-      assert page.has_css?("h1", text: "Are you sure you want to remove the breadcrumb?")
+      assert page.has_css?(".gem-c-error-summary")
 
       event_data = get_event_data
 
@@ -362,7 +362,7 @@ class Ga4TrackingTaggingTest < JavascriptIntegrationTest
       end
       click_button "Save"
 
-      assert page.has_css?("h1", text: "Tag related content")
+      assert page.has_css?(".gem-c-error-summary")
 
       event_data = get_event_data
 

--- a/test/integration/ga4_tracking_unpublish_test.rb
+++ b/test/integration/ga4_tracking_unpublish_test.rb
@@ -43,7 +43,7 @@ class Ga4TrackingUnpublishTest < JavascriptIntegrationTest
       fill_in "Redirect to URL", with: "an-invalid-value"
       click_button "Continue"
 
-      assert page.has_css?("h2", text: "Unpublish")
+      assert page.has_css?(".gem-c-error-summary")
 
       event_data = get_event_data
 


### PR DESCRIPTION
[MAIN-7352](https://gov-uk.atlassian.net/browse/MAIN-7352)
(populate the link above to make sure your PR is linked to the Jira ticket)

Makes some improvements to the GA4 integration tests for Form Errors: 
- Fixes one flakey test (wrong order of assertions)
- Updates the assertions to check page load to test the presence of an error summary component


[MAIN-7352]: https://gov-uk.atlassian.net/browse/MAIN-7352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ