### PR TITLE
Content block rendering duplication bugfix

### DIFF
--- a/app/services/html_renderer.rb
+++ b/app/services/html_renderer.rb
@@ -10,7 +10,7 @@ class HtmlRenderer
 
     html_content = Govspeak::Document.new(document).to_html
 
-    ContentBlockTools::ContentBlockReference.find_all_in_document(html_content).each do |content_block|
+    ContentBlockTools::ContentBlockReference.find_all_in_document(html_content).uniq.each do |content_block|
       code = content_block.embed_code
       html_content.gsub!(code, ContentBlockTools::ContentBlock.from_embed_code(code).render)
     end

--- a/test/unit/services/html_renderer_test.rb
+++ b/test/unit/services/html_renderer_test.rb
@@ -58,19 +58,43 @@ class HtmlRendererTest < ActiveSupport::TestCase
       assert_equal expected_output, HtmlRenderer.render_html(input)
     end
 
-    should "call ContentBlockTools::ContentBlock.from_embed_code when a content block embed code is present" do
-      input = "Before block, {{embed:content_block_contact:content-item}}, after block"
-
-      # ContentBlockTools has some internal logic and an API call that need stubbing out here
-      mock_content_block = Minitest::Mock.new
-      mock_content_block.expect(:render, "block content")
-      ContentBlockTools::ContentBlock.expects(:from_embed_code).with("{{embed:content_block_contact:content-item}}").returns(mock_content_block)
-
-      assert_equal "<p>Before block, block content, after block</p>", HtmlRenderer.render_html(input)
-    end
-
     should "return an empty string when given an empty document" do
       assert_equal "", HtmlRenderer.render_html("")
+    end
+
+    context "when the document contains content blocks" do
+      setup do
+        @mock_render = '<span class="content-block" data-embed-code="{{embed:content_block_contact:content-item}}">block content</span>'
+        @mock_content_block = stub(render: @mock_render)
+        @mock_render_two = '<span class="content-block" data-embed-code="{{embed:content_block_contact:content-item-two}}">different block content</span>'
+        @mock_content_block_two = stub(render: @mock_render_two)
+      end
+
+      should "correctly render the block when a single content block embed code is present" do
+        input = "Before block, {{embed:content_block_contact:content-item}}, after block"
+
+        ContentBlockTools::ContentBlock.expects(:from_embed_code).with("{{embed:content_block_contact:content-item}}").returns(@mock_content_block)
+
+        assert_equal "<p>Before block, #{@mock_render}, after block</p>", HtmlRenderer.render_html(input)
+      end
+
+      should "correctly render the blocks when two different content block embed codes are present" do
+        input = "Before block, {{embed:content_block_contact:content-item}}, {{embed:content_block_contact:content-item-two}}, after block"
+
+        ContentBlockTools::ContentBlock.expects(:from_embed_code).with("{{embed:content_block_contact:content-item}}").returns(@mock_content_block)
+        ContentBlockTools::ContentBlock.expects(:from_embed_code).with("{{embed:content_block_contact:content-item-two}}").returns(@mock_content_block_two)
+
+        assert_equal "<p>Before block, #{@mock_render}, #{@mock_render_two}, after block</p>", HtmlRenderer.render_html(input)
+      end
+
+      should "correctly render the blocks when provided with multiple instances of the same embed code" do
+        input = "Before block, {{embed:content_block_contact:content-item}}, {{embed:content_block_contact:content-item}}, {{embed:content_block_contact:content-item-two}}, after block"
+
+        ContentBlockTools::ContentBlock.expects(:from_embed_code).with("{{embed:content_block_contact:content-item}}").returns(@mock_content_block).once
+        ContentBlockTools::ContentBlock.expects(:from_embed_code).with("{{embed:content_block_contact:content-item-two}}").returns(@mock_content_block_two)
+
+        assert_equal "<p>Before block, #{@mock_render}, #{@mock_render}, #{@mock_render_two}, after block</p>", HtmlRenderer.render_html(input)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes a bug in `HtmlRenderer` when a document contains multiple occurences of the same content block embed code

`render_html `was operating off a list of every single embed code in the document, which meant when there were multiple occurrences of the same one it ran over that block twice. Since the rendered block content includes the code, this caused duplication.

Fixed this by limiting the list running that iteration to unique entries.
