### PR TITLE
Fix ordering of new simple smart answer options

### DIFF
--- a/app/assets/javascripts/smart-answers.js
+++ b/app/assets/javascripts/smart-answers.js
@@ -123,7 +123,20 @@
       }
     },
     initOption: function (e) {
-      var node = $(e.field).parents('.node').first()
+      var option = $(e.field)
+      var node = option.parents('.node').first()
+      var maxOrder = 0
+
+      // Find the maximum order value in the list of existing options
+      node.find('.option:visible .option-order')
+        .not(option.find('.option-order')).each(function () {
+          var val = parseInt($(this).val())
+          if (val > maxOrder) { maxOrder = val }
+        })
+
+      // Set the hidden input order value for the new option to maxOrder + 1
+      option.find('.option-order').val(maxOrder + 1)
+
       smartAnswerBuilder.reloadNextNodeList(node)
     },
     reloadAllNextNodeLists: function () {

--- a/app/views/simple_smart_answers/_node.html.erb
+++ b/app/views/simple_smart_answers/_node.html.erb
@@ -37,7 +37,7 @@
 
             <div class="form-group col-md-6">
               <%= f.label :next_node, "Next question for user", for: "edition_nodes_attributes_#{o.options[:parent_builder].index}_options_attributes_#{o.index}_node" %>
-              <%= o.hidden_field :order, :value => o.index.to_i + 1 %>
+              <%= o.hidden_field :order, :value => o.index.to_i + 1, :class => "option-order" %>
               <%= o.hidden_field :next_node, class: "next-node-id" %>
               <%= form_errors(o.object.errors[:next_node], "node") %>
               <select id="edition_nodes_attributes_<%= o.options[:parent_builder].index %>_options_attributes_<%= o.index %>_node" class="form-control required next-node-list" name="next-node-list">

--- a/test/integration/simple_smart_answers_test.rb
+++ b/test/integration/simple_smart_answers_test.rb
@@ -572,6 +572,30 @@ class SimpleSmartAnswersTest < LegacyJavascriptIntegrationTest
       end
     end
 
+    should "correctly order new answers" do
+      visit_edition @edition
+
+      within ".nodes .question:first-child" do
+        assert_equal "1", find(:css, ".option:nth-child(1) .option-order", visible: false).value
+        assert_equal "2", find(:css, ".option:nth-child(2) .option-order", visible: false).value
+
+        click_link("Add answer")
+
+        within ".option:nth-child(3)" do
+          assert_equal "3", find(:css, ".option-order", visible: false).value
+          find(:css, "input.option-label").set("A different answer")
+          select "Outcome 2 (Outcome Two)", from: "next-node-list"
+        end
+      end
+
+      save_edition
+
+      assert page.has_content?("Simple smart answer edition was successfully updated.")
+
+      labels = @edition.reload.nodes.where(slug: "question-1").first.options.map(&:label)
+      assert_equal ["That is the question", "That is not the question", "A different answer"], labels
+    end
+
     should "highlight an error on the select field when the next node is blank" do
       visit_edition @edition
 


### PR DESCRIPTION
### Changes

When a user clicked "Add answer" on a question, the new option was being saved with `order` 1 rather than a value placing it after the existing answers; this resulted in it appearing at the top of the list rather than at the end.

This was happening because the hidden order field for each option is rendered with the value `o.index.to_i + 1` which is fine for options already persisted but the nested_form gem renders the new options with an index of "new_options" which results in 0 when calling `to_i`, so every dynamically added option had an order of 1.

This change sets the order of newly added options via Javascript by finding the highest order of the question's answers.