### PR TITLE
Increase Rack QueryParser params_limit

### DIFF
--- a/config/initializers/rack_query_parser.rb
+++ b/config/initializers/rack_query_parser.rb
@@ -1,0 +1,3 @@
+# Increase params_limit from default of 4096 due to large simple smart answers exceeding this
+# Leave params_depth_limit as default 32
+Rack::Utils.default_query_parser = Rack::QueryParser.make_default(32, params_limit: 10_000)


### PR DESCRIPTION
We have some SimpleSmartAnswer records ([example](https://publisher.integration.publishing.service.gov.uk/editions/e31d89cf-605e-45cb-b152-82265195bda5)) which have a very large number of nodes. When attempting to save these records, the user sees an error because the size of the params exceeds the default limit put in place by Rack's QueryParser (4096). Increasing the `params_limit` will prevent this.