### PR TITLE
Updated guidance links as per instructions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,6 +65,6 @@ class ApplicationController < ActionController::Base
   end
 
   def require_user_accessibility_to_edition(edition)
-    render html: "You do not have permission to access this page - please <a href='https://www.gov.uk/guidance/contact-the-government-digital-service/request-a-thing#change-govuk-content'>raise a content request</a> with GDS to get it updated.".html_safe, status: :not_found unless edition.is_accessible_to?(current_user)
+    render html: "You do not have permission to access this page - please <a href='https://guidance.publishing.service.gov.uk/accounts-support/make-content-requests/ask-updates-content'>raise a content request</a> with GDS to get it updated.".html_safe, status: :not_found unless edition.is_accessible_to?(current_user)
   end
 end

--- a/app/views/editions/secondary_nav_tabs/add_edition_note.html.erb
+++ b/app/views/editions/secondary_nav_tabs/add_edition_note.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">Explain what changes you did or did not make and why. Include a link to the relevant Zendesk ticket and Jira card. You can also add an edition note when you send the edition for 2i review. <%= link_to "Read guidance on writing good change notes (opens in new tab)", "https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes", target: "_blank", rel: "noopener", class: "govuk-link--no-visited-state" %>.</p>
+    <p class="govuk-body">Explain what changes you did or did not make and why. Include a link to the relevant Zendesk ticket and Jira card. You can also add an edition note when you send the edition for 2i review. <%= link_to "Read guidance on writing good change notes (opens in new tab)", "https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/tone-of-voice/change-notes/", target: "_blank", rel: "noopener", class: "govuk-link--no-visited-state" %>.</p>
 
     <%= form_for(:note, :url=> notes_path, data: { module: "", ga4_section: "History and notes - #{title}" }) do |f| %>
       <%= hidden_field_tag :edition_id, resource.id %>

--- a/app/views/editions/secondary_nav_tabs/edit/editable/components/_public_change_note.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/editable/components/_public_change_note.html.erb
@@ -22,7 +22,7 @@
           },
           name: "edition[change_note]",
           value: edition.change_note,
-          hint: ("<p class=\"govuk-!-margin-0\">Tell users what has changed, where and why. Write in full sentences, leading with the most important words. For example, \"College A has been removed from the registered sponsors list because its licence has been suspended.\"</p><a href=\"https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes\" class=\"govuk-link--no-visited-state\" target=\"_blank\">Guidance on change notes (opens in a new tab)</a>").html_safe,
+          hint: ("<p class=\"govuk-!-margin-0\">Tell users what has changed, where and why. Write in full sentences, leading with the most important words. For example, \"College A has been removed from the registered sponsors list because its licence has been suspended.\"</p><a href=\"https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/tone-of-voice/change-notes\" class=\"govuk-link--no-visited-state\" target=\"_blank\">Guidance on change notes (opens in a new tab)</a>").html_safe,
         }),
       },
       {


### PR DESCRIPTION
[MAIN-7310](https://gov-uk.atlassian.net/browse/MAIN-7310)

Changed URLs of publishing guidance links in affected Publisher component pages.


[MAIN-7310]: https://gov-uk.atlassian.net/browse/MAIN-7310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ