### PR TITLE
Fix bug with semi-colon separated emails when submitting fact check request

### DIFF
--- a/app/lib/edition_progressor.rb
+++ b/app/lib/edition_progressor.rb
@@ -46,7 +46,7 @@ protected
   end
 
   def invalid_email_addresses?(addresses)
-    addresses.split(",").any? do |address|
+    addresses.split(Regexp.union(",", ";")).any? do |address|
       address.strip !~ EMAIL_REGEX
     end
   end

--- a/test/integration/edition_workflow_fact_check_api_test.rb
+++ b/test/integration/edition_workflow_fact_check_api_test.rb
@@ -63,10 +63,36 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       assert_current_path edition_path(@ready_edition.id)
     end
 
-    should "redirect back to the edit tab on submit and show success message with minimal inputs" do
+    should "redirect back to the edit tab on submit and show success message with optional fields empty" do
       date = 1.day.from_now
 
-      fill_in "Email addresses", with: "fact-checker-one@example.com"
+      fill_in "Email addresses", with: "fact-checker-one@example.com, fact-checker-two@example.com,fact-checker-three@example.com"
+      fill_in "Day", with: date.day
+      fill_in "Month", with: date.month
+      fill_in "Year", with: date.year
+      click_button "Send for fact check"
+
+      assert_current_path edition_path(@ready_edition.id)
+      assert page.has_text?("Sent to fact check")
+    end
+
+    should "successfully process the submission with semi-colon separated emails" do
+      date = 1.day.from_now
+
+      fill_in "Email addresses", with: "fact-checker-one@example.com; fact-checker-two@example.com;fact-checker-three@example.com"
+      fill_in "Day", with: date.day
+      fill_in "Month", with: date.month
+      fill_in "Year", with: date.year
+      click_button "Send for fact check"
+
+      assert_current_path edition_path(@ready_edition.id)
+      assert page.has_text?("Sent to fact check")
+    end
+
+    should "successfully send the api request with emails split by both separators" do
+      date = 1.day.from_now
+
+      fill_in "Email addresses", with: "fact-checker-one@example.com, fact-checker-two@example.com; fact-checker-three@example.com"
       fill_in "Day", with: date.day
       fill_in "Month", with: date.month
       fill_in "Year", with: date.year


### PR DESCRIPTION
This PR fixes an issue with `EditionProgressor#invalid_email_addresses? `not being able to handle semicolon separated emails, and expands integration tests around this failure
