### PR TITLE
Update content publishing guidance link in design system layout

### DIFF
--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -43,8 +43,8 @@ module FooterHelper
         text: "Check if publishing apps are working or if there’s any maintenance planned",
       },
       {
-        href: "https://www.gov.uk/government/content-publishing",
-        text: "How to write, publish, and improve content",
+        href: "https://guidance.publishing.service.gov.uk",
+        text: "Read the content and publishing guidance",
       },
     ]
   end

--- a/test/unit/helpers/footer_helper_test.rb
+++ b/test/unit/helpers/footer_helper_test.rb
@@ -15,7 +15,7 @@ class FooterHelperTest < ActionView::TestCase
           items: [
             { text: "Raise a support request", href: Plek.external_url_for("support") },
             { text: "Check if publishing apps are working or if there’s any maintenance planned", href: "https://status.publishing.service.gov.uk/" },
-            { text: "How to write, publish, and improve content", href: "https://www.gov.uk/government/content-publishing" },
+            { text: "Read the content and publishing guidance", href: "https://guidance.publishing.service.gov.uk" },
           ] },
       ], footer_items(is_editor: true)
     end
@@ -32,7 +32,7 @@ class FooterHelperTest < ActionView::TestCase
           items: [
             { text: "Raise a support request", href: Plek.external_url_for("support") },
             { text: "Check if publishing apps are working or if there’s any maintenance planned", href: "https://status.publishing.service.gov.uk/" },
-            { text: "How to write, publish, and improve content", href: "https://www.gov.uk/government/content-publishing" },
+            { text: "Read the content and publishing guidance", href: "https://guidance.publishing.service.gov.uk" },
           ] },
       ], footer_items(is_editor: false)
     end


### PR DESCRIPTION
## What
Update the guidance link in the footer

From: 
[How to write, publish, and improve content](https://www.gov.uk/government/content-publishing)
 
To:
[Read the content and publishing guidance](https://guidance.publishing.service.gov.uk/)

## Why
Request from content team to make the purpose of the link clearer and point to the updated location for the guidance.

[Zendesk](https://govuk.zendesk.com/agent/tickets/6774757)
[Jira](https://gov-uk.atlassian.net/browse/WHIT-3844)
