### PR TITLE
Change content type conversion options 

### DIFF
--- a/app/helpers/editions_helper.rb
+++ b/app/helpers/editions_helper.rb
@@ -31,7 +31,7 @@ module EditionsHelper
   end
 
   def legacy_format_conversion_select_options(edition)
-    possible_target_formats = Edition.convertible_formats - [edition.artefact.kind]
+    possible_target_formats = Edition.convertible_formats - [edition.format.underscore]
     possible_target_formats.map { |format_name| [format_name.humanize, format_name] }
   end
 
@@ -46,7 +46,7 @@ module EditionsHelper
       "transaction" => "Start page for a service",
     }
 
-    possible_target_formats = Edition.convertible_formats - [edition.artefact.kind]
+    possible_target_formats = Edition.convertible_formats - [edition.format.underscore]
     possible_target_formats.map do |format_name|
       {
         text: format_name.humanize,

--- a/test/unit/helpers/admin/edition_helper_test.rb
+++ b/test/unit/helpers/admin/edition_helper_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class EditionsHelperTest < ActionView::TestCase
+  should "exclude the current edition format, not artefact kind, from conversion options" do
+    artefact = stub(kind: "answer")
+    edition = stub(format: "transaction", artefact: artefact)
+
+    values = conversion_items(edition).map { |item| item[:value] }
+
+    assert_includes values, "answer"
+    assert_includes values, "completed_transaction"
+    assert_not_includes values, "transaction"
+  end
+end


### PR DESCRIPTION
This is enable user to change content type of edition based on the previous edition format, not artefact kind. See the card for details on the this issue.

[MAIN-1186](https://gov-uk.atlassian.net/jira/software/c/projects/MAIN/boards/1555?selectedIssue=MAIN-1186)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


[MAIN-1186]: https://gov-uk.atlassian.net/browse/MAIN-1186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ