### PR TITLE
[MAIN-7536] Send every editable field for other content types

### DIFF
--- a/app/models/local_transaction_edition.rb
+++ b/app/models/local_transaction_edition.rb
@@ -15,7 +15,7 @@ class LocalTransactionEdition < ApplicationRecord
 
   after_validation :merge_errors
 
-  GOVSPEAK_FIELDS = %i[introduction more_information need_to_know before_text after_text].freeze
+  GOVSPEAK_FIELDS = %i[introduction more_information need_to_know before_results after_results].freeze
 
   validates :lgsl_code, presence: { message: "Enter a LGSL code" }
   validate :valid_lgsl_code, if: -> { lgsl_code.present? }

--- a/app/presenters/formats/edition_format_presenter.rb
+++ b/app/presenters/formats/edition_format_presenter.rb
@@ -1,5 +1,7 @@
 module Formats
   class EditionFormatPresenter
+    FIELD_LABELS = {}.freeze
+
     def initialize(edition)
       @edition = edition
       @artefact = edition.artefact
@@ -10,18 +12,35 @@ module Formats
     end
 
     def render_for_fact_check_manager_api
-      return unless @edition.respond_to?(:whole_body)
+      blocks = fact_check_blocks
+      return title_and_whole_body_block if blocks.empty?
 
-      title_html = %(<h2 class="edition-title">#{ERB::Util.html_escape(@edition.title)}</h2>)
-      body_html = HtmlRenderer.render_html(@edition.whole_body)
-      body = [title_html, body_html.presence].compact.join("\n")
-
-      { content: { heading: "Body", body: } }
+      HtmlRenderer.render_hash(blocks)
     end
 
   private
 
     attr_reader :edition, :artefact
+
+    def fact_check_blocks
+      blocks = self.class::FIELD_LABELS.filter_map do |field, heading|
+        body = edition.editionable[field]
+
+        [field.to_s, { heading:, body: }] if body.present?
+      end
+
+      blocks.to_h
+    end
+
+    def title_and_whole_body_block
+      return unless edition.respond_to?(:whole_body)
+
+      title_html = %(<h2 class="edition-title">#{ERB::Util.html_escape(edition.title)}</h2>)
+      body_html = HtmlRenderer.render_html(edition.whole_body)
+      body = [title_html, body_html.presence].compact.join("\n")
+
+      { content: { heading: "Body", body: } }
+    end
 
     def optional_fields
       access_limited = { auth_bypass_ids: [edition.auth_bypass_id] }

--- a/app/presenters/formats/guide_presenter.rb
+++ b/app/presenters/formats/guide_presenter.rb
@@ -1,16 +1,12 @@
 module Formats
   class GuidePresenter < EditionFormatPresenter
-    def render_for_fact_check_manager_api
-      return unless @edition.respond_to?(:whole_body)
-
-      if @edition.editionable.is_a?(Parted) && @edition.parts.any?
-        HtmlRenderer.render_hash(@edition.parts.in_order.to_h { |part| [part.slug, { heading: part.title, body: part.body.presence }] })
-      else
-        super
-      end
-    end
-
   private
+
+    def fact_check_blocks
+      return {} unless edition.editionable.is_a?(Parted)
+
+      edition.parts.in_order.to_h { |part| [part.slug, { heading: part.title, body: part.body.presence }] }
+    end
 
     def schema_name
       "guide"

--- a/app/presenters/formats/local_transaction_presenter.rb
+++ b/app/presenters/formats/local_transaction_presenter.rb
@@ -1,5 +1,14 @@
 module Formats
   class LocalTransactionPresenter < EditionFormatPresenter
+    FIELD_LABELS = {
+      cta_text: "Button text",
+      introduction: "Introduction",
+      more_information: "Further information",
+      need_to_know: "What you need to know",
+      before_results: "Above results content",
+      after_results: "Below results content",
+    }.freeze
+
   private
 
     def schema_name

--- a/app/presenters/formats/place_presenter.rb
+++ b/app/presenters/formats/place_presenter.rb
@@ -1,5 +1,11 @@
 module Formats
   class PlacePresenter < EditionFormatPresenter
+    FIELD_LABELS = {
+      introduction: "Introduction",
+      more_information: "Further information",
+      need_to_know: "What you need to know",
+    }.freeze
+
   private
 
     def schema_name

--- a/app/presenters/formats/transaction_presenter.rb
+++ b/app/presenters/formats/transaction_presenter.rb
@@ -1,5 +1,15 @@
 module Formats
   class TransactionPresenter < EditionFormatPresenter
+    FIELD_LABELS = {
+      introduction: "Introduction",
+      start_button_text: "Start button text",
+      will_continue_on: "Text below the start button",
+      link: "Link to start of transaction",
+      more_information: "More information",
+      alternate_methods: "Other ways to apply",
+      need_to_know: "What you need to know",
+    }.freeze
+
   private
 
     def schema_name

--- a/test/unit/lib/fact_check_request_form_test.rb
+++ b/test/unit/lib/fact_check_request_form_test.rb
@@ -339,6 +339,33 @@ class FactCheckRequestFormTest < ActiveSupport::TestCase
 
       assert_equal expected_payload, @form.post_new_request_payload
     end
+
+    should "send a block per editable field for a format that declares them" do
+      transaction = FactoryBot.create(
+        :transaction_edition,
+        :draft,
+        title: "Apply for a licence",
+        introduction: "Apply online.",
+        more_information: "",
+        alternate_methods: "You can also apply by post.",
+      )
+      target_date = Time.zone.today + 5.days
+
+      @form.edition = transaction
+      @form.deadline_1i = target_date.year.to_s
+      @form.deadline_2i = target_date.month.to_s
+      @form.deadline_3i = target_date.day.to_s
+
+      payload = @form.post_new_request_payload
+
+      assert_equal(
+        %w[introduction start_button_text will_continue_on link alternate_methods need_to_know],
+        payload[:current_content].keys,
+      )
+      assert_equal({ heading: "Introduction", body: "<p>Apply online.</p>" }, payload[:current_content]["introduction"])
+      assert_equal({ heading: "Other ways to apply", body: "<p>You can also apply by post.</p>" }, payload[:current_content]["alternate_methods"])
+      assert_nil payload[:previous_content]
+    end
   end
 
   context ".resend_emails_payload" do

--- a/test/unit/presenters/formats/local_transaction_presenter_test.rb
+++ b/test/unit/presenters/formats/local_transaction_presenter_test.rb
@@ -205,5 +205,54 @@ class LocalTransactionPresenterTest < ActiveSupport::TestCase
         assert_equal expected, result[:details][:northern_ireland_availability]
       end
     end
+
+    context ".render_for_fact_check_manager_api" do
+      should "return a rendered block per field, in edit form order" do
+        edition = FactoryBot.create(
+          :local_transaction_edition,
+          cta_text: "Find your council",
+          introduction: "Report a problem to your council.",
+          more_information: "Councils respond within 5 working days.",
+          need_to_know: "You need your postcode.",
+          before_results: "Enter your postcode.",
+          after_results: "Contact your council if the details are wrong.",
+        )
+        presenter = Formats::LocalTransactionPresenter.new(edition)
+
+        expected = {
+          "cta_text" => { heading: "Button text", body: "<p>Find your council</p>" },
+          "introduction" => { heading: "Introduction", body: "<p>Report a problem to your council.</p>" },
+          "more_information" => { heading: "Further information", body: "<p>Councils respond within 5 working days.</p>" },
+          "need_to_know" => { heading: "What you need to know", body: "<p>You need your postcode.</p>" },
+          "before_results" => { heading: "Above results content", body: "<p>Enter your postcode.</p>" },
+          "after_results" => { heading: "Below results content", body: "<p>Contact your council if the details are wrong.</p>" },
+        }
+
+        result = presenter.render_for_fact_check_manager_api
+
+        assert_equal expected.keys, result.keys
+        assert_equal expected, result
+      end
+
+      should "render the govspeak in each field" do
+        edition = FactoryBot.create(:local_transaction_edition, before_results: "##Before")
+        presenter = Formats::LocalTransactionPresenter.new(edition)
+
+        assert_equal(
+          "<h2 id=\"before\">Before</h2>",
+          presenter.render_for_fact_check_manager_api["before_results"][:body],
+        )
+      end
+
+      should "omit any blank fields" do
+        edition = FactoryBot.create(:local_transaction_edition, more_information: "", cta_text: nil)
+        presenter = Formats::LocalTransactionPresenter.new(edition)
+
+        assert_equal(
+          %w[introduction need_to_know before_results after_results],
+          presenter.render_for_fact_check_manager_api.keys,
+        )
+      end
+    end
   end
 end

--- a/test/unit/presenters/formats/place_presenter_test.rb
+++ b/test/unit/presenters/formats/place_presenter_test.rb
@@ -68,4 +68,54 @@ class PlacePresenterTest < ActiveSupport::TestCase
     ]
     assert_equal expected, result[:routes]
   end
+
+  context ".render_for_fact_check_manager_api" do
+    should "return a rendered block per field, in edit form order" do
+      edition = FactoryBot.create(
+        :place_edition,
+        introduction: "Find your nearest office.",
+        more_information: "Offices open Monday to Friday.",
+        need_to_know: "You must book an appointment.",
+      )
+      presenter = Formats::PlacePresenter.new(edition)
+
+      expected = {
+        "introduction" => { heading: "Introduction", body: "<p>Find your nearest office.</p>" },
+        "more_information" => { heading: "Further information", body: "<p>Offices open Monday to Friday.</p>" },
+        "need_to_know" => { heading: "What you need to know", body: "<p>You must book an appointment.</p>" },
+      }
+
+      result = presenter.render_for_fact_check_manager_api
+
+      assert_equal expected.keys, result.keys
+      assert_equal expected, result
+    end
+
+    should "render the govspeak in each field" do
+      edition = FactoryBot.create(:place_edition, need_to_know: "%You must book an appointment.%")
+      presenter = Formats::PlacePresenter.new(edition)
+
+      assert_equal(
+        "<div role=\"note\" aria-label=\"Warning\" class=\"application-notice help-notice\">\n<p>You must book an appointment.</p>\n</div>",
+        presenter.render_for_fact_check_manager_api["need_to_know"][:body],
+      )
+    end
+
+    should "omit any blank fields" do
+      edition = FactoryBot.create(:place_edition, more_information: "", need_to_know: nil)
+      presenter = Formats::PlacePresenter.new(edition)
+
+      assert_equal %w[introduction], presenter.render_for_fact_check_manager_api.keys
+    end
+
+    should "fall back to the merged body when every field is blank, as empty content is rejected" do
+      edition = FactoryBot.create(:place_edition, introduction: nil, more_information: nil, need_to_know: nil)
+      presenter = Formats::PlacePresenter.new(edition)
+
+      assert_equal(
+        { content: { heading: "Body", body: "<h2 class=\"edition-title\">Far far away</h2>" } },
+        presenter.render_for_fact_check_manager_api,
+      )
+    end
+  end
 end

--- a/test/unit/presenters/formats/transaction_presenter_test.rb
+++ b/test/unit/presenters/formats/transaction_presenter_test.rb
@@ -145,4 +145,52 @@ class TransactionPresenterTest < ActiveSupport::TestCase
     ]
     assert_equal expected, result[:routes]
   end
+
+  context ".render_for_fact_check_manager_api" do
+    should "return a rendered block per field, in edit form order" do
+      edition = FactoryBot.create(
+        :transaction_edition,
+        introduction: "Apply online.",
+        start_button_text: "Start now",
+        will_continue_on: "the licensing service",
+        link: "https://www.gov.uk/apply",
+        more_information: "A decision takes 3 weeks.",
+        alternate_methods: "You can also apply by post.",
+        need_to_know: "You need your National Insurance number.",
+      )
+      presenter = Formats::TransactionPresenter.new(edition)
+
+      expected = {
+        "introduction" => { heading: "Introduction", body: "<p>Apply online.</p>" },
+        "start_button_text" => { heading: "Start button text", body: "<p>Start now</p>" },
+        "will_continue_on" => { heading: "Text below the start button", body: "<p>the licensing service</p>" },
+        "link" => { heading: "Link to start of transaction", body: "<p>https://www.gov.uk/apply</p>" },
+        "more_information" => { heading: "More information", body: "<p>A decision takes 3 weeks.</p>" },
+        "alternate_methods" => { heading: "Other ways to apply", body: "<p>You can also apply by post.</p>" },
+        "need_to_know" => { heading: "What you need to know", body: "<p>You need your National Insurance number.</p>" },
+      }
+
+      result = presenter.render_for_fact_check_manager_api
+
+      assert_equal expected.keys, result.keys
+      assert_equal expected, result
+    end
+
+    should "apply govspeak's typography to fields that are not govspeak on the published page" do
+      edition = FactoryBot.create(:transaction_edition, will_continue_on: "To be continued...")
+      presenter = Formats::TransactionPresenter.new(edition)
+
+      assert_equal "<p>To be continued\u2026</p>", presenter.render_for_fact_check_manager_api["will_continue_on"][:body]
+    end
+
+    should "omit any blank fields" do
+      edition = FactoryBot.create(:transaction_edition, more_information: "", alternate_methods: nil)
+      presenter = Formats::TransactionPresenter.new(edition)
+
+      assert_equal(
+        %w[introduction start_button_text will_continue_on link need_to_know],
+        presenter.render_for_fact_check_manager_api.keys,
+      )
+    end
+  end
 end


### PR DESCRIPTION
[MAIN-7536](https://gov-uk.atlassian.net/browse/MAIN-7536)

### Changes
Place, transaction and local transaction editions were sent to Fact Check Manager as a single merged body, which excluded some fields for visible content. Each format now declares `FIELD_LABELS` and sends one block per editable field, in the order they appear on the edit form and using that form's own labels. Blank fields are dropped, so Fact Check Manager marks a field the editor has emptied as "(REMOVED)" rather than showing an empty section.

Guides already sent a block per part and now override the same `fact_check_blocks` method rather than the whole presenter method. An empty guide part keeps its heading, because that section still exists on the page.

Also fixes `GOVSPEAK_FIELDS` on `LocalTransactionEdition`, which named `before_text` and `after_text` when the columns are `before_results` and `after_results`, so neither field was checked by `LinkValidator` or `SafeHtml`. Editions with a malformed link in either will now fail validation on save.

[MAIN-7536]: https://gov-uk.atlassian.net/browse/MAIN-7536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ