### PR TITLE
Bump content_block_tools from 1.14.1 to 2.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
-    content_block_tools (1.14.1)
+    content_block_tools (2.2.0)
       actionview (>= 6, < 8.1.4)
       gds-api-adapters (>= 101.0)
       govspeak (>= 10.6.3)


### PR DESCRIPTION
Resolves a bug where pension blocks are displaying with ££

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
