### PR TITLE
[MAIN-7249] Call edition#order_parts upon deleting a part

### DIFF
--- a/app/controllers/guide_parts_controller.rb
+++ b/app/controllers/guide_parts_controller.rb
@@ -102,13 +102,14 @@ class GuidePartsController < InheritedResources::Base
 
   def destroy
     @part = Part.find(params[:id])
-    if @part.destroy!
-      UpdateWorker.perform_async(@edition.id.to_s)
-      flash[:success] = "Chapter deleted successfully"
-      redirect_to edition_path(@edition)
-    else
-      render "confirm_destroy"
+    ActiveRecord::Base.transaction do
+      @part.destroy!
+      @edition.order_parts
+      @edition.save!
     end
+    UpdateWorker.perform_async(@edition.id.to_s)
+    flash[:success] = "Chapter deleted successfully"
+    redirect_to edition_path(@edition)
   rescue StandardError => e
     Rails.logger.error "Error #{e.class} #{e.message}"
     flash.now[:danger] = "Due to a service problem, the chapter couldn't be deleted"

--- a/test/functional/guide_parts_controller_test.rb
+++ b/test/functional/guide_parts_controller_test.rb
@@ -355,6 +355,20 @@ class GuidePartsControllerTest < ActionController::TestCase
         assert_equal "Chapter deleted successfully", flash[:success]
         assert @edition_with_parts.parts.exclude? part
       end
+
+      should "order the parts after deleting a part" do
+        login_as(FactoryBot.create(:user, :govuk_editor, organisation_content_id: "org-one"))
+        @edition_with_parts.parts.create!(title: "PART 3", slug: "part-three", order: 3)
+        middle_part = @edition_with_parts.parts.find_by(order: 2)
+
+        delete :destroy, params: { edition_id: @edition_with_parts.id, id: middle_part.id }
+
+        @edition_with_parts.reload
+
+        assert_equal 2, @edition_with_parts.parts.count
+        assert_equal [1, 2], @edition_with_parts.parts.in_order.map(&:order)
+        assert_equal %w[part-one part-three], @edition_with_parts.parts.in_order.map(&:slug)
+      end
     end
   end
 end


### PR DESCRIPTION
[MAIN-7249](https://gov-uk.atlassian.net/browse/MAIN-7249)

### Changes

We do not currently bump down the order numbers for a guide edition's parts upon deleting a part e.g. deleting the middle part for a guide edition having part order values of 1,2,3 results in the remaining parts having order 1,3. This is unlikely to result in an ordering issue because we do this whenever we add a new part or via the reorder functionality, however it is good to keep the orders in the right state.

The deletion and re-ordering are wrapped in a transaction so they're atomic.

[MAIN-7249]: https://gov-uk.atlassian.net/browse/MAIN-7249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ