### PR TITLE
Update regex to allow email addresses with apostrophes

### DIFF
--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -585,7 +585,7 @@ private
   def invalid_email_addresses?(addresses)
     email_regex = /\A[\w+\-%.']+@[a-z\d-]+(\.[a-z\d-]+)*\.[a-z]+\z/
     addresses.split(",").any? do |address|
-      address.strip !~ email_regex
+      !address.to_s.strip.match?(email_regex)
     end
   end
 

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -583,7 +583,7 @@ private
   end
 
   def invalid_email_addresses?(addresses)
-    email_regex = /\A[\w+\-%.]+@[a-z\d-]+(\.[a-z\d-]+)*\.[a-z]+\z/
+    email_regex = /\A[\w+\-%.']+@[a-z\d-]+(\.[a-z\d-]+)*\.[a-z]+\z/
     addresses.split(",").any? do |address|
       address.strip !~ email_regex
     end

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -846,7 +846,8 @@ class EditionsControllerTest < ActionController::TestCase
       end
 
       context "user has govuk_editor permission" do
-        ["test@test.com", "test1@test.com, test2@test.com"].each do |email_addresses|
+        # NOTE: We have allowed apostrophes in email addresses in response to a request relating to a valid HMRC email address
+        ["test@test.com", "test1@test.com, test2@test.com", "Name.O'Surname@dept.gov.uk"].each do |email_addresses|
           context "using email address(es) '#{email_addresses}'" do
             should "update the edition status to 'fact_check', generate the comment and save the user input" do
               edition = FactoryBot.create(:edition, :ready)


### PR DESCRIPTION
[MAIN-7459](https://gov-uk.atlassian.net/browse/MAIN-7459)

This deploys a small update to the email validation to allow email addresses which contain apostrophes. 
The fix is necessary as surnames with apostrophes such as O'Dowd within some government departments can then result in the user's email address containing an apostrophe. 

Have also added a small improvement to the existing regex matching code which should make this more efficient.  

[MAIN-7459]: https://gov-uk.atlassian.net/browse/MAIN-7459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ