### PR TITLE
Obtain content block for fact check from Publishing API rather than Content Store

### DIFF
--- a/app/services/html_renderer.rb
+++ b/app/services/html_renderer.rb
@@ -9,12 +9,32 @@ class HtmlRenderer
     return "" if document.blank?
 
     html_content = Govspeak::Document.new(document).to_html
+    references = ContentBlockTools::ContentBlockReference.find_all_in_document(html_content).uniq
 
-    ContentBlockTools::ContentBlockReference.find_all_in_document(html_content).uniq.each do |content_block|
-      code = content_block.embed_code
-      html_content.gsub!(code, ContentBlockTools::ContentBlock.from_embed_code(code).render)
+    references.each do |ref|
+      block = build_from_publishing_api(ref)
+      html_content.gsub!(ref.embed_code, block.render)
     end
 
     html_content.strip
+  end
+
+  def self.build_from_publishing_api(reference)
+    api_response = Services.publishing_api.get_content_items(
+      content_id_aliases: [reference.identifier],
+      document_type: reference.document_type,
+    ).parsed_content["results"].first
+
+    build_content_block(embed_code: reference.embed_code, api_response: api_response)
+  end
+
+  def self.build_content_block(embed_code:, api_response:)
+    ContentBlockTools::ContentBlock.new(
+      content_id: api_response["content_id"],
+      title: api_response["title"],
+      document_type: api_response["document_type"],
+      details: api_response["details"],
+      embed_code: embed_code,
+    )
   end
 end

--- a/test/unit/services/html_renderer_test.rb
+++ b/test/unit/services/html_renderer_test.rb
@@ -64,37 +64,132 @@ class HtmlRendererTest < ActiveSupport::TestCase
 
     context "when the document contains content blocks" do
       setup do
+        stub_publishing_api_responses_for_content_blocks
+
         @mock_render = '<span class="content-block" data-embed-code="{{embed:content_block_contact:content-item}}">block content</span>'
-        @mock_content_block = stub(render: @mock_render)
+
         @mock_render_two = '<span class="content-block" data-embed-code="{{embed:content_block_contact:content-item-two}}">different block content</span>'
-        @mock_content_block_two = stub(render: @mock_render_two)
+
+        stub_built_content_blocks
       end
 
-      should "correctly render the block when a single content block embed code is present" do
-        input = "Before block, {{embed:content_block_contact:content-item}}, after block"
+      context "rendering" do
+        context "when a single embed code is present" do
+          setup do
+            @document_contents = "First block: {{embed:content_block_contact:content-item}} done."
+          end
 
-        ContentBlockTools::ContentBlock.expects(:from_embed_code).with("{{embed:content_block_contact:content-item}}").returns(@mock_content_block)
+          should "render the block in the expected position" do
+            expected_html = "<p>First block: #{@mock_render} done.</p>"
 
-        assert_equal "<p>Before block, #{@mock_render}, after block</p>", HtmlRenderer.render_html(input)
-      end
+            assert_equal(
+              expected_html,
+              HtmlRenderer.render_html(@document_contents),
+            )
+          end
+        end
 
-      should "correctly render the blocks when two different content block embed codes are present" do
-        input = "Before block, {{embed:content_block_contact:content-item}}, {{embed:content_block_contact:content-item-two}}, after block"
+        context "when embed codes from two blocks are present" do
+          setup do
+            @document_contents = <<~MARKUP.squish
+              First block: {{embed:content_block_contact:content-item}} done.
+              Second block: {{embed:content_block_contact:content-item-two}} done.
+            MARKUP
+          end
 
-        ContentBlockTools::ContentBlock.expects(:from_embed_code).with("{{embed:content_block_contact:content-item}}").returns(@mock_content_block)
-        ContentBlockTools::ContentBlock.expects(:from_embed_code).with("{{embed:content_block_contact:content-item-two}}").returns(@mock_content_block_two)
+          should "render both blocks in the expected positions" do
+            expected_html = <<~HTML.squish
+              <p>First block: #{@mock_render} done.
+              Second block: #{@mock_render_two} done.</p>
+            HTML
 
-        assert_equal "<p>Before block, #{@mock_render}, #{@mock_render_two}, after block</p>", HtmlRenderer.render_html(input)
-      end
+            assert_equal(
+              expected_html,
+              HtmlRenderer.render_html(@document_contents),
+            )
+          end
+        end
 
-      should "correctly render the blocks when provided with multiple instances of the same embed code" do
-        input = "Before block, {{embed:content_block_contact:content-item}}, {{embed:content_block_contact:content-item}}, {{embed:content_block_contact:content-item-two}}, after block"
+        context "when a particular embed code appears more than once" do
+          setup do
+            @document_contents = <<~MARKUP.squish
+              First block: {{embed:content_block_contact:content-item}} done.
+              Second block: {{embed:content_block_contact:content-item-two}} done.
+              Second block again: {{embed:content_block_contact:content-item-two}} done.
+            MARKUP
+          end
 
-        ContentBlockTools::ContentBlock.expects(:from_embed_code).with("{{embed:content_block_contact:content-item}}").returns(@mock_content_block).once
-        ContentBlockTools::ContentBlock.expects(:from_embed_code).with("{{embed:content_block_contact:content-item-two}}").returns(@mock_content_block_two)
+          should "render the repeated block in all expected positions" do
+            expected_html = <<~HTML.squish
+              <p>First block: #{@mock_render} done.
+              Second block: #{@mock_render_two} done.
+              Second block again: #{@mock_render_two} done.</p>
+            HTML
 
-        assert_equal "<p>Before block, #{@mock_render}, #{@mock_render}, #{@mock_render_two}, after block</p>", HtmlRenderer.render_html(input)
+            assert_equal(
+              expected_html,
+              HtmlRenderer.render_html(@document_contents),
+            )
+          end
+        end
       end
     end
+  end
+
+  def stub_publishing_api_responses_for_content_blocks
+    stubbed_api_results_1 = {
+      "results" => [
+        {
+          "details" => { title: "Contact 1" },
+          "document_type" => "content_block_contact",
+          "title" => "Contact title",
+          "content_id" => "1234",
+        },
+      ],
+    }
+    stubbed_api_results_2 = {
+      "results" => [
+        {
+          "details" => { title: "Contact 2" },
+          "document_type" => "content_block_contact",
+          "title" => "Contact 2 title",
+          "content_id" => "4567",
+        },
+      ],
+    }
+
+    stubbed_api_response_1 = stub("stubbed_api_response_1", parsed_content: stubbed_api_results_1)
+    stubbed_api_response_2 = stub("stubbed_api_response_2", parsed_content: stubbed_api_results_2)
+
+    Services.publishing_api.stubs(:get_content_items).with(
+      content_id_aliases: %w[content-item],
+      document_type: "content_block_contact",
+    ).returns(stubbed_api_response_1)
+
+    Services.publishing_api.stubs(:get_content_items).with(
+      content_id_aliases: %w[content-item-two],
+      document_type: "content_block_contact",
+    ).returns(stubbed_api_response_2)
+  end
+
+  def stub_built_content_blocks
+    stubbed_content_block = stub(render: @mock_render)
+    stubbed_content_block_two = stub(render: @mock_render_two)
+
+    ContentBlockTools::ContentBlock.stubs(:new).with(
+      content_id: "1234",
+      title: "Contact title",
+      document_type: "content_block_contact",
+      details: { title: "Contact 1" },
+      embed_code: "{{embed:content_block_contact:content-item}}",
+    ).returns(stubbed_content_block)
+
+    ContentBlockTools::ContentBlock.stubs(:new).with(
+      content_id: "4567",
+      title: "Contact 2 title",
+      document_type: "content_block_contact",
+      details: { title: "Contact 2" },
+      embed_code: "{{embed:content_block_contact:content-item-two}}",
+    ).returns(stubbed_content_block_two)
   end
 end


### PR DESCRIPTION
## Refactor: Obtain content block for fact check from Publishing API rather than Content Store

Jira [CR-37](https://gov-uk.atlassian.net/browse/CR-37)

---

[RFC-192: Restrict base_paths to a smaller character set][rfc-192] is restricting GOV.UK  base paths to `a-z 0-9 . / -` (no underscores, no uppercase). Content blocks are affected because their `base_path` includes the `document_type` (e.g. `content_block_time_period`) which contains underscores, as in this `base_path`:

```
/content-blocks/content_block_time_period/tax-year
```

Before the change in this PR, when rendering content blocks to send for fact check, Publisher was getting the block `#details` from Content Store. The process used `base_path` within the Content Block Tools gem via the call to `ContentBlockTools::ContentBlock.from_embed_code(code)` which constructs the (invalid) `base_path` to make the call to the Content Store:

`ContentBlockTools::ContentBlockReference`:
```
def content_store_identifier
  "/content-blocks/#{document_type}/#{identifier}"
end
```

With this change Publisher's `HtmlRenderer`, instead of building a renderable block with a single call to `ContentBlockTools::ContentBlock.from_embed_code(code).render`, now:

- obtains the block `details` from Publishing API
- builds a renderable block using `ContentBlockTools::ContentBlock.new(...).render`

[rfc-192]:
https://github.com/alphagov/govuk-rfcs/pull/192/




[CR-37]: https://gov-uk.atlassian.net/browse/CR-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ