### PR TITLE
Remove data-ga4-track-links-only references

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -23,7 +23,7 @@
   <div data-module="ga4-page-view-tracking" data-attributes='<%= track_analytics_data_on_load(sanitized_title) %>'></div>
 
   <%#= render partial: "/shared/maintenance_banner" %>
-  
+
   <%= render "govuk_publishing_components/components/skip_link" %>
 
   <%= render "govuk_publishing_components/components/layout_header", {
@@ -48,7 +48,6 @@
       role="main"
       data-module="ga4-link-tracker ga4-form-setup ga4-index-section-setup ga4-event-tracker"
       data-ga4-link='{ "event_name": "navigation", "type": "generic_link" }'
-      data-ga4-track-links-only
       data-ga4-limit-to-element-class="govuk-link"
       data-ga4-do-not-redact
       data-ga4-no-copy="true"


### PR DESCRIPTION
## What/Why
- This attribute was removed from govuk_publishing_components as it wasn't actually needed, so we can remove it from this app.
- Jira card: https://gov-uk.atlassian.net/browse/PNP-10043

## Visual changes
None.