### PR TITLE
Update fact check sent inset message

### DIFF
--- a/app/views/editions/show.html.erb
+++ b/app/views/editions/show.html.erb
@@ -49,10 +49,10 @@
             <% if @edition.fact_check? %>
               <% latest_send_fact_check_action = @edition.latest_status_action(Action::SEND_FACT_CHECK) %>
               <% if latest_send_fact_check_action&.requester == current_user %>
-                <p class="govuk-body">You've requested this edition to be fact checked. We're awaiting a response.</p>
+                <p class="govuk-body">You’ve sent this edition for fact check. We’re awaiting a response.</p>
               <% else %>
-                <p class="govuk-body"><%= latest_send_fact_check_action&.requester&.name %> requested this edition to be fact checked.
-                  We're awaiting a response.</p>
+                <p class="govuk-body"><%= latest_send_fact_check_action&.requester&.name %> sent this edition for fact check.
+                  We’re awaiting a response.</p>
               <% end %>
               <p class="govuk-body"><%= link_to("Resend fact check email", resend_fact_check_email_page_edition_path, class: "govuk-link govuk-link--no-visited-state") %></p>
             <% end %>

--- a/app/views/shared/_fact_check.html.erb
+++ b/app/views/shared/_fact_check.html.erb
@@ -1,11 +1,11 @@
 <div class="alert alert-info">
   <% if latest_send_fact_check_action = @resource.latest_status_action(Action::SEND_FACT_CHECK) %>
-    <p><%= latest_send_fact_check_action&.requester&.name %> requested this edition be fact checked. We&rsquo;re awaiting a response.</p>
+    <p><%= latest_send_fact_check_action&.requester&.name %> sent this edition for fact check. We’re awaiting a response.</p>
     <% if current_user.has_editor_permissions?(@resource) %>
       <%= resend_fact_check_buttons(@resource) %>
     <% end %>
   <% else %>
-    <p>Someone requested this edition be fact checked. We&rsquo;re awaiting a response.</p>
+    <p>Someone sent this edition for fact check. We’re awaiting a response.</p>
   <% end %>
   <% if current_user.has_editor_permissions?(@resource) %>
     <%= render "shared/request_amendments" %>

--- a/test/integration/edition_edit_tab/edit_amends_needed_edition_test.rb
+++ b/test/integration/edition_edit_tab/edit_amends_needed_edition_test.rb
@@ -19,7 +19,7 @@ class EditAmendsNeededEditionTest < IntegrationTest
 
   should "not show the 'Resend fact check email' link and text" do
     assert page.has_no_link?("Resend fact check email")
-    assert page.has_no_text?("You've requested this edition to be fact checked. We're awaiting a response.")
+    assert page.has_no_text?("You’ve sent this edition for fact check. We’re awaiting a response.")
   end
 
   context "user does not have editor permissions" do

--- a/test/integration/edition_edit_tab/edit_archived_edition_test.rb
+++ b/test/integration/edition_edit_tab/edit_archived_edition_test.rb
@@ -70,7 +70,7 @@ class EditArchivedEditionTest < IntegrationTest
     visit edition_path(@archived_edition)
 
     assert page.has_no_link?("Resend fact check email")
-    assert page.has_no_text?("You've requested this edition to be fact checked. We're awaiting a response.")
+    assert page.has_no_text?("You’ve sent this edition for fact check. We’re awaiting a response.")
   end
 
   context "guide edition" do

--- a/test/integration/edition_edit_tab/edit_draft_edition_test.rb
+++ b/test/integration/edition_edit_tab/edit_draft_edition_test.rb
@@ -79,7 +79,7 @@ class EditDraftEditionTest < IntegrationTest
 
       should "not show the 'Resend fact check email' link and text" do
         assert page.has_no_link?("Resend fact check email")
-        assert page.has_no_text?("You've requested this edition to be fact checked. We're awaiting a response.")
+        assert page.has_no_text?("You’ve sent this edition for fact check. We’re awaiting a response.")
       end
 
       should "not show the 'Request amendments' link and text" do

--- a/test/integration/edition_edit_tab/edit_fact_check_edition_test.rb
+++ b/test/integration/edition_edit_tab/edit_fact_check_edition_test.rb
@@ -13,7 +13,7 @@ class EditFactCheckEditionTest < IntegrationTest
     visit edition_path(@fact_check_edition)
 
     assert page.has_link?("Resend fact check email")
-    assert page.has_text?("You've requested this edition to be fact checked. We're awaiting a response.")
+    assert page.has_text?("You’ve sent this edition for fact check. We’re awaiting a response.")
   end
 
   should "show the requester specific text to govuk editors" do
@@ -22,7 +22,7 @@ class EditFactCheckEditionTest < IntegrationTest
 
     visit edition_path(@fact_check_edition)
 
-    assert page.has_text?("Stub requester requested this edition to be fact checked. We're awaiting a response.")
+    assert page.has_text?("Stub requester sent this edition for fact check. We’re awaiting a response.")
   end
 
   should "show Preview link" do
@@ -47,7 +47,7 @@ class EditFactCheckEditionTest < IntegrationTest
       FactoryBot.create(:action, edition: @fact_check_edition, requester: @govuk_requester, request_type: Action::REQUEST_REVIEW)
       visit edition_path(@fact_check_edition)
 
-      assert page.has_text?("You've requested this edition to be fact checked. We're awaiting a response.")
+      assert page.has_text?("You’ve sent this edition for fact check. We’re awaiting a response.")
     end
   end
 
@@ -65,7 +65,7 @@ class EditFactCheckEditionTest < IntegrationTest
 
       should "show the 'Resend fact check' link" do
         assert page.has_link?("Resend fact check email")
-        assert page.has_text?("You've requested this edition to be fact checked. We're awaiting a response.")
+        assert page.has_text?("You’ve sent this edition for fact check. We’re awaiting a response.")
       end
 
       should "show the 'Request amendments' link" do
@@ -82,7 +82,7 @@ class EditFactCheckEditionTest < IntegrationTest
           FactoryBot.create(:action, edition: @welsh_edition, requester: @govuk_editor, request_type: Action::REQUEST_REVIEW)
           visit edition_path(@welsh_edition)
 
-          assert page.has_text?("You've requested this edition to be fact checked. We're awaiting a response.")
+          assert page.has_text?("You’ve sent this edition for fact check. We’re awaiting a response.")
         end
       end
     end
@@ -94,7 +94,7 @@ class EditFactCheckEditionTest < IntegrationTest
 
       should "not show the 'Resend fact check' link" do
         assert page.has_no_link?("Resend fact check email")
-        assert page.has_no_text?("You've requested this edition to be fact checked. We're awaiting a response.")
+        assert page.has_no_text?("You’ve sent this edition for fact check. We’re awaiting a response.")
       end
 
       should "not show the 'Request amendments' link" do
@@ -111,7 +111,7 @@ class EditFactCheckEditionTest < IntegrationTest
 
     should "not show the 'Resend fact check email' link or text to non-editors" do
       assert page.has_no_link?("Resend fact check email")
-      assert page.has_no_text?("You've requested this edition to be fact checked. We're awaiting a response.")
+      assert page.has_no_text?("You’ve sent this edition for fact check. We’re awaiting a response.")
     end
 
     should "not show any editable components" do

--- a/test/integration/edition_edit_tab/edit_fact_check_received_edition_test.rb
+++ b/test/integration/edition_edit_tab/edit_fact_check_received_edition_test.rb
@@ -49,7 +49,7 @@ class EditFactCheckReceivedEditionTest < IntegrationTest
 
     should "not show the 'Resend fact check email' link and text" do
       assert page.has_no_link?("Resend fact check email")
-      assert page.has_no_text?("You've requested this edition to be fact checked. We're awaiting a response.")
+      assert page.has_no_text?("You’ve sent this edition for fact check. We’re awaiting a response.")
     end
   end
 

--- a/test/integration/edition_edit_tab/edit_in_review_edition_test.rb
+++ b/test/integration/edition_edit_tab/edit_in_review_edition_test.rb
@@ -31,7 +31,7 @@ class EditInReviewEditionTest < IntegrationTest
 
       should "not show the 'Resend fact check email' link and text" do
         assert page.has_no_link?("Resend fact check email")
-        assert page.has_no_text?("You've requested this edition to be fact checked. We're awaiting a response.")
+        assert page.has_no_text?("You’ve sent this edition for fact check. We’re awaiting a response.")
       end
 
       should "not show the 'Request amendments' link" do
@@ -93,7 +93,7 @@ class EditInReviewEditionTest < IntegrationTest
 
       should "not show the 'Resend fact check email' link and text" do
         assert page.has_no_link?("Resend fact check email")
-        assert page.has_no_text?("You've requested this edition to be fact checked. We're awaiting a response.")
+        assert page.has_no_text?("You’ve sent this edition for fact check. We’re awaiting a response.")
       end
 
       should "show the 'Request amendments' link" do
@@ -193,7 +193,7 @@ class EditInReviewEditionTest < IntegrationTest
 
       should "not show the 'Resend fact check email' link and text" do
         assert page.has_no_link?("Resend fact check email")
-        assert page.has_no_text?("You've requested this edition to be fact checked. We're awaiting a response.")
+        assert page.has_no_text?("You’ve sent this edition for fact check. We’re awaiting a response.")
       end
 
       should "not show the 'Request amendments' link" do
@@ -255,7 +255,7 @@ class EditInReviewEditionTest < IntegrationTest
 
       should "not show the 'Resend fact check email' link and text" do
         assert page.has_no_link?("Resend fact check email")
-        assert page.has_no_text?("You've requested this edition to be fact checked. We're awaiting a response.")
+        assert page.has_no_text?("You’ve sent this edition for fact check. We’re awaiting a response.")
       end
 
       should "show the 'Request amendments' link" do

--- a/test/integration/edition_edit_tab/edit_published_edition_test.rb
+++ b/test/integration/edition_edit_tab/edit_published_edition_test.rb
@@ -52,7 +52,7 @@ class EditPublishedEditionTest < IntegrationTest
     visit edition_path(published_edition)
 
     assert page.has_no_link?("Resend fact check email")
-    assert page.has_no_text?("You've requested this edition to be fact checked. We're awaiting a response.")
+    assert page.has_no_text?("You’ve sent this edition for fact check. We’re awaiting a response.")
   end
 
   context "place edition" do

--- a/test/integration/edition_edit_tab/edit_ready_edition_test.rb
+++ b/test/integration/edition_edit_tab/edit_ready_edition_test.rb
@@ -38,7 +38,7 @@ class EditReadyEditionTest < IntegrationTest
 
     should "not show the 'Resend fact check email' link and text" do
       assert page.has_no_link?("Resend fact check email")
-      assert page.has_no_text?("You've requested this edition to be fact checked. We're awaiting a response.")
+      assert page.has_no_text?("You’ve sent this edition for fact check. We’re awaiting a response.")
     end
 
     should "show the 'Publish' button" do

--- a/test/integration/edition_edit_tab/edit_scheduled_for_publishing_edition_test.rb
+++ b/test/integration/edition_edit_tab/edit_scheduled_for_publishing_edition_test.rb
@@ -69,7 +69,7 @@ class EditScheduledForPublishingTest < IntegrationTest
 
   should "not show the 'Resend fact check email' link and text" do
     assert page.has_no_link?("Resend fact check email")
-    assert page.has_no_text?("You've requested this edition to be fact checked. We're awaiting a response.")
+    assert page.has_no_text?("You’ve sent this edition for fact check. We’re awaiting a response.")
   end
 
   context "that is welsh" do


### PR DESCRIPTION
Updates all instances of 'fact check sent' text for consistency.

## Screenshots

### Sent by self
<img width="738" height="184" alt="image" src="https://github.com/user-attachments/assets/809a56c0-c807-4e2d-a8f5-3336d60934c2" />

### Sent by another user
<img width="722" height="171" alt="image" src="https://github.com/user-attachments/assets/c99c6fb2-b470-496a-84d1-6e1936bb756c" />


[MAIN-7415](https://gov-uk.atlassian.net/browse/MAIN-7415)
(populate the link above to make sure your PR is linked to the Jira ticket)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


[MAIN-7415]: https://gov-uk.atlassian.net/browse/MAIN-7415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ