### PR TITLE
Update Important note title and date fields.

### DIFF
--- a/app/views/editions/_important_note.html.erb
+++ b/app/views/editions/_important_note.html.erb
@@ -5,9 +5,10 @@
   description_govspeak:
     sanitize("<div class='editions__important-note'>
       <p class='govuk-body govuk-!-font-weight-bold govuk-!-text-break-word editions__important-note__details'>#{h(note_details)}</p>
-      <p class='govuk-body-m'>#{note_author_name.present? ? "#{h(note_author_name)} added an important note on" : "Important note added on"}
+      <p class='govuk-body-m'>#{note_author_name.present? ? "#{h(note_author_name)}, " : "Added on"}
       <time class='govuk-body' datetime='#{note_date}'>#{note_date.to_fs(:govuk_date)}</time></p>
       </div>"),
+  banner_title: "Important note",
   show_banner_title: true,
   margin_bottom: 6,
 } %>

--- a/test/integration/edition_edit_test.rb
+++ b/test/integration/edition_edit_test.rb
@@ -136,9 +136,9 @@ class EditionEditTest < IntegrationTest
           visit edition_path(@draft_edition)
 
           within :css, ".govuk-notification-banner" do
-            assert page.has_text?("Important")
+            assert page.has_text?("Important note")
             assert page.has_text?(@note_text)
-            assert page.has_text?("#{@govuk_editor.name} added an important note on #{Time.zone.today.to_date.to_fs(:govuk_date)}")
+            assert page.has_text?("#{@govuk_editor.name}, #{Time.zone.today.to_date.to_fs(:govuk_date)}")
           end
         end
       end
@@ -150,9 +150,9 @@ class EditionEditTest < IntegrationTest
           visit edition_path(@draft_edition)
 
           within :css, ".govuk-notification-banner" do
-            assert page.has_text?("Important")
+            assert page.has_text?("Important note")
             assert page.has_text?(@note_text)
-            assert page.has_text?("Important note added on #{Time.zone.today.to_date.to_fs(:govuk_date)}")
+            assert page.has_text?("Added on #{Time.zone.today.to_date.to_fs(:govuk_date)}")
           end
         end
       end


### PR DESCRIPTION
Updates the title to `Important note` and the date field to `[name],[date]` or `Added on [date]` depending on whether a user has a name

[MAIN-7405](https://gov-uk.atlassian.net/browse/MAIN-7405)

<img width="819" height="291" alt="image" src="https://github.com/user-attachments/assets/38cdcc81-af20-437c-a605-e821d9e325ef" />

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


[MAIN-7405]: https://gov-uk.atlassian.net/browse/MAIN-7405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ