### PR TITLE
Ga4 refactor form setup

### DIFF
--- a/app/assets/javascripts/analytics_modules/ga4-form-setup.js
+++ b/app/assets/javascripts/analytics_modules/ga4-form-setup.js
@@ -30,9 +30,9 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
   Ga4FormSetup.prototype.addDataAttributes = function (form) {
     var section = form.closest('[data-ga4-section]').getAttribute('data-ga4-section')
     var toolName = form.closest('[data-ga4-tool-name]').getAttribute('data-ga4-tool-name')
-    var dataModule = form.dataset.module || null
     var type
     var eventData
+    var linkData
 
     if (form.querySelector('.gem-c-reorderable-list')) {
       type = 'reorder'
@@ -48,12 +48,9 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
       tool_name: toolName
     }
 
-    if (!form.querySelector('input[type="search"]')) {
-      if (dataModule) {
-        form.setAttribute('data-module', dataModule + ' ga4-form-tracker')
-      } else {
-        form.setAttribute('data-module', 'ga4-form-tracker')
-      }
+    linkData = {
+      event_name: 'navigation',
+      type: 'generic_link'
     }
 
     form.setAttribute('data-ga4-form-include-text', '')
@@ -61,7 +58,9 @@ window.GOVUK.analyticsGa4.analyticsModules = window.GOVUK.analyticsGa4.analytics
     form.setAttribute('data-ga4-form-record-json', '')
     form.setAttribute('data-ga4-form-use-text-count', '')
     form.setAttribute('data-ga4-form-use-select-count', '')
+    form.setAttribute('data-ga4-limit-to-element-class', 'govuk-link')
     form.setAttribute('data-ga4-form', JSON.stringify(eventData))
+    form.setAttribute('data-ga4-link', JSON.stringify(linkData))
 
     // If the form contains date-input components add ga4-form-section data-attributes
     var dateInputs = form.querySelectorAll('.govuk-date-input')

--- a/app/views/editions/secondary_nav_tabs/_edit.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_edit.html.erb
@@ -60,7 +60,7 @@
     <% end %>
   </div>
 <% else %>
-  <%= form_for @resource, as: :edition, url: edition_path(@resource), data: {module: "unsaved-changes-prompt", ga4_section: "Edit - #{@resource.title}"} do %>
+  <%= form_for @resource, as: :edition, url: edition_path(@resource), data: {module: "unsaved-changes-prompt ga4-form-tracker ga4-link-tracker", ga4_section: "Edit - #{@resource.title}"} do %>
     <div class="govuk-grid-row edit--editable">
       <div class="govuk-grid-column-two-thirds">
         <%= render partial: "editions/secondary_nav_tabs/edit/editable/#{@resource.kind_for_artefact}", locals: { edition: @resource } %>

--- a/app/views/editions/secondary_nav_tabs/_metadata.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_metadata.html.erb
@@ -3,7 +3,7 @@
     <%= header_for("Metadata") %>
 
     <% if Edition::PUBLISHING_API_DRAFT_STATES.include?(publication.state) && current_user.govuk_editor? %>
-      <%= form_for(@artefact, :html => { :class => "artefact", :id => "edit_artefact", :data => { module: "unsaved-changes-prompt", ga4_section: "Metadata - #{publication.title}" }}) do |f| %>
+      <%= form_for(@artefact, :html => { :class => "artefact", :id => "edit_artefact", :data => { module: "ga4-form-tracker unsaved-changes-prompt", ga4_section: "Metadata - #{publication.title}" }}) do |f| %>
         <%= f.hidden_field :id, value: @artefact.id %>
 
         <%= render "govuk_publishing_components/components/input", {

--- a/app/views/editions/secondary_nav_tabs/_progress_with_comment.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_progress_with_comment.html.erb
@@ -9,7 +9,7 @@
       </p>
     <% end %>
 
-    <%= form_for(:edition, url: form_url, data: { module: "", ga4_section: "Edit - #{title}" }) do %>
+    <%= form_for(:edition, url: form_url, data: { module: "ga4-form-tracker ga4-link-tracker", ga4_section: "Edit - #{title}" }) do %>
       <%= render "govuk_publishing_components/components/textarea", {
         label: {
           heading_size: "m",

--- a/app/views/editions/secondary_nav_tabs/_related_external_links.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_related_external_links.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= header_for(title) %>
     <% if current_user.has_editor_permissions?(@resource) %>
-      <%= form_for @edition.artefact, url: update_related_external_links_edition_path(@resource), data: {module: "unsaved-changes-prompt", ga4_section: title} do %>
+      <%= form_for @edition.artefact, url: update_related_external_links_edition_path(@resource), data: {module: "unsaved-changes-prompt ga4-form-tracker ga4-link-tracker", ga4_section: title} do %>
         <%
           if @edition.artefact.external_links.count == 0
             items = []

--- a/app/views/editions/secondary_nav_tabs/_unpublish.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_unpublish.html.erb
@@ -9,7 +9,7 @@
       text: "If you unpublish a page from GOV.UK it cannot be undone.",
     } %>
 
-    <%= form_for @edition, url: confirm_unpublish_edition_path, method: "get", data: { module: "", ga4_section: title } do |f| %>
+    <%= form_for @edition, url: confirm_unpublish_edition_path, method: "get", data: { module: "ga4-form-tracker", ga4_section: title } do |f| %>
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: "Redirect to URL",

--- a/app/views/editions/secondary_nav_tabs/add_edition_note.html.erb
+++ b/app/views/editions/secondary_nav_tabs/add_edition_note.html.erb
@@ -8,7 +8,7 @@
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">Explain what changes you did or did not make and why. Include a link to the relevant Zendesk ticket and Jira card. You can also add an edition note when you send the edition for 2i review. <%= link_to "Read guidance on writing good change notes (opens in new tab)", "https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/tone-of-voice/change-notes/", target: "_blank", rel: "noopener", class: "govuk-link--no-visited-state" %>.</p>
 
-    <%= form_for(:note, :url=> notes_path, data: { module: "", ga4_section: "History and notes - #{title}" }) do |f| %>
+    <%= form_for(:note, :url=> notes_path, data: { module: "ga4-form-tracker ga4-link-tracker", ga4_section: "History and notes - #{title}" }) do |f| %>
       <%= hidden_field_tag :edition_id, resource.id %>
 
       <%= render "govuk_publishing_components/components/textarea", {

--- a/app/views/editions/secondary_nav_tabs/confirm_destroy.html.erb
+++ b/app/views/editions/secondary_nav_tabs/confirm_destroy.html.erb
@@ -24,7 +24,7 @@
       text: "If you delete this edition it cannot be undone.",
     } %>
 
-    <%= form_for @edition, url: admin_delete_edition_path(@edition), method: :delete, data: { module: "", ga4_section: "Admin - #{title}" } do %>
+    <%= form_for @edition, url: admin_delete_edition_path(@edition), method: :delete, data: { module: "ga4-form-tracker ga4-link-tracker", ga4_section: "Admin - #{title}" } do %>
       <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete this edition?</p>
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/editions/secondary_nav_tabs/confirm_unpublish.html.erb
+++ b/app/views/editions/secondary_nav_tabs/confirm_unpublish.html.erb
@@ -1,5 +1,6 @@
 <% @edition = @resource %>
-<% content_for :title_context, @edition.title %>
+<% title = @edition.title %>
+<% content_for :title_context, title %>
 <% content_for :page_title, "Unpublish" %>
 <% content_for :title, "Unpublish" %>
 <div class="govuk-grid-row">
@@ -12,7 +13,7 @@
       text: "If you unpublish a page from GOV.UK it cannot be undone.",
     } %>
 
-    <%= form_for @edition, url: process_unpublish_edition_path(@edition), method: :post do %>
+    <%= form_for @edition, url: process_unpublish_edition_path(@edition), method: :post, data: { module: "ga4-form-tracker ga4-link-tracker", ga4_section: "Unpublish - #{title}" } do %>
       <%= hidden_field_tag :redirect_url, params[:redirect_url] %>
       <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to unpublish this document?</p>
       <div class="govuk-button-group">

--- a/app/views/editions/secondary_nav_tabs/edit_assignee/_edit_assignee.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit_assignee/_edit_assignee.html.erb
@@ -6,7 +6,7 @@
 <% content_for :page_title, title %>
 <% content_for :title, title %>
 
-<%= form_for @resource, url: url, data: {module: "", ga4_section: "Edit - #{title}"} do %>
+<%= form_for @resource, url: url, data: {module: "ga4-form-tracker ga4-link-tracker", ga4_section: "Edit - #{title}"} do %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= tag.div(**component_helper.all_attributes) do %>

--- a/app/views/editions/secondary_nav_tabs/guide_reorder_chapters_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/guide_reorder_chapters_page.html.erb
@@ -1,6 +1,7 @@
+<% title = "Reorder chapters" %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "Reorder chapters" %>
-<% content_for :title, "Reorder chapters" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 
 <% unless @edition.errors.empty? %>
   <% content_for :error_summary do %>
@@ -9,7 +10,7 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <%= form_with url: bulk_update_reorder_edition_guide_parts_path(@edition), data: { module: "unsaved-changes-prompt" } do %>
+  <%= form_with url: bulk_update_reorder_edition_guide_parts_path(@edition), data: { module: "unsaved-changes-prompt ga4-form-tracker ga4-link-tracker", ga4_section: "Edit - #{title}" } do %>
     <div class="govuk-grid-column-two-thirds">
       <p class="govuk-hint">Use the up and down buttons to reorder chapters, or select and hold on an item to reorder using drag and drop</p>
 

--- a/app/views/editions/secondary_nav_tabs/resend_fact_check_email_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/resend_fact_check_email_page.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds edit--resend-fact-check-email-page">
-    <%= form_for @resource, url: resend_fact_check_email_edition_path(@resource), data: { module: "", ga4_section: "Edit - #{title}" } do %>
+    <%= form_for @resource, url: resend_fact_check_email_edition_path(@resource), data: { module: "ga4-form-tracker ga4-link-tracker", ga4_section: "Edit - #{title}" } do %>
       <section class="govuk-!-margin-bottom-6">
         <%= render "govuk_publishing_components/components/heading", {
           text: "Email addresses",

--- a/app/views/editions/secondary_nav_tabs/send_to_fact_check_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/send_to_fact_check_page.html.erb
@@ -13,7 +13,7 @@
         <% content_for :error_summary, render("shared/error_summary", { object: @form, full_messages: false }) %>
       <% end %>
 
-      <%= form_with model: @form, scope: :fact_check_request_form, url: send_to_fact_check_edition_path(@edition), html: { novalidate: "novalidate" }, data: { module: "", ga4_section: "Edit - #{title}" } do %>
+      <%= form_with model: @form, scope: :fact_check_request_form, url: send_to_fact_check_edition_path(@edition), html: { novalidate: "novalidate" }, data: { module: "ga4-form-tracker ga4-link-tracker", ga4_section: "Edit - #{title}" } do %>
 
         <%= render "govuk_publishing_components/components/input", {
           label: {
@@ -98,7 +98,7 @@
 
     <% else %>
 
-      <%= form_for(:edition, url: send_to_fact_check_edition_path(@edition), html: { novalidate: "novalidate" }, data: { module: "", ga4_section: "Edit - #{title}" }) do %>
+      <%= form_for(:edition, url: send_to_fact_check_edition_path(@edition), html: { novalidate: "novalidate" }, data: { module: "ga4-form-tracker ga4-link-tracker", ga4_section: "Edit - #{title}" }) do %>
           <%= render "govuk_publishing_components/components/input", {
             label: {
               heading_size: "m",

--- a/app/views/editions/secondary_nav_tabs/tagging_breadcrumb_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/tagging_breadcrumb_page.html.erb
@@ -4,7 +4,7 @@
 <% content_for :page_title, title %>
 <% content_for :title, title %>
 
-<%= form_with model: @tagging_update_form_values, url: update_breadcrumb_edition_path(@resource), data: { module: "", ga4_section: "Tagging - #{title}" } do |f| %>
+<%= form_with model: @tagging_update_form_values, url: update_breadcrumb_edition_path(@resource), data: { module: "ga4-form-tracker ga4-link-tracker", ga4_section: "Tagging - #{title}" } do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "govuk_publishing_components/components/hint", {

--- a/app/views/editions/secondary_nav_tabs/tagging_mainstream_browse_pages_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/tagging_mainstream_browse_pages_page.html.erb
@@ -4,7 +4,7 @@
 <% content_for :page_title, title %>
 <% content_for :title, title %>
 
-<%= form_with model: @tagging_update_form_values, url: update_mainstream_browse_pages_edition_path(@edition), data: {module: "", ga4_section: "Tagging - #{title}"} do |f| %>
+<%= form_with model: @tagging_update_form_values, url: update_mainstream_browse_pages_edition_path(@edition), data: {module: "ga4-form-tracker ga4-link-tracker", ga4_section: "Tagging - #{title}"} do |f| %>
   <%= f.hidden_field :previous_version %>
 
   <div class="govuk-grid-row">

--- a/app/views/editions/secondary_nav_tabs/tagging_organisations_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/tagging_organisations_page.html.erb
@@ -9,7 +9,7 @@
     <p class="govuk-body">Tagging a page to an organisation makes it appear in searches filtered by that organisation.</p>
     <p class="govuk-body">For example, <%= link_to "a search for documents published by HMRC", "https://www.gov.uk/search/all?keywords=taxes&order=relevance&organisations%5B%5D=hm-revenue-customs", class: "govuk-link" %>.</p>
 
-    <%= form_with model: @tagging_update_form_values, url: update_organisations_edition_path(@resource), data: { module: "", ga4_section: "Tagging - #{title}" } do |f| %>
+    <%= form_with model: @tagging_update_form_values, url: update_organisations_edition_path(@resource), data: { module: "ga4-form-tracker ga4-link-tracker", ga4_section: "Tagging - #{title}" } do |f| %>
       <%= f.hidden_field :previous_version %>
 
       <%= render "govuk_publishing_components/components/select_with_search", {

--- a/app/views/editions/secondary_nav_tabs/tagging_related_content_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/tagging_related_content_page.html.erb
@@ -14,7 +14,7 @@
   <div class="govuk-grid-column-two-thirds tagging">
     <p class="govuk-body">Related content items are displayed in the sidebar.</p>
 
-    <%= form_with model: @tagging_update_form_values, url: update_related_content_edition_path(@resource), data: { module: "", ga4_section: "Tagging - #{title}" } do |f| %>
+    <%= form_with model: @tagging_update_form_values, url: update_related_content_edition_path(@resource), data: { module: "ga4-form-tracker ga4-link-tracker", ga4_section: "Tagging - #{title}" } do |f| %>
       <%
         if @tagging_update_form_values.ordered_related_items == nil
           items = [

--- a/app/views/editions/secondary_nav_tabs/tagging_remove_breadcrumb_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/tagging_remove_breadcrumb_page.html.erb
@@ -10,7 +10,7 @@
       <% content_for :error_summary, render("shared/error_summary", { object: @edition, full_messages: false }) %>
     <% end %>
 
-    <%= form_with model: @tagging_update_form_values, url: remove_breadcrumb_edition_path(@resource), data: { module: "", ga4_section: "Tagging - #{title}" } do |f| %>
+    <%= form_with model: @tagging_update_form_values, url: remove_breadcrumb_edition_path(@resource), data: { module: "ga4-form-tracker ga4-link-tracker", ga4_section: "Tagging - #{title}" } do |f| %>
       <%= f.hidden_field :previous_version %>
 
       <%= render "govuk_publishing_components/components/radio", {

--- a/app/views/editions/secondary_nav_tabs/tagging_reorder_related_content_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/tagging_reorder_related_content_page.html.erb
@@ -24,7 +24,7 @@
   <div class="govuk-grid-column-two-thirds tagging">
     <p class="govuk-hint">Use the up and down buttons to reorder related content items, or select and hold on an item to reorder using drag and drop</p>
 
-    <%= form_with model: @tagging_update_form_values, url: reorder_related_content_edition_path(@resource), data: { module: "", ga4_section: "Tagging - #{title}" } do |f| %>
+    <%= form_with model: @tagging_update_form_values, url: reorder_related_content_edition_path(@resource), data: { module: "ga4-form-tracker ga4-link-tracker", ga4_section: "Tagging - #{title}" } do |f| %>
       <%= render "govuk_publishing_components/components/reorderable_list", {
         items: @tagging_update_form_values.ordered_related_items.map do |related_item|
           {

--- a/app/views/editions/secondary_nav_tabs/update_important_note.html.erb
+++ b/app/views/editions/secondary_nav_tabs/update_important_note.html.erb
@@ -14,7 +14,7 @@
       To delete the important note, clear any comments and select ‘Save’.
     </p>
 
-    <%= form_for(:note, :url=> notes_path, data: { module: "", ga4_section: "History and notes - #{title}" }) do %>
+    <%= form_for(:note, :url=> notes_path, data: { module: "ga4-form-tracker ga4-link-tracker", ga4_section: "History and notes - #{title}" }) do %>
       <%= hidden_field_tag :edition_id, @edition.id %>
       <%= hidden_field_tag "note[type]", Action::IMPORTANT_NOTE %>
 

--- a/app/views/guide_parts/_part_page.html.erb
+++ b/app/views/guide_parts/_part_page.html.erb
@@ -26,7 +26,7 @@
   </div>
 </div>
 
-<%= form_with url: form_url, method: form_method, data: { module: "unsaved-changes-prompt" } do %>
+<%= form_with url: form_url, method: form_method, data: { module: "unsaved-changes-prompt ga4-form-tracker ga4-link-tracker", ga4_section: "Edit - #{title}" } do %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div data-module="slug-autofill" data-title-input-id="part_title" data-slug-input-id="part_slug">
@@ -70,7 +70,11 @@
 
     <% if current_user.has_editor_permissions?(edition) %>
       <div class="govuk-grid-column-one-third options-sidebar">
-        <div class="sidebar-components">
+        <div
+          class="sidebar-components"
+          data-module="ga4-link-tracker"
+          data-ga4-link='{ "event_name": "navigation", "type": "generic_link" }'
+        >
           <%= sidebar_options_heading %>
           <%= sidebar_items_list(guide_chapter_sidebar_buttons(edition, part)) %>
         </div>

--- a/app/views/guide_parts/confirm_destroy.html.erb
+++ b/app/views/guide_parts/confirm_destroy.html.erb
@@ -1,6 +1,7 @@
+<% title = "Delete chapter" %>
 <% content_for :title_context, @edition.title %>
-<% content_for :page_title, "Delete chapter" %>
-<% content_for :title, "Delete chapter" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -10,7 +11,7 @@
 
     <%= render "govuk_publishing_components/components/warning_text", { text: "Deleting this chapter will permanently remove it." } %>
 
-    <%= form_for @part, url: edition_guide_part_path(@edition, @part), method: :delete do %>
+    <%= form_for @part, url: edition_guide_part_path(@edition, @part), method: :delete, data: { module: "ga4-form-tracker ga4-link-tracker", ga4_section: "Edit - #{title}" } do %>
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {
           text: "Delete chapter",

--- a/app/views/homepage/popular_links/confirm_destroy.html.erb
+++ b/app/views/homepage/popular_links/confirm_destroy.html.erb
@@ -1,10 +1,11 @@
+<% title = "Delete draft" %>
 <% content_for :context, @latest_popular_links.title %>
-<% content_for :page_title, "Delete draft" %>
-<% content_for :title, "Delete draft" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_tag delete_popular_links_path(@latest_popular_links), method: :delete do %>
+    <%= form_tag delete_popular_links_path(@latest_popular_links), method: :delete, data: { module: "ga4-form-tracker ga4-link-tracker", ga4_section: "Popular links - #{title}" } do %>
       <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete this draft?</p>
       <div class="govuk-button-group govuk-!-margin-bottom-6">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/homepage/popular_links/edit.html.erb
+++ b/app/views/homepage/popular_links/edit.html.erb
@@ -1,5 +1,6 @@
-<% content_for :page_title, "Edit popular links" %>
-<% content_for :title, "Edit popular links" %>
+<% title = "Edit popular links" %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
 <% content_for :title_context, "Popular on GOV.UK" %>
 <% unless @latest_popular_links.errors.empty? %>
   <% content_for :error_summary do %>
@@ -18,7 +19,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @latest_popular_links, url: update_popular_links_path(@latest_popular_links), method: "patch" do |form| %>
+    <%= form_for @latest_popular_links, url: update_popular_links_path(@latest_popular_links), method: "patch", data: { module: "ga4-form-tracker ga4-link-tracker", ga4_section: "Popular links - #{title}" } do |form| %>
       <% @latest_popular_links.link_items.each_with_index do |item, index| %>
         <%= render "homepage/popular_links/form", item:, index:, form: %>
       <% end %>

--- a/spec/javascripts/spec/ga4-form-setup.spec.js
+++ b/spec/javascripts/spec/ga4-form-setup.spec.js
@@ -6,7 +6,7 @@ describe('GA4FormSetup', function () {
   beforeEach(function () {
     var moduleHtml =
       `<div data-module="ga4-form-setup" data-ga4-section="The section name" data-ga4-tool-name="Answer">
-        <form data-module="">
+        <form>
           <fieldset>
             <legend>Some date</legend>
             <div class="govuk-date-input"></div>
@@ -22,11 +22,8 @@ describe('GA4FormSetup', function () {
             </fieldset>
           </div>
         </form>
-        <form data-module="some-other-module">
-          <div class="gem-c-reorderable-list"></div>
-        </form>
         <form>
-          <input type="search">
+          <div class="gem-c-reorderable-list"></div>
         </form>
       </div>`
 
@@ -43,35 +40,21 @@ describe('GA4FormSetup', function () {
   })
 
   describe('when loaded', function () {
-    var form, formGA4Data, formEventData
-
-    it('adds/updates the "data-module" parameter of the form', function () {
-      form = module.querySelectorAll('form')[0]
-      formGA4Data = form.dataset
-
-      expect(formGA4Data.module).toBe('ga4-form-tracker')
-
-      form = module.querySelectorAll('form')[1]
-      formGA4Data = form.dataset
-
-      expect(formGA4Data.module).toBe('some-other-module ga4-form-tracker')
-
-      form = module.querySelectorAll('form')[2]
-      formGA4Data = form.dataset
-
-      expect(formGA4Data.module).toBe(undefined)
-    })
+    var form, formGA4Data, formEventData, linkEventData
 
     it('adds the correct parameters to the form', function () {
       form = module.querySelectorAll('form')[0]
       formGA4Data = form.dataset
       formEventData = JSON.parse(formGA4Data.ga4Form)
+      linkEventData = JSON.parse(formGA4Data.ga4Link)
 
       expect(formEventData.action).toBe('Save')
       expect(formEventData.event_name).toBe('form_response')
       expect(formEventData.section).toBe('The section name')
       expect(formEventData.tool_name).toBe('Answer')
       expect(formEventData.type).toBe('edit')
+      expect(linkEventData.event_name).toBe('navigation')
+      expect(linkEventData.type).toBe('generic_link')
       expect(Object.keys(formGA4Data)).toContain('ga4FormIncludeText')
       expect(Object.keys(formGA4Data)).toContain('ga4FormChangeTracking')
       expect(Object.keys(formGA4Data)).toContain('ga4FormRecordJson')


### PR DESCRIPTION
The changes here refactor elements of GA4 From Tracking in order to make this more stable (particularly in tests).

These involve
- moving where the `ga4-form-tracker` data-module is applied from the `ga4-form-setup` JS module to the various forms which require it. Since this is a module that is initialised on page load it makes more sense and feels less flaky to do it in the view. Every view that requires it needed to have an empty data-module adding for this to work anyway so this does not add superfluous code to those views.
- also adding the `ga4-link-tracker` data-module to views where it is needed.
- updating the `ga4-form-setup` JS module to remove where the data-module was being added. The addition of various data-attributes is left here since that is not needed until the user begins to interact with the form. There are also some data-attributes added for the `ga4-link-tracker` data-module. 
- updating the `ga4-form-setup` unit test to reflect the changes in the module. 
- some tidying up of other aspects of some of the views such as adding the `data-ga4-section` attribute where that had been left out of previous changes

Since all the GA4 work is pretty comprehensively covered by automated tests I am confident that these changes will do what is required without any breakages. 