### PR TITLE
MAIN-7339 Preview link revocation Rake task

### DIFF
--- a/lib/tasks/fact_check.rake
+++ b/lib/tasks/fact_check.rake
@@ -1,0 +1,16 @@
+namespace :fact_check do
+  desc "Revoke and renew draft preview links for given edition ids"
+  task :revoke_and_renew_draft_links, [:edition_id] => :environment do |_t, args|
+    edition_ids = args[:edition_id].split(",")
+
+    edition_ids.each do |id|
+      edition = Edition.find_by(id: id)
+
+      edition.auth_bypass_id = SecureRandom.uuid
+      edition.save!
+
+      UpdateWorker.perform_async(id)
+      FactCheckManagerApiService.update_fact_check_content(edition)
+    end
+  end
+end

--- a/test/support/factories.rb
+++ b/test/support/factories.rb
@@ -169,6 +169,10 @@ FactoryBot.define do
       end
     end
 
+    trait :auth_bypass_id do
+      auth_bypass_id { SecureRandom.uuid }
+    end
+
     trait :welsh do
       panopticon_id { create(:artefact, language: "cy", kind: kind_for_artefact).id }
     end

--- a/test/unit/tasks/revoke_and_renew_draft_links_test.rb
+++ b/test/unit/tasks/revoke_and_renew_draft_links_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+require "support/fact_check_manager_api_helpers"
+require "rake"
+
+class RevokeAndRenewDraftLinksTest < ActiveSupport::TestCase
+  setup do
+    stub_patch_update_fact_check_content(success: true)
+    @draft_edition = create_authed_edition
+    @second_draft_edition = create_authed_edition
+  end
+
+  context "#fact_check:revoke_and_renew_draft_links" do
+    should "clear the current auth_bypass_id for the given editions" do
+      Rake::Task["fact_check:revoke_and_renew_draft_links"].reenable
+      first_auth_bypass_id = @draft_edition.auth_bypass_id.to_s
+      second_auth_bypass_id = @second_draft_edition.auth_bypass_id.to_s
+
+      UpdateWorker.expects(:perform_async).with(@draft_edition.id.to_s)
+      UpdateWorker.expects(:perform_async).with(@second_draft_edition.id.to_s)
+      Rake::Task["fact_check:revoke_and_renew_draft_links"].invoke("#{@draft_edition.id},#{@second_draft_edition.id}")
+
+      @draft_edition.reload
+      @second_draft_edition.reload
+
+      assert_not_equal(first_auth_bypass_id, @draft_edition.auth_bypass_id.to_s)
+      assert_not_equal(second_auth_bypass_id, @second_draft_edition.auth_bypass_id.to_s)
+    end
+  end
+
+  def create_authed_edition
+    FactoryBot.create(:edition, :auth_bypass_id)
+  end
+end


### PR DESCRIPTION
As part of the Fact Check Manager work we need to implement this temporary measure to rotate auth bypass keys for preview links.

This rake task provides a new bypass  UUID for the given comma separated array of edition IDs, updates the edition with that new auth bypass then pushes that update to publishing-api and fact check manager.

[MAIN-7339](https://gov-uk.atlassian.net/browse/MAIN-7339)
(populate the link above to make sure your PR is linked to the Jira ticket)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


[MAIN-7339]: https://gov-uk.atlassian.net/browse/MAIN-7339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ