### PR TITLE
[MAIN-7397] Parallelise tests

### DIFF
--- a/test/functional/guide_parts_controller_test.rb
+++ b/test/functional/guide_parts_controller_test.rb
@@ -65,7 +65,7 @@ class GuidePartsControllerTest < ActionController::TestCase
 
           post :create, params: {
             edition_id: edition.id,
-            part: { id: 1, body: "test body", slug: "test-slug", title: "test title" },
+            part: { body: "test body", slug: "test-slug", title: "test title" },
             save: "save",
           }
 
@@ -78,7 +78,7 @@ class GuidePartsControllerTest < ActionController::TestCase
 
           post :create, params: {
             edition_id: edition.id,
-            part: { id: 1, body: "test body", slug: "test-slug", title: "test title" },
+            part: { body: "test body", slug: "test-slug", title: "test title" },
             save: "save and summary",
           }
 
@@ -97,7 +97,7 @@ class GuidePartsControllerTest < ActionController::TestCase
 
           post :create, params: {
             edition_id: edition.id,
-            part: { id: 1, body: "test body", slug: "test-slug", title: "test title" },
+            part: { body: "test body", slug: "test-slug", title: "test title" },
             save: "save and summary",
           }
 
@@ -117,7 +117,7 @@ class GuidePartsControllerTest < ActionController::TestCase
 
           post :create, params: {
             edition_id: edition.id,
-            part: { id: 1, body: "test body", slug: "test-slug", title: "test title" },
+            part: { body: "test body", slug: "test-slug", title: "test title" },
             save: "save and summary",
           }
 

--- a/test/models/host_content_update_event/action_test.rb
+++ b/test/models/host_content_update_event/action_test.rb
@@ -1,22 +1,19 @@
 require "test_helper"
 
 class HostContentUpdateEvent::ActionTest < ActiveSupport::TestCase
-  extend Minitest::Spec::DSL
+  test "returns a duck-typed representation of an Action" do
+    content_id = SecureRandom.uuid
+    host_content_update_event = FactoryBot.build(:host_content_update_event, document_type: "content_block_email_address", content_id:)
+    action = HostContentUpdateEvent::Action.new(host_content_update_event)
 
-  let(:content_id) { SecureRandom.uuid }
-
-  let(:host_content_update_event) { FactoryBot.build(:host_content_update_event, document_type: "content_block_email_address", content_id:) }
-  let(:action) { HostContentUpdateEvent::Action.new(host_content_update_event) }
-
-  it "returns a duck-typed representation of an Action" do
-    assert_equal action.request_type, HostContentUpdateEvent::Action::CONTENT_BLOCK_UPDATE
-    assert_equal action.created_at, host_content_update_event.created_at
-    assert_equal action.requester, host_content_update_event.author
-    assert_equal action.to_s, "Content block updated"
-    assert_equal action.comment, "Email address updated"
-    assert_equal action.block_url, "#{Plek.external_url_for('content-block-manager')}/content-id/#{content_id}"
-    assert_equal action.comment_sanitized, false
-    assert_equal action.is_fact_check_request?, false
-    assert_equal action.recipient_id, nil
+    assert_equal HostContentUpdateEvent::Action::CONTENT_BLOCK_UPDATE, action.request_type
+    assert_equal host_content_update_event.created_at, action.created_at
+    assert_equal host_content_update_event.author, action.requester
+    assert_equal "Content block updated", action.to_s
+    assert_equal "Email address updated", action.comment
+    assert_equal "#{Plek.external_url_for('content-block-manager')}/content-id/#{content_id}", action.block_url
+    assert_not action.comment_sanitized
+    assert_not action.is_fact_check_request?
+    assert_nil action.recipient_id
   end
 end

--- a/test/models/host_content_update_event_test.rb
+++ b/test/models/host_content_update_event_test.rb
@@ -1,12 +1,12 @@
 require "test_helper"
 
 class HostContentUpdateEventTest < ActiveSupport::TestCase
-  extend Minitest::Spec::DSL
+  setup do
+    @artefact = FactoryBot.create(:artefact)
+  end
 
-  let(:artefact) { FactoryBot.create(:artefact) }
-
-  describe ".all_for_artefact" do
-    it "returns all HostContentUpdateJobs" do
+  context ".all_for_artefact" do
+    should "return all HostContentUpdateJobs" do
       user1_uuid = SecureRandom.uuid
       user2_uuid = SecureRandom.uuid
 
@@ -28,7 +28,7 @@ class HostContentUpdateEventTest < ActiveSupport::TestCase
               .returns(users)
 
       Services.publishing_api.expects(:get_events_for_content_id).with(
-        artefact.content_id, { action: "HostContentUpdateJob" }
+        @artefact.content_id, { action: "HostContentUpdateJob" }
       ).returns(
         [
           {
@@ -37,11 +37,11 @@ class HostContentUpdateEventTest < ActiveSupport::TestCase
             "created_at" => "2024-01-01T00:00:00.000Z",
             "updated_at" => "2024-01-01T00:00:00.000Z",
             "request_id" => SecureRandom.uuid,
-            "content_id" => artefact.content_id,
+            "content_id" => @artefact.content_id,
             "payload" => {
               "title" => "Host content updated by content block update",
               "locale" => "en",
-              "content_id" => artefact.content_id,
+              "content_id" => @artefact.content_id,
               "source_block" => {
                 "title" => "An exciting piece of content",
                 "content_id" => "ef224ae6-7a81-4c59-830b-e9884fe57ec8",
@@ -57,11 +57,11 @@ class HostContentUpdateEventTest < ActiveSupport::TestCase
             "created_at" => "2023-12-01T00:00:00.000Z",
             "updated_at" => "2023-12-01T00:00:00.000Z",
             "request_id" => SecureRandom.uuid,
-            "content_id" => artefact.content_id,
+            "content_id" => @artefact.content_id,
             "payload" => {
               "title" => "Host content updated by content block update",
               "locale" => "en",
-              "content_id" => artefact.content_id,
+              "content_id" => @artefact.content_id,
               "source_block" => {
                 "title" => "Another exciting piece of content",
                 "content_id" => "5c5520ce-6677-4a76-bd6e-4515f46a804e",
@@ -73,7 +73,7 @@ class HostContentUpdateEventTest < ActiveSupport::TestCase
         ],
       )
 
-      result = HostContentUpdateEvent.all_for_artefact(artefact)
+      result = HostContentUpdateEvent.all_for_artefact(@artefact)
 
       assert_equal result.count, 2
 
@@ -93,131 +93,131 @@ class HostContentUpdateEventTest < ActiveSupport::TestCase
     end
   end
 
-  describe "#is_for_edition?" do
-    let(:created_at) { Time.zone.now - 5.weeks }
-    let(:published_at) { Time.zone.now - 4.weeks }
+  context "#is_for_edition?" do
+    setup do
+      @created_at = Time.zone.now - 5.weeks
+      @published_at = Time.zone.now - 4.weeks
+    end
 
-    describe "if the edition is in progress" do
-      let(:in_progress_edition) { FactoryBot.build(:edition, created_at:) }
-
-      before do
-        in_progress_edition.stubs(:in_progress?).returns(true)
+    context "if the edition is in progress" do
+      setup do
+        @in_progress_edition = FactoryBot.build(:edition, created_at: @created_at)
+        @in_progress_edition.stubs(:in_progress?).returns(true)
       end
 
-      it "returns true if the event occurred after the created_at date" do
-        event = FactoryBot.build(:host_content_update_event, created_at: created_at + 1.day)
+      should "return true if the event occurred after the created_at date" do
+        event = FactoryBot.build(:host_content_update_event, created_at: @created_at + 1.day)
 
-        assert event.is_for_edition?(in_progress_edition)
+        assert event.is_for_edition?(@in_progress_edition)
       end
 
-      it "returns false if the event occurred before the created_at date" do
-        event = FactoryBot.build(:host_content_update_event, created_at: created_at - 1.day)
+      should "return false if the event occurred before the created_at date" do
+        event = FactoryBot.build(:host_content_update_event, created_at: @created_at - 1.day)
 
-        assert_not event.is_for_edition?(in_progress_edition)
+        assert_not event.is_for_edition?(@in_progress_edition)
       end
     end
 
-    describe "if the edition is scheduled for publishing" do
-      let(:scheduled_edition) { FactoryBot.build(:edition, created_at:) }
-
-      before do
-        scheduled_edition.stubs(:scheduled_for_publishing?).returns(true)
+    context "if the edition is scheduled for publishing" do
+      setup do
+        @scheduled_edition = FactoryBot.build(:edition, created_at: @created_at)
+        @scheduled_edition.stubs(:scheduled_for_publishing?).returns(true)
       end
 
-      it "returns true if the event occurred after the created_at date" do
-        event = FactoryBot.build(:host_content_update_event, created_at: created_at + 1.day)
+      should "return true if the event occurred after the created_at date" do
+        event = FactoryBot.build(:host_content_update_event, created_at: @created_at + 1.day)
 
-        assert event.is_for_edition?(scheduled_edition)
+        assert event.is_for_edition?(@scheduled_edition)
       end
 
-      it "returns false if the event occurred before the created_at date" do
-        event = FactoryBot.build(:host_content_update_event, created_at: created_at - 1.day)
+      should "return false if the event occurred before the created_at date" do
+        event = FactoryBot.build(:host_content_update_event, created_at: @created_at - 1.day)
 
-        assert_not event.is_for_edition?(scheduled_edition)
-      end
-    end
-
-    describe "if the edition is published" do
-      let(:state) { "published" }
-      let(:published_edition) { FactoryBot.build(:edition, state:, created_at:) }
-
-      before do
-        published_edition.stubs(:published_at).returns(published_at)
-      end
-
-      it "returns true if the event occurred after the published_at date" do
-        event = FactoryBot.build(:host_content_update_event, created_at: published_at + 1.day)
-
-        assert event.is_for_edition?(published_edition)
-      end
-
-      it "returns false if the event occurred before the created_at date" do
-        event = FactoryBot.build(:host_content_update_event, created_at: created_at - 3.days)
-
-        assert_not event.is_for_edition?(published_edition)
+        assert_not event.is_for_edition?(@scheduled_edition)
       end
     end
 
-    describe "if the edition is archived" do
-      let(:state) { "archived" }
-      let(:archived_edition) { FactoryBot.build(:edition, state:, created_at:) }
-      describe "if the edition is superseded" do
-        let(:superseded_at) { Time.zone.now - 4.days }
+    context "if the edition is published" do
+      setup do
+        @state = "published"
+        @published_edition = FactoryBot.build(:edition, state: @state, created_at: @created_at)
+        @published_edition.stubs(:published_at).returns(@published_at)
+      end
 
-        before do
-          archived_edition.stubs(:superseded_at).returns(superseded_at)
+      should "return true if the event occurred after the published_at date" do
+        event = FactoryBot.build(:host_content_update_event, created_at: @published_at + 1.day)
+
+        assert event.is_for_edition?(@published_edition)
+      end
+
+      should "return false if the event occurred before the created_at date" do
+        event = FactoryBot.build(:host_content_update_event, created_at: @created_at - 3.days)
+
+        assert_not event.is_for_edition?(@published_edition)
+      end
+    end
+
+    context "if the edition is archived" do
+      setup do
+        @state = "archived"
+        @archived_edition = FactoryBot.build(:edition, state: @state, created_at: @created_at)
+      end
+
+      context "if the edition is superseded" do
+        setup do
+          @superseded_at = Time.zone.now - 4.days
+          @archived_edition.stubs(:superseded_at).returns(@superseded_at)
         end
 
-        it "returns true if the event occurred after the created_at date" do
-          event = FactoryBot.build(:host_content_update_event, created_at: created_at + 1.minute)
+        should "return true if the event occurred after the created_at date" do
+          event = FactoryBot.build(:host_content_update_event, created_at: @created_at + 1.minute)
 
-          assert event.is_for_edition?(archived_edition)
+          assert event.is_for_edition?(@archived_edition)
         end
 
-        it "returns true if the event occurred before the superseded date" do
-          event = FactoryBot.build(:host_content_update_event, created_at: superseded_at - 1.minute)
+        should "return true if the event occurred before the superseded date" do
+          event = FactoryBot.build(:host_content_update_event, created_at: @superseded_at - 1.minute)
 
-          assert event.is_for_edition?(archived_edition)
+          assert event.is_for_edition?(@archived_edition)
         end
 
-        it "returns false if the event occurred before the created_at date" do
-          event = FactoryBot.build(:host_content_update_event, created_at: created_at - 1.minute)
+        should "return false if the event occurred before the created_at date" do
+          event = FactoryBot.build(:host_content_update_event, created_at: @created_at - 1.minute)
 
-          assert_not event.is_for_edition?(archived_edition)
+          assert_not event.is_for_edition?(@archived_edition)
         end
 
-        it "returns false if the event occurred after the superseded date" do
-          event = FactoryBot.build(:host_content_update_event, created_at: superseded_at + 1.minute)
+        should "return false if the event occurred after the superseded date" do
+          event = FactoryBot.build(:host_content_update_event, created_at: @superseded_at + 1.minute)
 
-          assert_not event.is_for_edition?(archived_edition)
+          assert_not event.is_for_edition?(@archived_edition)
         end
       end
 
-      describe "if the edition has been unpublished" do
-        let(:artefact_updated_at) { Time.zone.now - 4.days }
-        let(:artefact) { FactoryBot.build(:artefact, updated_at: artefact_updated_at, state: "archived") }
-
-        before do
-          archived_edition.stubs(:artefact).returns(artefact)
+      context "if the edition has been unpublished" do
+        setup do
+          @artefact_updated_at = Time.zone.now - 4.days
+          @artefact = FactoryBot.build(:artefact, updated_at: @artefact_updated_at, state: "archived")
+          @archived_edition.stubs(:artefact).returns(@artefact)
         end
 
-        it "returns true if the event occurred after the archived date" do
-          event = FactoryBot.build(:host_content_update_event, created_at: artefact_updated_at - 1.minute)
+        should "return true if the event occurred after the archived date" do
+          event = FactoryBot.build(:host_content_update_event, created_at: @artefact_updated_at - 1.minute)
 
-          assert event.is_for_edition?(archived_edition)
+          assert event.is_for_edition?(@archived_edition)
         end
 
-        it "returns false if the event occurred before the archived date" do
-          event = FactoryBot.build(:host_content_update_event, created_at: artefact_updated_at + 1.minute)
+        should "return false if the event occurred before the archived date" do
+          event = FactoryBot.build(:host_content_update_event, created_at: @artefact_updated_at + 1.minute)
 
-          assert_not event.is_for_edition?(archived_edition)
+          assert_not event.is_for_edition?(@archived_edition)
         end
       end
     end
   end
 
-  describe "#to_action" do
-    it "returns the object as an action" do
+  context "#to_action" do
+    should "return the object as an action" do
       event = FactoryBot.build(:host_content_update_event)
       action = mock("HostContentUpdateEvent::Action")
       HostContentUpdateEvent::Action.expects(:new).with(event).returns(action)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,6 +42,16 @@ class ActiveSupport::TestCase
   include WebMock::API
   include GovukSchemas::AssertMatchers
 
+  parallelize(workers: :number_of_processors)
+
+  parallelize_setup do |worker|
+    SimpleCov.command_name "#{SimpleCov.command_name}-#{worker}"
+  end
+
+  parallelize_teardown do |_worker|
+    SimpleCov.result
+  end
+
   setup do
     Sidekiq::Testing.inline!
     stub_any_publishing_api_call

--- a/test/traits/recordable_actions_test.rb
+++ b/test/traits/recordable_actions_test.rb
@@ -1,88 +1,88 @@
 require "test_helper"
 
 class RecordableActionsTest < ActiveSupport::TestCase
-  extend Minitest::Spec::DSL
+  setup do
+    @object_under_test = FactoryBot.create(:edition)
+    @user = FactoryBot.create(:user)
+  end
 
-  let(:object_under_test) { FactoryBot.create(:edition) }
-  let(:user) { FactoryBot.create(:user) }
-
-  describe "#published_by" do
-    it "returns who published the object" do
-      object_under_test.actions.create!(
+  context "#published_by" do
+    should "return who published the object" do
+      @object_under_test.actions.create!(
         request_type: Action::PUBLISH,
-        requester: user,
+        requester: @user,
       )
 
-      assert_equal user, object_under_test.published_by
+      assert_equal @user, @object_under_test.published_by
     end
 
-    it "returns nil when there are no published actions" do
-      assert_nil object_under_test.published_by
+    should "return nil when there are no published actions" do
+      assert_nil @object_under_test.published_by
     end
   end
 
-  describe "#published_at" do
-    it "returns when the object was created" do
+  context "#published_at" do
+    should "return when the object was created" do
       created_at = Time.zone.now - 4.days
-      object_under_test.actions.create!(
+      @object_under_test.actions.create!(
         request_type: Action::PUBLISH,
-        requester: user,
+        requester: @user,
         created_at:,
       )
 
-      assert_in_delta created_at, object_under_test.published_at, 1
+      assert_in_delta created_at, @object_under_test.published_at, 1
     end
 
-    it "returns nil when there are no published actions" do
-      assert_nil object_under_test.published_at
+    should "return nil when there are no published actions" do
+      assert_nil @object_under_test.published_at
     end
   end
 
-  describe "#superseded_at" do
-    it "returns when the object was superseded by another edition" do
+  context "#superseded_at" do
+    should "return when the object was superseded by another edition" do
       expected_superseded_at = Time.zone.now - 3.days
 
       subsequent_editions = 4.times.map { stub("Edition") }
       subsequent_editions.first.stubs(:published_at).returns(expected_superseded_at)
 
-      object_under_test.stubs(:subsequent_siblings).returns(subsequent_editions)
+      @object_under_test.stubs(:subsequent_siblings).returns(subsequent_editions)
 
-      assert_equal expected_superseded_at, object_under_test.superseded_at
+      assert_equal expected_superseded_at, @object_under_test.superseded_at
     end
 
-    it "returns nil when there are no subsequent editions" do
-      object_under_test.stubs(:subsequent_siblings).returns([])
+    should "return nil when there are no subsequent editions" do
+      @object_under_test.stubs(:subsequent_siblings).returns([])
 
-      assert_nil object_under_test.superseded_at
+      assert_nil @object_under_test.superseded_at
     end
 
-    it "returns nil when the first subsequent edition is not published" do
+    should "return nil when the first subsequent edition is not published" do
       unpublished_edition = stub("Edition", published_at: nil)
-      object_under_test.stubs(:subsequent_siblings).returns([unpublished_edition])
+      @object_under_test.stubs(:subsequent_siblings).returns([unpublished_edition])
 
-      assert_nil object_under_test.superseded_at
+      assert_nil @object_under_test.superseded_at
     end
   end
 
-  describe "#latest_status_action" do
-    it "returns the action of that type even when a newer action of a different type exists" do
+  context "#latest_status_action" do
+    should "return the action of that type even when a newer action of a different type exists" do
       edition = FactoryBot.create(:edition, :in_review)
-      edition.new_action(user, Action::SEND_FACT_CHECK)
+      edition.new_action(@user, Action::SEND_FACT_CHECK)
 
       assert_equal Action::REQUEST_REVIEW, edition.latest_status_action(Action::REQUEST_REVIEW).request_type
     end
 
-    it "returns nil when no action of that type exists" do
+    should "return nil when no action of that type exists" do
       edition = FactoryBot.create(:edition, :in_review)
 
       assert_nil edition.latest_status_action(Action::SEND_FACT_CHECK)
     end
 
-    it "returns the latest status action when no type argument provided" do
+    should "return the latest status action when no type argument provided" do
       edition = FactoryBot.create(:edition, :in_review)
-      edition.new_action(user, Action::SEND_FACT_CHECK)
-      edition.new_action(user, Action::REQUEST_AMENDMENTS)
-      edition.new_action(user, Action::IMPORTANT_NOTE)
+      edition.new_action(@user, Action::SEND_FACT_CHECK)
+      edition.new_action(@user, Action::REQUEST_AMENDMENTS)
+      edition.new_action(@user, Action::IMPORTANT_NOTE)
 
       assert_equal Action::REQUEST_AMENDMENTS, edition.latest_status_action.request_type
     end


### PR DESCRIPTION
[MAIN-7397](https://gov-uk.atlassian.net/browse/MAIN-7397)
[MAIN-1236](https://gov-uk.atlassian.net/browse/MAIN-1236)

- Enable Rails' built-in parallel test runner with workers set to `:number_of_processors`. This brings down the time taken for the test suite to run locally and on CI from ~9 minutes to ~4 minutes.

- Following the [pattern on Whitehall](https://github.com/alphagov/whitehall/blob/c94022d66e82a727eeb572036091092995966f2f/test/test_helper.rb#L72), add parallelize_setup/parallelize_teardown hooks to give each test worker a unique SimpleCov command_name, so worker coverage results merge instead of overwriting each other.

- Rewrite test files that were using Minitest::Spec::DSL (describe/it/let). The anonymous classes that DSL creates cannot be Marshalled across worker processes, which the parallel runner requires.

- Remove id from create params in guide_parts_controller_test. Explicitly setting the id isn't something the create action does in reality, and was causing test flakiness when the id was already taken.

[MAIN-7397]: https://gov-uk.atlassian.net/browse/MAIN-7397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MAIN-1236]: https://gov-uk.atlassian.net/browse/MAIN-1236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ