### PR TITLE
2i display width bugfix.

### DIFF
--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -43,7 +43,6 @@
               <% end %>
             <% end %>
           <% end %>
-        </div>
       <% elsif @edition.ready? || @edition.fact_check? %>
         <% if current_user.has_editor_permissions?(@edition) %>
           <%= render "govuk_publishing_components/components/inset_text", {} do %>


### PR DESCRIPTION
[MAIN-7477](https://gov-uk.atlassian.net/browse/MAIN-7477)

A conditional statement introduced in #3360 included an extra </div> which renders when Edition is in-review, causing display issues as the width column was being escaped. This PR removes that extra line.

[MAIN-7477]: https://gov-uk.atlassian.net/browse/MAIN-7477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ