### PR TITLE
Fix invalid email address issue in FCM

### DIFF
--- a/app/lib/fact_check_request_form.rb
+++ b/app/lib/fact_check_request_form.rb
@@ -25,7 +25,7 @@ class FactCheckRequestForm
   validate :deadline_in_range, on: :send
   validate :deadline_present, on: :send
 
-  EMAIL_REGEX = /\A[\w+\-%.]+@[a-z\d-]+(\.[a-z\d-]+)*\.[a-z]+\z/
+  EMAIL_REGEX = /\A[\w+\-%.']+@[a-z\d-]+(\.[a-z\d-]+)*\.[a-z]+\z/
 
   def deadline
     return unless deadline_1i.present? && deadline_2i.present? && deadline_3i.present?
@@ -82,7 +82,7 @@ private
   def valid_email_addresses
     return if email_addresses.blank?
 
-    if split_email_addresses.any? { |address| address.strip !~ EMAIL_REGEX }
+    if split_email_addresses.any? { |address| !address.to_s.strip.match?(EMAIL_REGEX) }
       errors.add(:email_addresses, "Email addresses are invalid")
     end
   end

--- a/test/unit/lib/fact_check_request_form_test.rb
+++ b/test/unit/lib/fact_check_request_form_test.rb
@@ -49,6 +49,13 @@ class FactCheckRequestFormTest < ActiveSupport::TestCase
         assert_empty @form.errors[:email_addresses]
       end
 
+      should "validate an email address with valid but unusual characters" do
+        @form.email_addresses = "James.O'Stewart42@test.gov.uk"
+
+        assert @form.valid?(:send)
+        assert_empty @form.errors[:email_addresses]
+      end
+
       should "split and validate multiple comma-separated email addresses" do
         ["james.stewart@test.gov.uk, stewart.james@test.gov.uk", "james.stewart@test.gov.uk,stewart.james@test.gov.uk"].each do |emails|
           @form.email_addresses = emails


### PR DESCRIPTION
[MAIN-7460](https://gov-uk.atlassian.net/browse/MAIN-7460)

Upgrade Regex to account for apostrophes and use a standard method for regex - .match?

- This method is purely for checking if a pattern exists, is more memory efficient and therefore faster.
- Allows us to use the negation at the start of the method chain, to improve readability.
- Uses .to_s to avoid any issues with address being nil (as to_s will convert this to an empty string)

[MAIN-7460]: https://gov-uk.atlassian.net/browse/MAIN-7460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ