### PR TITLE
Main 7451 update ga4 page view event

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -6,6 +6,8 @@
   <meta name="govuk:user-created-at" content="<%= current_user&.created_at&.to_date %>">
   <meta name="govuk:user-organisation-name" content="<%= current_user&.gds_editor? ? "Government Digital Service" : "nil" %>">
   <meta name="govuk:user-role" content="<%= current_user&.role %>">
+  <meta name="govuk:format" content="<%= "#{action_name}-#{controller_name}" %>">
+  <meta name="govuk:content-id" content=<%= @edition.present? ? "#{@edition.id}" : "nil" %>>
   <%= javascript_include_tag "domain-config" %>
   <%= javascript_include_tag "govuk_publishing_components/load-analytics" %>
   <%= javascript_include_tag "es6-components", type: "module" %>


### PR DESCRIPTION
[MAIN-7451](https://gov-uk.atlassian.net/browse/MAIN-7451)
(populate the link above to make sure your PR is linked to the Jira ticket)

The additions here add some values to extra parameters in the `page_view` event which is fired every time a page loads. This adds data to the `dataLayer` object which is used by GA4 to analyse user engagement. 

The parameters we are adding here are 
- document_type: 
  - the value for this is derived from the name of the controller and the action
  - it is inferred from the "govuk:format" metatag
- content_id: the value for this is the id of the edition or "nil" if there is no edition relevant to the current page
  - it is inferred from the "govuk:content-id" metatag

This can be tested locally by running `window.dataLayer` in the browser console and inspecting values for "page_view" after a page load. 

[MAIN-7451]: https://gov-uk.atlassian.net/browse/MAIN-7451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ