### PR TITLE
Set default for `ga4_form_tracking` feature to `true`

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -19,7 +19,7 @@ Flipflop.configure do
             description: "Shows link to Content Block Manager from Mainstream editor"
 
     feature :ga4_form_tracking,
-            default: false,
+            default: true,
             description: "Add tracking to forms across publisher"
   end
 


### PR DESCRIPTION
[MAIN-7378](https://gov-uk.atlassian.net/browse/MAIN-7378)

As a first step towards removing the "GA4 Form Tracking" feature flag this PR sets the default state of that feature to "On" so that we can test this tracking with real users and ensure there are no unwanted side effects before removing it. 

[MAIN-7378]: https://gov-uk.atlassian.net/browse/MAIN-7378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ