### PR TITLE
Update send to fact check page UI

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -77,7 +77,7 @@ class Edition < ApplicationRecord
         }
 
   ACTIONS = {
-    send_fact_check: "Send to Fact check",
+    send_fact_check: "Send for fact check",
     resend_fact_check: "Resend fact check email",
     request_review: "Send to 2nd pair of eyes",
     schedule_for_publishing: "Schedule for publishing",

--- a/app/views/editions/secondary_nav_tabs/send_to_fact_check_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/send_to_fact_check_page.html.erb
@@ -1,7 +1,7 @@
 <% @edition = @resource %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "Send to fact check" %>
-<% content_for :title, "Send to fact check" %>
+<% content_for :page_title, "Send for fact check" %>
+<% content_for :title, "Send for fact check" %>
 <% template = render template: "event_mailer/request_fact_check", formats: [:text] %>
 
 <div class="govuk-grid-row">
@@ -35,7 +35,7 @@
           name: "fact_check_request_form[reason_for_change]",
           id: "reason_for_change",
           value: @form.reason_for_change,
-          rows: 14,
+          rows: 5,
           hint: ("This is shown in the email sent to the department"),
           error_items: errors_for(@form.errors, :reason_for_change, use_full_message: false),
         } %>
@@ -49,6 +49,7 @@
           id: "zendesk_number",
           value: @form.zendesk_number,
           prefix: "https://govuk.zendesk.com/tickets/",
+          hint: ("This will generate a link to the ticket in the email"),
           error_items: errors_for(@form.errors, :zendesk_number, use_full_message: false),
         } %>
 
@@ -87,7 +88,7 @@
 
         <div class="govuk-button-group">
           <%= render "govuk_publishing_components/components/button", {
-            text: "Send to fact check",
+            text: "Send for fact check",
           } %>
           <%= link_to("Cancel", edition_path, class: "govuk-link govuk-link--no-visited-state") %>
         </div>
@@ -121,7 +122,7 @@
 
         <div class="govuk-button-group">
           <%= render "govuk_publishing_components/components/button", {
-            text: "Send to fact check",
+            text: "Send for fact check",
           } %>
           <%= link_to("Cancel", edition_path, class: "govuk-link govuk-link--no-visited-state") %>
         </div>

--- a/test/functional/legacy_editions_controller_test.rb
+++ b/test/functional/legacy_editions_controller_test.rb
@@ -711,7 +711,7 @@ class LegacyEditionsControllerTest < ActionController::TestCase
         post :update,
              params: {
                id: @welsh_edition.id,
-               commit: "Send to Fact check",
+               commit: "Send for fact check",
                edition: {
                  activity_send_fact_check_attributes: {
                    request_type: "send_fact_check",
@@ -734,7 +734,7 @@ class LegacyEditionsControllerTest < ActionController::TestCase
         post :update,
              params: {
                id: @edition.id,
-               commit: "Send to Fact check",
+               commit: "Send for fact check",
                edition: {
                  activity_send_fact_check_attributes: {
                    request_type: "send_fact_check",

--- a/test/integration/edition_workflow_fact_check_api_test.rb
+++ b/test/integration/edition_workflow_fact_check_api_test.rb
@@ -21,7 +21,7 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
 
     should "render the page" do
       assert page.has_text?(@ready_edition.title)
-      assert page.has_text?("Send to fact check")
+      assert page.has_text?("Send for fact check")
       assert page.has_text?("Email addresses")
       assert page.has_text?("Reason for change (optional)")
       assert page.has_text?("Zendesk ticket number (optional)")
@@ -29,7 +29,7 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       assert page.has_css?(".gem-c-hint", text: "This is shown in the email sent to the department")
       assert page.has_css?(".gem-c-hint", text: "This defaults to 5 working days from today")
       assert page.has_css?(".govuk-input__prefix", text: "https://govuk.zendesk.com/tickets/")
-      assert page.has_button?("Send to fact check")
+      assert page.has_button?("Send for fact check")
       assert page.has_link?("Cancel")
     end
 
@@ -57,7 +57,7 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       fill_in "Day", with: date.day
       fill_in "Month", with: date.month
       fill_in "Year", with: date.year
-      click_button "Send to fact check"
+      click_button "Send for fact check"
 
       assert_current_path edition_path(@ready_edition.id)
       assert page.has_text?("Sent to fact check")
@@ -72,7 +72,7 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       fill_in "Day", with: date.day
       fill_in "Month", with: date.month
       fill_in "Year", with: date.year
-      click_button "Send to fact check"
+      click_button "Send for fact check"
 
       assert_current_path edition_path(@ready_edition.id)
       assert page.has_text?("Sent to fact check")
@@ -87,7 +87,7 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       fill_in "Day", with: date.day
       fill_in "Month", with: date.month
       fill_in "Year", with: date.year
-      click_button "Send to fact check"
+      click_button "Send for fact check"
       @ready_edition.reload
 
       assert_current_path send_to_fact_check_edition_path(@ready_edition.id)
@@ -102,7 +102,7 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       fill_in "Day", with: 999
       fill_in "Month", with: 999
       fill_in "Year", with: 999
-      click_button "Send to fact check"
+      click_button "Send for fact check"
       @ready_edition.reload
 
       assert_current_path send_to_fact_check_edition_path(@ready_edition.id)
@@ -119,7 +119,7 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       fill_in "Day", with: date.day
       fill_in "Month", with: date.month
       fill_in "Year", with: date.year
-      click_button "Send to fact check"
+      click_button "Send for fact check"
       @ready_edition.reload
 
       assert_current_path send_to_fact_check_edition_path(@ready_edition.id)
@@ -144,7 +144,7 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       fill_in "Day", with: date.day
       fill_in "Month", with: date.month
       fill_in "Year", with: date.year
-      click_button "Send to fact check"
+      click_button "Send for fact check"
 
       assert_current_path send_to_fact_check_edition_path(@ready_edition.id)
       assert page.has_text?("Email addresses are invalid")
@@ -162,7 +162,7 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       fill_in "Day", with: "not"
       fill_in "Month", with: "a"
       fill_in "Year", with: "number"
-      click_button "Send to fact check"
+      click_button "Send for fact check"
 
       assert_current_path send_to_fact_check_edition_path(@ready_edition.id)
       assert page.has_text?("Enter a deadline")
@@ -181,7 +181,7 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       fill_in "Day", with: date.day
       fill_in "Month", with: date.month
       fill_in "Year", with: date.year
-      click_button "Send to fact check"
+      click_button "Send for fact check"
 
       assert_current_path send_to_fact_check_edition_path(@ready_edition.id)
       assert page.has_text?("Due to a service problem, the request could not be made")
@@ -203,7 +203,7 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       fill_in "Day", with: date.day
       fill_in "Month", with: date.month
       fill_in "Year", with: date.year
-      click_button "Send to fact check"
+      click_button "Send for fact check"
     end
   end
 

--- a/test/integration/edition_workflow_test.rb
+++ b/test/integration/edition_workflow_test.rb
@@ -378,12 +378,12 @@ class EditionWorkflowTest < IntegrationTest
 
     should "render the page" do
       assert page.has_text?(@ready_edition.title)
-      assert page.has_text?("Send to fact check")
+      assert page.has_text?("Send for fact check")
       assert page.has_text?("Email addresses")
       assert page.has_css?(".gem-c-hint", text: "You can enter multiple email addresses if you comma separate them as follows: fact-checker-one@example.com, fact-checker-two@example.com")
       assert page.has_text?("Customised message")
       assert page.has_text?("The GOV.UK Content Team made the changes because")
-      assert page.has_button?("Send to fact check")
+      assert page.has_button?("Send for fact check")
       assert page.has_link?("Cancel")
     end
 
@@ -395,7 +395,7 @@ class EditionWorkflowTest < IntegrationTest
     should "redirect back to the edit tab on submit and show success message" do
       fill_in "Email addresses", with: "fact-checker-one@example.com"
       fill_in "Customised message", with: "Please check this"
-      click_button "Send to fact check"
+      click_button "Send for fact check"
 
       assert_current_path edition_path(@ready_edition.id)
       assert page.has_text?("Sent to fact check")
@@ -405,7 +405,7 @@ class EditionWorkflowTest < IntegrationTest
       assert page.has_text?("The GOV.UK Content Team made the changes because")
 
       fill_in "Email addresses", with: "fact-checker-one@example.com"
-      click_button "Send to fact check"
+      click_button "Send for fact check"
 
       assert_current_path edition_path(@ready_edition.id)
       assert page.has_text?("Sent to fact check")
@@ -414,7 +414,7 @@ class EditionWorkflowTest < IntegrationTest
     should "display an error message if an email address is invalid" do
       fill_in "Email addresses", with: "fact-checker-one.com"
       fill_in "Customised message", with: "Please check this"
-      click_button "Send to fact check"
+      click_button "Send for fact check"
 
       assert_current_path send_to_fact_check_edition_path(@ready_edition.id)
       assert page.has_text?("Enter email addresses and/or customised message")
@@ -423,7 +423,7 @@ class EditionWorkflowTest < IntegrationTest
     should "display an error message if customised message is empty" do
       fill_in "Email addresses", with: "fact-checker-one@example.com"
       fill_in "Customised message", with: ""
-      click_button "Send to fact check"
+      click_button "Send for fact check"
 
       assert_current_path send_to_fact_check_edition_path(@ready_edition.id)
       assert page.has_text?("Enter email addresses and/or customised message")
@@ -432,7 +432,7 @@ class EditionWorkflowTest < IntegrationTest
     should "keep user inputs when there is an error" do
       fill_in "Email addresses", with: "fact-checker-one.com"
       fill_in "Customised message", with: "Please check this"
-      click_button "Send to fact check"
+      click_button "Send for fact check"
 
       assert_current_path send_to_fact_check_edition_path(@ready_edition.id)
       assert page.has_text?("Enter email addresses and/or customised message")

--- a/test/integration/ga4_tracking_edit_test.rb
+++ b/test/integration/ga4_tracking_edit_test.rb
@@ -344,7 +344,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
     should "push the correct values to the dataLayer when events are triggered" do
       fill_in "Email addresses", with: "fact-checker-one@example.com"
       fill_in "Customised message", with: "Some message"
-      click_button "Send to fact check"
+      click_button "Send for fact check"
 
       event_data = get_event_data
 
@@ -364,7 +364,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
 
       assert_equal "Save", event_data[2]["action"]
       assert_equal "form_response", event_data[2]["event_name"]
-      assert_equal "Send to fact check", event_data[2]["section"]
+      assert_equal "Send for fact check", event_data[2]["section"]
       assert_equal "{\"Email addresses\":\"28\",\"Customised message\":\"12\"}", event_data[2]["text"]
       assert_equal "Answer", event_data[2]["tool_name"]
       assert_equal "edit", event_data[2]["type"]

--- a/test/integration/legacy_edition_workflow_test.rb
+++ b/test/integration/legacy_edition_workflow_test.rb
@@ -70,7 +70,7 @@ class LegacyEditionWorkflowTest < LegacyJavascriptIntegrationTest
 
     within "#send_fact_check_form" do
       fill_in "Email address", with: "user@example.com"
-      click_on "Send to Fact check"
+      click_on "Send for fact check"
     end
     assert page.has_content?("Simple smart answer updated")
 
@@ -89,7 +89,7 @@ class LegacyEditionWorkflowTest < LegacyJavascriptIntegrationTest
 
     within "#send_fact_check_form" do
       fill_in "Email address", with: "user@example.com"
-      click_on "Send to Fact check"
+      click_on "Send for fact check"
     end
     assert page.has_content?("Simple smart answer updated")
 
@@ -726,7 +726,7 @@ class LegacyEditionWorkflowTest < LegacyJavascriptIntegrationTest
     send_for_generic_action(simple_smart_answer, button_text) do
       fill_in "Email", with: email
       fill_in "Customised message", with: message
-      click_on "Send to Fact check"
+      click_on "Send for fact check"
     end
     assert page.has_content?("updated")
   end


### PR DESCRIPTION
Jonny updated the button text, zendesk hint text, and reason for change box size. This applies those updates

[MAIN-7360](https://gov-uk.atlassian.net/browse/MAIN-7360)
(populate the link above to make sure your PR is linked to the Jira ticket)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


[MAIN-7360]: https://gov-uk.atlassian.net/browse/MAIN-7360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ