### PR TITLE
[MAIN-7370] Add draft preview fields to fact-check-manager API payloads

### DIFF
--- a/app/lib/gds_api/fact_check_manager.rb
+++ b/app/lib/gds_api/fact_check_manager.rb
@@ -14,11 +14,15 @@ class GdsApi::FactCheckManager < GdsApi::Base
   # @option [hash] previous_content Hash containing HTML content of previous content version to check against
   # @option [string] deadline Date a response is requested by. Use iso8601 date format: "2026-02-09"
   # @param [array] recipients Array of emails to be notified of the request
+  # @option [uuid] draft_auth_bypass_id The edition's auth_bypass_id for draft origin preview access
+  # @option [uuid] draft_content_id The edition's content_id for draft origin preview access
+  # @option [string] draft_slug The edition's slug for the draft origin preview URL path
   #
   # @return [GdsApi::Response] Basic response with code
 
   def post_fact_check(source_app:, source_id:, requester_name:, requester_email:, current_content:,
-                      recipients:, source_title: nil, source_url: nil, previous_content: nil, deadline: nil)
+                      recipients:, source_title: nil, source_url: nil, previous_content: {}, deadline: nil,
+                      draft_auth_bypass_id: nil, draft_content_id: nil, draft_slug: nil)
     post_json(
       "#{endpoint}/api/requests",
       source_app:,
@@ -31,6 +35,9 @@ class GdsApi::FactCheckManager < GdsApi::Base
       previous_content:,
       deadline:,
       recipients:,
+      draft_auth_bypass_id:,
+      draft_content_id:,
+      draft_slug:,
     )
   end
 
@@ -53,10 +60,14 @@ class GdsApi::FactCheckManager < GdsApi::Base
   # @param [uuid] source_id The unique ID for the content
   # @param [hash] current_content
   # @option [string] source_title The title of the content (optional)
-  def patch_update_content(source_app:, source_id:, current_content:, source_title: nil)
+  # @option [uuid] draft_auth_bypass_id The edition's auth_bypass_id for draft origin preview access (optional)
+  # @option [string] draft_slug The edition's slug for the draft origin preview URL path (optional)
+  def patch_update_content(source_app:, source_id:, current_content:, source_title: nil, draft_auth_bypass_id: nil, draft_slug: nil)
     payload = {
       source_title:,
       current_content:,
+      draft_auth_bypass_id:,
+      draft_slug:,
     }.compact
 
     patch_json("#{endpoint}/api/requests/#{source_app}/#{source_id}", payload)

--- a/app/services/fact_check_manager_api_service.rb
+++ b/app/services/fact_check_manager_api_service.rb
@@ -14,7 +14,7 @@ class FactCheckManagerApiService
 
   def self.build_post_payload(edition, requester, email_addresses)
     current_content_presenter = Formats::GenericEditionPresenter.new(edition)
-    previous_content = nil
+    previous_content = {}
     if edition.published_edition
       previous_content_presenter = Formats::GenericEditionPresenter.new(edition.published_edition)
       previous_content = previous_content_presenter.render_for_fact_check_manager_api
@@ -29,7 +29,10 @@ class FactCheckManagerApiService
       current_content: current_content_presenter.render_for_fact_check_manager_api,
       previous_content: previous_content,
       deadline: working_days_after(Date.current, how_many: 5).to_fs(:iso8601),
-      recipients: email_addresses.split(",").map(&:strip) }
+      recipients: email_addresses.split(",").map(&:strip),
+      draft_auth_bypass_id: edition.auth_bypass_id,
+      draft_content_id: edition.content_id,
+      draft_slug: edition.slug }
   end
 
   def self.update_fact_check_content(edition)
@@ -40,6 +43,8 @@ class FactCheckManagerApiService
       source_id: edition.id,
       source_title: edition.title,
       current_content: current_content_presenter.render_for_fact_check_manager_api,
+      draft_auth_bypass_id: edition.auth_bypass_id,
+      draft_slug: edition.slug,
     )
   end
 end

--- a/test/unit/services/fact_check_manager_api_service_test.rb
+++ b/test/unit/services/fact_check_manager_api_service_test.rb
@@ -29,7 +29,7 @@ class FactCheckManagerApiServiceTest < ActiveSupport::TestCase
   context ".update_fact_check_content" do
     should "call the fact check manager api adapter" do
       Services.fact_check_manager_api.expects(:patch_update_content)
-              .with(source_app: "publisher", source_id: @edition.id, source_title: "New Title", current_content: { body: "some body" })
+              .with(source_app: "publisher", source_id: @edition.id, source_title: "New Title", current_content: { body: "some body" }, draft_auth_bypass_id: @edition.auth_bypass_id, draft_slug: @edition.slug)
               .returns("stub response")
 
       FactCheckManagerApiService.update_fact_check_content(@edition)
@@ -48,9 +48,12 @@ class FactCheckManagerApiServiceTest < ActiveSupport::TestCase
                              requester_name: "Ben",
                              requester_email: "joe1@bloggs.com",
                              current_content: { body: "some body" },
-                             previous_content: nil,
+                             previous_content: {},
                              deadline: "2026-02-09",
-                             recipients: ["stub@email.com"] }
+                             recipients: ["stub@email.com"],
+                             draft_content_id: @edition.content_id,
+                             draft_auth_bypass_id: @edition.auth_bypass_id,
+                             draft_slug: @edition.slug }
 
         assert_equal expected_payload, payload
       end


### PR DESCRIPTION
[MAIN-7370](https://gov-uk.atlassian.net/browse/MAIN-7370)

### Changes
An edition's `auth_bypass_id`, `content_id` and `slug` are required to generate the draft origin preview link in fact-check-manager. These fields are added to the API payload for `post_fact_check`. The `auth_bypass_id` and `slug` are added to `patch_fact_check` to allow changes to their values to be pushed to fact-check-manager.

These fields are optional for the gds-api methods but always sent from Publisher via the service that calls them.

[MAIN-7370]: https://gov-uk.atlassian.net/browse/MAIN-7370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ