### PR TITLE
2 page fact check request flow

### DIFF
--- a/app/assets/stylesheets/edit.scss
+++ b/app/assets/stylesheets/edit.scss
@@ -52,6 +52,8 @@
     .non-functional-link{
       @extend .govuk-link; // stylelint-disable-line scss/at-extend-no-missing-placeholder
       color: govuk-colour("blue"); // govuk-functional-colour("link") once that is working
+      pointer-events: none;
+      cursor: default;
     }
 
     .gem-c-govspeak h2{

--- a/app/controllers/editions_controller.rb
+++ b/app/controllers/editions_controller.rb
@@ -35,6 +35,7 @@ class EditionsController < InheritedResources::Base
                          schedule_page
                          send_to_fact_check
                          send_to_fact_check_page
+                         send_to_fact_check_email_preview_page
                          resend_fact_check_email_page
                          resend_fact_check_email
                          add_edition_note
@@ -56,7 +57,7 @@ class EditionsController < InheritedResources::Base
   before_action only: %i[schedule_page] do
     require_schedulable
   end
-  before_action only: %i[send_to_fact_check_page send_to_fact_check] do
+  before_action only: %i[send_to_fact_check_page send_to_fact_check_email_preview_page send_to_fact_check] do
     require_can_send_fact_check
   end
   before_action only: %i[show admin metadata tagging history related_external_links unpublish] do
@@ -101,7 +102,13 @@ class EditionsController < InheritedResources::Base
   end
 
   def send_to_fact_check_page
-    @form ||= FactCheckRequestForm.new
+    @form = FactCheckRequestForm.new(
+      permitted_fact_check_request_form_params.merge(
+        edition: @resource,
+        user: current_user,
+      ),
+    )
+
     render "secondary_nav_tabs/send_to_fact_check_page"
   end
 
@@ -254,16 +261,18 @@ class EditionsController < InheritedResources::Base
           ),
         )
 
-        if @form.valid?(:send) && send_to_fact_check_for_edition(@resource, @form, comment)
-          flash[:success] = "Sent to fact check"
-          redirect_to edition_path(resource)
+        unless @form.valid?(:send)
+          render "secondary_nav_tabs/send_to_fact_check_page"
           return
         end
 
-        flash.now[:danger] = SERVICE_REQUEST_ERROR_MESSAGE if @form.errors.none?
-
-        # TODO: These two lines not required once below block for legacy flow is removed.
-        render "secondary_nav_tabs/send_to_fact_check_page"
+        if send_to_fact_check_for_edition(@resource, @form, comment)
+          flash[:success] = "Sent to fact check"
+          redirect_to edition_path(@resource)
+        else
+          flash.now[:danger] = SERVICE_REQUEST_ERROR_MESSAGE
+          render "secondary_nav_tabs/send_to_fact_check_email_preview_page"
+        end
         return
       end
 
@@ -282,6 +291,21 @@ class EditionsController < InheritedResources::Base
     end
     flash.now[:danger] = SERVICE_REQUEST_ERROR_MESSAGE
     render "secondary_nav_tabs/send_to_fact_check_page"
+  end
+
+  def send_to_fact_check_email_preview_page
+    @form ||= FactCheckRequestForm.new(
+      permitted_fact_check_request_form_params.merge(
+        edition: @resource,
+        user: current_user,
+      ),
+    )
+
+    if @form.valid?(:send)
+      render "secondary_nav_tabs/send_to_fact_check_email_preview_page"
+    else
+      render "secondary_nav_tabs/send_to_fact_check_page"
+    end
   end
 
   def skip_review
@@ -642,6 +666,8 @@ private
   end
 
   def permitted_fact_check_request_form_params
+    return {} if params[:fact_check_request_form].blank?
+
     params.require(:fact_check_request_form).permit(:email_addresses,
                                                     :reason_for_change,
                                                     :zendesk_number,

--- a/app/lib/fact_check_request_form.rb
+++ b/app/lib/fact_check_request_form.rb
@@ -73,6 +73,30 @@ class FactCheckRequestForm
     }
   end
 
+  def reason_text
+    return if reason_for_change.blank?
+
+    escaped_reason = ERB::Util.html_escape(reason_for_change)
+    formatted_reason = escaped_reason.to_s.gsub(/\r?\n/, "<br>")
+    "Reason for change: “#{formatted_reason}”\n\n"
+  end
+
+  def zendesk_text
+    return if zendesk_number.blank?
+
+    "Zendesk ticket: <span class='non-functional-link'>#{zendesk_number}</span>\n\n"
+  end
+
+  def formatted_deadline
+    deadline ? deadline.strftime("%A %-e %B %Y").strip : "Not specified"
+  end
+
+  def split_email_addresses
+    return [] if email_addresses.blank?
+
+    email_addresses.split(Regexp.union(",", ";")).map(&:strip).compact_blank
+  end
+
 private
 
   def user_has_editor_permissions
@@ -111,11 +135,11 @@ private
     errors.add(:deadline, "Enter a deadline") if deadline.blank?
   end
 
-  def split_email_addresses
-    return if email_addresses.blank?
+  # def split_email_addresses
+  #   return if email_addresses.blank?
 
-    email_addresses.split(Regexp.union(",", ";")).map(&:strip)
-  end
+  #   email_addresses.split(Regexp.union(",", ";")).map(&:strip)
+  # end
 
   def current_content_presenter
     @current_content_presenter ||= EditionPresenterFactory.get_presenter(edition)

--- a/app/views/editions/secondary_nav_tabs/_send_fact_check_email_preview.html.erb
+++ b/app/views/editions/secondary_nav_tabs/_send_fact_check_email_preview.html.erb
@@ -1,57 +1,50 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: "Example email",
-      heading_level: 2,
-      font_size: "m",
-      padding: true,
-    } %>
-    <p class="govuk-body">This shows the format of the fact check email that will be sent.</p>
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Fact check email preview",
+  heading_level: 2,
+  font_size: "m",
+  padding: true,
+} %>
+<p class="govuk-body">This shows the fact check email that will be sent.<br><br>You cannot open the links in this preview. They will work in the fact check email.
+</p>
 
-    <article class="edit--send-fact-check-email-preview">
-      <header>
-        <p class="govuk-body">Government Digital Service</p>
-      </header>
+<article class="edit--send-fact-check-email-preview">
+  <header>
+    <p class="govuk-body">Government Digital Service</p>
+  </header>
 
-      <%= render "govuk_publishing_components/components/govspeak", {} do %>
-        <%= Govspeak::Document.new(<<~GOV_SPEAK).to_html.html_safe
-            Hi,
+  <%= render "govuk_publishing_components/components/govspeak", {} do %>
+    <%= Govspeak::Document.new(<<~GOV_SPEAK).to_html.html_safe
+        Hi,
 
-            We need you to check the factual accuracy of changes made to ‘#{@edition.title}’ before it’s published on GOV.UK.
+        We need you to check the factual accuracy of changes made to ‘#{@edition.title}’ before it’s published on GOV.UK.
 
-            Reason for change: Your input will go here.
+        #{@form.reason_text}#{@form.zendesk_text}^ Deadline: #{@form.formatted_deadline}
 
-            Zendesk ticket: Your input will go here.
+        ---
 
-            ^ Deadline: DD Month YYYY
+        ## Review the changes
+        <span class="non-functional-link">View the fact check – #{@edition.title}</span>
 
-            ---
+        You can share this link with the subject matter experts.
 
-            ## Review the changes
-            <span class="non-functional-link">View the fact check - #{@edition.title}</span>
+        They can view the information and check the changes, but are not able to submit a response.
 
-            You can share this link with the subject matter experts. The link expires when the content is published.
+        When fact checking, the subject matter experts should:
 
-            They can view the information and check the changes, but are not able to submit a response.
+        * check the changed content for factual accuracy
+        * tell us if anything is wrong, and why
 
-            When fact checking, they should:
+        They do not need to suggest new wording.
 
-            * check the changed content for factual accuracy
-            * tell us if anything is wrong, and why
+        ---
 
-            They do not need to suggest new wording.
+        ## Submit your fact check response
+        <span class="non-functional-link">Respond to the fact check</span>
 
-            ---
+        Only one fact check response can be submitted.
 
-            ## Submit your fact check response
-            <span class="non-functional-link">Respond to the fact check</span>
-
-            Only one fact check response can be submitted.
-
-            Do not reply to this email.
-          GOV_SPEAK
-        %>
-      <% end %>
-    </article>
-  </div>
-</div>
+        Do not reply to this email.
+      GOV_SPEAK
+    %>
+  <% end %>
+</article>

--- a/app/views/editions/secondary_nav_tabs/send_to_fact_check_email_preview_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/send_to_fact_check_email_preview_page.html.erb
@@ -1,0 +1,48 @@
+<% @edition = @resource %>
+<% title = "Check email and send for fact check" %>
+<% content_for :title_context, @edition.title %>
+<% content_for :page_title, title %>
+<% content_for :title, title %>
+
+<% content_for :back_link, send_to_fact_check_page_edition_path(
+  @edition,
+  fact_check_request_form: {
+    email_addresses: @form.email_addresses,
+    reason_for_change: @form.reason_for_change,
+    zendesk_number: @form.zendesk_number,
+    deadline_3i: @form.deadline_3i.presence || @form.deadline&.day,
+    deadline_2i: @form.deadline_2i.presence || @form.deadline&.month,
+    deadline_1i: @form.deadline_1i.presence || @form.deadline&.year,
+  },
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/inset_text" do %>
+      <p class="govuk-body">The fact check email will be sent to:</p>
+      <%= render "govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items: @form.split_email_addresses,
+      } %>
+    <% end %>
+
+    <%= form_with model: @form, scope: :fact_check_request_form, url: send_to_fact_check_edition_path(@edition), method: :post, html: { novalidate: "novalidate" }, data: { module: "ga4-form-tracker ga4-link-tracker", ga4_section: "Edit - #{title}" } do |f| %>
+
+      <%= f.hidden_field :email_addresses %>
+      <%= f.hidden_field :reason_for_change %>
+      <%= f.hidden_field :zendesk_number %>
+      <%= f.hidden_field :deadline_3i %>
+      <%= f.hidden_field :deadline_2i %>
+      <%= f.hidden_field :deadline_1i %>
+
+      <div class="govuk-button-group govuk-!-margin-top-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Confirm and send for fact check",
+        } %>
+      </div>
+    <% end %>
+
+    <%= render partial: "editions/secondary_nav_tabs/send_fact_check_email_preview" %>
+
+  </div>
+</div>

--- a/app/views/editions/secondary_nav_tabs/send_to_fact_check_page.html.erb
+++ b/app/views/editions/secondary_nav_tabs/send_to_fact_check_page.html.erb
@@ -13,7 +13,7 @@
         <% content_for :error_summary, render("shared/error_summary", { object: @form, full_messages: false }) %>
       <% end %>
 
-      <%= form_with model: @form, scope: :fact_check_request_form, url: send_to_fact_check_edition_path(@edition), html: { novalidate: "novalidate" }, data: { module: "ga4-form-tracker ga4-link-tracker", ga4_section: "Edit - #{title}" } do %>
+      <%= form_with model: @form, scope: :fact_check_request_form, url: send_to_fact_check_email_preview_page_edition_path(@edition), html: { novalidate: "novalidate" }, data: { module: "ga4-form-tracker ga4-link-tracker", ga4_section: "Edit - #{title}" } do %>
 
         <%= render "govuk_publishing_components/components/input", {
           label: {
@@ -90,7 +90,7 @@
 
         <div class="govuk-button-group">
           <%= render "govuk_publishing_components/components/button", {
-            text: "Send for fact check",
+            text: "Continue",
           } %>
           <%= link_to("Cancel", edition_path, class: "govuk-link govuk-link--no-visited-state") %>
         </div>
@@ -132,7 +132,3 @@
     <% end %>
   </div>
 </div>
-
-<% if Flipflop.enabled?(:fact_check_manager_api) %>
-  <%= render partial: "editions/secondary_nav_tabs/send_fact_check_email_preview" %>
-<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,7 @@ Rails.application.routes.draw do
     member do
       get "send_to_fact_check_page"
       post "send_to_fact_check"
+      post "send_to_fact_check_email_preview_page"
       get "resend_fact_check_email_page"
       patch "resend_fact_check_email"
     end

--- a/test/functional/editions_controller_test.rb
+++ b/test/functional/editions_controller_test.rb
@@ -1285,7 +1285,7 @@ class EditionsControllerTest < ActionController::TestCase
                                        deadline_1i: default_test_deadline.year },
           }
 
-          assert_template "secondary_nav_tabs/send_to_fact_check_page"
+          assert_template "secondary_nav_tabs/send_to_fact_check_email_preview_page"
           assert_equal "Due to a service problem, the request could not be made", flash[:danger]
           edition.reload
           assert_equal "ready", edition.state
@@ -1303,7 +1303,7 @@ class EditionsControllerTest < ActionController::TestCase
                                        deadline_1i: default_test_deadline.year },
           }
 
-          assert_template "secondary_nav_tabs/send_to_fact_check_page"
+          assert_template "secondary_nav_tabs/send_to_fact_check_email_preview_page"
           assert_equal "Due to a service problem, the request could not be made", flash[:danger]
           edition.reload
           assert_equal "ready", edition.state
@@ -1324,6 +1324,91 @@ class EditionsControllerTest < ActionController::TestCase
           assert_equal "Due to a service problem, the request could not be made", flash[:danger]
           edition.reload
           assert_equal "ready", edition.state
+        end
+
+        should "pre-populate the form when query parameters are present" do
+          edition = FactoryBot.create(:edition, :ready)
+
+          get :send_to_fact_check_page, params: {
+            id: edition.id,
+            fact_check_request_form: {
+              email_addresses: "prefilled@example.com",
+              reason_for_change: "Prefilled reason for change",
+              zendesk_number: "1234567",
+            },
+          }
+
+          assert_response :success
+          assert_equal "prefilled@example.com", assigns(:form).email_addresses
+          assert_equal "Prefilled reason for change", assigns(:form).reason_for_change
+          assert_equal "1234567", assigns(:form).zendesk_number
+        end
+
+        should "initialize an empty form when no query parameters are present" do
+          edition = FactoryBot.create(:edition, :ready)
+
+          get :send_to_fact_check_page, params: { id: edition.id }
+
+          assert_response :success
+          assert_nil assigns(:form).email_addresses
+          assert_nil assigns(:form).reason_for_change
+          assert_nil assigns(:form).zendesk_number
+        end
+      end
+    end
+
+    context "#send_to_fact_check_email_preview_page" do
+      context "user has govuk_editor permission" do
+        should "render Page 2 preview when valid parameters are provided" do
+          edition = FactoryBot.create(:edition, :ready)
+
+          post :send_to_fact_check_email_preview_page, params: {
+            id: edition.id,
+            fact_check_request_form: { email_addresses: "stub@email.com",
+                                       deadline_1i: default_test_deadline.year,
+                                       deadline_2i: default_test_deadline.month,
+                                       deadline_3i: default_test_deadline.day },
+          }
+
+          assert_template "secondary_nav_tabs/send_to_fact_check_email_preview_page"
+        end
+
+        should "redirect to edition path with an error message when edition is in a state where going to fact check is not available" do
+          edition = FactoryBot.create(:edition, :published)
+
+          post :send_to_fact_check_email_preview_page, params: {
+            id: edition.id,
+            fact_check_request_form: { email_addresses: "stub@email.com",
+                                       deadline_1i: default_test_deadline.year,
+                                       deadline_2i: default_test_deadline.month,
+                                       deadline_3i: default_test_deadline.day },
+          }
+
+          assert_redirected_to edition_path
+          assert_equal "Edition is not in a state where it can be sent to fact check", flash[:danger]
+        end
+      end
+
+      context "user does not have govuk_editor permission" do
+        setup do
+          user = FactoryBot.create(:user)
+          login_as(user)
+        end
+
+        should "render an error message when user lacks permission" do
+          edition = FactoryBot.create(:edition, :ready)
+
+          post :send_to_fact_check_email_preview_page, params: {
+            id: edition.id,
+            fact_check_request_form: {
+              email_addresses: "stub@email.com",
+              deadline_1i: default_test_deadline.year,
+              deadline_2i: default_test_deadline.month,
+              deadline_3i: default_test_deadline.day,
+            },
+          }
+
+          assert_equal "You do not have correct editor permissions for this action.", flash[:danger]
         end
       end
     end

--- a/test/integration/edition_workflow_fact_check_api_test.rb
+++ b/test/integration/edition_workflow_fact_check_api_test.rb
@@ -21,7 +21,7 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
 
     should "render the page" do
       assert page.has_text?(@ready_edition.title)
-      assert page.has_text?("Send for fact check")
+      assert page.has_text?("Send to fact check")
       assert page.has_text?("Email addresses")
       assert page.has_text?("Reason for change (optional)")
       assert page.has_text?("Zendesk ticket number (optional)")
@@ -29,19 +29,25 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       assert page.has_css?(".gem-c-hint", text: "This is shown in the email sent to the department")
       assert page.has_css?(".gem-c-hint", text: "This defaults to 5 working days from today")
       assert page.has_css?(".govuk-input__prefix", text: "https://govuk.zendesk.com/tickets/")
-      assert page.has_button?("Send for fact check")
+      assert page.has_button?("Continue")
       assert page.has_link?("Cancel")
     end
 
     should "pre-populate the email preview with the edition title" do
+      fill_in "Email addresses", with: "fact-checker@example.com"
+      click_button "Continue"
+
       assert page.has_css?(".edit--send-fact-check-email-preview", text: @ready_edition.title)
     end
 
     should "render govspeak elements of the email preview" do
+      fill_in "Email addresses", with: "fact-checker@example.com"
+      click_button "Continue"
+
       assert page.has_css?(".edit--send-fact-check-email-preview")
       within ".edit--send-fact-check-email-preview" do
         assert page.has_css?("header", text: "Government Digital Service")
-        assert page.has_css?("div", class: "application-notice info-notice", text: "Deadline: DD Month YYYY")
+        assert page.has_text?("Deadline:")
         assert page.has_css?("h2", id: "review-the-changes", text: "Review the changes")
       end
     end
@@ -70,7 +76,8 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       fill_in "Day", with: date.day
       fill_in "Month", with: date.month
       fill_in "Year", with: date.year
-      click_button "Send for fact check"
+      click_button "Continue"
+      click_button "Confirm and send for fact check"
 
       assert_current_path edition_path(@ready_edition.id)
       assert page.has_text?("Sent to fact check")
@@ -83,7 +90,8 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       fill_in "Day", with: date.day
       fill_in "Month", with: date.month
       fill_in "Year", with: date.year
-      click_button "Send for fact check"
+      click_button "Continue"
+      click_button "Confirm and send for fact check"
 
       assert_current_path edition_path(@ready_edition.id)
       assert page.has_text?("Sent to fact check")
@@ -96,7 +104,8 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       fill_in "Day", with: date.day
       fill_in "Month", with: date.month
       fill_in "Year", with: date.year
-      click_button "Send for fact check"
+      click_button "Continue"
+      click_button "Confirm and send for fact check"
 
       assert_current_path edition_path(@ready_edition.id)
       assert page.has_text?("Sent to fact check")
@@ -111,7 +120,8 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       fill_in "Day", with: date.day
       fill_in "Month", with: date.month
       fill_in "Year", with: date.year
-      click_button "Send for fact check"
+      click_button "Continue"
+      click_button "Confirm and send for fact check"
 
       assert_current_path edition_path(@ready_edition.id)
       assert page.has_text?("Sent to fact check")
@@ -126,10 +136,10 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       fill_in "Day", with: date.day
       fill_in "Month", with: date.month
       fill_in "Year", with: date.year
-      click_button "Send for fact check"
+      click_button "Continue"
       @ready_edition.reload
 
-      assert_current_path send_to_fact_check_edition_path(@ready_edition.id)
+      assert_current_path send_to_fact_check_email_preview_page_edition_path(@ready_edition.id)
       assert_equal "ready", @ready_edition.state
       assert page.has_text?("Email addresses are invalid")
     end
@@ -141,10 +151,10 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       fill_in "Day", with: 999
       fill_in "Month", with: 999
       fill_in "Year", with: 999
-      click_button "Send for fact check"
+      click_button "Continue"
       @ready_edition.reload
 
-      assert_current_path send_to_fact_check_edition_path(@ready_edition.id)
+      assert_current_path send_to_fact_check_email_preview_page_edition_path(@ready_edition.id)
       assert_equal "ready", @ready_edition.state
       assert page.has_text?("Enter a deadline")
     end
@@ -158,12 +168,46 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       fill_in "Day", with: date.day
       fill_in "Month", with: date.month
       fill_in "Year", with: date.year
-      click_button "Send for fact check"
+      click_button "Continue"
       @ready_edition.reload
 
-      assert_current_path send_to_fact_check_edition_path(@ready_edition.id)
+      assert_current_path send_to_fact_check_email_preview_page_edition_path(@ready_edition.id)
       assert_equal "ready", @ready_edition.state
       assert page.has_text?("Zendesk ticket number must be at least 7 digits long")
+    end
+
+    should "allow user to return from Page 2 to Page 1 with pre-populated form values when Back is clicked" do
+      date = 2.days.from_now
+
+      fill_in "Email addresses", with: "fact-checker-one@example.com"
+      fill_in "Zendesk ticket number (optional)", with: 1_234_567
+      fill_in "Reason for change", with: "Initial reason"
+      fill_in "Day", with: date.day
+      fill_in "Month", with: date.month
+      fill_in "Year", with: date.year
+      click_button "Continue"
+
+      assert_current_path send_to_fact_check_email_preview_page_edition_path(@ready_edition.id)
+
+      click_link "Back"
+
+      assert_current_path send_to_fact_check_page_edition_path(@ready_edition.id), ignore_query: true
+      assert page.has_field?("Email addresses", with: "fact-checker-one@example.com")
+      assert page.has_field?("Zendesk ticket number (optional)", with: "1234567")
+      assert page.has_field?("Reason for change", with: "Initial reason")
+      assert page.has_field?("Day", with: date.day.to_s)
+      assert page.has_field?("Month", with: date.month.to_s)
+      assert page.has_field?("Year", with: date.year.to_s)
+    end
+
+    should "render the reason for change enclosed in English curly quotes in the email preview" do
+      fill_in "Email addresses", with: "fact-checker@example.com"
+      fill_in "Reason for change", with: "Factual updates to section 2."
+      click_button "Continue"
+
+      within ".edit--send-fact-check-email-preview" do
+        assert page.has_text?("Reason for change: “Factual updates to section 2.”")
+      end
     end
   end
 
@@ -183,9 +227,9 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       fill_in "Day", with: date.day
       fill_in "Month", with: date.month
       fill_in "Year", with: date.year
-      click_button "Send for fact check"
+      click_button "Continue"
 
-      assert_current_path send_to_fact_check_edition_path(@ready_edition.id)
+      assert_current_path send_to_fact_check_email_preview_page_edition_path(@ready_edition.id)
       assert page.has_text?("Email addresses are invalid")
       assert page.has_css?("input[value='fact-checker-one.com']")
       assert page.has_css?("input[value='1234567']")
@@ -201,9 +245,9 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       fill_in "Day", with: "not"
       fill_in "Month", with: "a"
       fill_in "Year", with: "number"
-      click_button "Send for fact check"
+      click_button "Continue"
 
-      assert_current_path send_to_fact_check_edition_path(@ready_edition.id)
+      assert_current_path send_to_fact_check_email_preview_page_edition_path(@ready_edition.id)
       assert page.has_text?("Enter a deadline")
       assert page.has_css?("input[value='fact-checker-one@email.com']")
       assert page.has_css?("input[value='not']")
@@ -220,16 +264,15 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       fill_in "Day", with: date.day
       fill_in "Month", with: date.month
       fill_in "Year", with: date.year
-      click_button "Send for fact check"
+      click_button "Continue"
+      click_button "Confirm and send for fact check"
 
       assert_current_path send_to_fact_check_edition_path(@ready_edition.id)
       assert page.has_text?("Due to a service problem, the request could not be made")
-      assert page.has_css?("input[value='fact-checker-one@example.com']")
-      assert page.has_css?("input[value='1234567']")
-      assert page.has_css?("textarea", text: "A reason")
-      assert page.has_css?("input[value='#{date.day}']")
-      assert page.has_css?("input[value='#{date.month}']")
-      assert page.has_css?("input[value='#{date.year}']")
+      assert page.has_text?("fact-checker-one@example.com")
+      assert page.has_text?("1234567")
+      assert page.has_text?("A reason")
+      assert page.has_field?("fact_check_request_form[email_addresses]", type: "hidden", with: "fact-checker-one@example.com", visible: :all)
     end
 
     should "log the error" do
@@ -242,7 +285,8 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
       fill_in "Day", with: date.day
       fill_in "Month", with: date.month
       fill_in "Year", with: date.year
-      click_button "Send for fact check"
+      click_button "Continue"
+      click_button "Confirm and send for fact check"
     end
   end
 
@@ -359,18 +403,15 @@ class EditionWorkflowFactCheckApiTest < IntegrationTest
     should "send a simple smart answer to fact check" do
       stub_post_new_fact_check_request(success: true)
       ready_edition = FactoryBot.create(:simple_smart_answer_edition, :ready)
-      date = 1.day.from_now
 
       visit send_to_fact_check_page_edition_path(ready_edition)
 
-      assert page.has_text?("Send for fact check")
+      assert page.has_button?("Continue")
       assert page.has_text?("Reason for change (optional)")
 
       fill_in "Email addresses", with: "fact-checker-one@example.com"
-      fill_in "Day", with: date.day
-      fill_in "Month", with: date.month
-      fill_in "Year", with: date.year
-      click_button "Send for fact check"
+      click_button "Continue"
+      click_button "Confirm and send for fact check"
 
       assert_current_path edition_path(ready_edition.id)
       assert page.has_text?("Sent to fact check")

--- a/test/integration/ga4_tracking_edit_test.rb
+++ b/test/integration/ga4_tracking_edit_test.rb
@@ -600,7 +600,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
       fill_in "Month", with: "11"
       fill_in "Year", with: "2025"
       click_link "Cancel"
-      click_button "Send for fact check"
+      click_button "Continue"
 
       event_data = get_event_data
 
@@ -654,7 +654,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
       fill_in "Day", with: ""
       fill_in "Month", with: ""
       fill_in "Year", with: ""
-      click_button "Send for fact check"
+      click_button "Continue"
 
       assert page.has_css?("h2", text: "There is a problem")
 
@@ -688,7 +688,7 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
       fill_in "Day", with: "28"
       fill_in "Month", with: "9"
       fill_in "Year", with: "2024"
-      click_button "Send for fact check"
+      click_button "Continue"
 
       assert page.has_css?("h2", text: "There is a problem")
 
@@ -714,6 +714,42 @@ class Ga4TrackingEditTest < JavascriptIntegrationTest
       assert_equal "The date must be today or up to 30 days in the future", event_data[2]["text"]
       assert_equal "Answer", event_data[2]["tool_name"]
       assert_equal "Edit edition", event_data[2]["type"]
+    end
+
+    should "push the correct values to the dataLayer on Page 2 form submission and go back" do
+      today = Date.parse("2025-10-29")
+
+      Timecop.freeze(today) do
+        fill_in "Email addresses", with: "fact-checker-one@example.com"
+        click_button "Continue"
+
+        assert page.has_button?("Confirm and send for fact check")
+
+        disable_form_submit
+        disable_links
+
+        click_link "Back"
+        click_button "Confirm and send for fact check"
+
+        event_data = get_event_data
+
+        # Page 2 "Back" link navigation event
+        assert_equal "navigation", event_data[0]["event_name"]
+        assert_equal "back", event_data[0]["type"]
+        assert_equal "Back", event_data[0]["text"]
+        assert_equal "false", event_data[0]["external"]
+        assert_equal current_host, event_data[0]["link_domain"]
+        assert_equal "primary click", event_data[0]["method"]
+        assert event_data[0]["url"].start_with?("/editions/#{@edition.id}/send_to_fact_check_page")
+
+        # Page 2 final submit form response event
+        assert_equal "Save", event_data[1]["action"]
+        assert_equal "form_response", event_data[1]["event_name"]
+        assert_equal "Edit - Check email and send for fact check", event_data[1]["section"]
+        assert_equal "{}", event_data[1]["text"]
+        assert_equal "Answer", event_data[1]["tool_name"]
+        assert_equal "edit", event_data[1]["type"]
+      end
     end
   end
 


### PR DESCRIPTION
[MAIN-7432](https://gov-uk.atlassian.net/browse/MAIN-7432)

2 page fact check request flow:

- Set up a 2nd page with appropriate routes for fact check
- Configured email preview to follow design
- Adjusted components and submission action to account for 2 Page flow



[MAIN-7432]: https://gov-uk.atlassian.net/browse/MAIN-7432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ