### PR TITLE
Main 7487 update error sending for Fact Check Manager

### DIFF
--- a/app/controllers/api/fact_check_response_controller.rb
+++ b/app/controllers/api/fact_check_response_controller.rb
@@ -18,7 +18,7 @@ module Api
                            requester_name: response_params[:responder_name])
         render json: { id: edition.id }, status: :ok
       else
-        render json: { errors: edition.errors.full_messages }, status: :unprocessable_entity
+        render json: { errors: edition.errors }, status: :unprocessable_entity
       end
     end
 

--- a/test/api/fact_check_response_controller_test.rb
+++ b/test/api/fact_check_response_controller_test.rb
@@ -124,11 +124,10 @@ class FactCheckResponseControllerTest < IntegrationTest
 
     should "return 422 with edition in invalid non-published state" do
       @edition = FactoryBot.create(:answer_edition, :draft)
-
       post api_fact_check_response_path, params: { edition_id: @edition.id, responder_name: "Joe Bloggs", accepted: true }, as: :json
 
       assert_response :unprocessable_entity
-      assert_includes response.parsed_body["errors"], "State Edition is not in a state where fact check can be submitted"
+      assert_includes response.parsed_body.dig("errors", "state"), "Edition is not in a state where fact check can be submitted"
     end
 
     should "return 422 with published edition" do
@@ -136,7 +135,7 @@ class FactCheckResponseControllerTest < IntegrationTest
       post api_fact_check_response_path, params: { edition_id: @edition.id, responder_name: "Joe Bloggs", accepted: true }, as: :json
 
       assert_response :unprocessable_entity
-      assert_includes response.parsed_body["errors"], "State Edition is not in a state where fact check can be submitted"
+      assert_includes response.parsed_body.dig("errors", "state"), "Edition is not in a state where fact check can be submitted"
     end
   end
 end


### PR DESCRIPTION
[MAIN-7487](https://gov-uk.atlassian.net/browse/MAIN-7487)

Send .errors instead of full messages to make processing easier on FCM side. 
[Relates to FCM PR](https://github.com/alphagov/fact-check-manager/pull/210)


[MAIN-7487]: https://gov-uk.atlassian.net/browse/MAIN-7487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ