### PR TITLE
Main 7209 correct section values

### DIFF
--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -48,7 +48,7 @@
     <% end %>
   </div>
 <% else %>
-  <%= form_for @resource, as: :edition, url: edition_path(@resource), data: {module: "unsaved-changes-prompt"} do %>
+  <%= form_for @resource, as: :edition, url: edition_path(@resource), data: {module: "unsaved-changes-prompt", ga4_section: "Edit - #{@resource.title}"} do %>
     <div class="govuk-grid-row edit--editable">
       <div class="govuk-grid-column-two-thirds">
         <%= render partial: "editions/secondary_nav_tabs/edit/editable/#{@resource.kind_for_artefact}", locals: { edition: @resource } %>

--- a/app/views/editions/secondary_nav_tabs/_metadata.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_metadata.html.erb
@@ -3,7 +3,7 @@
     <%= header_for("Metadata") %>
 
     <% if Edition::PUBLISHING_API_DRAFT_STATES.include?(publication.state) && current_user.govuk_editor? %>
-      <%= form_for(@artefact, :html => { :class => "artefact", :id => "edit_artefact", :data => { module: "unsaved-changes-prompt" }}) do |f| %>
+      <%= form_for(@artefact, :html => { :class => "artefact", :id => "edit_artefact", :data => { module: "unsaved-changes-prompt", ga4_section: "Metadata - #{publication.title}" }}) do |f| %>
         <%= f.hidden_field :id, value: @artefact.id %>
 
         <%= render "govuk_publishing_components/components/input", {

--- a/app/views/editions/secondary_nav_tabs/_progress_with_comment.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_progress_with_comment.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (form_url:, comment_label_text:, submit_button_text:, text: nil, schedule_fields: nil) %>
+<%# locals: (title:, form_url:, comment_label_text:, submit_button_text:, text: nil, schedule_fields: nil) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -9,7 +9,7 @@
       </p>
     <% end %>
 
-    <%= form_for(:edition, url: form_url, data: {module: ""}) do %>
+    <%= form_for(:edition, url: form_url, data: { module: "", ga4_section: "Edit - #{title}" }) do %>
       <%= render "govuk_publishing_components/components/textarea", {
         label: {
           heading_size: "m",

--- a/app/views/editions/secondary_nav_tabs/_related_external_links.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_related_external_links.html.erb
@@ -1,8 +1,10 @@
+<% title = "Related external links" %>
+
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds" data-ga4-section="Related external links">
-    <%= header_for("Related external links") %>
+  <div class="govuk-grid-column-two-thirds">
+    <%= header_for(title) %>
     <% if current_user.has_editor_permissions?(@resource) %>
-      <%= form_for @edition.artefact, url: update_related_external_links_edition_path(@resource), data: {module: "unsaved-changes-prompt"} do %>
+      <%= form_for @edition.artefact, url: update_related_external_links_edition_path(@resource), data: {module: "unsaved-changes-prompt", ga4_section: title} do %>
         <%
           if @edition.artefact.external_links.count == 0
             items = []
@@ -24,6 +26,9 @@
           empty_fields: true,
           items: items,
           empty: empty,
+          data_attributes: {
+            "ga4-section": title,
+          },
         } %>
 
         <%= render "govuk_publishing_components/components/inset_text", {

--- a/app/views/editions/secondary_nav_tabs/_unpublish.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_unpublish.html.erb
@@ -1,13 +1,15 @@
+<% title = "Unpublish" %>
+
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds" data-ga4-section="Unpublish">
+  <div class="govuk-grid-column-two-thirds">
     <% @edition = @resource %>
-    <%= header_for("Unpublish") %>
+    <%= header_for(title) %>
 
     <%= render "govuk_publishing_components/components/inset_text", {
       text: "If you unpublish a page from GOV.UK it cannot be undone.",
     } %>
 
-    <%= form_for @edition, url: confirm_unpublish_edition_path, method: "get", data: { module: "" } do |f| %>
+    <%= form_for @edition, url: confirm_unpublish_edition_path, method: "get", data: { module: "", ga4_section: title } do |f| %>
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: "Redirect to URL",

--- a/app/views/editions/secondary_nav_tabs/add_edition_note.html.erb
+++ b/app/views/editions/secondary_nav_tabs/add_edition_note.html.erb
@@ -1,13 +1,14 @@
 <% @edition = @resource %>
+<% title =  "Add edition note" %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "Add edition note" %>
-<% content_for :title, "Add edition note" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">Explain what changes you did or did not make and why. Include a link to the relevant Zendesk ticket and Jira card. You can also add an edition note when you send the edition for 2i review. <%= link_to "Read guidance on writing good change notes (opens in new tab)", "https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes", target: "_blank", rel: "noopener", class: "govuk-link--no-visited-state" %>.</p>
 
-    <%= form_for(:note, :url=> notes_path, data: { module: "" }) do |f| %>
+    <%= form_for(:note, :url=> notes_path, data: { module: "", ga4_section: "History and notes - #{title}" }) do |f| %>
       <%= hidden_field_tag :edition_id, resource.id %>
 
       <%= render "govuk_publishing_components/components/textarea", {

--- a/app/views/editions/secondary_nav_tabs/approve_fact_check_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/approve_fact_check_page.html.erb
@@ -1,10 +1,12 @@
 <% @edition = @resource %>
+<% title = "Approve fact check" %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "Approve fact check" %>
-<% content_for :title, "Approve fact check" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 
 <%= render "editions/secondary_nav_tabs/progress_with_comment", {
   form_url: approve_fact_check_edition_path(@edition),
   comment_label_text: "Comment (optional)",
   submit_button_text: "Approve fact check",
+  title:,
 } %>

--- a/app/views/editions/secondary_nav_tabs/cancel_scheduled_publishing_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/cancel_scheduled_publishing_page.html.erb
@@ -1,10 +1,12 @@
 <% @edition = @resource %>
+<% title = "Cancel scheduled publishing" %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "Cancel scheduled publishing" %>
-<% content_for :title, "Cancel scheduled publishing" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 
 <%= render "editions/secondary_nav_tabs/progress_with_comment", {
   form_url: cancel_scheduled_publishing_edition_path(@edition),
   comment_label_text: "Comment (optional)" ,
   submit_button_text: "Cancel scheduled publishing" ,
+  title:,
 } %>

--- a/app/views/editions/secondary_nav_tabs/confirm_destroy.html.erb
+++ b/app/views/editions/secondary_nav_tabs/confirm_destroy.html.erb
@@ -1,7 +1,8 @@
 <% @edition = @resource %>
+<% title = "Delete edition" %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "Delete edition" %>
-<% content_for :title, "Delete edition" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 <div class="govuk-grid-row">
   <% unless @edition.errors.empty? %>
     <% content_for :error_summary do %>
@@ -23,7 +24,7 @@
       text: "If you delete this edition it cannot be undone.",
     } %>
 
-    <%= form_for @edition, url: admin_delete_edition_path(@edition), method: :delete, data: { module: "" } do %>
+    <%= form_for @edition, url: admin_delete_edition_path(@edition), method: :delete, data: { module: "", ga4_section: "Admin - #{title}" } do %>
       <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete this edition?</p>
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/editions/secondary_nav_tabs/edit_assignee/_edit_assignee.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit_assignee/_edit_assignee.html.erb
@@ -6,7 +6,7 @@
 <% content_for :page_title, title %>
 <% content_for :title, title %>
 
-<%= form_for @resource, url: url, data: {module: ""} do %>
+<%= form_for @resource, url: url, data: {module: "", ga4_section: "Edit - #{title}"} do %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= tag.div(**component_helper.all_attributes) do %>

--- a/app/views/editions/secondary_nav_tabs/no_changes_needed_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/no_changes_needed_page.html.erb
@@ -1,10 +1,12 @@
 <% @edition = @resource %>
+<% title = "No changes needed" %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "No changes needed" %>
-<% content_for :title, "No changes needed" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 
 <%= render "editions/secondary_nav_tabs/progress_with_comment", {
   form_url: no_changes_needed_edition_path(@edition),
   comment_label_text: "Comment (optional)",
   submit_button_text: "Approve 2i",
+  title:,
 } %>

--- a/app/views/editions/secondary_nav_tabs/request_amendments_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/request_amendments_page.html.erb
@@ -1,10 +1,12 @@
 <% @edition = @resource %>
+<% title = "Request amendments" %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "Request amendments" %>
-<% content_for :title, "Request amendments" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 
 <%= render "editions/secondary_nav_tabs/progress_with_comment", {
   form_url: request_amendments_edition_path(@edition),
   comment_label_text: "Amendment details (optional)",
   submit_button_text: "Request amendments",
+  title:,
 } %>

--- a/app/views/editions/secondary_nav_tabs/resend_fact_check_email_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/resend_fact_check_email_page.html.erb
@@ -1,11 +1,12 @@
 <% @edition = @resource %>
+<% title = "Resend fact check email" %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "Resend fact check email" %>
-<% content_for :title, "Resend fact check email" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds edit--resend-fact-check-email-page">
-    <%= form_for @resource, url: resend_fact_check_email_edition_path(@resource), data: { module: ""} do %>
+    <%= form_for @resource, url: resend_fact_check_email_edition_path(@resource), data: { module: "", ga4_section: "Edit - #{title}" } do %>
       <section class="govuk-!-margin-bottom-6">
         <%= render "govuk_publishing_components/components/heading", {
           text: "Email addresses",

--- a/app/views/editions/secondary_nav_tabs/schedule_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/schedule_page.html.erb
@@ -1,12 +1,14 @@
 <% @edition = @resource %>
+<% title = "Schedule publication" %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "Schedule publication" %>
-<% content_for :title, "Schedule publication" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 
 <%= render "editions/secondary_nav_tabs/progress_with_comment", {
   form_url: schedule_edition_path(@edition),
   comment_label_text: "Comment (optional)",
   submit_button_text: "Schedule",
+  title:,
   schedule_fields: (render "govuk_publishing_components/components/fieldset", {
     legend_text: "Publication date",
     heading_size: "m",

--- a/app/views/editions/secondary_nav_tabs/send_to_2i_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/send_to_2i_page.html.erb
@@ -1,7 +1,8 @@
 <% @edition = @resource %>
+<% title = "Send to 2i" %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "Send to 2i" %>
-<% content_for :title, "Send to 2i" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 
 <%= render "editions/secondary_nav_tabs/progress_with_comment", {
   form_url: send_to_2i_edition_path(@edition),
@@ -10,4 +11,5 @@
     #{link_to("Read guidance on writing good change notes (opens in new tab)", "https://gov-uk.atlassian.net/l/cp/dwn06raQ", target: "_blank", rel: "noopener noreferrer", class: "govuk-link govuk-link--no-visited-state")}".html_safe,
   comment_label_text: "Comment (optional)" ,
   submit_button_text: "Send to 2i",
+  title:,
 } %>

--- a/app/views/editions/secondary_nav_tabs/send_to_fact_check_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/send_to_fact_check_page.html.erb
@@ -1,7 +1,8 @@
 <% @edition = @resource %>
+<% title = "Send to fact check" %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "Send for fact check" %>
-<% content_for :title, "Send for fact check" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 <% template = render template: "event_mailer/request_fact_check", formats: [:text] %>
 
 <div class="govuk-grid-row">
@@ -12,7 +13,7 @@
         <% content_for :error_summary, render("shared/error_summary", { object: @form, full_messages: false }) %>
       <% end %>
 
-      <%= form_with model: @form, scope: :fact_check_request_form, url: send_to_fact_check_edition_path(@edition), html: { novalidate: "novalidate" }, data: { module: "" } do %>
+      <%= form_with model: @form, scope: :fact_check_request_form, url: send_to_fact_check_edition_path(@edition), html: { novalidate: "novalidate" }, data: { module: "", ga4_section: "Edit - #{title}" } do %>
 
         <%= render "govuk_publishing_components/components/input", {
           label: {
@@ -96,7 +97,7 @@
 
     <% else %>
 
-      <%= form_for(:edition, url: send_to_fact_check_edition_path(@edition), html: { novalidate: "novalidate" }, data: { module: "" }) do %>
+      <%= form_for(:edition, url: send_to_fact_check_edition_path(@edition), html: { novalidate: "novalidate" }, data: { module: "", ga4_section: "Edit - #{title}" }) do %>
           <%= render "govuk_publishing_components/components/input", {
             label: {
               heading_size: "m",

--- a/app/views/editions/secondary_nav_tabs/send_to_publish_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/send_to_publish_page.html.erb
@@ -1,10 +1,12 @@
 <% @edition = @resource %>
+<% title = "Send to publish" %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "Send to publish" %>
-<% content_for :title, "Send to publish" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 
 <%= render "editions/secondary_nav_tabs/progress_with_comment", {
   form_url: send_to_publish_edition_path(@edition),
   comment_label_text: "Comment (optional)",
   submit_button_text: "Send to publish",
+  title:,
 } %>

--- a/app/views/editions/secondary_nav_tabs/skip_review_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/skip_review_page.html.erb
@@ -1,11 +1,13 @@
 <% @edition = @resource %>
+<% title = "Skip review" %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "Skip review" %>
-<% content_for :title, "Skip review" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 
 <%= render "editions/secondary_nav_tabs/progress_with_comment", {
   form_url: skip_review_edition_path(@edition),
   text: "You should only skip review in exceptional circumstances, for example if you’re the only person responding to an emergency out of hours call.",
   comment_label_text: "Comment (optional)",
   submit_button_text: "Skip review",
+  title:,
 } %>

--- a/app/views/editions/secondary_nav_tabs/tagging_breadcrumb_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/tagging_breadcrumb_page.html.erb
@@ -1,9 +1,10 @@
 <% @edition = @resource %>
+<% title = "Set GOV.UK breadcrumb" %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "Set GOV.UK breadcrumb" %>
-<% content_for :title, "Set GOV.UK breadcrumb" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 
-<%= form_with model: @tagging_update_form_values, url: update_breadcrumb_edition_path(@resource), data: { module: "" } do |f| %>
+<%= form_with model: @tagging_update_form_values, url: update_breadcrumb_edition_path(@resource), data: { module: "", ga4_section: "Tagging - #{title}" } do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/hint", {

--- a/app/views/editions/secondary_nav_tabs/tagging_mainstream_browse_pages_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/tagging_mainstream_browse_pages_page.html.erb
@@ -1,9 +1,10 @@
 <% @edition = @resource %>
+<% title = "Tag browse pages" %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "Tag browse pages" %>
-<% content_for :title, "Tag browse pages" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 
-<%= form_with model: @tagging_update_form_values, url: update_mainstream_browse_pages_edition_path(@edition), data: {module: ""} do |f| %>
+<%= form_with model: @tagging_update_form_values, url: update_mainstream_browse_pages_edition_path(@edition), data: {module: "", ga4_section: "Tagging - #{title}"} do |f| %>
   <%= f.hidden_field :previous_version %>
 
   <div class="govuk-grid-row">

--- a/app/views/editions/secondary_nav_tabs/tagging_organisations_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/tagging_organisations_page.html.erb
@@ -1,14 +1,15 @@
 <% @edition = @resource %>
+<% title = "Tag organisations" %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "Tag organisations" %>
-<% content_for :title, "Tag organisations" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">Tagging a page to an organisation makes it appear in searches filtered by that organisation.</p>
     <p class="govuk-body">For example, <%= link_to "a search for documents published by HMRC", "https://www.gov.uk/search/all?keywords=taxes&order=relevance&organisations%5B%5D=hm-revenue-customs", class: "govuk-link" %>.</p>
 
-    <%= form_with model: @tagging_update_form_values, url: update_organisations_edition_path(@resource), data: { module: "" } do |f| %>
+    <%= form_with model: @tagging_update_form_values, url: update_organisations_edition_path(@resource), data: { module: "", ga4_section: "Tagging - #{title}" } do |f| %>
       <%= f.hidden_field :previous_version %>
 
       <%= render "govuk_publishing_components/components/select_with_search", {

--- a/app/views/editions/secondary_nav_tabs/tagging_related_content_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/tagging_related_content_page.html.erb
@@ -1,7 +1,8 @@
 <% @edition = @resource %>
+<% title = "Tag related content" %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "Tag related content" %>
-<% content_for :title, "Tag related content" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 
 <% if !@tagging_update_form_values.errors.empty? %>
   <div class="govuk-grid-row">
@@ -13,7 +14,7 @@
   <div class="govuk-grid-column-two-thirds tagging">
     <p class="govuk-body">Related content items are displayed in the sidebar.</p>
 
-    <%= form_with model: @tagging_update_form_values, url: update_related_content_edition_path(@resource), data: { module: "" } do |f| %>
+    <%= form_with model: @tagging_update_form_values, url: update_related_content_edition_path(@resource), data: { module: "", ga4_section: "Tagging - #{title}" } do |f| %>
       <%
         if @tagging_update_form_values.ordered_related_items == nil
           items = [
@@ -42,6 +43,9 @@
         empty_fields: false,
         items: items,
         empty: empty,
+        data_attributes: {
+          "ga4-section": title,
+        },
       } %>
 
       <div class="govuk-button-group govuk-!-margin-top-6">

--- a/app/views/editions/secondary_nav_tabs/tagging_remove_breadcrumb_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/tagging_remove_breadcrumb_page.html.erb
@@ -1,7 +1,8 @@
 <% @edition = @resource %>
+<% title = "Are you sure you want to remove the breadcrumb?" %>
 <% content_for :title_context, @edition.title %>
-<% content_for :title, "Are you sure you want to remove the breadcrumb?" %>
-<% content_for :page_title, "Are you sure you want to remove the breadcrumb?" %>
+<% content_for :title, title %>
+<% content_for :page_title, title %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -9,7 +10,7 @@
       <% content_for :error_summary, render("shared/error_summary", { object: @edition, full_messages: false }) %>
     <% end %>
 
-    <%= form_with model: @tagging_update_form_values, url: remove_breadcrumb_edition_path(@resource), data: { module: "" } do |f| %>
+    <%= form_with model: @tagging_update_form_values, url: remove_breadcrumb_edition_path(@resource), data: { module: "", ga4_section: "Tagging - #{title}" } do |f| %>
       <%= f.hidden_field :previous_version %>
 
       <%= render "govuk_publishing_components/components/radio", {

--- a/app/views/editions/secondary_nav_tabs/tagging_reorder_related_content_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/tagging_reorder_related_content_page.html.erb
@@ -1,7 +1,8 @@
 <% @edition = @resource %>
+<% title = "Reorder related content" %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "Reorder related content" %>
-<% content_for :title, "Reorder related content" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 
 <% if !@tagging_update_form_values.errors.empty? %>
   <div class="govuk-grid-row">
@@ -23,7 +24,7 @@
   <div class="govuk-grid-column-two-thirds tagging">
     <p class="govuk-hint">Use the up and down buttons to reorder related content items, or select and hold on an item to reorder using drag and drop</p>
 
-    <%= form_with model: @tagging_update_form_values, url: reorder_related_content_edition_path(@resource), data: { module: "" } do |f| %>
+    <%= form_with model: @tagging_update_form_values, url: reorder_related_content_edition_path(@resource), data: { module: "", ga4_section: "Tagging - #{title}" } do |f| %>
       <%= render "govuk_publishing_components/components/reorderable_list", {
         items: @tagging_update_form_values.ordered_related_items.map do |related_item|
           {

--- a/app/views/editions/secondary_nav_tabs/update_important_note.html.erb
+++ b/app/views/editions/secondary_nav_tabs/update_important_note.html.erb
@@ -1,7 +1,8 @@
 <% @edition = @resource %>
+<% title = "Update important note" %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "Update important note" %>
-<% content_for :title, "Update important note" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -13,7 +14,7 @@
       To delete the important note, clear any comments and select ‘Save’.
     </p>
 
-    <%= form_for(:note, :url=> notes_path, data: { module: "" }) do %>
+    <%= form_for(:note, :url=> notes_path, data: { module: "", ga4_section: "History and notes - #{title}" }) do %>
       <%= hidden_field_tag :edition_id, @edition.id %>
       <%= hidden_field_tag "note[type]", Action::IMPORTANT_NOTE %>
 

--- a/app/views/filtered_editions/_find_content_filter.html.erb
+++ b/app/views/filtered_editions/_find_content_filter.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: find_content_path, method: :get, data: { "ga4-search-type": "index_additions", "ga4-search-section": "Find content", "ga4-search-url": find_content_path } do %>
+<%= form_with url: find_content_path, method: :get, data: { ga4_search_type: "index_additions", ga4_search_section: "Find content", ga4_search_url: find_content_path, ga4_section: "Find content" } do %>
   <div class="govuk-grid-row find-content">
     <div class="govuk-grid-column-one-quarter">
       <%= render "govuk_publishing_components/components/input", {

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -52,7 +52,6 @@
       data-ga4-limit-to-element-class="govuk-link"
       data-ga4-do-not-redact
       data-ga4-no-copy="true"
-      data-ga4-section="<%= yield(:title) %>"
       data-ga4-tool-name="<%= @resource ? @resource.format.underscore.humanize : "Publisher" %>"
     >
       <%= render "shared/flash", flash: flash %>

--- a/test/integration/ga4_tracking_admin_test.rb
+++ b/test/integration/ga4_tracking_admin_test.rb
@@ -22,7 +22,7 @@ class Ga4TrackingAdminTest < JavascriptIntegrationTest
 
       assert_equal "Save", event_data[0]["action"]
       assert_equal "form_response", event_data[0]["event_name"]
-      assert_equal "Delete edition", event_data[0]["section"]
+      assert_equal "Admin - Delete edition", event_data[0]["section"]
       assert_equal "Answer", event_data[0]["tool_name"]
       assert_equal "edit", event_data[0]["type"]
     end

--- a/test/integration/ga4_tracking_edit_test.rb
+++ b/test/integration/ga4_tracking_edit_test.rb
@@ -70,7 +70,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
 
       assert_equal "Save", event_data[5]["action"]
       assert_equal "form_response", event_data[5]["event_name"]
-      assert_equal "Answer edition", event_data[5]["section"]
+      assert_equal "Edit - Answer edition", event_data[5]["section"]
       assert_equal "{\"Title\":\"9\",\"Meta tag description\":\"24\",\"Body\":\"13\",\"Is this beta content?\":\"No\"}", event_data[5]["text"]
       assert_equal "Answer", event_data[5]["tool_name"]
       assert_equal "edit", event_data[5]["type"]
@@ -148,7 +148,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
 
       assert_equal "Save", event_data[1]["action"]
       assert_equal "form_response", event_data[1]["event_name"]
-      assert_equal "Assign person", event_data[1]["section"]
+      assert_equal "Edit - Assign person", event_data[1]["section"]
       assert_equal "{\"Choose a person to assign\":\"None\"}", event_data[1]["text"]
       assert_equal "Answer", event_data[1]["tool_name"]
       assert_equal "edit", event_data[1]["type"]
@@ -162,7 +162,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
 
       assert_equal "Save", event_data[3]["action"]
       assert_equal "form_response", event_data[3]["event_name"]
-      assert_equal "Assign person", event_data[3]["section"]
+      assert_equal "Edit - Assign person", event_data[3]["section"]
       assert_equal "{\"Choose a person to assign\":\"[REDACTED]\"}", event_data[3]["text"]
       assert_equal "Answer", event_data[3]["tool_name"]
       assert_equal "edit", event_data[3]["type"]
@@ -192,7 +192,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
 
       assert_equal "Save", event_data[1]["action"]
       assert_equal "form_response", event_data[1]["event_name"]
-      assert_equal "Assign 2i reviewer", event_data[1]["section"]
+      assert_equal "Edit - Assign 2i reviewer", event_data[1]["section"]
       assert_equal "{\"Choose a person to assign\":\"None\"}", event_data[1]["text"]
       assert_equal "Answer", event_data[1]["tool_name"]
       assert_equal "edit", event_data[1]["type"]
@@ -206,7 +206,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
 
       assert_equal "Save", event_data[3]["action"]
       assert_equal "form_response", event_data[3]["event_name"]
-      assert_equal "Assign 2i reviewer", event_data[3]["section"]
+      assert_equal "Edit - Assign 2i reviewer", event_data[3]["section"]
       assert_equal "{\"Choose a person to assign\":\"[REDACTED]\"}", event_data[3]["text"]
       assert_equal "Answer", event_data[3]["tool_name"]
       assert_equal "edit", event_data[3]["type"]
@@ -234,7 +234,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
 
       assert_equal "Save", event_data[1]["action"]
       assert_equal "form_response", event_data[1]["event_name"]
-      assert_equal "Send to 2i", event_data[1]["section"]
+      assert_equal "Edit - Send to 2i", event_data[1]["section"]
       assert_equal "{\"Comment (optional)\":\"12\"}", event_data[1]["text"]
       assert_equal "Answer", event_data[1]["tool_name"]
       assert_equal "edit", event_data[1]["type"]
@@ -265,7 +265,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
 
       assert_equal "Save", event_data[1]["action"]
       assert_equal "form_response", event_data[1]["event_name"]
-      assert_equal "Skip review", event_data[1]["section"]
+      assert_equal "Edit - Skip review", event_data[1]["section"]
       assert_equal "{\"Comment (optional)\":\"26\"}", event_data[1]["text"]
       assert_equal "Answer", event_data[1]["tool_name"]
       assert_equal "edit", event_data[1]["type"]
@@ -294,7 +294,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
 
       assert_equal "Save", event_data[1]["action"]
       assert_equal "form_response", event_data[1]["event_name"]
-      assert_equal "Request amendments", event_data[1]["section"]
+      assert_equal "Edit - Request amendments", event_data[1]["section"]
       assert_equal "{\"Amendment details (optional)\":\"22\"}", event_data[1]["text"]
       assert_equal "Answer", event_data[1]["tool_name"]
       assert_equal "edit", event_data[1]["type"]
@@ -323,7 +323,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
 
       assert_equal "Save", event_data[1]["action"]
       assert_equal "form_response", event_data[1]["event_name"]
-      assert_equal "No changes needed", event_data[1]["section"]
+      assert_equal "Edit - No changes needed", event_data[1]["section"]
       assert_equal "{\"Comment (optional)\":\"21\"}", event_data[1]["text"]
       assert_equal "Answer", event_data[1]["tool_name"]
       assert_equal "edit", event_data[1]["type"]
@@ -364,7 +364,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
 
       assert_equal "Save", event_data[2]["action"]
       assert_equal "form_response", event_data[2]["event_name"]
-      assert_equal "Send for fact check", event_data[2]["section"]
+      assert_equal "Edit - Send to fact check", event_data[2]["section"]
       assert_equal "{\"Email addresses\":\"28\",\"Customised message\":\"12\"}", event_data[2]["text"]
       assert_equal "Answer", event_data[2]["tool_name"]
       assert_equal "edit", event_data[2]["type"]
@@ -398,7 +398,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
 
       assert_equal "Save", event_data[0]["action"]
       assert_equal "form_response", event_data[0]["event_name"]
-      assert_equal "Resend fact check email", event_data[0]["section"]
+      assert_equal "Edit - Resend fact check email", event_data[0]["section"]
       assert_equal "{}", event_data[0]["text"]
       assert_equal "Answer", event_data[0]["tool_name"]
       assert_equal "edit", event_data[0]["type"]
@@ -449,7 +449,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
 
       assert_equal "Save", event_data[3]["action"]
       assert_equal "form_response", event_data[3]["event_name"]
-      assert_equal "Schedule publication", event_data[3]["section"]
+      assert_equal "Edit - Schedule publication", event_data[3]["section"]
       assert_equal "{\"Comment (optional)\":\"26\",\"Publication date - Day\":\"1\",\"Publication date - Month\":\"12\",\"Publication date - Year\":\"2026\",\"Publication time - Hour\":\"09\",\"Publication time - Minute\":\"01\"}", event_data[3]["text"]
       assert_equal "Answer", event_data[3]["tool_name"]
       assert_equal "edit", event_data[3]["type"]
@@ -482,7 +482,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
 
       assert_equal "Save", event_data[1]["action"]
       assert_equal "form_response", event_data[1]["event_name"]
-      assert_equal "Cancel scheduled publishing", event_data[1]["section"]
+      assert_equal "Edit - Cancel scheduled publishing", event_data[1]["section"]
       assert_equal "{\"Comment (optional)\":\"39\"}", event_data[1]["text"]
       assert_equal "Answer", event_data[1]["tool_name"]
       assert_equal "edit", event_data[1]["type"]
@@ -511,7 +511,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
 
       assert_equal "Save", event_data[1]["action"]
       assert_equal "form_response", event_data[1]["event_name"]
-      assert_equal "Send to publish", event_data[1]["section"]
+      assert_equal "Edit - Send to publish", event_data[1]["section"]
       assert_equal "{\"Comment (optional)\":\"34\"}", event_data[1]["text"]
       assert_equal "Answer", event_data[1]["tool_name"]
       assert_equal "edit", event_data[1]["type"]

--- a/test/integration/ga4_tracking_history_notes_test.rb
+++ b/test/integration/ga4_tracking_history_notes_test.rb
@@ -30,7 +30,7 @@ class Ga4TrackingHistoryNotesTest < JavascriptIntegrationTest
 
       assert_equal "Save", event_data[1]["action"]
       assert_equal "form_response", event_data[1]["event_name"]
-      assert_equal "Add edition note", event_data[1]["section"]
+      assert_equal "History and notes - Add edition note", event_data[1]["section"]
       assert_equal "{\"Edition note\":\"26\"}", event_data[1]["text"]
       assert_equal "Answer", event_data[1]["tool_name"]
       assert_equal "edit", event_data[1]["type"]
@@ -58,7 +58,7 @@ class Ga4TrackingHistoryNotesTest < JavascriptIntegrationTest
 
       assert_equal "Save", event_data[1]["action"]
       assert_equal "form_response", event_data[1]["event_name"]
-      assert_equal "Update important note", event_data[1]["section"]
+      assert_equal "History and notes - Update important note", event_data[1]["section"]
       assert_equal "{\"Important note\":\"25\"}", event_data[1]["text"]
       assert_equal "Answer", event_data[1]["tool_name"]
       assert_equal "edit", event_data[1]["type"]

--- a/test/integration/ga4_tracking_metadata_test.rb
+++ b/test/integration/ga4_tracking_metadata_test.rb
@@ -55,7 +55,7 @@ class Ga4TrackingMetadataTest < JavascriptIntegrationTest
       # Form submitted with "Slug" field filled in and "English" selected from the Language field
       assert_equal "Save", event_data[3]["action"]
       assert_equal "form_response", event_data[3]["event_name"]
-      assert_equal "Answer edition", event_data[3]["section"]
+      assert_equal "Metadata - Answer edition", event_data[3]["section"]
       assert_equal "{\"Slug\":\"12\",\"Language\":\"English\"}", event_data[3]["text"]
       assert_equal "Answer", event_data[3]["tool_name"]
       assert_equal "edit", event_data[3]["type"]

--- a/test/integration/ga4_tracking_tagging_test.rb
+++ b/test/integration/ga4_tracking_tagging_test.rb
@@ -46,7 +46,7 @@ class Ga4TrackingTaggingTest < JavascriptIntegrationTest
       # Form submitted with "Capital Gains Tax" selected
       assert_equal "Save", event_data[2]["action"]
       assert_equal "form_response", event_data[2]["event_name"]
-      assert_equal "Set GOV.UK breadcrumb", event_data[2]["section"]
+      assert_equal "Tagging - Set GOV.UK breadcrumb", event_data[2]["section"]
       assert_equal "{\"Tax\":\"Capital Gains Tax\"}", event_data[2]["text"]
       assert_equal "Answer", event_data[2]["tool_name"]
       assert_equal "edit", event_data[2]["type"]
@@ -91,7 +91,7 @@ class Ga4TrackingTaggingTest < JavascriptIntegrationTest
       # Form submitted with "No, keep the breadcrumb" selected
       assert_equal "Save", event_data[2]["action"]
       assert_equal "form_response", event_data[2]["event_name"]
-      assert_equal "Are you sure you want to remove the breadcrumb?", event_data[2]["section"]
+      assert_equal "Tagging - Are you sure you want to remove the breadcrumb?", event_data[2]["section"]
       assert_equal "{\"Are you sure you want to remove the breadcrumb?\":\"No, keep the breadcrumb\"}", event_data[2]["text"]
       assert_equal "Answer", event_data[2]["tool_name"]
       assert_equal "edit", event_data[2]["type"]
@@ -166,7 +166,7 @@ class Ga4TrackingTaggingTest < JavascriptIntegrationTest
       # Form submitted with "Benefits and financial support for families (draft)" and "Capital Gains Tax" selected
       assert_equal "Save", event_data[4]["action"]
       assert_equal "form_response", event_data[4]["event_name"]
-      assert_equal "Tag browse pages", event_data[4]["section"]
+      assert_equal "Tagging - Tag browse pages", event_data[4]["section"]
       assert_equal "{\"Benefits\":\"Benefits and financial support for families (draft)\",\"Tax\":\"Capital Gains Tax\"}", event_data[4]["text"]
       assert_equal "Answer", event_data[4]["tool_name"]
       assert_equal "edit", event_data[4]["type"]
@@ -213,7 +213,7 @@ class Ga4TrackingTaggingTest < JavascriptIntegrationTest
       # Form submitted with "Department for Education" and "Student Loans Company" selected
       assert_equal "Save", event_data[2]["action"]
       assert_equal "form_response", event_data[2]["event_name"]
-      assert_equal "Tag organisations", event_data[2]["section"]
+      assert_equal "Tagging - Tag organisations", event_data[2]["section"]
       assert_equal "{\"Organisations\":\"2\"}", event_data[2]["text"]
       assert_equal "Answer", event_data[2]["tool_name"]
       assert_equal "edit", event_data[2]["type"]
@@ -241,7 +241,7 @@ class Ga4TrackingTaggingTest < JavascriptIntegrationTest
       # Form submitted with "Student Loans Company" selected
       assert_equal "Save", event_data[1]["action"]
       assert_equal "form_response", event_data[1]["event_name"]
-      assert_equal "Tag organisations", event_data[1]["section"]
+      assert_equal "Tagging - Tag organisations", event_data[1]["section"]
       assert_equal "{\"Organisations\":\"Student Loans Company\"}", event_data[1]["text"]
       assert_equal "Answer", event_data[1]["tool_name"]
       assert_equal "edit", event_data[1]["type"]
@@ -348,7 +348,7 @@ class Ga4TrackingTaggingTest < JavascriptIntegrationTest
       # form submitted with "/universal-credit" and "/company-tax-returns" selected
       assert_equal "Save", event_data[6]["action"]
       assert_equal "form_response", event_data[6]["event_name"]
-      assert_equal "Tag related content", event_data[6]["section"]
+      assert_equal "Tagging - Tag related content", event_data[6]["section"]
       # Requires change in add-another.js to retrieve this value
       # assert_equal "{\"Tag related content\":\"17,20\"}", event_data[6]["text"]
       assert_equal "Answer", event_data[6]["tool_name"]
@@ -414,7 +414,7 @@ class Ga4TrackingTaggingTest < JavascriptIntegrationTest
 
       assert_equal "Save", event_data[2]["action"]
       assert_equal "form_response", event_data[2]["event_name"]
-      assert_equal "Reorder related content", event_data[2]["section"]
+      assert_equal "Tagging - Reorder related content", event_data[2]["section"]
       # This requires work to be done in the "Reorderable list" component to return the correct data
       # assert_equal "{\"Position for /prepare-file-annual-accounts-for-limited-company\":\"1\",\"Position for /corporation-tax\":\"2\",\"Position for /company-tax-returns\":\"3\",\"Position for /company-tax-returns\":\"4\"}", event_data[2]["text"].gsub(/[\"][[:space:]]+/, '"')
       assert_equal "reorder", event_data[2]["type"]


### PR DESCRIPTION
[MAIN-7209](https://gov-uk.atlassian.net/browse/MAIN-7209)

The changes here correct a wrong value that was being pushed to the dataLayer when forms are submitted: the "section" value of the "form_response" event. Originally this was set at a "global" level to replicate the page title but a different value is required for a number of forms, as specified in the Jira ticket. This value is inferred from the `data-ga4-section` attribute. 

To ensure the correct value is reported:
- the `data-ga4-section` attribute is removed from the base layout view
- the correct value is added to the `data-ga4-section` in each view that requires it
- the correct value replaces the current one in the appropriate integration tests

[MAIN-7209]: https://gov-uk.atlassian.net/browse/MAIN-7209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ