### PR TITLE
[MAIN-7468] Improve zendesk number validation

### DIFF
--- a/app/lib/fact_check_request_form.rb
+++ b/app/lib/fact_check_request_form.rb
@@ -12,20 +12,22 @@ class FactCheckRequestForm
   attribute :deadline_2i, :string
   attribute :deadline_3i, :string
   attribute :reason_for_change, :string, default: nil
-  # If this is typecast to integer, then non-integer values would be cast to 0 and accepted. Numericality handles non-int strings.
   attribute :zendesk_number, :string, default: nil
 
   validates :email_addresses, presence: { message: "Enter one or more email addresses" }, on: :send
-  validates :zendesk_number, numericality: { only_integer: true,
-                                             greater_than: 999_999,
-                                             message: "Zendesk number must be a number at least 7 digits long",
-                                             allow_blank: true }, on: :send
 
+  validate :valid_zendesk_number, on: :send
   validate :valid_email_addresses, on: :send
   validate :deadline_in_range, on: :send
   validate :deadline_present, on: :send
 
   EMAIL_REGEX = /\A[\w+\-%.']+@[a-z\d-]+(\.[a-z\d-]+)*\.[a-z]+\z/
+  ZENDESK_NUMBER_REGEX = /\A\d{7,}\z/
+
+  def zendesk_number=(value)
+    value = value.strip.delete_prefix("#").strip if value.is_a?(String)
+    super
+  end
 
   def deadline
     return unless deadline_1i.present? && deadline_2i.present? && deadline_3i.present?
@@ -84,6 +86,16 @@ private
 
     if split_email_addresses.any? { |address| !address.to_s.strip.match?(EMAIL_REGEX) }
       errors.add(:email_addresses, "Email addresses are invalid")
+    end
+  end
+
+  def valid_zendesk_number
+    return if zendesk_number.blank?
+
+    if !zendesk_number.match?(ZENDESK_NUMBER_REGEX)
+      errors.add(:zendesk_number, "Zendesk ticket number must be at least 7 digits long")
+    elsif zendesk_number.start_with?("0")
+      errors.add(:zendesk_number, "Zendesk ticket numbers cannot start with zero")
     end
   end
 

--- a/app/lib/gds_api/fact_check_manager.rb
+++ b/app/lib/gds_api/fact_check_manager.rb
@@ -20,7 +20,7 @@ class GdsApi::FactCheckManager < GdsApi::Base
   #   If a new part has been added to the document, do not provide its ID in previous_content.
   # @param [string] deadline Date a response is requested by. Use iso8601 date format: "2026-02-09"
   # @option [string] reason_for_change optional free-text response of why the change has been made, to populate the notification email. Line breaks are retained.
-  # @option [integer] zendesk_number optional number for zendesk ticket linked to the change
+  # @option [string] zendesk_number optional string of digits for the zendesk ticket linked to the change
   # @option [uuid] draft_auth_bypass_id The edition's auth_bypass_id for draft origin preview access
   # @option [uuid] draft_content_id The edition's content_id for draft origin preview access
   # @option [string] draft_slug The edition's slug for the draft origin preview URL path

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -1268,7 +1268,7 @@ class EditionsControllerTest < ActionController::TestCase
 
           assert_template "secondary_nav_tabs/send_to_fact_check_page"
           assert_template "govuk_publishing_components/components/_error_summary"
-          assert_select ".gem-c-error-summary__list-item", "Zendesk number must be a number at least 7 digits long"
+          assert_select ".gem-c-error-summary__list-item", "Zendesk ticket number must be at least 7 digits long"
           edition.reload
           assert_equal "ready", edition.state
         end

--- a/test/integration/edition_workflow_fact_check_api_test.rb
+++ b/test/integration/edition_workflow_fact_check_api_test.rb
@@ -163,7 +163,7 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
 
       assert_current_path send_to_fact_check_edition_path(@ready_edition.id)
       assert_equal "ready", @ready_edition.state
-      assert page.has_text?("Zendesk number must be a number at least 7 digits long")
+      assert page.has_text?("Zendesk ticket number must be at least 7 digits long")
     end
   end
 

--- a/test/integration/ga4_tracking_edit_test.rb
+++ b/test/integration/ga4_tracking_edit_test.rb
@@ -670,7 +670,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
       assert_equal "error", event_data[1]["action"]
       assert_equal "form_error", event_data[1]["event_name"]
       assert_equal "Zendesk number", event_data[1]["section"]
-      assert_equal "Zendesk number must be a number at least 7 digits long", event_data[1]["text"]
+      assert_equal "Zendesk ticket number must be at least 7 digits long", event_data[1]["text"]
       assert_equal "Answer", event_data[1]["tool_name"]
       assert_equal "Edit edition", event_data[1]["type"]
 
@@ -697,7 +697,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
       assert_equal "error", event_data[0]["action"]
       assert_equal "form_error", event_data[0]["event_name"]
       assert_equal "Zendesk number", event_data[0]["section"]
-      assert_equal "Zendesk number must be a number at least 7 digits long", event_data[0]["text"]
+      assert_equal "Zendesk ticket number must be at least 7 digits long", event_data[0]["text"]
       assert_equal "Answer", event_data[0]["tool_name"]
       assert_equal "Edit edition", event_data[0]["type"]
 

--- a/test/unit/lib/fact_check_request_form_test.rb
+++ b/test/unit/lib/fact_check_request_form_test.rb
@@ -16,13 +16,6 @@ class FactCheckRequestFormTest < ActiveSupport::TestCase
     context "validations on :send" do
       should validate_presence_of(:email_addresses).on(:send).with_message("Enter one or more email addresses")
 
-      should validate_numericality_of(:zendesk_number)
-               .only_integer
-               .is_greater_than(999_999)
-               .with_message("Zendesk number must be a number at least 7 digits long")
-               .allow_nil
-               .on(:send)
-
       should_not validate_presence_of(:zendesk_number).on(:send)
       should_not validate_presence_of(:reason_for_change).on(:send)
     end
@@ -95,6 +88,65 @@ class FactCheckRequestFormTest < ActiveSupport::TestCase
         assert_not @form.valid?(:send)
         assert_not_empty @form.errors[:email_addresses]
         assert_includes @form.errors[:email_addresses], "Email addresses are invalid"
+      end
+    end
+
+    context "#valid_zendesk_number" do
+      should "be valid when the zendesk number is 7 or more digits" do
+        %w[1234567 12345678 1234567890].each do |zendesk_number|
+          @form.zendesk_number = zendesk_number
+
+          assert @form.valid?(:send), "Expected #{zendesk_number} to be valid"
+          assert_empty @form.errors[:zendesk_number]
+        end
+      end
+
+      should "be valid when the zendesk number is blank" do
+        [nil, "", "   "].each do |zendesk_number|
+          @form.zendesk_number = zendesk_number
+
+          assert @form.valid?(:send)
+          assert_empty @form.errors[:zendesk_number]
+        end
+      end
+
+      should "strip a leading # from the zendesk number" do
+        @form.zendesk_number = "#1234567"
+
+        assert @form.valid?(:send)
+        assert_equal "1234567", @form.zendesk_number
+      end
+
+      should "strip surrounding whitespace from the zendesk number" do
+        [" 1234567 ", " #1234567", "# 1234567"].each do |zendesk_number|
+          @form.zendesk_number = zendesk_number
+
+          assert @form.valid?(:send), "Expected '#{zendesk_number}' to be valid"
+          assert_equal "1234567", @form.zendesk_number
+        end
+      end
+
+      should "raise an error when the zendesk number is fewer than 7 digits" do
+        @form.zendesk_number = "123456"
+
+        assert_not @form.valid?(:send)
+        assert_includes @form.errors[:zendesk_number], "Zendesk ticket number must be at least 7 digits long"
+      end
+
+      should "raise an error when the zendesk number contains non-digit characters" do
+        %w[123invalid4 notanumber 12345.67 -1234567 1234567# 123#4567].each do |zendesk_number|
+          @form.zendesk_number = zendesk_number
+
+          assert_not @form.valid?(:send), "Expected #{zendesk_number} to be invalid"
+          assert_includes @form.errors[:zendesk_number], "Zendesk ticket number must be at least 7 digits long"
+        end
+      end
+
+      should "raise an error when the zendesk number starts with zero" do
+        @form.zendesk_number = "0123456"
+
+        assert_not @form.valid?(:send)
+        assert_includes @form.errors[:zendesk_number], "Zendesk ticket numbers cannot start with zero"
       end
     end
 


### PR DESCRIPTION
[MAIN-7468](https://gov-uk.atlassian.net/browse/MAIN-7468)

### Changes

- Strip surrounding whitespace and a leading `#` from the zendesk ticket number on the fact check request form, rather than rejecting the input
- Replace the numericality validation with a regex: non-numeric input or fewer than 7 digits gets "Zendesk ticket number must be at least 7 digits long", and an otherwise-valid number starting with zero gets "Zendesk ticket numbers cannot start with zero"
- Update the Fact Check Manager adapter docs to describe `zendesk_number` as a string

### UI

**"Must be at least 7 digits long" error message**
<img width="768" height="722" alt="image" src="https://github.com/user-attachments/assets/1689524d-673a-46bb-9ed4-75a98e3e58c9" />

**"Cannot start with zero" error message**
<img width="794" height="780" alt="image" src="https://github.com/user-attachments/assets/7014e95e-0183-4762-b5de-97fbd28f4280" />



[MAIN-7468]: https://gov-uk.atlassian.net/browse/MAIN-7468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ