### PR TITLE
[MAIN-7533] Allow fact check responses via API controller for all environments

### DIFF
--- a/app/controllers/api/fact_check_response_controller.rb
+++ b/app/controllers/api/fact_check_response_controller.rb
@@ -1,14 +1,7 @@
 module Api
   class FactCheckResponseController < Api::BaseController
     def process_response
-      # Temporarily locking this down to local running and Integration environment while FCM is in development
-      unless Rails.env.local? || Rails.env.test? || ENV["GOVUK_ENVIRONMENT"] == "integration"
-        return render json: { errors: "Not enabled on this environment" }, status: :bad_request
-      end
-
-      if response_params.failure?
-        return param_errors
-      end
+      return param_errors if response_params.failure?
 
       edition = Edition.find(response_params[:edition_id])
 

--- a/test/api/fact_check_response_controller_test.rb
+++ b/test/api/fact_check_response_controller_test.rb
@@ -9,22 +9,6 @@ class FactCheckResponseControllerTest < IntegrationTest
     [123, %w[invalid], { invalid: true }, true]
   end
 
-  context "in a production environment" do
-    setup do
-      Rails.env.stubs(:local?).returns(false)
-      Rails.env.stubs(:test?).returns(false)
-    end
-
-    should "return 400" do
-      ClimateControl.modify GOVUK_ENVIRONMENT: "production" do
-        post api_fact_check_response_path, params: { edition_id: @edition.id, responder_name: "Joe Bloggs", accepted: true }, as: :json
-
-        assert_response :bad_request
-        assert_includes response.parsed_body["errors"], "Not enabled on this environment"
-      end
-    end
-  end
-
   context "#process_response" do
     should "return a success response with valid params" do
       post api_fact_check_response_path, params: { edition_id: @edition.id, responder_name: "Joe Bloggs", accepted: true }, as: :json


### PR DESCRIPTION
[MAIN-7533](https://gov-uk.atlassian.net/browse/MAIN-7533)

### Changes

Allow fact check responses via the API controller FactCheckResponseController for all environments.

[MAIN-7533]: https://gov-uk.atlassian.net/browse/MAIN-7533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ