### PR TITLE
Update hint text from 'Refer to the' to 'Read the' govspeak guidance

### DIFF
--- a/app/views/editions/secondary_nav_tabs/edit/editable/_local_transaction.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/editable/_local_transaction.html.erb
@@ -39,7 +39,7 @@
   name: "edition[introduction]",
   value: edition.editionable.introduction,
   rows: 16,
-  hint: ("Set the scene for the user. Explain that it’s the responsibility of the local council and that we’ll take you there. Read the #{link_to("Govspeak guidance (opens in new tab)", "https://govspeak-preview.publishing.service.gov.uk/guide", target: "_blank", rel: "noopener", class: "govuk-link govuk-link--no-visited-state")}").html_safe,
+  hint: ("Set the scene for the user. Explain that it’s the responsibility of the local council and that we’ll take you there. Read the #{link_to("Govspeak guide (opens in new tab)", "https://govspeak-preview.publishing.service.gov.uk/guide", target: "_blank", rel: "noopener", class: "govuk-link govuk-link--no-visited-state")}").html_safe,
 } %>
 
 <%= render "govuk_publishing_components/components/textarea", {

--- a/app/views/editions/secondary_nav_tabs/edit/editable/_place.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/editable/_place.html.erb
@@ -20,7 +20,7 @@
   name: "edition[introduction]",
   value: edition.editionable.introduction,
   rows: 16,
-  hint: ("Refer to the #{link_to("Govspeak guidance (opens in new tab)", "https://govspeak-preview.publishing.service.gov.uk/guide", target: "_blank", rel: "noopener", class: "govuk-link govuk-link--no-visited-state")}").html_safe,
+  hint: ("Read the #{link_to("Govspeak guide (opens in new tab)", "https://govspeak-preview.publishing.service.gov.uk/guide", target: "_blank", rel: "noopener", class: "govuk-link govuk-link--no-visited-state")}").html_safe,
 } %>
 
 <%= render "govuk_publishing_components/components/textarea", {

--- a/app/views/editions/secondary_nav_tabs/edit/editable/_transaction.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/editable/_transaction.html.erb
@@ -10,7 +10,7 @@
   name: "edition[introduction]",
   value: edition.introduction,
   rows: 16,
-  hint: ("Set the scene for the user. What is about to happen? For example, “you will need to fill in a form, print it out and take it to the post office”. Refer to the #{link_to("Govspeak guidance (opens in new tab)", "https://govspeak-preview.publishing.service.gov.uk/guide", target: "_blank", rel: "noopener", class: "govuk-link govuk-link--no-visited-state")}").html_safe,
+  hint: ("Set the scene for the user. What is about to happen? For example, “you will need to fill in a form, print it out and take it to the post office”. Read the #{link_to("Govspeak guide (opens in new tab)", "https://govspeak-preview.publishing.service.gov.uk/guide", target: "_blank", rel: "noopener", class: "govuk-link govuk-link--no-visited-state")}").html_safe,
 } %>
 
 <%= render "govuk_publishing_components/components/radio", {

--- a/app/views/editions/secondary_nav_tabs/edit/editable/components/_body.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/editable/components/_body.html.erb
@@ -6,5 +6,5 @@
   name: "edition[body]",
   value: edition.body,
   rows: 14,
-  hint: ("Refer to the #{link_to("Govspeak guidance (opens in new tab)", "https://govspeak-preview.publishing.service.gov.uk/guide", target: "_blank", rel: "noopener", class: "govuk-link govuk-link--no-visited-state")}").html_safe,
+  hint: ("Read the #{link_to("Govspeak guide (opens in new tab)", "https://govspeak-preview.publishing.service.gov.uk/guide", target: "_blank", rel: "noopener", class: "govuk-link govuk-link--no-visited-state")}").html_safe,
 } %>

--- a/app/views/editions/secondary_nav_tabs/edit/editable/components/_part.html.erb
+++ b/app/views/editions/secondary_nav_tabs/edit/editable/components/_part.html.erb
@@ -31,7 +31,7 @@
   name: "edition[parts_attributes][][body]",
   value: part.body,
   rows: 14,
-  hint: ("Refer to the #{link_to("Govspeak guidance (opens in new tab)", "https://govspeak-preview.publishing.service.gov.uk/guide", target: "_blank", rel: "noopener", class: "govuk-link govuk-link--no-visited-state")}").html_safe,
+  hint: ("Read the #{link_to("Govspeak guide (opens in new tab)", "https://govspeak-preview.publishing.service.gov.uk/guide", target: "_blank", rel: "noopener", class: "govuk-link govuk-link--no-visited-state")}").html_safe,
 } %>
 
 <%= hidden_field_tag "edition[parts_attributes][][id]", part.id %>

--- a/app/views/guide_parts/_part_page.html.erb
+++ b/app/views/guide_parts/_part_page.html.erb
@@ -64,7 +64,7 @@
         name: "part[body]",
         value: part.body,
         rows: 14,
-        hint: ("Refer to the #{link_to("Govspeak guidance (opens in new tab)", "https://govspeak-preview.publishing.service.gov.uk/guide", target: "_blank", rel: "noopener", class: "govuk-link govuk-link--no-visited-state")}").html_safe,
+        hint: ("Read the #{link_to("Govspeak guide (opens in new tab)", "https://govspeak-preview.publishing.service.gov.uk/guide", target: "_blank", rel: "noopener", class: "govuk-link govuk-link--no-visited-state")}").html_safe,
       } %>
     </div>
 

--- a/test/integration/edition_edit_tab/edit_draft_edition_test.rb
+++ b/test/integration/edition_edit_tab/edit_draft_edition_test.rb
@@ -53,7 +53,7 @@ class EditDraftEditionTest < IntegrationTest
 
       should "show Body text field prefilled" do
         assert page.has_text?("Body")
-        assert page.has_text?("Refer to the Govspeak guidance (opens in new tab)")
+        assert page.has_text?("Read the Govspeak guide (opens in new tab)")
         assert page.has_field?("edition[body]", with: "The body")
       end
 
@@ -143,7 +143,7 @@ class EditDraftEditionTest < IntegrationTest
         assert page.has_field?("edition[place_type]", with: "The place type")
 
         assert page.has_css?(".govuk-label", text: "Introduction")
-        assert page.has_css?(".govuk-hint", text: "Refer to the Govspeak guidance (opens in new tab)")
+        assert page.has_css?(".govuk-hint", text: "Read the Govspeak guide (opens in new tab)")
         assert page.has_field?("edition[introduction]", with: "some intro")
 
         assert page.has_css?(".govuk-label", text: "Further information (optional)")
@@ -201,7 +201,7 @@ class EditDraftEditionTest < IntegrationTest
         assert page.has_field?("edition[cta_text]", with: "Find your local council")
 
         assert page.has_css?(".govuk-label", text: "Introduction")
-        assert page.has_css?(".govuk-hint", text: "Set the scene for the user. Explain that it’s the responsibility of the local council and that we’ll take you there. Read the Govspeak guidance (opens in new tab)")
+        assert page.has_css?(".govuk-hint", text: "Set the scene for the user. Explain that it’s the responsibility of the local council and that we’ll take you there. Read the Govspeak guide (opens in new tab)")
         assert page.has_field?("edition[introduction]", with: "Test introduction")
 
         assert page.has_css?(".govuk-label", text: "Further information (optional)")
@@ -855,7 +855,7 @@ class EditDraftEditionTest < IntegrationTest
 
         assert page.has_field?("edition[introduction]", with: "Transaction introduction")
         assert page.has_css?(".govuk-label", text: "Introduction")
-        assert page.has_css?(".govuk-hint", text: "Set the scene for the user. What is about to happen? For example, “you will need to fill in a form, print it out and take it to the post office”. Refer to the Govspeak guidance (opens in new tab)")
+        assert page.has_css?(".govuk-hint", text: "Set the scene for the user. What is about to happen? For example, “you will need to fill in a form, print it out and take it to the post office”. Read the Govspeak guide (opens in new tab)")
 
         assert page.has_field?("edition[start_button_text]")
         assert page.has_text?("Start button text")


### PR DESCRIPTION
[MAIN-7406](https://gov-uk.atlassian.net/browse/MAIN-7406)
(populate the link above to make sure your PR is linked to the Jira ticket)

<img width="782" height="169" alt="image" src="https://github.com/user-attachments/assets/0014a969-8171-4d0e-9c1f-982f2ef640d0" />

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


[MAIN-7406]: https://gov-uk.atlassian.net/browse/MAIN-7406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ