### PR TITLE
Main 7426 edit page add amend ga4

### DIFF
--- a/app/views/editions/secondary_nav_tabs/edit/editable/_guide.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/editable/_guide.html.erb
@@ -9,6 +9,10 @@
   secondary_solid: true,
   href: new_edition_guide_part_path(edition),
   margin_bottom: 6,
+  data_attributes: {
+    module: "ga4-link-tracker",
+    ga4_link: '{ "event_name": "navigation", "type": "accordion", "index_link": 1, "index_section": 1, "index_section_count": 1 }',
+  },
 } %>
 
 <%= render "govuk_publishing_components/components/radio", {

--- a/app/views/editions/secondary_nav_tabs/edit/editable/components/_guide_chapter_list.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/editable/components/_guide_chapter_list.html.erb
@@ -7,7 +7,6 @@
 
 <% if edition.parts.presence %>
   <%= render "govuk_publishing_components/components/accordion", {
-    disable_ga4: true,
     heading_level: 4,
     items: edition.parts.sort_by(&:order).map do |part|
       { 

--- a/test/integration/ga4_tracking_edit_test.rb
+++ b/test/integration/ga4_tracking_edit_test.rb
@@ -8,7 +8,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
     setup_users
 
     @edition = FactoryBot.create(:answer_edition, title: "Answer edition")
-    @guide_edition = FactoryBot.create(:guide_edition, title: "Guide edition")
+    @guide_edition = FactoryBot.create(:guide_edition_with_two_parts, title: "Guide edition")
     @assigned_edition = FactoryBot.create(:edition, assigned_to: @author, created_at: 5.days.ago)
     @in_review_edition = FactoryBot.create(:edition, :in_review, reviewer: @reviewer, created_at: 6.days.ago)
 
@@ -90,6 +90,123 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
       assert_equal "Enter a title", event_data[0]["text"]
       assert_equal "Title", event_data[0]["section"]
       assert_equal "Answer", event_data[0]["tool_name"]
+    end
+  end
+
+  context "Edit page of a Guide edition" do
+    setup do
+      visit edition_path(@guide_edition)
+      disable_links
+      disable_form_submit
+    end
+
+    should "push the correct values to the dataLayer when Guide edition accordion controls are clicked" do
+      click_button "Show all sections"
+      within all(".govuk-accordion__section-header")[0] do
+        click_button "Hide"
+        click_button "Show"
+      end
+      within all(".govuk-accordion__section-content")[0] do
+        click_link "Delete chapter"
+      end
+      within all(".govuk-accordion__section-header")[1] do
+        click_button "Hide"
+        click_button "Show"
+      end
+      within all(".govuk-accordion__section-content")[1] do
+        click_link "Delete chapter"
+      end
+      click_link "Add a new chapter"
+      click_button "Hide all sections"
+      click_button "Save"
+
+      event_data = get_event_data
+
+      # click_button "Show all sections"
+      assert_equal "opened", event_data[0]["action"]
+      assert_equal "select_content", event_data[0]["event_name"]
+      assert_equal "accordion", event_data[0]["type"]
+      assert_equal "Show all sections", event_data[0]["text"]
+      assert_equal "0", event_data[0]["index"]["index_section"]
+      assert_equal "2", event_data[0]["index"]["index_section_count"]
+
+      # click_button "Hide"
+      assert_equal "closed", event_data[1]["action"]
+      assert_equal "select_content", event_data[1]["event_name"]
+      assert_equal "accordion", event_data[1]["type"]
+      assert_equal @guide_edition.parts[0].title, event_data[1]["text"]
+      assert_equal "1", event_data[1]["index"]["index_section"]
+      assert_equal "2", event_data[1]["index"]["index_section_count"]
+
+      # click_button "Show"
+      assert_equal "opened", event_data[2]["action"]
+      assert_equal "select_content", event_data[2]["event_name"]
+      assert_equal "accordion", event_data[2]["type"]
+      assert_equal @guide_edition.parts[0].title, event_data[2]["text"]
+      assert_equal "1", event_data[2]["index"]["index_section"]
+      assert_equal "2", event_data[2]["index"]["index_section_count"]
+
+      # click_link "Delete chapter"
+      assert_equal "navigation", event_data[3]["event_name"]
+      assert_equal "accordion", event_data[3]["type"]
+      assert_equal "Delete chapter", event_data[3]["text"]
+      assert_equal "2", event_data[3]["index"]["index_link"]
+      assert_equal "1", event_data[3]["index"]["index_section"]
+      assert_equal "2", event_data[3]["index"]["index_section_count"]
+      assert_equal current_host, event_data[3]["link_domain"]
+      assert_equal "/editions/#{@guide_edition.id}/guide_parts/#{@guide_edition.parts[0].id}/confirm_destroy", event_data[3]["url"]
+
+      # click_button "Hide"
+      assert_equal "closed", event_data[4]["action"]
+      assert_equal "select_content", event_data[4]["event_name"]
+      assert_equal "accordion", event_data[4]["type"]
+      assert_equal @guide_edition.parts[1].title, event_data[4]["text"]
+      assert_equal "2", event_data[4]["index"]["index_section"]
+      assert_equal "2", event_data[4]["index"]["index_section_count"]
+
+      # click_button "Show"
+      assert_equal "opened", event_data[5]["action"]
+      assert_equal "select_content", event_data[5]["event_name"]
+      assert_equal "accordion", event_data[5]["type"]
+      assert_equal @guide_edition.parts[1].title, event_data[5]["text"]
+      assert_equal "2", event_data[5]["index"]["index_section"]
+      assert_equal "2", event_data[5]["index"]["index_section_count"]
+
+      # click_link "Delete chapter"
+      assert_equal "navigation", event_data[6]["event_name"]
+      assert_equal "accordion", event_data[6]["type"]
+      assert_equal "Delete chapter", event_data[6]["text"]
+      assert_equal "2", event_data[6]["index"]["index_link"]
+      assert_equal "2", event_data[6]["index"]["index_section"]
+      assert_equal "2", event_data[6]["index"]["index_section_count"]
+      assert_equal current_host, event_data[6]["link_domain"]
+      assert_equal "/editions/#{@guide_edition.id}/guide_parts/#{@guide_edition.parts[1].id}/confirm_destroy", event_data[6]["url"]
+
+      # click_link "Add a new chapter"
+      assert_equal "navigation", event_data[7]["event_name"]
+      assert_equal "accordion", event_data[7]["type"]
+      assert_equal "Add a new chapter", event_data[7]["text"]
+      assert_equal "1", event_data[7]["index"]["index_link"]
+      assert_equal "1", event_data[7]["index"]["index_section"]
+      assert_equal "1", event_data[7]["index"]["index_section_count"]
+      assert_equal current_host, event_data[7]["link_domain"]
+      assert_equal "/editions/#{@guide_edition.id}/guide_parts/new", event_data[7]["url"]
+
+      # click_button "Hide all sections"
+      assert_equal "closed", event_data[8]["action"]
+      assert_equal "select_content", event_data[8]["event_name"]
+      assert_equal "accordion", event_data[8]["type"]
+      assert_equal "Hide all sections", event_data[8]["text"]
+      assert_equal "0", event_data[8]["index"]["index_section"]
+      assert_equal "2", event_data[8]["index"]["index_section_count"]
+
+      # click_button "Save"
+      assert_equal "Save", event_data[9]["action"]
+      assert_equal "form_response", event_data[9]["event_name"]
+      assert_equal "Edit - Guide edition", event_data[9]["section"]
+      assert_equal "{\"Title\":\"13,6,7\",\"Slug\":\"8,8\",\"Body\":\"26,31\",\"Is every chapter part of a step by step?\":\"No\",\"Is this beta content?\":\"No\"}", event_data[9]["text"]
+      assert_equal "Guide", event_data[9]["tool_name"]
+      assert_equal "edit", event_data[9]["type"]
     end
   end
 


### PR DESCRIPTION
[MAIN-7426](https://gov-uk.atlassian.net/browse/MAIN-7426)

Adds the relevant tracking to the Edit page for Guide Editions. The addition of this page required tracking to be added to the accordion section controls as detailed in the Jira ticket and shown in the screenshots below. 

Much of the tracking is already in place so this PR 
- adds some tests for all the user interactions with the relevant elements on the page
- adds some data-attributes to the view to provide the correct values to be tracked

Tracking can be tested locally with these steps: 
- run `document.querySelector('form').addEventListener('submit',function(e){e.preventDefault()})`  in the browser console. This will disable the form submission so that all data gathered from user interaction with the form, including submission, will be visible in the console. 
- run `document.addEventListener('click',function(e){if(e.target.href)(e.preventDefault())})` in the browser console. This will disable links from navigating away from the page so that all data gathered from user interaction with the form will be visible in the console. 
- run `window.GOVUK.analyticsGa4.showDebug = true` in the browser console. The browser console will then display the tracking data for all user interactions with the form (including submission) as they occur. 

|||
|-|-|
|<img width="594" height="941" alt="Screenshot 2026-05-20 at 17 58 56" src="https://github.com/user-attachments/assets/702a78b7-df03-4244-aa87-547a0e87bd4c" />|<img width="594" height="941" alt="Screenshot 2026-05-20 at 18 03 42" src="https://github.com/user-attachments/assets/ab9fe5f7-be3c-4177-93f1-10e1ff417769" />|

[MAIN-7426]: https://gov-uk.atlassian.net/browse/MAIN-7426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ