### PR TITLE
Fix exception handler for Notify errors in `ApplicationController`

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,19 +34,17 @@ class ApplicationController < ActionController::Base
   end
 
   def notify_bad_request(exception)
-    # TODO: control this via the log level rather than an environment variable
-    if %w[integration staging].include?(ENV["GOVUK_ENVIRONMENT"]) && exception.message =~ /team-only API key/
-      # in production we care about all errors
-      # in staging and integration the team-only error may be encountered by
-      # end-users who should see a more helpful error message
-      raise
-    else
+    # If we use a team-only Notify API key in future for staging and integration
+    # the team-only error may be encountered, this logs a more helpful message
+    if GovukEnvironment.current != "production" && exception.message =~ /team-only API key/
       error = <<~ERROR
         Error: One or more recipients not in GOV.UK Notify team (code: 400).
         This error will not occur in Production.
       ERROR
 
-      render plain: error, status: :bad_request
+      Rails.logger.error("#{error}, code: #{exception.code}")
+    else
+      raise
     end
   end
 

--- a/test/integration/legacy_edition_workflow_test.rb
+++ b/test/integration/legacy_edition_workflow_test.rb
@@ -258,30 +258,6 @@ class LegacyEditionWorkflowTest < LegacyJavascriptIntegrationTest
     assert_equal "Blah blah fact check message", resent_fact_check_email.body.to_s
   end
 
-  test "sending a fact check email to a non-permitted address will return an error" do
-    raises_exception = lambda { |_request, _params|
-      response = Minitest::Mock.new
-      response.expect :code, 400
-      response.expect :body, "Can't send to this recipient using a team-only API key"
-      raise Notifications::Client::BadRequestError, response
-    }
-
-    EventMailer.stub(:request_fact_check, raises_exception) do
-      @simple_smart_answer.update!(state: "ready")
-      visit_edition @simple_smart_answer
-
-      click_link("Fact check")
-
-      within "#send_fact_check_form" do
-        fill_in "Customised message", with: "Blah blah fact check message"
-        fill_in "Email address", with: "user-to-ask-for-fact-check@example.com"
-        click_on "Send"
-      end
-
-      assert page.has_content? "Error: One or more recipients not in GOV.UK Notify team (code: 400).\nThis error will not occur in Production."
-    end
-  end
-
   should "be able to send simple smart answer for review" do
     @simple_smart_answer.assigned_to = bob
 


### PR DESCRIPTION
- Logic for this contradicted the comment and would surely result in exceptions being raised in non-prod environments rather than being handled gracefully.
- User (dev) friendly 'Team only key' errors would be raised in prod, not in staging or integration

Hopefully, this PR can correct the above so that we can use the team-only Notify key more effectively in Integration.

Needs manual testing in integration to ensure that we can send emails to team members. 
