### PR TITLE
Main 7444 ga4 ready page links

### DIFF
--- a/app/views/editions/_secondary_navigation.html.erb
+++ b/app/views/editions/_secondary_navigation.html.erb
@@ -1,5 +1,9 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div
+    class="govuk-grid-column-full"
+    data-module="ga4-link-tracker"
+    data-ga4-link='{ "event_name": "navigation", "type": "generic_link" }'
+  >
     <%= render "govuk_publishing_components/components/secondary_navigation", {
       aria_label: "Document navigation",
       items: edition_nav_items(@edition, current_user),

--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -23,7 +23,11 @@
     </div>
     <% if @resource.scheduled_for_publishing? %>
       <div class="govuk-grid-column-one-third options-sidebar">
-        <div class="sidebar-components">
+        <div
+          class="sidebar-components"
+          data-module="ga4-link-tracker"
+          data-ga4-link='{ "event_name": "navigation", "type": "generic_link" }'
+        >
           <%= sidebar_options_heading %>
 
           <%= sidebar_items_list(scheduled_for_publishing_sidebar_buttons(@resource)) %>
@@ -31,7 +35,11 @@
       </div>
     <% elsif @resource.published? %>
       <div class="govuk-grid-column-one-third options-sidebar">
-        <div class="sidebar-components">
+        <div
+          class="sidebar-components"
+          data-module="ga4-link-tracker"
+          data-ga4-link='{ "event_name": "navigation", "type": "generic_link" }'
+        >
           <%= sidebar_options_heading %>
 
           <%= sidebar_items_list(published_sidebar_buttons(@resource)) %>
@@ -39,7 +47,11 @@
       </div>
     <% elsif !@resource.archived? %>
       <div class="govuk-grid-column-one-third options-sidebar">
-        <div class="sidebar-components">
+        <div
+          class="sidebar-components"
+          data-module="ga4-link-tracker"
+          data-ga4-link='{ "event_name": "navigation", "type": "generic_link" }'
+        >
           <%= sidebar_options_heading %>
 
           <%= sidebar_items_list(non_published_sidebar_buttons(@resource)) %>
@@ -66,7 +78,11 @@
         </div>
       </div>
       <div class="govuk-grid-column-one-third options-sidebar">
-        <div class="sidebar-components">
+        <div
+          class="sidebar-components"
+          data-module="ga4-link-tracker"
+          data-ga4-link='{ "event_name": "navigation", "type": "generic_link" }'
+        >
           <%= sidebar_options_heading %>
 
           <%= sidebar_items_list(non_published_sidebar_buttons(@resource)) %>

--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -8,7 +8,11 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds editions__edit__summary">
+  <div
+    class="govuk-grid-column-two-thirds editions__edit__summary"
+    data-module="ga4-link-tracker"
+    data-ga4-link='{ "event_name": "navigation", "type": "generic_link" }'
+  >
     <%= render "govuk_publishing_components/components/summary_list", {
       items: document_summary_items(@edition, @reviewer),
     } %>
@@ -18,48 +22,55 @@
     <% if @edition.important_note %>
       <%= render partial: "important_note" %>
     <% end %>
-    <% if @edition.in_review? %>
-      <% latest_request_review_action = @edition.latest_status_action(Action::REQUEST_REVIEW) %>
-      <%= render "govuk_publishing_components/components/inset_text", {} do %>
-        <% if latest_request_review_action&.requester == current_user %>
-          <p class="govuk-body">You've sent this edition to be reviewed</p>
-          <% if current_user.skip_review? %>
-            <p class="govuk-body"><%= link_to("Skip review", skip_review_page_edition_path, class: "govuk-link govuk-link--no-visited-state") %></p>
-          <% end %>
-        <% else %>
-          <p class="govuk-body"><%= latest_request_review_action&.requester&.name %> sent this edition to be reviewed</p>
-          <% if current_user.has_editor_permissions?(@edition) %>
-            <p class="govuk-body"><%= link_to("Request amendments", request_amendments_page_edition_path, class: "govuk-link govuk-link--no-visited-state") %></p>
-            <p class="govuk-body"><%= link_to("No changes needed", no_changes_needed_page_edition_path, class: "govuk-link govuk-link--no-visited-state") %></p>
-          <% end %>
-        <% end %>
-      <% end %>
-  <% elsif @edition.ready? || @edition.fact_check? %>
-      <% if current_user.has_editor_permissions?(@edition) %>
-        <%= render "govuk_publishing_components/components/inset_text", {} do %>
-          <% if @edition.fact_check? %>
-            <% latest_send_fact_check_action = @edition.latest_status_action(Action::SEND_FACT_CHECK) %>
-            <% if latest_send_fact_check_action&.requester == current_user %>
-              <p class="govuk-body">You've requested this edition to be fact checked. We're awaiting a response.</p>
+
+    <div
+      data-module="ga4-link-tracker"
+      data-ga4-link='{ "event_name": "navigation", "type": "generic_link" }'
+    >
+      <% if @edition.in_review? %>
+        <% latest_request_review_action = @edition.latest_status_action(Action::REQUEST_REVIEW) %>
+          <%= render "govuk_publishing_components/components/inset_text", {} do %>
+            <% if latest_request_review_action&.requester == current_user %>
+              <p class="govuk-body">You've sent this edition to be reviewed</p>
+              <% if current_user.skip_review? %>
+                <p class="govuk-body"><%= link_to("Skip review", skip_review_page_edition_path, class: "govuk-link govuk-link--no-visited-state") %></p>
+              <% end %>
             <% else %>
-              <p class="govuk-body"><%= latest_send_fact_check_action&.requester&.name %> requested this edition to be fact checked.
-                We're awaiting a response.</p>
+              <p class="govuk-body"><%= latest_request_review_action&.requester&.name %> sent this edition to be reviewed</p>
+              <% if current_user.has_editor_permissions?(@edition) %>
+                <p class="govuk-body"><%= link_to("Request amendments", request_amendments_page_edition_path, class: "govuk-link govuk-link--no-visited-state") %></p>
+                <p class="govuk-body"><%= link_to("No changes needed", no_changes_needed_page_edition_path, class: "govuk-link govuk-link--no-visited-state") %></p>
+              <% end %>
             <% end %>
-            <p class="govuk-body"><%= link_to("Resend fact check email", resend_fact_check_email_page_edition_path, class: "govuk-link govuk-link--no-visited-state") %></p>
           <% end %>
-          <p class="govuk-body"><%= link_to("Request amendments", request_amendments_page_edition_path, class: "govuk-link govuk-link--no-visited-state") %></p>
+        </div>
+      <% elsif @edition.ready? || @edition.fact_check? %>
+        <% if current_user.has_editor_permissions?(@edition) %>
+          <%= render "govuk_publishing_components/components/inset_text", {} do %>
+            <% if @edition.fact_check? %>
+              <% latest_send_fact_check_action = @edition.latest_status_action(Action::SEND_FACT_CHECK) %>
+              <% if latest_send_fact_check_action&.requester == current_user %>
+                <p class="govuk-body">You've requested this edition to be fact checked. We're awaiting a response.</p>
+              <% else %>
+                <p class="govuk-body"><%= latest_send_fact_check_action&.requester&.name %> requested this edition to be fact checked.
+                  We're awaiting a response.</p>
+              <% end %>
+              <p class="govuk-body"><%= link_to("Resend fact check email", resend_fact_check_email_page_edition_path, class: "govuk-link govuk-link--no-visited-state") %></p>
+            <% end %>
+            <p class="govuk-body"><%= link_to("Request amendments", request_amendments_page_edition_path, class: "govuk-link govuk-link--no-visited-state") %></p>
+          <% end %>
+        <% end %>
+      <% elsif @edition.fact_check_received? %>
+        <% if current_user.has_editor_permissions?(@edition) %>
+          <%= render "govuk_publishing_components/components/inset_text", {} do %>
+            <p class="govuk-body">We have received a fact check response for this edition.</p>
+            <p class="govuk-body">Please check the response in History and notes and select an action below.</p>
+            <p class="govuk-body"><%= link_to("Request amendments", request_amendments_page_edition_path, class: "govuk-link govuk-link--no-visited-state") %></p>
+            <p class="govuk-body"><%= link_to("No changes needed", approve_fact_check_page_edition_path, class: "govuk-link govuk-link--no-visited-state") %></p>
+          <% end %>
         <% end %>
       <% end %>
-  <% elsif @edition.fact_check_received? %>
-      <% if current_user.has_editor_permissions?(@edition) %>
-        <%= render "govuk_publishing_components/components/inset_text", {} do %>
-          <p class="govuk-body">We have received a fact check response for this edition.</p>
-          <p class="govuk-body">Please check the response in History and notes and select an action below.</p>
-          <p class="govuk-body"><%= link_to("Request amendments", request_amendments_page_edition_path, class: "govuk-link govuk-link--no-visited-state") %></p>
-          <p class="govuk-body"><%= link_to("No changes needed", approve_fact_check_page_edition_path, class: "govuk-link govuk-link--no-visited-state") %></p>
-        <% end %>
-      <% end %>
-  <% end %>
+    </div>
   </div>
 </div>
 

--- a/app/views/filtered_editions/fact_check.html.erb
+++ b/app/views/filtered_editions/fact_check.html.erb
@@ -2,7 +2,12 @@
 <% content_for :title, "Fact check" %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full fact-check">
+  <div
+    class="govuk-grid-column-full fact-check"
+    data-module="ga4-link-tracker"
+    data-ga4-link='{ "event_name": "navigation", "type": "generic_link" }'
+    data-ga4-limit-to-element-class="govuk-link"
+  >
     <%= render "govuk_publishing_components/components/tabs", {
       panel_border: false,
       tabs: [

--- a/app/views/filtered_editions/my_content.html.erb
+++ b/app/views/filtered_editions/my_content.html.erb
@@ -2,7 +2,11 @@
 <% content_for :title, "My content" %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full my-content">
+  <div
+    class="govuk-grid-column-full my-content"
+    data-module="ga4-link-tracker"
+    data-ga4-link='{ "event_name": "navigation", "type": "generic_link" }'
+  >
     <% if @presenter.editions.any? %>
       <%= render "govuk_publishing_components/components/table", {
         first_cell_is_header: true,

--- a/app/views/filtered_editions/two_eye_queue.html.erb
+++ b/app/views/filtered_editions/two_eye_queue.html.erb
@@ -2,7 +2,12 @@
 <% content_for :title, "2i queue" %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full two-eye-queue">
+  <div
+    class="govuk-grid-column-full two-eye-queue"
+    data-module="ga4-link-tracker"
+    data-ga4-link='{ "event_name": "navigation", "type": "generic_link" }'
+    data-ga4-limit-to-element-class="govuk-link"
+  >
 		<%= render "govuk_publishing_components/components/tabs", {
       panel_border: false,
 			tabs: [

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -48,8 +48,7 @@
       id="main-content"
       class="govuk-main-wrapper govuk-main-wrapper--auto-spacing"
       role="main"
-      data-module="ga4-link-tracker ga4-form-setup ga4-index-section-setup ga4-event-tracker"
-      data-ga4-link='{ "event_name": "navigation", "type": "generic_link" }'
+      data-module="ga4-form-setup ga4-index-section-setup ga4-event-tracker"
       data-ga4-do-not-redact
       data-ga4-no-copy="true"
       data-ga4-tool-name="<%= @resource ? @resource.format.underscore.humanize : "Publisher" %>"

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -50,7 +50,6 @@
       role="main"
       data-module="ga4-link-tracker ga4-form-setup ga4-index-section-setup ga4-event-tracker"
       data-ga4-link='{ "event_name": "navigation", "type": "generic_link" }'
-      data-ga4-limit-to-element-class="govuk-link"
       data-ga4-do-not-redact
       data-ga4-no-copy="true"
       data-ga4-tool-name="<%= @resource ? @resource.format.underscore.humanize : "Publisher" %>"

--- a/test/integration/ga4_tracking_edit_test.rb
+++ b/test/integration/ga4_tracking_edit_test.rb
@@ -210,6 +210,59 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
     end
   end
 
+  context "Guide edition in 'ready' state" do
+    setup do
+      @guide_edition.state = "ready"
+      @guide_edition.save!
+      visit edition_path(@guide_edition)
+      disable_links
+      disable_form_submit
+    end
+
+    should "push the correct values to the dataLayer when the 'Option' links are clicked" do
+      within ".sidebar-components" do
+        click_link "Reorder chapters"
+        click_link "Fact check"
+        click_link "Schedule"
+        click_link "Publish"
+      end
+
+      event_data = get_event_data
+
+      assert_equal "navigation", event_data[0]["event_name"]
+      assert_equal "generic_link", event_data[0]["type"]
+      assert_equal "/editions/#{@guide_edition.id}/guide_parts/reorder", event_data[0]["url"]
+      assert_equal "Reorder chapters", event_data[0]["text"]
+      assert_equal "false", event_data[0]["external"]
+      assert_equal current_host, event_data[0]["link_domain"]
+      assert_equal "primary click", event_data[0]["method"]
+
+      assert_equal "navigation", event_data[1]["event_name"]
+      assert_equal "generic_link", event_data[1]["type"]
+      assert_equal "/editions/#{@guide_edition.id}/send_to_fact_check_page", event_data[1]["url"]
+      assert_equal "Fact check", event_data[1]["text"]
+      assert_equal "false", event_data[1]["external"]
+      assert_equal current_host, event_data[1]["link_domain"]
+      assert_equal "primary click", event_data[1]["method"]
+
+      assert_equal "navigation", event_data[2]["event_name"]
+      assert_equal "generic_link", event_data[2]["type"]
+      assert_equal "/editions/#{@guide_edition.id}/schedule_page", event_data[2]["url"]
+      assert_equal "Schedule", event_data[2]["text"]
+      assert_equal "false", event_data[2]["external"]
+      assert_equal current_host, event_data[2]["link_domain"]
+      assert_equal "primary click", event_data[2]["method"]
+
+      assert_equal "navigation", event_data[3]["event_name"]
+      assert_equal "generic_link", event_data[3]["type"]
+      assert_equal "/editions/#{@guide_edition.id}/send_to_publish_page", event_data[3]["url"]
+      assert_equal "Publish", event_data[3]["text"]
+      assert_equal "false", event_data[3]["external"]
+      assert_equal current_host, event_data[3]["link_domain"]
+      assert_equal "primary click", event_data[3]["method"]
+    end
+  end
+
   context "Edit a guide page" do
     setup do
       visit edition_path(@guide_edition)

--- a/test/integration/ga4_tracking_edit_test.rb
+++ b/test/integration/ga4_tracking_edit_test.rb
@@ -93,6 +93,41 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
     end
   end
 
+  context "Edit page of edition in 'scheduled' state" do
+    setup do
+      @edition.state = "scheduled_for_publishing"
+      @edition.publish_at = Time.zone.now + 1.day
+      @edition.save!
+      visit edition_path(@edition)
+      disable_links
+    end
+
+    should "push the correct values to the dataLayer when the 'Option' links are clicked" do
+      within ".sidebar-components" do
+        click_link "Cancel scheduling"
+        click_link "Publish now"
+      end
+
+      event_data = get_event_data
+
+      assert_equal "navigation", event_data[0]["event_name"]
+      assert_equal "generic_link", event_data[0]["type"]
+      assert_equal "/editions/#{@edition.id}/cancel_scheduled_publishing_page", event_data[0]["url"]
+      assert_equal "Cancel scheduling", event_data[0]["text"]
+      assert_equal "false", event_data[0]["external"]
+      assert_equal current_host, event_data[0]["link_domain"]
+      assert_equal "primary click", event_data[0]["method"]
+
+      assert_equal "navigation", event_data[1]["event_name"]
+      assert_equal "generic_link", event_data[1]["type"]
+      assert_equal "/editions/#{@edition.id}/send_to_publish_page", event_data[1]["url"]
+      assert_equal "Publish now", event_data[1]["text"]
+      assert_equal "false", event_data[1]["external"]
+      assert_equal current_host, event_data[1]["link_domain"]
+      assert_equal "primary click", event_data[1]["method"]
+    end
+  end
+
   context "Edit page of a Guide edition" do
     setup do
       visit edition_path(@guide_edition)


### PR DESCRIPTION
[MAIN-7444](https://gov-uk.atlassian.net/browse/MAIN-7444)

Add tracking to links in the "Options" sidebar on the edit page for editions in "Ready" and "Scheduled" states (see screenshots below). 

This involves 
- refactoring the addition of the `ga4-link-tracker` data-module and the `data-ga4-link` and `data-ga4-limit-to-element-class` attributes to remove them from the base layout view and add them at more specific levels in the layout (where required). This is to allow greater control of the values these return appropriate to the elements being recorded. 
- adding some integration tests for edit pages of editions in the appropriate states.

The values returned can be tested locally by 
- navigating to the page
- running `document.addEventListener('click',function(e){if(e.target.href)(e.preventDefault())})` in the browser console to disable links
- running `window.GOVUK.analyticsGa4.showDebug = true` in the browser console to allow the data returned from user actions to be displayed

|State|Links affected|
|-|-|
|Ready|<img width="379" height="441" alt="Screenshot 2026-06-16 at 09 01 14" src="https://github.com/user-attachments/assets/1e98d0fa-5310-4436-aee2-0c392e81de02" />|
|Scheduled|<img width="379" height="240" alt="Screenshot 2026-06-16 at 09 06 02" src="https://github.com/user-attachments/assets/7a3c5263-ffaa-4d38-95c9-7f896c03f3e6" />|

[MAIN-7444]: https://gov-uk.atlassian.net/browse/MAIN-7444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ