### PR TITLE
MAIN-7404 - Update Fact Check docs

### DIFF
--- a/docs/fact-checking.md
+++ b/docs/fact-checking.md
@@ -4,11 +4,10 @@ Publisher comes with a system to allow editions not yet published to be external
 
 ## Process
 
-1. When a content designer clicks the "Fact check" button on an edition, they are presented with a form allowing them to input the email addresses they would like the fact check request to go to.
-1. The fact checker who receives the email then reviews the draft version of the edition, and once happy, replies to the email with the review.
-1. The email arrives in a Gmail inbox. Details of which inbox can be found in secrets under `govuk::apps::publisher::fact_check_username` and `govuk::apps::publisher::fact_check_password`.
-1. Every 5 minutes, the [mail_fetcher](../script/mail_fetcher) script runs which reads any new emails from the inbox, parses the response and adds it to the edition in the database.
+1. When a content designer clicks the "Fact check" button on an edition, they are presented with a form allowing them to input the email addresses they would like the fact check request to go to. 
+1. Upon sending this email, a comparison age is generated in Fact Check Manager via the API.
+1. The email contains a link to the comparison page in Fact Check Manager showing the content of the previous and current versions in a comparison view.
+1. If the user has signon permissions to respond, the user follows the steps in Fact Check Manager to either indicate that the changes are correct, or indicate the changes are incorrect with a comment.
+1. When that fact check is sent, Publisher recieves an API request from Fact Check Manager that updates the status of the edition with the response, either positive or negative, and any relevant note.
 
-**Note:** The ID of the edition is included in the subject line of the fact check email. It's important that this is never removed, otherwise the app will be [unable to match the email with the edition](https://docs.publishing.service.gov.uk/manual/alerts/publisher-unprocessed-fact-check-emails.html). Be aware that for integration and staging environments, the edition ID must be prefixed with `dev-` e.g. `[dev-1594a727e9c5442ba183a6b3ea02b237]`
-
-**Information:** Sometimes fact check emails will fail to be processed. We use Prometheus to report this, and you can see how many are currently in the production fact-check inbox using [this grafana page](https://grafana.eks.production.govuk.digital/explore?schemaVersion=1&panes=%7B%22fj9%22%3A%7B%22datasource%22%3A%22prometheus%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22publisher_fact_check_unprocessed_emails_total%22%2C%22range%22%3Atrue%2C%22instant%22%3Atrue%2C%22datasource%22%3A%7B%22type%22%3A%22prometheus%22%2C%22uid%22%3A%22prometheus%22%7D%2C%22editorMode%22%3A%22code%22%2C%22legendFormat%22%3A%22unprocessed_emails%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-30d%22%2C%22to%22%3A%22now%22%7D%7D%7D&orgId=1).
+**Note:** Due to security requirements we need to manually reset the edition's `auth_bypass_id` and thus invalidate existing preview links at this stage. We can do this by supplying a comma separated list of quote edition IDs to the [associated rake task](https://github.com/alphagov/publisher/pull/3284/changes#diff-84ce051a6ca45ebf2ca70242f2b143f331c43aeb926b4344c862b68a425e3ac4R2). For example `fact_check:revoke_and_renew_draft_links["edition_id1","edition_id2"]`


### PR DESCRIPTION
The fact checking process has changed significantly from the email setup that existed previously. This commit updates the relevant documentation to reflect the new process.

[MAIN-7404](https://gov-uk.atlassian.net/browse/MAIN-7404)
(populate the link above to make sure your PR is linked to the Jira ticket)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


[MAIN-7404]: https://gov-uk.atlassian.net/browse/MAIN-7404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ