### PR TITLE
Modify rake task to search actual ContentID rather than document ID

### DIFF
--- a/lib/tasks/access_and_permissions.rake
+++ b/lib/tasks/access_and_permissions.rake
@@ -3,7 +3,7 @@ require "csv"
 namespace :permissions do
   desc "Add an organisation to a document's access permissions list"
   task :add_organisation_access, %i[document_content_id org_content_id log_file] => :environment do |_, args|
-    document = Artefact.find_by(id: args[:document_content_id])
+    document = Artefact.find_by(content_id: args[:document_content_id])
 
     if document.nil?
       message = "Document ID #{args[:document_content_id]} not found, no permissions added for organisation with ID: #{args[:org_content_id]}"
@@ -41,7 +41,7 @@ namespace :permissions do
         end
 
         Rake::Task["permissions:add_organisation_access"].reenable
-        Rake::Task["permissions:add_organisation_access"].invoke(document.id, args[:organisation_id], log_file)
+        Rake::Task["permissions:add_organisation_access"].invoke(document.content_id, args[:organisation_id], log_file)
       rescue StandardError => e
         log_file.puts "--- Error occurred ---"
         log_file.puts e.detailed_message
@@ -57,14 +57,14 @@ namespace :permissions do
     document_content_id = args[:document_content_id]
     org_content_id = args[:org_content_id]
 
-    document = Artefact.find_by(id: document_content_id)
+    document = Artefact.find_by(content_id: document_content_id)
 
     if document.nil?
       puts "Document ID #{document_content_id} not found, no permissions removed for organisation with ID: #{org_content_id}"
     else
       editions = Edition.where(panopticon_id: document.id).select { |edition| edition.owning_org_content_ids.include?(org_content_id) }
       if editions.empty?
-        puts "Organisation with ID #{org_content_id} did not have access to document with ID: #{document.id}. No permissions changed"
+        puts "Organisation with ID #{org_content_id} did not have access to document with ID: #{document.content_id}. No permissions changed"
       else
         editions.each do |edition|
           owning_org_content_ids = edition.owning_org_content_ids - [org_content_id]
@@ -81,7 +81,7 @@ namespace :permissions do
   desc "Remove all access permissions from a document"
   task :remove_all_access_flags, %i[document_content_id] => :environment do |_, args|
     document_content_id = args[:document_content_id]
-    document = Artefact.find_by(id: document_content_id)
+    document = Artefact.find_by(content_id: document_content_id)
 
     if document.nil?
       puts "Document ID #{document_content_id} not found, no permissions changed"
@@ -90,7 +90,7 @@ namespace :permissions do
         edition.update_columns(owning_org_content_ids: [])
       end
       document.save_as_task!("PermissionsClear")
-      puts "All access permissions for all organisations successfully removed from document with ID - #{document.id}"
+      puts "All access permissions for all organisations successfully removed from document with ID - #{document.content_id}"
     end
   rescue ActiveRecord::RecordNotFound => e
     puts "An error occurred while processing document with ID #{document_content_id}: #{e.message}"

--- a/test/unit/tasks/access_and_permissions_test.rb
+++ b/test/unit/tasks/access_and_permissions_test.rb
@@ -33,7 +33,7 @@ class AccessAndPermissionsTaskTest < ActiveSupport::TestCase
   test "add_organisation_access assigns permissions correctly" do
     organisation_id = "test-org-id"
 
-    @add_organisation_access_task.invoke(@artefact1.id, organisation_id)
+    @add_organisation_access_task.invoke(@artefact1.content_id, organisation_id)
     @edition1.reload
 
     assert_includes @edition1.owning_org_content_ids, organisation_id
@@ -44,7 +44,7 @@ class AccessAndPermissionsTaskTest < ActiveSupport::TestCase
     organisation_id = "test-org-id"
     @edition1.update!(owning_org_content_ids: [organisation_id])
 
-    @add_organisation_access_task.invoke(@artefact1.id, organisation_id)
+    @add_organisation_access_task.invoke(@artefact1.content_id, organisation_id)
     @edition1.reload
 
     assert_equal(1, @edition1.owning_org_content_ids.count { |id| id == organisation_id })
@@ -59,7 +59,7 @@ class AccessAndPermissionsTaskTest < ActiveSupport::TestCase
     original_edition_updated_at = @edition1.updated_at
     original_artefact_updated_at = @artefact1.updated_at
 
-    @add_organisation_access_task.invoke(@artefact1.id, organisation_id)
+    @add_organisation_access_task.invoke(@artefact1.content_id, organisation_id)
     @edition1.reload
     @artefact1.reload
 
@@ -85,7 +85,7 @@ class AccessAndPermissionsTaskTest < ActiveSupport::TestCase
     edition1 = FactoryBot.create(:edition, panopticon_id: artefact.id, owning_org_content_ids: [organisation_id])
     edition2 = FactoryBot.create(:edition, panopticon_id: artefact.id, owning_org_content_ids: [organisation_id])
 
-    @remove_organisation_access_task.invoke(artefact.id, organisation_id)
+    @remove_organisation_access_task.invoke(artefact.content_id, organisation_id)
     edition1.reload
     edition2.reload
 
@@ -99,7 +99,7 @@ class AccessAndPermissionsTaskTest < ActiveSupport::TestCase
     artefact = FactoryBot.create(:artefact)
     edition = FactoryBot.create(:edition, panopticon_id: artefact.id, owning_org_content_ids: [org_id_to_keep, org_id_to_remove])
 
-    @remove_organisation_access_task.invoke(artefact.id, org_id_to_remove)
+    @remove_organisation_access_task.invoke(artefact.content_id, org_id_to_remove)
     edition.reload
 
     assert_not_includes edition.owning_org_content_ids, org_id_to_remove
@@ -113,7 +113,7 @@ class AccessAndPermissionsTaskTest < ActiveSupport::TestCase
     edition1 = FactoryBot.create(:edition, panopticon_id: artefact.id, owning_org_content_ids: [organisation_id1, organisation_id2])
     edition2 = FactoryBot.create(:edition, panopticon_id: artefact.id, owning_org_content_ids: [organisation_id1, organisation_id2])
 
-    @remove_all_access_flags_task.invoke(artefact.id)
+    @remove_all_access_flags_task.invoke(artefact.content_id)
     edition1.reload
     edition2.reload
 
@@ -130,7 +130,7 @@ class AccessAndPermissionsTaskTest < ActiveSupport::TestCase
     artefact2 = FactoryBot.create(:artefact)
     edition2 = FactoryBot.create(:edition, panopticon_id: artefact2.id, owning_org_content_ids: [organisation_id1])
 
-    @remove_all_access_flags_task.invoke(artefact1.id)
+    @remove_all_access_flags_task.invoke(artefact1.content_id)
     edition1.reload
     edition2.reload
 


### PR DESCRIPTION
The language in the rake task was confusing, and rails has a nasty habit of trying to cast pure int strings into int type, causing failures in the task. This modification updates the task to represent what the prompt is asking for rather than what it actually wanted.

Now we search by the content ID rather than the artefact ID.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
