### PR TITLE
[MAIN-7456] Enable design system UI for Simple Smart Answers Fact Checks

### DIFF
--- a/app/controllers/legacy_editions_controller.rb
+++ b/app/controllers/legacy_editions_controller.rb
@@ -16,6 +16,8 @@ class LegacyEditionsController < InheritedResources::Base
   end
   after_action :report_state_counts, only: %i[create duplicate progress destroy]
 
+  FACT_CHECK_SERVICE_REQUEST_ERROR_MESSAGE = "Due to a service problem, the fact check request could not be updated. The edition was successfully saved".freeze
+
   def index
     redirect_to root_path
   end
@@ -106,7 +108,11 @@ class LegacyEditionsController < InheritedResources::Base
 
         return_to = params[:return_to] || edition_path(resource)
 
-        flash[:notice] = "#{description(resource)} edition was successfully updated."
+        if !attempted_activity && resource.can_resend_fact_check? && Flipflop.enabled?(:fact_check_manager_api)
+          update_fact_check_content
+        else
+          flash[:notice] = "#{description(resource)} edition was successfully updated."
+        end
 
         redirect_to return_to
       end
@@ -367,6 +373,21 @@ protected
   end
 
 private
+
+  def update_fact_check_content
+    form = FactCheckRequestForm.new(edition: resource, user: current_user)
+
+    unless form.valid?(:update) && Services.fact_check_manager_api.patch_update_content(**form.update_content_payload)
+      Rails.logger.error "Request form validation errors: #{form.errors.full_messages.join(', ')}"
+      flash[:danger] = FACT_CHECK_SERVICE_REQUEST_ERROR_MESSAGE
+      return
+    end
+
+    flash[:notice] = "#{description(resource)} edition was successfully updated. Fact check request updated."
+  rescue GdsApi::HTTPErrorResponse => e
+    Rails.logger.error "API Error Response for Edition id #{resource.id}: #{e.class} #{e.message}"
+    flash[:danger] = FACT_CHECK_SERVICE_REQUEST_ERROR_MESSAGE
+  end
 
   def redirect_url
     make_govuk_url_relative params["redirect_url"]

--- a/app/helpers/edition_activity_buttons_helper.rb
+++ b/app/helpers/edition_activity_buttons_helper.rb
@@ -28,7 +28,9 @@ module EditionActivityButtonsHelper
   end
 
   def resend_fact_check_buttons(edition)
-    build_review_button(edition, "resend_fact_check", "Resend fact check email")
+    link_to "Resend fact check email",
+            resend_fact_check_email_page_edition_path(edition),
+            class: "btn btn-info #{'disabled' unless edition.can_resend_fact_check?} add-top-margin"
   end
 
   def progress_buttons(edition, options = {})
@@ -48,10 +50,16 @@ module EditionActivityButtonsHelper
       disabled = !edition.send("can_#{activity}?")
       next if disabled && options.fetch(:skip_disabled_buttons, false)
 
-      link_to title,
-              "##{activity}_form",
-              data: { toggle: "modal" },
-              class: "btn btn-large btn-#{button_color} #{'disabled' if disabled}"
+      if !disabled && activity == "send_fact_check"
+        link_to title,
+                send_to_fact_check_page_edition_path(edition),
+                class: "btn btn-large btn-#{button_color}"
+      else
+        link_to title,
+                "##{activity}_form",
+                data: { toggle: "modal" },
+                class: "btn btn-large btn-#{button_color} #{'disabled' if disabled}"
+      end
     end
 
     buttons.join("\n").html_safe

--- a/app/views/shared/_edition_history.html.erb
+++ b/app/views/shared/_edition_history.html.erb
@@ -23,6 +23,8 @@
               <%= action.to_s %> by
               <% if action.requester %>
                 <%= mail_to action.requester.email, action.requester.name %>
+              <% elsif action.requester_name %>
+                <%= action.requester_name %>
               <% else %>
                 GOV.UK Bot
               <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,10 +26,6 @@ Rails.application.routes.draw do
   constraints NewDesignSystemConstraint.new do
     resources :editions do
       member do
-        get "send_to_fact_check_page"
-        post "send_to_fact_check"
-        get "resend_fact_check_email_page"
-        patch "resend_fact_check_email"
         get "approve_fact_check_page"
         post "approve_fact_check"
         get "request_amendments_page"
@@ -98,6 +94,18 @@ Rails.application.routes.draw do
           get "confirm_destroy"
         end
       end
+    end
+  end
+
+  # The fact check send/resend flow uses the design system EditionsController for
+  # all content types, including those (such as simple smart answers) that
+  # otherwise still use the legacy (Bootstrap) UI.
+  resources :editions, only: [] do
+    member do
+      get "send_to_fact_check_page"
+      post "send_to_fact_check"
+      get "resend_fact_check_email_page"
+      patch "resend_fact_check_email"
     end
   end
 

--- a/test/functional/legacy_editions_controller_test.rb
+++ b/test/functional/legacy_editions_controller_test.rb
@@ -854,6 +854,103 @@ class LegacyEditionsControllerTest < ActionController::TestCase
     end
   end
 
+  context "#update calling the fact check manager API" do
+    setup do
+      @simple_smart_answer = FactoryBot.create(:simple_smart_answer_edition, :fact_check)
+      FactoryBot.create(
+        :action,
+        requester: @user,
+        request_type: Action::SEND_FACT_CHECK,
+        edition: @simple_smart_answer,
+        email_addresses: "fact-checker-one@example.com",
+      )
+    end
+
+    context "fact_check_manager_api is enabled" do
+      setup do
+        @test_strategy.switch!(:fact_check_manager_api, true)
+        stub_patch_update_fact_check_content(success: true, source_id: @simple_smart_answer.id)
+      end
+
+      should "send the updated content to the fact check manager API when saving a fact check edition" do
+        Services.fact_check_manager_api.expects(:patch_update_content).with(has_entries(source_id: @simple_smart_answer.id)).returns(GdsApi::Response.new(code: 200))
+
+        post :update,
+             params: {
+               id: @simple_smart_answer.id,
+               edition: { title: "Updated title" },
+             }
+
+        @simple_smart_answer.reload
+        assert_equal "Updated title", @simple_smart_answer.title
+        assert_includes flash[:notice], "Fact check request updated."
+      end
+
+      should "render an error but still save the edition if the fact check manager API call fails" do
+        stub_patch_update_fact_check_content(success: false, source_id: @simple_smart_answer.id)
+
+        post :update,
+             params: {
+               id: @simple_smart_answer.id,
+               edition: { title: "Updated title" },
+             }
+
+        @simple_smart_answer.reload
+        assert_equal "Updated title", @simple_smart_answer.title
+        assert_equal "Due to a service problem, the fact check request could not be updated. The edition was successfully saved", flash[:danger]
+      end
+
+      should "not call the fact check manager API when the edition is not out for fact check" do
+        draft = FactoryBot.create(:simple_smart_answer_edition, :draft)
+        Services.fact_check_manager_api.expects(:patch_update_content).never
+
+        post :update,
+             params: {
+               id: draft.id,
+               edition: { title: "Updated title" },
+             }
+      end
+
+      should "not call the fact check manager API when a workflow activity is being performed" do
+        Services.fact_check_manager_api.expects(:patch_update_content).never
+
+        post :update,
+             params: {
+               id: @simple_smart_answer.id,
+               commit: "Request amendments",
+               edition: {
+                 activity_request_amendments_attributes: {
+                   request_type: "request_amendments",
+                   comment: "Please fix this",
+                 },
+               },
+             }
+
+        @simple_smart_answer.reload
+        assert_equal "amends_needed", @simple_smart_answer.state
+      end
+    end
+
+    context "fact_check_manager_api is disabled" do
+      setup do
+        @test_strategy.switch!(:fact_check_manager_api, false)
+      end
+
+      should "not call the fact check manager API when saving a fact check edition" do
+        Services.fact_check_manager_api.expects(:patch_update_content).never
+
+        post :update,
+             params: {
+               id: @simple_smart_answer.id,
+               edition: { title: "Updated title" },
+             }
+
+        @simple_smart_answer.reload
+        assert_equal "Updated title", @simple_smart_answer.title
+      end
+    end
+  end
+
   context "#review" do
     setup do
       artefact = FactoryBot.create(:artefact)

--- a/test/integration/edition_workflow_fact_check_api_test.rb
+++ b/test/integration/edition_workflow_fact_check_api_test.rb
@@ -324,4 +324,55 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       assert_equal "some new content", @fact_check_edition.body
     end
   end
+
+  context "Simple smart answer using the design system fact check pages" do
+    setup do
+      stub_linkables
+    end
+
+    should "send a simple smart answer to fact check" do
+      stub_post_new_fact_check_request(success: true)
+      ready_edition = FactoryBot.create(:simple_smart_answer_edition, :ready)
+      date = 1.day.from_now
+
+      visit send_to_fact_check_page_edition_path(ready_edition)
+
+      assert page.has_text?("Send for fact check")
+      assert page.has_text?("Reason for change (optional)")
+
+      fill_in "Email addresses", with: "fact-checker-one@example.com"
+      fill_in "Day", with: date.day
+      fill_in "Month", with: date.month
+      fill_in "Year", with: date.year
+      click_button "Send for fact check"
+
+      assert_current_path edition_path(ready_edition.id)
+      assert page.has_text?("Sent to fact check")
+
+      ready_edition.reload
+      assert ready_edition.fact_check?
+    end
+
+    should "resend a simple smart answer fact check email" do
+      stub_post_resend_fact_check_emails(success: true)
+      fact_check_edition = FactoryBot.create(:simple_smart_answer_edition, :fact_check)
+      FactoryBot.create(
+        :action,
+        requester: @govuk_editor,
+        request_type: Action::SEND_FACT_CHECK,
+        edition: fact_check_edition,
+        email_addresses: "fact-checker-one@example.com",
+      )
+
+      visit resend_fact_check_email_page_edition_path(fact_check_edition)
+
+      assert page.has_text?("Resend fact check email")
+      assert page.has_text?("fact-checker-one@example.com")
+
+      click_button "Resend fact check email"
+
+      assert_current_path edition_path(fact_check_edition.id)
+      assert page.has_text?("Fact check email re-sent")
+    end
+  end
 end

--- a/test/integration/legacy_edition_workflow_test.rb
+++ b/test/integration/legacy_edition_workflow_test.rb
@@ -52,11 +52,9 @@ class LegacyEditionWorkflowTest < LegacyJavascriptIntegrationTest
 
       click_link("Fact check")
 
-      within "#send_fact_check_form" do
-        customised_message = page.find_field("Customised message")
-        assert customised_message
-        assert customised_message.value.include? "Deadline: 8 May 2017 (5 working days from today - 28 April 2017)"
-      end
+      customised_message = page.find_field("Customised message")
+      assert customised_message
+      assert customised_message.value.include? "Deadline: 8 May 2017 (5 working days from today - 28 April 2017)"
     end
   end
 
@@ -68,11 +66,9 @@ class LegacyEditionWorkflowTest < LegacyJavascriptIntegrationTest
 
     ActionMailer::Base.deliveries.clear
 
-    within "#send_fact_check_form" do
-      fill_in "Email address", with: "user@example.com"
-      click_on "Send for fact check"
-    end
-    assert page.has_content?("Simple smart answer updated")
+    fill_in "Email addresses", with: "user@example.com"
+    click_on "Send for fact check"
+    assert page.has_content?("Sent to fact check")
 
     fact_check_email = ActionMailer::Base.deliveries.select { |mail| mail.to.include? "user@example.com" }.last
     assert fact_check_email
@@ -87,11 +83,9 @@ class LegacyEditionWorkflowTest < LegacyJavascriptIntegrationTest
 
     ActionMailer::Base.deliveries.clear
 
-    within "#send_fact_check_form" do
-      fill_in "Email address", with: "user@example.com"
-      click_on "Send for fact check"
-    end
-    assert page.has_content?("Simple smart answer updated")
+    fill_in "Email addresses", with: "user@example.com"
+    click_on "Send for fact check"
+    assert page.has_content?("Sent to fact check")
 
     fact_check_email = ActionMailer::Base.deliveries.select { |mail| mail.to.include? "user@example.com" }.last
     assert fact_check_email
@@ -106,12 +100,11 @@ class LegacyEditionWorkflowTest < LegacyJavascriptIntegrationTest
 
     ActionMailer::Base.deliveries.clear
 
-    within "#send_fact_check_form" do
-      fill_in "Customised message", with: "Blah"
-      fill_in "Email address", with: "user@example.com"
-      click_on "Send"
-    end
+    fill_in "Customised message", with: "Blah"
+    fill_in "Email addresses", with: "user@example.com"
+    click_on "Send for fact check"
 
+    assert page.has_content?("Sent to fact check")
     assert page.has_css?(".label", text: "Fact check sent")
 
     click_on "History and notes"
@@ -135,13 +128,11 @@ class LegacyEditionWorkflowTest < LegacyJavascriptIntegrationTest
 
     ActionMailer::Base.deliveries.clear
 
-    within "#send_fact_check_form" do
-      fill_in "Customised message", with: "Blah"
-      fill_in "Email address", with: "user1@example.com, user2@example.com"
-      click_on "Send"
-    end
+    fill_in "Customised message", with: "Blah"
+    fill_in "Email addresses", with: "user1@example.com, user2@example.com"
+    click_on "Send for fact check"
 
-    assert page.has_css?(".label", text: "Fact check sent")
+    assert page.has_content?("Sent to fact check")
     @simple_smart_answer.reload
     assert @simple_smart_answer.fact_check?
 
@@ -171,37 +162,25 @@ class LegacyEditionWorkflowTest < LegacyJavascriptIntegrationTest
 
     click_link("Fact check")
 
-    within "#send_fact_check_form" do
-      fill_in "Customised message", with: "Blah"
-      fill_in "Email address", with: "user1"
-      click_on "Send"
-    end
+    fill_in "Customised message", with: "Blah"
+    fill_in "Email addresses", with: "user1"
+    click_on "Send for fact check"
 
-    assert page.has_content? "The email addresses you entered appear to be invalid."
+    assert page.has_content? "Enter email addresses and/or customised message"
     @simple_smart_answer.reload
     assert_not @simple_smart_answer.fact_check?
 
-    click_link("Fact check")
+    fill_in "Email addresses", with: "user1@example.com user2@example.com"
+    click_on "Send for fact check"
 
-    within "#send_fact_check_form" do
-      fill_in "Customised message", with: "Blah"
-      fill_in "Email address", with: "user1@example.com user2@example.com"
-      click_on "Send"
-    end
-
-    assert page.has_content? "The email addresses you entered appear to be invalid."
+    assert page.has_content? "Enter email addresses and/or customised message"
     @simple_smart_answer.reload
     assert_not @simple_smart_answer.fact_check?
 
-    click_link("Fact check")
+    fill_in "Email addresses", with: "user1, user2@example.com"
+    click_on "Send for fact check"
 
-    within "#send_fact_check_form" do
-      fill_in "Customised message", with: "Blah"
-      fill_in "Email address", with: "user1, user2@example.com"
-      click_on "Send"
-    end
-
-    assert page.has_content? "The email addresses you entered appear to be invalid."
+    assert page.has_content? "Enter email addresses and/or customised message"
     @simple_smart_answer.reload
     assert_not @simple_smart_answer.fact_check?
   end
@@ -234,20 +213,19 @@ class LegacyEditionWorkflowTest < LegacyJavascriptIntegrationTest
 
     click_link("Fact check")
 
-    within "#send_fact_check_form" do
-      fill_in "Customised message", with: "Blah blah fact check message"
-      fill_in "Email address", with: "user-to-ask-for-fact-check@example.com"
-      click_on "Send"
-    end
+    fill_in "Customised message", with: "Blah blah fact check message"
+    fill_in "Email addresses", with: "user-to-ask-for-fact-check@example.com"
+    click_on "Send for fact check"
+    assert page.has_content?("Sent to fact check")
 
     ActionMailer::Base.deliveries.clear
 
-    send_for_generic_action @simple_smart_answer, "Resend fact check email" do
-      assert page.has_content? "Blah blah fact check message"
-      assert page.has_content? "user-to-ask-for-fact-check@example.com"
-      click_on "Resend"
-    end
-    assert page.has_content?("updated")
+    click_link "Resend fact check email"
+
+    assert page.has_content? "Blah blah fact check message"
+    assert page.has_content? "user-to-ask-for-fact-check@example.com"
+    click_on "Resend fact check email"
+    assert page.has_content?("Fact check email re-sent")
 
     click_on "History and notes"
     assert page.has_content? "Resend fact check by Alice"
@@ -272,13 +250,11 @@ class LegacyEditionWorkflowTest < LegacyJavascriptIntegrationTest
 
       click_link("Fact check")
 
-      within "#send_fact_check_form" do
-        fill_in "Customised message", with: "Blah blah fact check message"
-        fill_in "Email address", with: "user-to-ask-for-fact-check@example.com"
-        click_on "Send"
-      end
+      fill_in "Customised message", with: "Blah blah fact check message"
+      fill_in "Email addresses", with: "user-to-ask-for-fact-check@example.com"
+      click_on "Send for fact check"
 
-      assert page.has_content? "Error: One or more recipients not in GOV.UK Notify team (code: 400).\nThis error will not occur in Production."
+      assert page.has_content? "Due to a service problem, the request could not be made"
     end
   end
 
@@ -719,16 +695,15 @@ class LegacyEditionWorkflowTest < LegacyJavascriptIntegrationTest
   end
 
   def send_for_fact_check(simple_smart_answer)
-    button_text = "Fact check"
-    email = "test@example.com"
-    message = "Let us know what you think"
+    visit_edition simple_smart_answer
+    click_link "Fact check"
 
-    send_for_generic_action(simple_smart_answer, button_text) do
-      fill_in "Email", with: email
-      fill_in "Customised message", with: message
-      click_on "Send for fact check"
-    end
-    assert page.has_content?("updated")
+    fill_in "Email addresses", with: "test@example.com"
+    fill_in "Customised message", with: "Let us know what you think"
+    click_on "Send for fact check"
+
+    assert page.has_content?("Sent to fact check")
+    simple_smart_answer.reload
   end
 
   def send_action(simple_smart_answer, button_text, modal_button_text, message)

--- a/test/integration/routes_test.rb
+++ b/test/integration/routes_test.rb
@@ -44,6 +44,13 @@ class RoutesTest < LegacyIntegrationTest
           should "route to legacy editions controller" do
             assert_legacy_editions_controller
           end
+
+          should "route fact check send and resend actions to the design system editions controller" do
+            assert_routing("/editions/#{@edition.id}/send_to_fact_check_page", controller: "editions", action: "send_to_fact_check_page", id: @edition.id.to_s)
+            assert_routing({ method: "post", path: "/editions/#{@edition.id}/send_to_fact_check" }, controller: "editions", action: "send_to_fact_check", id: @edition.id.to_s)
+            assert_routing("/editions/#{@edition.id}/resend_fact_check_email_page", controller: "editions", action: "resend_fact_check_email_page", id: @edition.id.to_s)
+            assert_routing({ method: "patch", path: "/editions/#{@edition.id}/resend_fact_check_email" }, controller: "editions", action: "resend_fact_check_email", id: @edition.id.to_s)
+          end
         end
       end
     end


### PR DESCRIPTION
[MAIN-7456](https://gov-uk.atlassian.net/browse/MAIN-7456)

Simple smart answers still use the legacy Bootstrap UI, but the fact check process can be handled by the design system UI (like other content types).

- Move the send/resend fact check routes out of the NewDesignSystemConstraint block so they are available for all content types.

- Point the Bootstrap UI's "Fact check" and "Resend to fact check" buttons at the design system send/resend controller actions.


[MAIN-7456]: https://gov-uk.atlassian.net/browse/MAIN-7456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ