### PR TITLE
Add CSS rule to `important-note` text on "2i queue" page

### DIFF
--- a/app/assets/stylesheets/publications.scss
+++ b/app/assets/stylesheets/publications.scss
@@ -52,6 +52,7 @@
     font-weight: 400;
     margin-bottom: govuk-spacing(1);
     margin-top: govuk-spacing(1);
+    word-break: break-word;
 
     &::before {
       content: open-quote;


### PR DESCRIPTION
[MAIN-7369](https://gov-uk.atlassian.net/browse/MAIN7369)

Applies a `word-break: break-word` CSS rule to important note text on the "2i Queue" page to stop the text overflowing its container when it contains long strings like URLs or email addresses. 

|Before|After|
|-|-|
|<img width="1155" height="410" alt="Screenshot 2026-04-13 at 14 33 30" src="https://github.com/user-attachments/assets/38067a4b-bd49-455a-a8c1-48434b578559" />|<img width="1155" height="410" alt="Screenshot 2026-04-13 at 14 33 13" src="https://github.com/user-attachments/assets/79e12567-2eb0-44bf-b451-e0207762f7dd" />|

[MAIN-7369]: https://gov-uk.atlassian.net/browse/MAIN-7369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ