### PR TITLE
Update `flash` partial to add GA4 data-attributes to flash messages

### DIFF
--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,15 +1,35 @@
+<% component_helper = GovukPublishingComponents::Presenters::ComponentWrapperHelper.new(local_assigns) %>
+
 <% [:success, :info, :warning, :danger, :notice, :alert].select { |k| flash[k].present? }.each do |k| %>
+  <% data_attributes = {
+    module: "ga4-auto-tracker",
+    "ga4-auto": {
+      event_name: "flash_#{k.to_s}",
+      action: "#{k.to_s}_alerts",
+      text: sanitize(flash[k]),
+    },
+  } %>
+
   <% if k == :warning || k == :danger || k == :alert %>
-    <%= render "govuk_publishing_components/components/error_alert", {
-      message: sanitize(flash[k]),
-    } %>
+    <%= tag.div(**component_helper.all_attributes) do %>
+      <%= render "govuk_publishing_components/components/error_alert", {
+        message: sanitize(flash[k]),
+        data_attributes: data_attributes,
+      } %>
+    <% end %>
   <% elsif k == :notice || k == :info %>
-    <%= render "govuk_publishing_components/components/notice", {
-      description: sanitize(flash[k]),
-    } %>
+    <%= tag.div(**component_helper.all_attributes) do %>
+      <%= render "govuk_publishing_components/components/notice", {
+        description: sanitize(flash[k]),
+        data_attributes: data_attributes,
+      } %>
+    <% end %>
   <% elsif k == :success %>
-    <%= render "govuk_publishing_components/components/success_alert", {
-      message: sanitize(flash[k]),
-    } %>
+    <%= tag.div(**component_helper.all_attributes) do %>
+      <%= render "govuk_publishing_components/components/success_alert", {
+        message: sanitize(flash[k]),
+        data_attributes: data_attributes,
+      } %>
+    <% end %>
   <% end %>
 <% end %>

--- a/test/integration/ga4_tracking_flash_messages_test.rb
+++ b/test/integration/ga4_tracking_flash_messages_test.rb
@@ -1,0 +1,120 @@
+require "integration_test_helper"
+require "support/ga4_test_helpers"
+
+class Ga4TrackingFlashMessagesTest < JavascriptIntegrationTest
+  include Ga4TestHelpers
+
+  setup do
+    setup_users
+    @edition = FactoryBot.create(:edition)
+    @ready_edition = FactoryBot.create(:edition, :ready)
+    @published_edition = FactoryBot.create(:edition, :published)
+  end
+
+  context "Danger alerts" do
+    should "push the correct values to the dataLayer when a welsh_editor attempts to navigate to the 'Create new content' page" do
+      login_as_welsh_editor
+      visit new_artefact_path
+
+      assert page.has_css?(".gem-c-error-alert")
+
+      event_data = get_event_data
+
+      assert_equal "danger_alerts", event_data[0]["action"]
+      assert_equal "flash_danger", event_data[0]["event_name"]
+      assert_equal "You do not have permission to see this page.", event_data[0]["text"]
+    end
+
+    should "push the correct values to the dataLayer when user does not have govuk_editor permission" do
+      login_as(@no_editor)
+      visit history_update_important_note_edition_path(@edition)
+
+      assert page.has_css?(".gem-c-error-alert")
+
+      event_data = get_event_data
+
+      assert_equal "danger_alerts", event_data[0]["action"]
+      assert_equal "flash_danger", event_data[0]["event_name"]
+      assert_equal "You do not have correct editor permissions for this action.", event_data[0]["text"]
+    end
+
+    should "push the correct values to the dataLayer on a server error" do
+      EditionProgressor.any_instance.expects(:progress).returns(false)
+
+      visit send_to_2i_page_edition_path(@edition)
+      fill_in "Comment (optional)", with: "Some comment"
+      click_button "Send to 2i"
+
+      assert page.has_css?(".gem-c-error-alert")
+
+      event_data = get_event_data
+
+      assert_equal "danger_alerts", event_data[0]["action"]
+      assert_equal "flash_danger", event_data[0]["event_name"]
+      assert_equal "Due to a service problem, the request could not be made", event_data[0]["text"]
+    end
+
+    should "push the correct values to the dataLayer when the edition is not in a valid state to be sent to 2i" do
+      visit send_to_2i_page_edition_path(@ready_edition)
+      fill_in "Comment (optional)", with: "Some comment"
+      click_button "Send to 2i"
+
+      assert page.has_css?(".gem-c-error-alert")
+
+      event_data = get_event_data
+
+      assert_equal "danger_alerts", event_data[0]["action"]
+      assert_equal "flash_danger", event_data[0]["event_name"]
+      assert_equal "Edition is not in a state where it can be sent to 2i", event_data[0]["text"]
+    end
+  end
+
+  context "Warning alerts" do
+    should "push the correct values to the dataLayer when another user has already created a new edition" do
+      visit edition_path(@published_edition)
+      click_on "Admin"
+
+      FactoryBot.create(:edition, panopticon_id: @published_edition.artefact.id)
+
+      click_button "Save"
+
+      assert page.has_css?(".gem-c-error-alert")
+
+      event_data = get_event_data
+
+      assert_equal "warning_alerts", event_data[0]["action"]
+      assert_equal "flash_warning", event_data[0]["event_name"]
+      assert_equal "Another person has created a newer edition", event_data[0]["text"]
+    end
+  end
+
+  context "Success alerts" do
+    should "push the correct flash message values to the dataLayer when edition is successfully saved" do
+      visit edition_path(@edition)
+      fill_in "Title", with: "The new title"
+      click_button "Save"
+
+      assert page.has_css?(".gem-c-success-alert")
+
+      event_data = get_event_data
+
+      assert_equal "success_alerts", event_data[0]["action"]
+      assert_equal "flash_success", event_data[0]["event_name"]
+      assert_equal "Edition updated successfully.", event_data[0]["text"]
+    end
+
+    should "push the correct flash message values to the dataLayer when edition is successfully sent to 2i" do
+      visit send_to_2i_page_edition_path(@edition)
+      fill_in "Comment (optional)", with: "Some comment"
+      click_button "Send to 2i"
+
+      assert page.has_css?(".gem-c-success-alert")
+
+      event_data = get_event_data
+
+      assert_equal "success_alerts", event_data[0]["action"]
+      assert_equal "flash_success", event_data[0]["event_name"]
+      assert_equal "Sent to 2i", event_data[0]["text"]
+    end
+  end
+end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -23,6 +23,7 @@ class IntegrationTest < ActionDispatch::IntegrationTest
     # tests that cover the oauth interaction properly
     @author = FactoryBot.create(:user, :govuk_editor, name: "Author", email: "test@example.com")
     @reviewer = FactoryBot.create(:user, :govuk_editor, name: "Reviewer", email: "test@example.com")
+    @no_editor = FactoryBot.create(:user, name: "No Editor", email: "test@example.com")
     @other = FactoryBot.create(:user, :govuk_editor, :skip_review, name: "Other", email: "test@example.com")
   end
 


### PR DESCRIPTION
[MAIN-7345](https://gov-uk.atlassian.net/browse/MAIN-7345)

Add GA4 event tracking to Flash messages by adding the following data-attributes to each instance of a flash message across Publisher as described in the Jira ticket: 
- the `ga4-auto-tracker` data-module
- parameters for the `data-ga4-auto` attribute: 
  - event_name
  - text
  - action

It feels like this should include some tests but I am unsure what tests we would add for this. Adding integration test for every instance of a flash message (there are probably around 150 across Publisher) to check that each instance fires the correct event on page load seems a little excessive. For reference there are existing functional test associated with various controllers in the tests below which could be repurposed as integration tests but would involve alot of work. 
- artefacts_controller_test.rb
- content_item_controller_test.rb
- downtimes_controller_test.rb
- editions_controller_test.rb
- guide_parts_controller_test.rb
- homepage_controller_test.rb
- notes_controller_test.rb
- tagging_controller_test.rb

This can tested manually as below: 
- run `window.dataLayer` in the browser console after a page with a flash message loads. 
- In this work we are interested in the "event_data" events. There should be one of these for the flash message with the values listed in the Jira ticket.

[MAIN-7345]: https://gov-uk.atlassian.net/browse/MAIN-7345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ