### PR TITLE
Update value for `overflow-wrap` in stylesheet to `anywhere`

### DIFF
--- a/app/assets/stylesheets/publications.scss
+++ b/app/assets/stylesheets/publications.scss
@@ -52,7 +52,7 @@
     font-weight: 400;
     margin-bottom: govuk-spacing(1);
     margin-top: govuk-spacing(1);
-    overflow-wrap: break-word;
+    overflow-wrap: anywhere;
 
     &::before {
       content: open-quote;


### PR DESCRIPTION
This prevents text with long words overflowing its container. This occurs in the important note  text in the 2i Queue tab as shown below and visible on [this page](https://publisher.publishing.service.gov.uk/2i-queue). 

|Before|After|
|-|-|
|<img width="1155" height="413" alt="Screenshot 2026-07-06 at 14 23 11" src="https://github.com/user-attachments/assets/90795a29-c39c-4762-994f-80074286ec77" />|<img width="1155" height="413" alt="Screenshot 2026-07-06 at 14 22 55" src="https://github.com/user-attachments/assets/9a8c3067-0e84-4854-a827-cc3a4eef6417" />|