### PR TITLE
Allow empty strings for `comment` in FactCheckResponseContract

### DIFF
--- a/app/contracts/fact_check_response_contract.rb
+++ b/app/contracts/fact_check_response_contract.rb
@@ -3,11 +3,11 @@ class FactCheckResponseContract < Dry::Validation::Contract
     required(:edition_id).filled(:string)
     required(:responder_name).filled(:string)
     required(:accepted).filled(:bool)
-    optional(:comment).filled(:string)
+    optional(:comment).value(:string)
   end
 
   rule(:comment, :accepted) do
-    if !values[:accepted] && values[:comment].nil?
+    if !values[:accepted] && values[:comment].blank?
       key.failure("must be provided if the fact check is rejected")
     end
   end

--- a/test/api/fact_check_response_controller_test.rb
+++ b/test/api/fact_check_response_controller_test.rb
@@ -66,6 +66,21 @@ class FactCheckResponseControllerTest < IntegrationTest
       assert_includes response.parsed_body["errors"], "comment must be provided if the fact check is rejected"
     end
 
+    should "return 422 when rejected with an empty comment" do
+      post api_fact_check_response_path, params: { edition_id: @edition.id, responder_name: "Joe Bloggs", accepted: false, comment: "" }, as: :json
+
+      assert_response :unprocessable_entity
+      assert_includes response.parsed_body["errors"], "comment must be provided if the fact check is rejected"
+    end
+
+    should "return a success response when accepted with an empty comment" do
+      post api_fact_check_response_path, params: { edition_id: @edition.id, responder_name: "Joe Bloggs", accepted: true, comment: "" }, as: :json
+      @edition.reload
+
+      assert_response :success
+      assert @edition.actions.last.comment == "Changes are correct."
+    end
+
     %i[edition_id responder_name accepted].each do |param|
       should "return 422 when missing #{param}" do
         params = { edition_id: @edition.id, responder_name: "Joe Bloggs", accepted: true }


### PR DESCRIPTION
Fact Check Manager responses send over an empty string for `comment` when there is no comment on the response (rather than omitting the key or sending `nil`). This change permits that behaviour rather than causing a validation error.
