### PR TITLE
Pass edition to path helper in reviewer_edit_link

### DIFF
--- a/app/helpers/tabbed_nav_helper.rb
+++ b/app/helpers/tabbed_nav_helper.rb
@@ -48,7 +48,7 @@ module TabbedNavHelper
   def reviewer_edit_link(edition)
     if current_user.has_editor_permissions?(edition)
       {
-        href: edit_reviewer_edition_path,
+        href: edit_reviewer_edition_path(edition),
         link_text: "Edit",
       }
     else


### PR DESCRIPTION
### Changes

If the `edit_reviewer_edition_path` path helper is called whilst creating a new guide part (e.g. if it is "in 2i"), the edition ID cannot be retrieved from `params[:id]`. The edition is now passed to the path helper to account for this.